### PR TITLE
Implement links RPC service and share LinkItem type

### DIFF
--- a/frontend/src/config/links.ts
+++ b/frontend/src/config/links.ts
@@ -1,7 +1,4 @@
-export interface LinkItem {
-	title: string;
-	url: string;
-}
+import { LinkItem } from '../shared/RpcModels';
 
 const Links: LinkItem[] = [
 	{ title: 'Discord', url: 'https://discord.gg/xXUZFTuzSw' },

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -18,6 +18,10 @@ export interface UserData {
   bearerToken: string;
 }
 
+export interface AdminVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+
 export interface AdminVarsHostname1 {
   hostname: string;
 }
@@ -30,6 +34,11 @@ export interface AdminVarsVersion1 {
   version: string;
 }
 
-export interface AdminVarsFfmpegVersion1 {
-  ffmpeg_version: string;
+export interface AdminLinksHome1 {
+  links: any;
+}
+
+export interface LinkItem {
+  title: string;
+  url: string;
 }

--- a/rpc/admin/links/models.py
+++ b/rpc/admin/links/models.py
@@ -1,1 +1,12 @@
 
+from pydantic import BaseModel
+
+
+class LinkItem(BaseModel):
+  title: str
+  url: str
+
+
+class AdminLinksHome1(BaseModel):
+  links: list[LinkItem]
+

--- a/rpc/admin/links/services.py
+++ b/rpc/admin/links/services.py
@@ -1,1 +1,19 @@
 
+from fastapi import Request
+from rpc.models import RPCResponse
+from .models import LinkItem, AdminLinksHome1
+
+
+async def get_home_v1(request: Request) -> RPCResponse:
+  links = [
+    LinkItem(title="Discord", url="https://discord.gg/xXUZFTuzSw"),
+    LinkItem(title="GitHub", url="https://github.com/elide-us"),
+    LinkItem(title="TikTok", url="https://www.tiktok.com/@elide.us"),
+    LinkItem(title="BlueSky", url="https://bsky.app/profile/elideusgroup.com"),
+    LinkItem(title="Suno", url="https://suno.com/@elideus"),
+    LinkItem(title="Patreon", url="https://patreon.com/Elideus"),
+  ]
+
+  payload = AdminLinksHome1(links=links)
+  return RPCResponse(op="urn:admin:links:home:1", payload=payload, version=1)
+

--- a/tests/test_rpc_admin_namespace.py
+++ b/tests/test_rpc_admin_namespace.py
@@ -60,3 +60,15 @@ def test_get_ffmpeg_version(monkeypatch):
   assert response.op == "urn:admin:vars:ffmpeg_version:1"
   assert response.payload.ffmpeg_version == "ffmpeg version 6.0"
 
+
+def test_get_home_links():
+  app = FastAPI()
+  request = Request({"type": "http", "app": app})
+
+  rpc_request = RPCRequest(op="urn:admin:links:get_home:1")
+  response = asyncio.run(handle_rpc_request(rpc_request, request))
+
+  assert response.op == "urn:admin:links:home:1"
+  assert len(response.payload.links) == 6
+  assert response.payload.links[0].title == "Discord"
+

--- a/tests/test_rpc_response.py
+++ b/tests/test_rpc_response.py
@@ -50,3 +50,9 @@ def test_rpc_environment_flow(monkeypatch):
     res = client.post("/rpc", json=req)
     assert res.status_code == 200
     assert res.json()["payload"]["ffmpeg_version"] == "ffmpeg version 6.0"
+
+    req["op"] = "urn:admin:links:get_home:1"
+    res = client.post("/rpc", json=req)
+    assert res.status_code == 200
+    assert isinstance(res.json()["payload"], dict)
+    assert len(res.json()["payload"]["links"]) == 6


### PR DESCRIPTION
## Summary
- add LinkItem and AdminLinksHome1 Pydantic models
- implement links service returning static links
- expose LinkItem via generated RpcModels library
- update front end links config to import shared LinkItem type
- test links RPC handler and endpoint

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686a20599e8883259252b5af3ef1e82a