### PR TITLE
Add REPO rpc support

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,10 +1,12 @@
 import { Box, Typography, Link } from '@mui/material';
 import { useEffect, useState } from 'react';
-import { fetchHostname, fetchVersion } from './rpcClient';
+import { fetchHostname, fetchVersion, fetchRepo } from './rpcClient';
 
 const Home = (): JSX.Element => {
   const [appVersion, setAppVersion] = useState('');
   const [hostname, setHostname] = useState('');
+  const [repo, setRepo] = useState('');
+  const [build, setBuild] = useState('');
 
   useEffect(() => {
     void (async () => {
@@ -22,6 +24,17 @@ const Home = (): JSX.Element => {
         setHostname(cleanHost);
       } catch {
         setHostname('unknown');
+      }
+
+      try {
+        const repoInfo = await fetchRepo();
+        const cleanRepo = repoInfo.repo.replace(/^"|"$/g, '');
+        const cleanBuild = repoInfo.build.replace(/^"|"$/g, '');
+        setRepo(cleanRepo);
+        setBuild(cleanBuild);
+      } catch {
+        setRepo('');
+        setBuild('');
       }
     })();
   }, []);
@@ -53,7 +66,7 @@ const Home = (): JSX.Element => {
       <Typography sx={{ fontSize: 14, mt: 1 }}>
         GitHub:{' '}
         <Link
-          href="https://github.com/elide-us/elideus-group"
+          href={repo}
           target="_blank"
           rel="noopener noreferrer"
           sx={{ color: 'text.primary', textDecoration: 'none' }}
@@ -62,7 +75,7 @@ const Home = (): JSX.Element => {
         </Link>{' '}
         -{' '}
         <Link
-          href="https://github.com/elide-us/elideus-group/actions"
+          href={build}
           target="_blank"
           rel="noopener noreferrer"
           sx={{ color: 'text.primary', textDecoration: 'none' }}

--- a/frontend/src/generated_rpc_models.tsx
+++ b/frontend/src/generated_rpc_models.tsx
@@ -18,6 +18,11 @@ export interface AdminVarsHostname1 {
   hostname: string;
 }
 
+export interface AdminVarsRepo1 {
+  repo: string;
+  build: string;
+}
+
 export interface AdminVarsVersion1 {
   version: string;
 }

--- a/frontend/src/rpcClient.ts
+++ b/frontend/src/rpcClient.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import {
   AdminVarsHostname1,
+  AdminVarsRepo1,
   AdminVarsVersion1,
   RPCRequest,
   RPCResponse,
@@ -24,5 +25,11 @@ export const fetchHostname = async (): Promise<AdminVarsHostname1> => {
   const request = buildRequest('urn:admin:vars:get_hostname:1');
   const response = await axios.post<RPCResponse>('/rpc', request);
   return response.data.payload as AdminVarsHostname1;
+};
+
+export const fetchRepo = async (): Promise<AdminVarsRepo1> => {
+  const request = buildRequest('urn:admin:vars:get_repo:1');
+  const response = await axios.post<RPCResponse>('/rpc', request);
+  return response.data.payload as AdminVarsRepo1;
 };
 

--- a/rpc/admin/vars/handler.py
+++ b/rpc/admin/vars/handler.py
@@ -1,5 +1,5 @@
 from fastapi import Request, HTTPException
-from rpc.admin.vars.services import get_version_v1, get_hostname_v1
+from rpc.admin.vars.services import get_version_v1, get_hostname_v1, get_repo_v1
 
 async def handle_vars_request(urn: list[str], request: Request):
   match urn:
@@ -7,6 +7,8 @@ async def handle_vars_request(urn: list[str], request: Request):
       return await get_version_v1(request)
     case ["get_hostname", "1"]:
       return await get_hostname_v1(request)
+    case ["get_repo", "1"]:
+      return await get_repo_v1(request)
     case _:
       raise HTTPException(status_code=404, detail="Unknown RPC operation")
 

--- a/rpc/admin/vars/models.py
+++ b/rpc/admin/vars/models.py
@@ -6,3 +6,7 @@ class AdminVarsVersion1(BaseModel):
 class AdminVarsHostname1(BaseModel):
   hostname: str
 
+class AdminVarsRepo1(BaseModel):
+  repo: str
+  build: str
+

--- a/rpc/admin/vars/services.py
+++ b/rpc/admin/vars/services.py
@@ -1,5 +1,5 @@
 from fastapi import Request
-from rpc.admin.vars.models import AdminVarsVersion1, AdminVarsHostname1
+from rpc.admin.vars.models import AdminVarsVersion1, AdminVarsHostname1, AdminVarsRepo1
 from rpc.models import RPCResponse
 
 async def get_version_v1(request: Request):
@@ -11,3 +11,8 @@ async def get_hostname_v1(request: Request):
   hostname = request.app.state.hostname
   payload = AdminVarsHostname1(hostname=hostname)
   return RPCResponse(op="urn:admin:vars:hostname:1", payload=payload, version=1)
+
+async def get_repo_v1(request: Request):
+  repo = request.app.state.repo
+  payload = AdminVarsRepo1(repo=repo, build=f"{repo}/actions")
+  return RPCResponse(op="urn:admin:vars:repo:1", payload=payload, version=1)

--- a/server/config.py
+++ b/server/config.py
@@ -10,5 +10,6 @@ def _get_str_env_var(var_name: str, default: str | None = None) -> str:
 
 VERSION = _get_str_env_var("VERSION")
 HOSTNAME = _get_str_env_var("HOSTNAME")
+REPO = _get_str_env_var("REPO")
 
 

--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -1,11 +1,12 @@
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
-from server.config import VERSION, HOSTNAME
+from server.config import VERSION, HOSTNAME, REPO
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
   app.state.version = VERSION
   app.state.hostname = HOSTNAME
+  app.state.repo = REPO
 
   try:
     yield

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -3,6 +3,7 @@ import uuid
 from importlib import reload
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+os.environ.setdefault('REPO', 'https://repo')
 from server import rpc_router, lifespan
 
 
@@ -14,6 +15,7 @@ def create_app():
 def test_rpc_environment_flow(monkeypatch):
     monkeypatch.setenv("VERSION", "9.9.9")
     monkeypatch.setenv("HOSTNAME", "unit-host")
+    monkeypatch.setenv("REPO", "https://repo")
 
     # reload config after setting env vars
     import server.config as config
@@ -35,4 +37,10 @@ def test_rpc_environment_flow(monkeypatch):
         res = client.post("/rpc", json=req)
         assert res.status_code == 200
         assert res.json()["payload"]["hostname"] == "unit-host"
+
+        req["op"] = "urn:admin:vars:get_repo:1"
+        res = client.post("/rpc", json=req)
+        assert res.status_code == 200
+        assert res.json()["payload"]["repo"] == "https://repo"
+        assert res.json()["payload"]["build"] == "https://repo/actions"
 

--- a/tests/test_rpc_admin.py
+++ b/tests/test_rpc_admin.py
@@ -29,3 +29,17 @@ def test_get_hostname():
     assert response.op == "urn:admin:vars:hostname:1"
     assert response.payload.hostname == "test-host"
 
+def test_get_repo():
+    app = FastAPI()
+    app.state.version = "1.0.0"
+    app.state.hostname = "test-host"
+    app.state.repo = "https://github.com/test/repo"
+    request = Request({"type": "http", "app": app})
+
+    rpc_request = RPCRequest(op="urn:admin:vars:get_repo:1")
+    response = asyncio.run(handle_rpc_request(rpc_request, request))
+
+    assert response.op == "urn:admin:vars:repo:1"
+    assert response.payload.repo == "https://github.com/test/repo"
+    assert response.payload.build == "https://github.com/test/repo/actions"
+


### PR DESCRIPTION
## Summary
- expose new `REPO` environment variable
- provide `get_repo` rpc call returning repo and build links
- generate TS interfaces and rpc client helpers
- load repo link in Home page dynamically
- add tests for new rpc flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68695f5b9ff88325a353bdd18959a9fc