### PR TITLE
Add automated RPC client generation

### DIFF
--- a/devgenerate.cmd
+++ b/devgenerate.cmd
@@ -9,3 +9,8 @@ IF ERRORLEVEL 1 (
     ECHO "UserContext generation failed."
     EXIT /b 1
 )
+python scripts\generate_rpc_client.py
+IF ERRORLEVEL 1 (
+    ECHO "RPC client generation failed."
+    EXIT /b 1
+)

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -3,130 +3,130 @@ import { useEffect, useState } from 'react';
 import type { LinkItem } from './shared/RpcModels';
 import Logo from './assets/elideus_group_green.png';
 import {
-	fetchHostname,
-	fetchVersion,
-	fetchRepo,
-	fetchFfmpegVersion,
-	fetchHomeLinks,
-} from './rpcClient';
+        fetchHostname,
+        fetchVersion,
+        fetchRepo,
+        fetchFfmpegVersion,
+} from './rpc/admin/vars';
+import { fetchHome } from './rpc/admin/links';
 
 const Home = (): JSX.Element => {
-	const [appVersion, setAppVersion] = useState('');
-	const [hostname, setHostname] = useState('');
-	const [repo, setRepo] = useState('');
-	const [ffmpegVersion, setFfmpegVersion] = useState<string | null>(null);
+        const [appVersion, setAppVersion] = useState('');
+        const [hostname, setHostname] = useState('');
+        const [repo, setRepo] = useState('');
+        const [ffmpegVersion, setFfmpegVersion] = useState<string | null>(null);
         const [links, setLinks] = useState<LinkItem[]>([]);
 
-	useEffect(() => {
-		void (async () => {
-			try {
-				const version = await fetchVersion();
-				const cleanVersion = version.version.replace(/^"|"$/g, '');
-				setAppVersion(cleanVersion);
-			} catch {
-				setAppVersion('unknown');
-			}
+        useEffect(() => {
+                void (async () => {
+                        try {
+                                const version = await fetchVersion();
+                                const cleanVersion = version.version.replace(/^"|"$/g, '');
+                                setAppVersion(cleanVersion);
+                        } catch {
+                                setAppVersion('unknown');
+                        }
 
-			try {
-				const host = await fetchHostname();
-				const cleanHost = host.hostname.replace(/^"|"$/g, '');
-				setHostname(cleanHost);
-			} catch {
-				setHostname('unknown');
-			}
+                        try {
+                                const host = await fetchHostname();
+                                const cleanHost = host.hostname.replace(/^"|"$/g, '');
+                                setHostname(cleanHost);
+                        } catch {
+                                setHostname('unknown');
+                        }
 
-			try {
-				const repoInfo = await fetchRepo();
-				const cleanRepo = repoInfo.repo.replace(/^"|"$/g, '');
-				setRepo(cleanRepo);
-			} catch {
-				setRepo('unknown');
-			}
+                        try {
+                                const repoInfo = await fetchRepo();
+                                const cleanRepo = repoInfo.repo.replace(/^"|"$/g, '');
+                                setRepo(cleanRepo);
+                        } catch {
+                                setRepo('unknown');
+                        }
 
-			try {
-				const ffmpegInfo = await fetchFfmpegVersion();
-				const cleanFfmpeg = ffmpegInfo.ffmpeg_version.replace(/^"|"$/g, '');
-				setFfmpegVersion(cleanFfmpeg);
-			} catch {
-				setFfmpegVersion('unknown');
-			}
+                        try {
+                                const ffmpegInfo = await fetchFfmpegVersion();
+                                const cleanFfmpeg = ffmpegInfo.ffmpeg_version.replace(/^"|"$/g, '');
+                                setFfmpegVersion(cleanFfmpeg);
+                        } catch {
+                                setFfmpegVersion('unknown');
+                        }
 
-			try {
-				const homeLinks = await fetchHomeLinks();
-				setLinks(homeLinks.links);
-			} catch {
-				setLinks([]);
-			}
-		})();
-	}, []);
+                        try {
+                                const homeLinks = await fetchHome();
+                                setLinks(homeLinks.links);
+                        } catch {
+                                setLinks([]);
+                        }
+                })();
+        }, []);
 
-	return (
-		<Box
-			sx={{
-				display: 'flex',
-				flexDirection: 'column',
-				alignItems: 'center',
-				justifyContent: 'flex-start',
-				height: '100vh',
-				backgroundColor: 'background.paper',
-				paddingTop: '20px',
-			}}
-		>
-			<CardMedia component="img" alt="Elideus Group Image" image={Logo} />
-			<Typography variant="body1">AI Engineering and Consulting Services</Typography>
-			<Box sx={{ marginTop: '20px', width: '300px', textAlign: 'center' }}>
-				{links.map((link) => (
-					<Link key={link.title}
-						href={link.url}
-						title={link.title}
-						underline="none"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						{link.title}
-					</Link>
-				))}
-			</Box>
-			<Typography variant="body1" sx={{ marginTop: '20px' }}>
-				v{appVersion} running on {hostname}
-			</Typography>
-			<Typography variant="body1" sx={{ marginTop: '4px' }}>
-				{ffmpegVersion ? ffmpegVersion : 'Loading version...'}
-			</Typography>
-			<Typography variant="body1" sx={{ marginTop: '4px' }}>
-				GitHub:{' '}
-				<Link
-					href={repo}
-					target="_blank"
-					rel="noopener noreferrer"
-					underline="none"
-					sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}
-				>
-					repo
-				</Link>
-					{' '}-{' '}
-				<Link
-					href={repo ? `${repo}/actions` : ''}
-					target="_blank"
-					rel="noopener noreferrer"
-					underline="none"
-					sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}
-				>
-					build
-				</Link>
-			</Typography>
-			<Typography variant="body1" sx={{ marginTop: '20px' }}>
-				Contact us at:{' '}
-				<Link
-					href="mailto:contact@elideusgroup.com"
-					underline="none"
-					sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}
-				>
-					contact@elideusgroup.com
-				</Link>
-			</Typography>
-		</Box>
-	);
+        return (
+                <Box
+                        sx={{
+                                display: 'flex',
+                                flexDirection: 'column',
+                                alignItems: 'center',
+                                justifyContent: 'flex-start',
+                                height: '100vh',
+                                backgroundColor: 'background.paper',
+                                paddingTop: '20px',
+                        }}
+                >
+                        <CardMedia component="img" alt="Elideus Group Image" image={Logo} />
+                        <Typography variant="body1">AI Engineering and Consulting Services</Typography>
+                        <Box sx={{ marginTop: '20px', width: '300px', textAlign: 'center' }}>
+                                {links.map((link) => (
+                                        <Link key={link.title}
+                                                href={link.url}
+                                                title={link.title}
+                                                underline="none"
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                        >
+                                                {link.title}
+                                        </Link>
+                                ))}
+                        </Box>
+                        <Typography variant="body1" sx={{ marginTop: '20px' }}>
+                                v{appVersion} running on {hostname}
+                        </Typography>
+                        <Typography variant="body1" sx={{ marginTop: '4px' }}>
+                                {ffmpegVersion ? ffmpegVersion : 'Loading version...'}
+                        </Typography>
+                        <Typography variant="body1" sx={{ marginTop: '4px' }}>
+                                GitHub:{' '}
+                                <Link
+                                        href={repo}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        underline="none"
+                                        sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}
+                                >
+                                        repo
+                                </Link>
+                                        {' '}-{' '}
+                                <Link
+                                        href={repo ? `${repo}/actions` : ''}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        underline="none"
+                                        sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}
+                                >
+                                        build
+                                </Link>
+                        </Typography>
+                        <Typography variant="body1" sx={{ marginTop: '20px' }}>
+                                Contact us at:{' '}
+                                <Link
+                                        href="mailto:contact@elideusgroup.com"
+                                        underline="none"
+                                        sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}
+                                >
+                                        contact@elideusgroup.com
+                                </Link>
+                        </Typography>
+                </Box>
+        );
 };
 
 export default Home;

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -1,5 +1,5 @@
 import type { RouteItem, AdminLinksRoutes1 } from './shared/RpcModels';
