### PR TITLE
Add tests to CI and generate TS helper

### DIFF
--- a/.github/workflows/generate_ts.yml
+++ b/.github/workflows/generate_ts.yml
@@ -1,0 +1,28 @@
+name: Generate TypeScript Library
+
+on:
+  push:
+    branches:
+      - main-generate
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Generate TypeScript library
+        run: python scripts/generate_ts_library.py
+      - name: Commit generated library
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: 'frontend/src/generated_rpc_models.tsx'
+          message: 'chore: auto-generate TypeScript library'

--- a/.github/workflows/main_elideus-group.yml
+++ b/.github/workflows/main_elideus-group.yml
@@ -16,6 +16,34 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+
+    - name: Install Node dependencies
+      run: |
+        cd frontend
+        npm ci
+
+    - name: Run frontend tests
+      run: |
+        cd frontend
+        npx vitest run
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt -r requirements-dev.txt
+
+    - name: Run backend tests
+      run: pytest -q
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 

--- a/devgenerate.cmd
+++ b/devgenerate.cmd
@@ -1,0 +1,6 @@
+@ECHO OFF
+python scripts\generate_ts_library.py
+IF ERRORLEVEL 1 (
+    ECHO "TypeScript generation failed."
+    EXIT /b 1
+)

--- a/devstart.cmd
+++ b/devstart.cmd
@@ -13,7 +13,14 @@ IF ERRORLEVEL 1 (
 CALL npm run type-check
 IF ERRORLEVEL 1 (
     ECHO "npm run type-check failed. Exiting."
-ECHO )
+    EXIT /b 1
+)
+
+CALL npm test -- --run
+IF ERRORLEVEL 1 (
+    ECHO "npm test failed. Exiting."
+    EXIT /b 1
+)
 
 CALL npm run build
 IF ERRORLEVEL 1 (
@@ -21,4 +28,9 @@ IF ERRORLEVEL 1 (
     EXIT /b 1
 )
 cd ..
+CALL pytest
+IF ERRORLEVEL 1 (
+    ECHO "pytest failed. Exiting."
+    EXIT /b 1
+)
 python -m uvicorn main:app --reload


### PR DESCRIPTION
## Summary
- ensure CI runs frontend and backend tests
- add workflow to regenerate the TypeScript library on `main-generate` branch
- allow developers to generate the TypeScript library locally
- run tests from `devstart.cmd`

## Testing
- `pytest -q`
- `npm test --prefix frontend -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6869640e5ea48325897dbd9381fa2b69