### PR TITLE
Revert TSX library generation to use any

### DIFF
--- a/frontend/src/generated_rpc_models.tsx
+++ b/frontend/src/generated_rpc_models.tsx
@@ -1,18 +1,18 @@
 export interface RPCRequest {
   op: string;
-  payload: unknown;
+  payload: any;
   version: number;
-  user_id: unknown;
-  timestamp: unknown;
-  metadata: unknown;
+  user_id: any;
+  timestamp: any;
+  metadata: any;
 }
 
 export interface RPCResponse {
   op: string;
-  payload: unknown;
+  payload: any;
   version: number;
-  timestamp: unknown;
-  metadata: unknown;
+  timestamp: any;
+  metadata: any;
 }
 
 export interface AdminVarsHostname1 {
@@ -22,4 +22,3 @@ export interface AdminVarsHostname1 {
 export interface AdminVarsVersion1 {
   version: string;
 }
-

--- a/scripts/generate_ts_library.py
+++ b/scripts/generate_ts_library.py
@@ -30,10 +30,7 @@ def load_module(path: str):
 
 def field_to_ts(name: str, annotation: Any) -> str:
     """Convert a single Pydantic field to TypeScript."""
-    ts_type = PY_TO_TS.get(annotation)
-    if ts_type is None:
-        # Avoid using the `any` type to satisfy ESLint's no-explicit-any rule.
-        ts_type = 'unknown'
+    ts_type = PY_TO_TS.get(annotation, 'any')
     return f"  {name}: {ts_type};"
 
 


### PR DESCRIPTION
## Summary
- revert TypeScript interface generation back to using `any` for unknown fields
- regenerate frontend RPC models accordingly

## Testing
- `pytest -q`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c0c47350832592496ec4eb070cee