### PR TITLE
Add ffmpeg version RPC and frontend display

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,12 +1,13 @@
 import { Box, Typography, Link } from '@mui/material';
 import { useEffect, useState } from 'react';
-import { fetchHostname, fetchVersion, fetchRepo } from './rpcClient';
+import { fetchHostname, fetchVersion, fetchRepo, fetchFfmpegVersion } from './rpcClient';
 
 const Home = (): JSX.Element => {
   const [appVersion, setAppVersion] = useState('');
   const [hostname, setHostname] = useState('');
   const [repo, setRepo] = useState('');
   const [build, setBuild] = useState('');
+  const [ffmpegVersion, setFfmpegVersion] = useState<string | null>(null);
 
   useEffect(() => {
     void (async () => {
@@ -35,6 +36,14 @@ const Home = (): JSX.Element => {
       } catch {
         setRepo('');
         setBuild('');
+      }
+
+      try {
+        const ffmpegInfo = await fetchFfmpegVersion();
+        const cleanFfmpeg = ffmpegInfo.ffmpeg_version.replace(/^"|"$/g, '');
+        setFfmpegVersion(cleanFfmpeg);
+      } catch {
+        setFfmpegVersion('unknown');
       }
     })();
   }, []);
@@ -82,6 +91,9 @@ const Home = (): JSX.Element => {
         >
           build
         </Link>
+      </Typography>
+      <Typography sx={{ fontSize: 14, mt: 1 }}>
+        {ffmpegVersion ? ffmpegVersion : 'Loading version...'}
       </Typography>
     </Box>
   );

--- a/frontend/src/rpcClient.ts
+++ b/frontend/src/rpcClient.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
 import {
-	AdminVarsHostname1,
-	AdminVarsRepo1,
-	AdminVarsVersion1,
-	RPCRequest,
-	RPCResponse,
+        AdminVarsHostname1,
+        AdminVarsRepo1,
+        AdminVarsVersion1,
+        AdminVarsFfmpegVersion1,
+        RPCRequest,
+        RPCResponse,
 } from './generated_rpc_models';
 
 const buildRequest = (op: string): RPCRequest => ({
@@ -31,4 +32,10 @@ export const fetchRepo = async (): Promise<AdminVarsRepo1> => {
     const request = buildRequest('urn:admin:vars:get_repo:1');
     const response = await axios.post<RPCResponse>('/rpc', request);
     return response.data.payload as AdminVarsRepo1;
+};
+
+export const fetchFfmpegVersion = async (): Promise<AdminVarsFfmpegVersion1> => {
+    const request = buildRequest('urn:admin:vars:get_ffmpeg_version:1');
+    const response = await axios.post<RPCResponse>('/rpc', request);
+    return response.data.payload as AdminVarsFfmpegVersion1;
 };

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -30,3 +30,7 @@ export interface AdminVarsRepo1 {
 export interface AdminVarsVersion1 {
   version: string;
 }
+
+export interface AdminVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}

--- a/frontend/tests/rpcClient.test.ts
+++ b/frontend/tests/rpcClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 import axios from 'axios';
-import { fetchVersion, fetchHostname } from '../src/rpcClient';
+import { fetchVersion, fetchHostname, fetchFfmpegVersion } from '../src/rpcClient';
 
 vi.mock('axios');
 
@@ -14,10 +14,17 @@ describe('rpcClient', () => {
 		expect(res.version).toBe('1.0.0');
 	});
 
-	it('fetchHostname posts correct request', async () => {
-		mockedPost.mockResolvedValueOnce({ data: { payload: { hostname: 'host' } } });
-		const res = await fetchHostname();
-		expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_hostname:1' }));
-		expect(res.hostname).toBe('host');
-	});
+        it('fetchHostname posts correct request', async () => {
+                mockedPost.mockResolvedValueOnce({ data: { payload: { hostname: 'host' } } });
+                const res = await fetchHostname();
+                expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_hostname:1' }));
+                expect(res.hostname).toBe('host');
+        });
+
+        it('fetchFfmpegVersion posts correct request', async () => {
+                mockedPost.mockResolvedValueOnce({ data: { payload: { ffmpeg_version: 'ffmpeg version 6.0' } } });
+                const res = await fetchFfmpegVersion();
+                expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_ffmpeg_version:1' }));
+                expect(res.ffmpeg_version).toBe('ffmpeg version 6.0');
+        });
 });

--- a/rpc/admin/vars/handler.py
+++ b/rpc/admin/vars/handler.py
@@ -9,5 +9,7 @@ async def handle_vars_request(urn: list[str], request: Request):
       return await services.get_hostname_v1(request)
     case ["get_repo", "1"]:
       return await services.get_repo_v1(request)
+    case ["get_ffmpeg_version", "1"]:
+      return await services.get_ffmpeg_version_v1(request)
     case _:
       raise HTTPException(status_code=404, detail="Unknown RPC operation")

--- a/rpc/admin/vars/models.py
+++ b/rpc/admin/vars/models.py
@@ -10,3 +10,6 @@ class AdminVarsRepo1(BaseModel):
   repo: str
   build: str
 
+class AdminVarsFfmpegVersion1(BaseModel):
+  ffmpeg_version: str
+

--- a/rpc/admin/vars/services.py
+++ b/rpc/admin/vars/services.py
@@ -1,5 +1,6 @@
-from fastapi import Request
-from rpc.admin.vars.models import AdminVarsVersion1, AdminVarsHostname1, AdminVarsRepo1
+import asyncio
+from fastapi import Request, HTTPException
+from rpc.admin.vars.models import AdminVarsVersion1, AdminVarsHostname1, AdminVarsRepo1, AdminVarsFfmpegVersion1
 from rpc.models import RPCResponse
 
 async def get_version_v1(request: Request):
@@ -16,3 +17,20 @@ async def get_repo_v1(request: Request):
   repo = request.app.state.repo
   payload = AdminVarsRepo1(repo=repo, build=f"{repo}/actions")
   return RPCResponse(op="urn:admin:vars:repo:1", payload=payload, version=1)
+
+async def get_ffmpeg_version_v1(request: Request):
+  try:
+    process = await asyncio.create_subprocess_exec(
+      "ffmpeg", "-version",
+      stdout=asyncio.subprocess.PIPE,
+      stderr=asyncio.subprocess.PIPE
+    )
+    stdout, stderr = await process.communicate()
+    if stdout:
+      version_line = stdout.decode().splitlines()[0]
+    else:
+      version_line = stderr.decode().splitlines()[0]
+    payload = AdminVarsFfmpegVersion1(ffmpeg_version=version_line)
+    return RPCResponse(op="urn:admin:vars:ffmpeg_version:1", payload=payload, version=1)
+  except Exception as e:
+    raise HTTPException(status_code=500, detail=f"Error checking ffmpeg: {e}")

--- a/tests/test_rpc_response.py
+++ b/tests/test_rpc_response.py
@@ -37,3 +37,17 @@ def test_rpc_environment_flow(monkeypatch):
     assert res.status_code == 200
     assert res.json()["payload"]["repo"] == "https://repo"
     assert res.json()["payload"]["build"] == "https://repo/actions"
+
+    import rpc.admin.vars.services as services
+
+    async def fake_exec(*args, **kwargs):
+      class Proc:
+        async def communicate(self):
+          return (b"ffmpeg version 6.0", b"")
+      return Proc()
+
+    monkeypatch.setattr(services.asyncio, "create_subprocess_exec", fake_exec)
+    req["op"] = "urn:admin:vars:get_ffmpeg_version:1"
+    res = client.post("/rpc", json=req)
+    assert res.status_code == 200
+    assert res.json()["payload"]["ffmpeg_version"] == "ffmpeg version 6.0"


### PR DESCRIPTION
## Summary
- expose `get_ffmpeg_version_v1` service and route
- generate `AdminVarsFfmpegVersion1` model and client helpers
- show ffmpeg version on the home page
- expand Python and TypeScript tests for the new RPC

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6869c4fc1708832592b9d96cc1c0cc83