### PR TITLE
Fix RPC endpoint path

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,1 +1,10 @@
+"""Server package exposing router modules for external import.
 
+This allows tests and application code to import the configured routers using
+`from server import rpc_router` instead of reaching into the routers package
+directly."""
+
+from .routers import rpc as rpc_router
+from .routers import web as web_router
+
+__all__ = ["rpc_router", "web_router"]

--- a/server/routers/rpc.py
+++ b/server/routers/rpc.py
@@ -4,6 +4,7 @@ from rpc.models import RPCRequest, RPCResponse
 
 router = APIRouter()
 
+@router.post("")
 @router.post("/")
 async def post_root(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   return await handle_rpc_request(rpc_request, request)


### PR DESCRIPTION
## Summary
- export router modules via server package for tests
- handle POST requests to `/rpc` without a trailing slash

## Testing
- `pytest -q`
- `npm test --silent --run`

------
https://chatgpt.com/codex/tasks/task_e_686947f8763c8325970a14454286399e