### PR TITLE
Fix home links data parsing

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -15,7 +15,7 @@ const Home = (): JSX.Element => {
 	const [hostname, setHostname] = useState('');
 	const [repo, setRepo] = useState('');
 	const [ffmpegVersion, setFfmpegVersion] = useState<string | null>(null);
-	const [links, setLinks] = useState<LinkItem[]>([]);
+        const [links, setLinks] = useState<LinkItem[]>([]);
 
 	useEffect(() => {
 		void (async () => {
@@ -51,12 +51,15 @@ const Home = (): JSX.Element => {
 				setFfmpegVersion('unknown');
 			}
 
-			try {
-				const homeLinks = await fetchHomeLinks();
-				setLinks(homeLinks.links);
-			} catch {
-				setLinks([]);
-			}
+                        try {
+                                const homeLinks = await fetchHomeLinks();
+                                const normalized = Array.isArray(homeLinks.links)
+                                        ? homeLinks.links
+                                        : Object.values(homeLinks.links);
+                                setLinks(normalized);
+                        } catch {
+                                setLinks([]);
+                        }
 		})();
 	}, []);
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,1 +1,9 @@
+"""Server package exposing router modules for external import.
 
+This allows tests and application code to import the configured routers using
+`from server import rpc_router` instead of reaching into the routers package directly."""
+
+from . import lifespan
+from .routers import rpc_router, web_router
+
+__all__ = ["rpc_router", "web_router", "lifespan"]


### PR DESCRIPTION
## Summary
- update Home page to normalize array vs object format from the admin links RPC call
- restore exports in `server/__init__.py` for tests

## Testing
- `npm run lint --prefix frontend`
- `npm test --prefix frontend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aec4ff9248325b74a03ca84de40d9