### PR TITLE
Remove user_id from RPC models and update dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ scripts/
 __pycache__/
 *.pyc
 .env
+tests/

--- a/frontend/src/generated_rpc_models.tsx
+++ b/frontend/src/generated_rpc_models.tsx
@@ -2,7 +2,6 @@ export interface RPCRequest {
   op: string;
   payload: any;
   version: number;
-  user_id: any;
   timestamp: any;
   metadata: any;
 }

--- a/frontend/src/rpcClient.ts
+++ b/frontend/src/rpcClient.ts
@@ -10,7 +10,6 @@ const buildRequest = (op: string): RPCRequest => ({
   op,
   payload: null,
   version: 1,
-  user_id: crypto.randomUUID(),
   timestamp: Date.now(),
   metadata: null,
 });

--- a/rpc/admin/handler.py
+++ b/rpc/admin/handler.py
@@ -1,8 +1,7 @@
-from typing import List
 from fastapi import Request, HTTPException
 from rpc.admin.vars.handler import handle_vars_request
 
-async def handle_admin_request(urn: List, request: Request):
+async def handle_admin_request(urn: list[str], request: Request):
   match urn:
     case ["vars", *rest]:
       return await handle_vars_request(rest, request)

--- a/rpc/admin/vars/handler.py
+++ b/rpc/admin/vars/handler.py
@@ -1,8 +1,7 @@
-from typing import List
 from fastapi import Request, HTTPException
 from rpc.admin.vars.services import get_version_v1, get_hostname_v1
 
-async def handle_vars_request(urn: List, request: Request):
+async def handle_vars_request(urn: list[str], request: Request):
   match urn:
     case ["get_version", "1"]:
       return await get_version_v1(request)

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -1,6 +1,5 @@
 from pydantic import BaseModel, Field
 from typing import Any, Optional
-from uuid import UUID
 from datetime import datetime, timezone
 
 class RPCRequest(BaseModel):
@@ -8,10 +7,6 @@ class RPCRequest(BaseModel):
   payload: Optional[dict[str, Any]] = None
   version: int = 1
 
-  user_id: UUID = Field(
-    ...,
-    description="Internal GUID uniquely identifying the authenticated user"
-  )
   timestamp: Optional[datetime] = Field(
     default_factory=lambda: datetime.now(timezone.utc),
     description="Client-supplied or default UTC timestamp"

--- a/server/config.py
+++ b/server/config.py
@@ -3,8 +3,8 @@ import os, dotenv
 dotenv.load_dotenv()
 
 def _get_str_env_var(var_name: str, default: str | None = None) -> str:
-  value = os.getenv(var_name)
-  if not value:
+  value = os.getenv(var_name, default)
+  if value is None:
     raise RuntimeError(f"ERROR: {var_name} missing.")
   return value
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -26,7 +26,6 @@ def test_rpc_environment_flow(monkeypatch):
     with TestClient(app) as client:
         req = {
             "op": "urn:admin:vars:get_version:1",
-            "user_id": str(uuid.uuid4()),
         }
         res = client.post("/rpc", json=req)
         assert res.status_code == 200

--- a/tests/test_rpc_admin.py
+++ b/tests/test_rpc_admin.py
@@ -11,7 +11,7 @@ def test_get_version():
     app.state.hostname = "test-host"
     request = Request({"type": "http", "app": app})
 
-    rpc_request = RPCRequest(op="urn:admin:vars:get_version:1", user_id=uuid.uuid4())
+    rpc_request = RPCRequest(op="urn:admin:vars:get_version:1")
     response = asyncio.run(handle_rpc_request(rpc_request, request))
 
     assert response.op == "urn:admin:vars:version:1"
@@ -23,7 +23,7 @@ def test_get_hostname():
     app.state.hostname = "test-host"
     request = Request({"type": "http", "app": app})
 
-    rpc_request = RPCRequest(op="urn:admin:vars:get_hostname:1", user_id=uuid.uuid4())
+    rpc_request = RPCRequest(op="urn:admin:vars:get_hostname:1")
     response = asyncio.run(handle_rpc_request(rpc_request, request))
 
     assert response.op == "urn:admin:vars:hostname:1"

--- a/tests/test_server_components.py
+++ b/tests/test_server_components.py
@@ -34,7 +34,7 @@ def test_lifespan_sets_state(monkeypatch):
 def test_handle_rpc_request_invalid_prefix():
     app = FastAPI()
     request = Request({'type': 'http', 'app': app})
-    rpc_request = RPCRequest(op='invalid', user_id=uuid.uuid4())
+    rpc_request = RPCRequest(op='invalid')
     with pytest.raises(HTTPException) as exc:
         asyncio.run(handle_rpc_request(rpc_request, request))
     assert exc.value.status_code == 400
@@ -43,7 +43,7 @@ def test_handle_rpc_request_invalid_prefix():
 def test_handle_rpc_request_unknown_domain():
     app = FastAPI()
     request = Request({'type': 'http', 'app': app})
-    rpc_request = RPCRequest(op='urn:unknown:op:1', user_id=uuid.uuid4())
+    rpc_request = RPCRequest(op='urn:unknown:op:1')
     with pytest.raises(HTTPException) as exc:
         asyncio.run(handle_rpc_request(rpc_request, request))
     assert exc.value.status_code == 404


### PR DESCRIPTION
## Summary
- drop `user_id` field from `RPCRequest`
- regenerate TypeScript models and update client usage
- update tests to no longer pass `user_id`
- exclude test suite from Docker build context
- modernise a few Python types and env var helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869556547088325ade23c7f4e441d16