### PR TITLE
Improve test coverage and sanitize version display

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -10,14 +10,16 @@ const Home = (): JSX.Element => {
     void (async () => {
       try {
         const version = await fetchVersion();
-        setAppVersion(version.version);
+        const cleanVersion = version.version.replace(/^"|"$/g, '');
+        setAppVersion(cleanVersion);
       } catch {
         setAppVersion('unknown');
       }
 
       try {
         const host = await fetchHostname();
-        setHostname(host.hostname);
+        const cleanHost = host.hostname.replace(/^"|"$/g, '');
+        setHostname(cleanHost);
       } catch {
         setHostname('unknown');
       }

--- a/frontend/tests/rpcClient.test.ts
+++ b/frontend/tests/rpcClient.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import axios from 'axios';
+import { fetchVersion, fetchHostname } from '../src/rpcClient';
+
+vi.mock('axios');
+
+beforeAll(() => {
+  (global as any).crypto = { randomUUID: () => '0000' };
+});
+
+const mockedPost = axios.post as unknown as ReturnType<typeof vi.fn>;
+
+
+describe('rpcClient', () => {
+  it('fetchVersion posts correct request', async () => {
+    mockedPost.mockResolvedValueOnce({ data: { payload: { version: '1.0.0' } } });
+    const res = await fetchVersion();
+    expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_version:1' }));
+    expect(res.version).toBe('1.0.0');
+  });
+
+  it('fetchHostname posts correct request', async () => {
+    mockedPost.mockResolvedValueOnce({ data: { payload: { hostname: 'host' } } });
+    const res = await fetchHostname();
+    expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_hostname:1' }));
+    expect(res.hostname).toBe('host');
+  });
+});
+

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,1 +1,10 @@
+"""Server package exposing router modules for external import.
 
+This allows tests and application code to import the configured routers using
+`from server import rpc_router` instead of reaching into the routers package
+directly."""
+
+from .routers import rpc as rpc_router
+from .routers import web as web_router
+
+__all__ = ["rpc_router", "web_router"]

--- a/server/routers/rpc.py
+++ b/server/routers/rpc.py
@@ -4,6 +4,7 @@ from rpc.models import RPCRequest, RPCResponse
 
 router = APIRouter()
 
+@router.post("")
 @router.post("/")
 async def post_root(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   return await handle_rpc_request(rpc_request, request)

--- a/tests/test_generate_ts_library.py
+++ b/tests/test_generate_ts_library.py
@@ -1,0 +1,18 @@
+import tempfile
+from textwrap import dedent
+from types import ModuleType
+
+from scripts import generate_ts_library as gen
+from pydantic import BaseModel
+
+
+def test_model_to_ts_simple():
+    class Sample(BaseModel):
+        name: str
+        age: int
+
+    ts = gen.model_to_ts(Sample)
+    assert 'export interface Sample' in ts
+    assert 'name: string;' in ts
+    assert 'age: number;' in ts
+

--- a/tests/test_server_components.py
+++ b/tests/test_server_components.py
@@ -1,0 +1,69 @@
+import uuid
+import asyncio
+from importlib import reload
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
+
+import server.config as config
+from server import lifespan
+from rpc.handler import handle_rpc_request
+from rpc.admin.vars.handler import handle_vars_request
+from rpc.admin.vars.services import get_version_v1, get_hostname_v1
+from rpc.models import RPCRequest
+
+
+def test_get_str_env_var_missing(monkeypatch):
+    monkeypatch.delenv('MISSING_VAR', raising=False)
+    with pytest.raises(RuntimeError):
+        config._get_str_env_var('MISSING_VAR')
+
+
+def test_lifespan_sets_state(monkeypatch):
+    monkeypatch.setenv('VERSION', '1.2.3')
+    monkeypatch.setenv('HOSTNAME', 'test-host')
+    reload(config)
+    reload(lifespan)
+    app = FastAPI(lifespan=lifespan.lifespan)
+    with TestClient(app) as client:
+        assert client.app.state.version == '1.2.3'
+        assert client.app.state.hostname == 'test-host'
+
+
+def test_handle_rpc_request_invalid_prefix():
+    app = FastAPI()
+    request = Request({'type': 'http', 'app': app})
+    rpc_request = RPCRequest(op='invalid', user_id=uuid.uuid4())
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(handle_rpc_request(rpc_request, request))
+    assert exc.value.status_code == 400
+
+
+def test_handle_rpc_request_unknown_domain():
+    app = FastAPI()
+    request = Request({'type': 'http', 'app': app})
+    rpc_request = RPCRequest(op='urn:unknown:op:1', user_id=uuid.uuid4())
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(handle_rpc_request(rpc_request, request))
+    assert exc.value.status_code == 404
+
+
+def test_handle_vars_request_unknown_operation():
+    app = FastAPI()
+    request = Request({'type': 'http', 'app': app})
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(handle_vars_request(['unknown', '1'], request))
+    assert exc.value.status_code == 404
+
+
+def test_services_read_from_state():
+    app = FastAPI()
+    app.state.version = 'x.y.z'
+    app.state.hostname = 'host'
+    request = Request({'type': 'http', 'app': app})
+    version_res = asyncio.run(get_version_v1(request))
+    assert version_res.payload.version == 'x.y.z'
+    host_res = asyncio.run(get_hostname_v1(request))
+    assert host_res.payload.hostname == 'host'
+


### PR DESCRIPTION
## Summary
- add backend and frontend tests
- ensure Home component strips quotes from RPC payload

## Testing
- `pytest -q`
- `npm test --silent --run`


------
https://chatgpt.com/codex/tasks/task_e_686947f8763c8325970a14454286399e