### PR TITLE
Simplify repo model

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -6,7 +6,6 @@ const Home = (): JSX.Element => {
   const [appVersion, setAppVersion] = useState('');
   const [hostname, setHostname] = useState('');
   const [repo, setRepo] = useState('');
-  const [build, setBuild] = useState('');
   const [ffmpegVersion, setFfmpegVersion] = useState<string | null>(null);
 
   useEffect(() => {
@@ -30,12 +29,9 @@ const Home = (): JSX.Element => {
       try {
         const repoInfo = await fetchRepo();
         const cleanRepo = repoInfo.repo.replace(/^"|"$/g, '');
-        const cleanBuild = repoInfo.build.replace(/^"|"$/g, '');
         setRepo(cleanRepo);
-        setBuild(cleanBuild);
       } catch {
         setRepo('');
-        setBuild('');
       }
 
       try {
@@ -84,7 +80,7 @@ const Home = (): JSX.Element => {
         </Link>{' '}
         -{' '}
         <Link
-          href={build}
+          href={repo ? `${repo}/actions` : ''}
           target="_blank"
           rel="noopener noreferrer"
           sx={{ color: 'text.primary', textDecoration: 'none' }}

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -24,7 +24,6 @@ export interface AdminVarsHostname1 {
 
 export interface AdminVarsRepo1 {
   repo: string;
-  build: string;
 }
 
 export interface AdminVarsVersion1 {

--- a/rpc/admin/vars/models.py
+++ b/rpc/admin/vars/models.py
@@ -8,7 +8,6 @@ class AdminVarsHostname1(BaseModel):
 
 class AdminVarsRepo1(BaseModel):
   repo: str
-  build: str
 
 class AdminVarsFfmpegVersion1(BaseModel):
   ffmpeg_version: str

--- a/rpc/admin/vars/services.py
+++ b/rpc/admin/vars/services.py
@@ -15,7 +15,7 @@ async def get_hostname_v1(request: Request):
 
 async def get_repo_v1(request: Request):
   repo = request.app.state.repo
-  payload = AdminVarsRepo1(repo=repo, build=f"{repo}/actions")
+  payload = AdminVarsRepo1(repo=repo)
   return RPCResponse(op="urn:admin:vars:repo:1", payload=payload, version=1)
 
 async def get_ffmpeg_version_v1(request: Request):

--- a/tests/test_rpc_admin_namespace.py
+++ b/tests/test_rpc_admin_namespace.py
@@ -40,7 +40,6 @@ def test_get_repo():
 
   assert response.op == "urn:admin:vars:repo:1"
   assert response.payload.repo == "https://repo"
-  assert response.payload.build == "https://repo/actions"
 
 def test_get_ffmpeg_version(monkeypatch):
   app = FastAPI()

--- a/tests/test_rpc_response.py
+++ b/tests/test_rpc_response.py
@@ -36,7 +36,6 @@ def test_rpc_environment_flow(monkeypatch):
     res = client.post("/rpc", json=req)
     assert res.status_code == 200
     assert res.json()["payload"]["repo"] == "https://repo"
-    assert res.json()["payload"]["build"] == "https://repo/actions"
 
     import rpc.admin.vars.services as services
 

--- a/tests/test_server_components.py
+++ b/tests/test_server_components.py
@@ -37,7 +37,6 @@ def test_services_read_from_state(monkeypatch):
   assert host_res.payload.hostname == "unit-host"
   repo_res = asyncio.run(get_repo_v1(request))
   assert repo_res.payload.repo == "https://repo"
-  assert repo_res.payload.build == "https://repo/actions"
   async def fake_exec(*args, **kwargs):
     class Proc:
       async def communicate(self):


### PR DESCRIPTION
## Summary
- remove redundant `build` field from `AdminVarsRepo1`
- adjust repo service to stop sending `build`
- update React to compute build link on render
- keep RPC model interfaces in sync
- update tests for new response shape

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run type-check`
- `npm --prefix frontend run test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a07fc0ea88325bd4fb49a9e4cdf14