-import { fetchRoutes } from './rpcClient';
+import { fetchRoutes } from './rpc/admin/links';
 
 export const getRoutes = async (): Promise<RouteItem[]> => {
     try {

--- a/frontend/src/rpc/admin/links/index.ts
+++ b/frontend/src/rpc/admin/links/index.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { RPCRequest, RPCResponse, AdminLinksHome1, AdminLinksRoutes1 } from '@/shared/RpcModels';
+
+const rpcCall = async <T>(op: string): Promise<T> => {
+    const request: RPCRequest = {
+        op,
+        payload: null,
+        version: 1,
+        timestamp: Date.now(),
+        metadata: null,
+    };
+    const response = await axios.post<RPCResponse>('/rpc', request);
+    return response.data.payload as T;
+};
+
+export const fetchHome = (): Promise<AdminLinksHome1> => rpcCall('urn:admin:links:get_home:1');
+export const fetchRoutes = (): Promise<AdminLinksRoutes1> => rpcCall('urn:admin:links:get_routes:1');

--- a/frontend/src/rpc/admin/vars/index.ts
+++ b/frontend/src/rpc/admin/vars/index.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+import { RPCRequest, RPCResponse, AdminVarsFfmpegVersion1, AdminVarsHostname1, AdminVarsRepo1, AdminVarsVersion1 } from '@/shared/RpcModels';
+
+const rpcCall = async <T>(op: string): Promise<T> => {
+    const request: RPCRequest = {
+        op,
+        payload: null,
+        version: 1,
+        timestamp: Date.now(),
+        metadata: null,
+    };
+    const response = await axios.post<RPCResponse>('/rpc', request);
+    return response.data.payload as T;
+};
+
+export const fetchVersion = (): Promise<AdminVarsVersion1> => rpcCall('urn:admin:vars:get_version:1');
+export const fetchHostname = (): Promise<AdminVarsHostname1> => rpcCall('urn:admin:vars:get_hostname:1');
+export const fetchRepo = (): Promise<AdminVarsRepo1> => rpcCall('urn:admin:vars:get_repo:1');
+export const fetchFfmpegVersion = (): Promise<AdminVarsFfmpegVersion1> => rpcCall('urn:admin:vars:get_ffmpeg_version:1');

--- a/frontend/tests/rpcClient.test.ts
+++ b/frontend/tests/rpcClient.test.ts
@@ -1,43 +1,51 @@
 import { describe, it, expect, vi } from 'vitest';
 import axios from 'axios';
-import { fetchVersion, fetchHostname, fetchFfmpegVersion, fetchHomeLinks, fetchRoutes } from '../src/rpcClient';
+import { fetchVersion, fetchHostname, fetchRepo, fetchFfmpegVersion } from '../src/rpc/admin/vars';
+import { fetchHome, fetchRoutes } from '../src/rpc/admin/links';
 
 vi.mock('axios');
-
 const mockedPost = axios.post as unknown as ReturnType<typeof vi.fn>;
 
 describe('rpcClient', () => {
-	it('fetchVersion posts correct request', async () => {
-		mockedPost.mockResolvedValueOnce({ data: { payload: { version: '9.9.9' } } });
-		const res = await fetchVersion();
-		expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_version:1' }));
-		expect(res.version).toBe('9.9.9');
-	});
+    it('fetchVersion posts correct request', async () => {
+        mockedPost.mockResolvedValueOnce({ data: { payload: { version: '9.9.9' } } });
+        const res = await fetchVersion();
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_version:1' }));
+        expect(res.version).toBe('9.9.9');
+    });
 
-        it('fetchHostname posts correct request', async () => {
-                mockedPost.mockResolvedValueOnce({ data: { payload: { hostname: 'unit-host' } } });
-                const res = await fetchHostname();
-                expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_hostname:1' }));
-                expect(res.hostname).toBe('unit-host');
-        });
+    it('fetchHostname posts correct request', async () => {
+        mockedPost.mockResolvedValueOnce({ data: { payload: { hostname: 'unit-host' } } });
+        const res = await fetchHostname();
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_hostname:1' }));
+        expect(res.hostname).toBe('unit-host');
+    });
 
-        it('fetchFfmpegVersion posts correct request', async () => {
-                mockedPost.mockResolvedValueOnce({ data: { payload: { ffmpeg_version: 'ffmpeg version 6.0' } } });
-                const res = await fetchFfmpegVersion();
-                expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_ffmpeg_version:1' }));
-                expect(res.ffmpeg_version).toBe('ffmpeg version 6.0');
-        });
+    it('fetchRepo posts correct request', async () => {
+        mockedPost.mockResolvedValueOnce({ data: { payload: { repo: 'https://repo' } } });
+        const res = await fetchRepo();
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_repo:1' }));
+        expect(res.repo).toBe('https://repo');
+    });
 
-        it('fetchHomeLinks posts correct request', async () => {
-                mockedPost.mockResolvedValueOnce({ data: { payload: { links: [] } } });
-                const res = await fetchHomeLinks();
-                expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:links:get_home:1' }));
-                expect(Array.isArray(res.links)).toBe(true);
-        });
+    it('fetchFfmpegVersion posts correct request', async () => {
+        mockedPost.mockResolvedValueOnce({ data: { payload: { ffmpeg_version: 'ffmpeg version 6.0' } } });
+        const res = await fetchFfmpegVersion();
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_ffmpeg_version:1' }));
+        expect(res.ffmpeg_version).toBe('ffmpeg version 6.0');
+    });
+
+    it('fetchHome posts correct request', async () => {
+        mockedPost.mockResolvedValueOnce({ data: { payload: { links: [] } } });
+        const res = await fetchHome();
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:links:get_home:1' }));
+        expect(Array.isArray(res.links)).toBe(true);
+    });
+
+    it('fetchRoutes posts correct request', async () => {
+        mockedPost.mockResolvedValueOnce({ data: { payload: { routes: [] } } });
+        const res = await fetchRoutes();
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:links:get_routes:1' }));
+        expect(Array.isArray(res.routes)).toBe(true);
+    });
 });
-        it('fetchRoutes posts correct request', async () => {
-                mockedPost.mockResolvedValueOnce({ data: { payload: { routes: [] } } });
-                const res = await fetchRoutes();
-                expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:links:get_routes:1' }));
-                expect(Array.isArray(res.routes)).toBe(true);
-        });

--- a/scripts/generate_rpc_client.py
+++ b/scripts/generate_rpc_client.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+import os
+import re
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+RPC_ROOT = os.path.join(REPO_ROOT, 'rpc')
+FRONTEND_RPC = os.path.join(REPO_ROOT, 'frontend', 'src', 'rpc')
+
+CASE_RE = re.compile(r'case \["([^\"]+)",\s*"([^\"]+)"\]:')
+FUNC_RE = re.compile(r'services\.([A-Za-z0-9_]+)')
+PAYLOAD_RE = re.compile(r'payload\s*=\s*([A-Za-z0-9_]+)\(')
+
+def camel_case(name: str) -> str:
+  parts = name.split('_')
+  return ''.join(p.capitalize() for p in parts)
+
+def urn_to_func(op: str) -> str:
+  if op.startswith('get_'):
+    op = op[4:]
+  return 'fetch' + camel_case(op)
+
+def parse_service_models(path: str) -> dict[str, str]:
+  models: dict[str, str] = {}
+  if not os.path.exists(path):
+    return models
+  with open(path, 'r') as f:
+    lines = f.readlines()
+  current = None
+  for line in lines:
+    func = re.match(r'async def (\w+)\(', line)
+    if func:
+      current = func.group(1)
+      continue
+    m = PAYLOAD_RE.search(line)
+    if m and current:
+      models[current] = m.group(1)
+      current = None
+  return models
+
+def parse_handler(path: str) -> tuple[list[str], list[dict[str, str]]]:
+  with open(path, 'r') as f:
+    lines = f.readlines()
+  operations: list[dict[str, str]] = []
+  for idx, line in enumerate(lines):
+    case = CASE_RE.search(line)
+    if case:
+      op, ver = case.groups()
+      func = ''
+      for look in range(idx + 1, idx + 3):
+        if look < len(lines):
+          m = FUNC_RE.search(lines[look])
+          if m:
+            func = m.group(1)
+            break
+      operations.append({'op': op, 'version': ver, 'func': func})
+  rel_dir = os.path.relpath(os.path.dirname(path), RPC_ROOT)
+  parts = rel_dir.split(os.sep)
+  return parts, operations
+
+def generate_ts(base: list[str], ops: list[dict[str, str]], service_models: dict[str, str]) -> str:
+  models = {service_models.get(o['func'], 'any') for o in ops}
+  model_imports = ', '.join(sorted(m for m in models if m != 'any'))
+  lines = ["import axios from 'axios';"]
+  if model_imports:
+    lines.append(f"import {{ RPCRequest, RPCResponse, {model_imports} }} from '@/shared/RpcModels';")
+  else:
+    lines.append("import { RPCRequest, RPCResponse } from '@/shared/RpcModels';")
+  lines.append('')
+  lines.append('const rpcCall = async <T>(op: string): Promise<T> => {')
+  lines.append('    const request: RPCRequest = {')
+  lines.append('        op,')
+  lines.append('        payload: null,')
+  lines.append('        version: 1,')
+  lines.append('        timestamp: Date.now(),')
+  lines.append('        metadata: null,')
+  lines.append('    };')
+  lines.append("    const response = await axios.post<RPCResponse>('/rpc', request);")
+  lines.append('    return response.data.payload as T;')
+  lines.append('};')
+  lines.append('')
+  base_urn = ':'.join(['urn'] + base)
+  for o in ops:
+    func_name = urn_to_func(o['op'])
+    model = service_models.get(o['func'], 'any')
+    urn = f"{base_urn}:{o['op']}:{o['version']}"
+    lines.append(f"export const {func_name} = (): Promise<{model}> => rpcCall('{urn}');")
+  lines.append('')
+  return "\n".join(lines)
+
+def main() -> None:
+  for root, dirs, files in os.walk(RPC_ROOT):
+    if 'handler.py' not in files:
+      continue
+    handler_path = os.path.join(root, 'handler.py')
+    service_path = os.path.join(root, 'services.py')
+    base_parts, ops = parse_handler(handler_path)
+    service_models = parse_service_models(service_path)
+    if not ops:
+      continue
+    out_dir = os.path.join(FRONTEND_RPC, *base_parts)
+    os.makedirs(out_dir, exist_ok=True)
+    content = generate_ts(base_parts, ops, service_models)
+    with open(os.path.join(out_dir, 'index.ts'), 'w') as f:
+      f.write(content)
+    print(f"✅ Wrote {os.path.join(out_dir, 'index.ts')}")
+
+if __name__ == '__main__':
+  main()

--- a/tests/test_generated_libraries.py
+++ b/tests/test_generated_libraries.py
@@ -38,3 +38,9 @@ def test_main_writes_user_context(tmp_path, monkeypatch):
     monkeypatch.setattr(ctxgen, 'FRONTEND_SRC', str(tmp_path))
     ctxgen.main()
     assert (tmp_path / 'UserContext.tsx').exists()
+from scripts import generate_rpc_client as clientgen
+
+def test_main_writes_rpc_client(tmp_path, monkeypatch):
+  monkeypatch.setattr(clientgen, 'FRONTEND_RPC', str(tmp_path))
+  clientgen.main()
+  assert (tmp_path / 'admin' / 'vars' / 'index.ts').exists()


### PR DESCRIPTION
## Summary
- generate TS RPC client functions by parsing Python handlers
- integrate new generator into devgenerate.cmd
- update Home page and routing to use generated clients
- provide RPC client tests and generator unit tests

## Testing
- `npm test --prefix frontend --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686afda5eee883258a73a23fcea9b9a0