### PR TITLE
Add UserContext generator and models

### DIFF
--- a/rpc/models.py
+++ b/rpc/models.py
@@ -29,3 +29,11 @@ class RPCResponse(BaseModel):
     default=None,
     description="Optional metadata like processing time or status notes"
   )
+
+# User context models for frontend integration
+class UserData(BaseModel):
+ bearerToken: str
+
+
+class UserContext(BaseModel):
+ userData: Optional[UserData] = None

--- a/scripts/generate_user_context.py
+++ b/scripts/generate_user_context.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+import os
+from scripts.generate_ts_library import model_to_ts
+from rpc.models import UserData, UserContext
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), '..')
+FRONTEND_SRC = os.path.join(REPO_ROOT, 'frontend', 'src')
+
+
+def generate_user_context() -> str:
+ content: list[str] = ['import { createContext } from \"react\";', '']
+ content.append(model_to_ts(UserData).strip())
+ content.append(model_to_ts(UserContext).strip())
+ content.append('const defaultContext: UserContext = {')
+ content.append(' userData: null,')
+ content.append('};')
+ content.append('')
+ content.append('const UserContextObject = createContext<UserContext>(defaultContext);')
+ content.append('')
+ content.append('export default UserContextObject;')
+ return "\n".join(content)
+
+
+def main() -> None:
+ out_path = os.path.join(FRONTEND_SRC, 'generated_user_context.tsx')
+ with open(out_path, 'w') as f:
+  f.write(generate_user_context())
+ print(f"✅ Wrote UserContext to '{out_path}'")
+
+
+if __name__ == '__main__':
+ main()

--- a/tests/test_generate_ts_library.py
+++ b/tests/test_generate_ts_library.py
@@ -14,3 +14,13 @@ def test_model_to_ts_simple():
   assert 'age: number;' in ts
   assert 'active: boolean;' in ts
   assert 'pi: number;' in ts
+
+
+from scripts import generate_user_context as ugen
+
+
+def test_generate_user_context():
+ ts = ugen.generate_user_context()
+ assert 'export interface UserData' in ts
+ assert 'export interface UserContext' in ts
+ assert 'createContext<UserContext>' in ts

--- a/tests/test_rpc_admin.py
+++ b/tests/test_rpc_admin.py
@@ -39,6 +39,6 @@ def test_get_repo():
   response = asyncio.run(handle_rpc_request(rpc_request, request))
 
   assert response.op == "urn:admin:vars:repo:1"
-  assert response.payload.repo == "https:///repo"
+  assert response.payload.repo == "https://repo"
   assert response.payload.build == "https://repo/actions"
 


### PR DESCRIPTION
## Summary
- add Pydantic models `UserData` and `UserContext`
- generate a new UserContext TS file from a Python script
- add generator tests
- fix repo URL check in tests

## Testing
- `pytest -q`
- `npx vitest run --dir frontend` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6869a4ee3d5c8325b4954541ffee3e38