### PR TITLE
Connect frontend RPC calls and tests

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,9 +1,28 @@
 import { Box, Typography, Link } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { fetchHostname, fetchVersion } from './rpcClient';
 
 const Home = (): JSX.Element => {
-  // In a real app, these might be provided by your backend or environment
-  const appVersion = "0.0.1"; // Replace with dynamic version if available
-  const hostname = "elideusgroup.com"; // Replace with dynamic hostname if available
+  const [appVersion, setAppVersion] = useState('');
+  const [hostname, setHostname] = useState('');
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const version = await fetchVersion();
+        setAppVersion(version.version);
+      } catch {
+        setAppVersion('unknown');
+      }
+
+      try {
+        const host = await fetchHostname();
+        setHostname(host.hostname);
+      } catch {
+        setHostname('unknown');
+      }
+    })();
+  }, []);
 
   return (
     <Box

--- a/frontend/src/generated_rpc_models.tsx
+++ b/frontend/src/generated_rpc_models.tsx
@@ -22,3 +22,4 @@ export interface AdminVarsHostname1 {
 export interface AdminVarsVersion1 {
   version: string;
 }
+

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -8,7 +8,8 @@ if (!rootElement) {
 }
 
 createRoot(rootElement).render(
-	<StrictMode>
-		<App />
-	</StrictMode>
-)
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);
+

--- a/frontend/src/rpcClient.ts
+++ b/frontend/src/rpcClient.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import {
+  AdminVarsHostname1,
+  AdminVarsVersion1,
+  RPCRequest,
+  RPCResponse,
+} from './generated_rpc_models';
+
+const buildRequest = (op: string): RPCRequest => ({
+  op,
+  payload: null,
+  version: 1,
+  user_id: crypto.randomUUID(),
+  timestamp: Date.now(),
+  metadata: null,
+});
+
+export const fetchVersion = async (): Promise<AdminVarsVersion1> => {
+  const request = buildRequest('urn:admin:vars:get_version:1');
+  const response = await axios.post<RPCResponse>('/rpc', request);
+  return response.data.payload as AdminVarsVersion1;
+};
+
+export const fetchHostname = async (): Promise<AdminVarsHostname1> => {
+  const request = buildRequest('urn:admin:vars:get_hostname:1');
+  const response = await axios.post<RPCResponse>('/rpc', request);
+  return response.data.payload as AdminVarsHostname1;
+};
+

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1,0 +1,39 @@
+import os
+import uuid
+from importlib import reload
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from server import rpc_router, lifespan
+
+
+def create_app():
+    from main import app
+    return app
+
+
+def test_rpc_environment_flow(monkeypatch):
+    monkeypatch.setenv("VERSION", "9.9.9")
+    monkeypatch.setenv("HOSTNAME", "unit-host")
+
+    # reload config after setting env vars
+    import server.config as config
+    reload(config)
+    reload(lifespan)
+
+    app = FastAPI(lifespan=lifespan.lifespan)
+    app.include_router(rpc_router.router, prefix="/rpc")
+
+    with TestClient(app) as client:
+        req = {
+            "op": "urn:admin:vars:get_version:1",
+            "user_id": str(uuid.uuid4()),
+        }
+        res = client.post("/rpc", json=req)
+        assert res.status_code == 200
+        assert res.json()["payload"]["version"] == "9.9.9"
+
+        req["op"] = "urn:admin:vars:get_hostname:1"
+        res = client.post("/rpc", json=req)
+        assert res.status_code == 200
+        assert res.json()["payload"]["hostname"] == "unit-host"
+


### PR DESCRIPTION
## Summary
- integrate TypeScript RPC models via new `rpcClient` helper
- load version and hostname through RPC in `Home`
- tidy `index.tsx` formatting
- expand tests to cover environment variable flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68686b634eb483259236c0c8e61d3e69