### PR TITLE
Fix user context generation imports

### DIFF
--- a/frontend/src/shared/UserContext.tsx
+++ b/frontend/src/shared/UserContext.tsx
@@ -1,8 +1,6 @@
 import { createContext } from 'react';
+import type { UserData } from './RpcModels';
 
-export interface UserData {
-  bearerToken: string;
-}
 export interface UserContext {
   userData: UserData | null;
   setUserData: (data: UserData | null) => void;

--- a/scripts/generate_user_context.py
+++ b/scripts/generate_user_context.py
@@ -1,20 +1,14 @@
 from __future__ import annotations
-import os, sys
-
-from genlib import model_to_ts
+import os
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, REPO_ROOT)
-
-from rpc.models import UserData
 
 FRONTEND_SRC = os.path.join(REPO_ROOT, "frontend", "src", "shared")
 
 def generate_user_context() -> str:
-    content: list[str] = ["import { createContext } from 'react';", ""]
+    content: list[str] = ["import { createContext } from 'react';", "import type { UserData } from './RpcModels';", ""]
 
-    # ✅ Step 1: Generate UserData from Pydantic
-    content.append(model_to_ts(UserData).strip())
+    # UserData interface is defined in RpcModels.tsx
 
     # ✅ Step 2: Manually write the correct React-facing UserContext interface
     content.append('export interface UserContext {')

--- a/tests/test_generated_libraries.py
+++ b/tests/test_generated_libraries.py
@@ -25,7 +25,7 @@ def test_model_to_ts_simple():
 
 def test_generate_user_context():
     ts = ctxgen.generate_user_context()
-    assert 'export interface UserData' in ts
+    assert "import type { UserData } from './RpcModels';" in ts or "import { UserData } from './RpcModels';" in ts
     assert 'export interface UserContext' in ts or 'export interface UserContextType' in ts
     assert 'createContext<UserContext' in ts or 'createContext<UserContextType' in ts
 


### PR DESCRIPTION
## Summary
- avoid duplicating `UserData` in generated user context
- reference `UserData` from `RpcModels.tsx`
- update tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae121f71c832593cfb61a477916ac