### PR TITLE
Refactor RPC services to use env provider

### DIFF
--- a/rpc/admin/vars/services.py
+++ b/rpc/admin/vars/services.py
@@ -4,17 +4,20 @@ from rpc.admin.vars.models import AdminVarsVersion1, AdminVarsHostname1, AdminVa
 from rpc.models import RPCResponse
 
 async def get_version_v1(request: Request):
-  version = request.app.state.version
+  env = request.app.state.env_provider
+  version = env.get("VERSION")
   payload = AdminVarsVersion1(version=version)
   return RPCResponse(op="urn:admin:vars:version:1", payload=payload, version=1)
 
 async def get_hostname_v1(request: Request):
-  hostname = request.app.state.hostname
+  env = request.app.state.env_provider
+  hostname = env.get("HOSTNAME")
   payload = AdminVarsHostname1(hostname=hostname)
   return RPCResponse(op="urn:admin:vars:hostname:1", payload=payload, version=1)
 
 async def get_repo_v1(request: Request):
-  repo = request.app.state.repo
+  env = request.app.state.env_provider
+  repo = env.get("REPO")
   payload = AdminVarsRepo1(repo=repo)
   return RPCResponse(op="urn:admin:vars:repo:1", payload=payload, version=1)
 

--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -1,14 +1,9 @@
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
-from server.config import VERSION, HOSTNAME, REPO
 from server.providers import ProviderRegistry
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-  app.state.version = VERSION
-  app.state.hostname = HOSTNAME
-  app.state.repo = REPO
-
   registry = ProviderRegistry(app)
   app.state.providers = registry
 

--- a/server/providers/__init__.py
+++ b/server/providers/__init__.py
@@ -72,5 +72,5 @@ class ProviderRegistry:
       await provider.startup()
 
   async def shutdown(self):
-    for key, provider in reversed(self.providers.items()):
+    for key, provider in reversed(list(self.providers.items())):
       await provider.shutdown()

--- a/tests/test_rpc_admin_namespace.py
+++ b/tests/test_rpc_admin_namespace.py
@@ -1,13 +1,18 @@
 import asyncio
 from fastapi import FastAPI, Request
+from server.providers.env_provider import EnvironmentProvider
 
 from rpc.handler import handle_rpc_request
 from rpc.models import RPCRequest
 
-def test_get_version():
-  app = FastAPI()
-  app.state.version = "9.9.9"
-  app.state.hostname = "unit-host"
+def test_get_version(monkeypatch):
+  monkeypatch.setenv("VERSION", "9.9.9")
+  monkeypatch.setenv("HOSTNAME", "unit-host")
+  monkeypatch.setenv("REPO", "https://repo")
+  monkeypatch.setenv("DISCORD_SECRET", "token")
+  env = EnvironmentProvider(app := FastAPI())
+  app.state.env_provider = env
+  asyncio.run(env.startup())
   request = Request({"type": "http", "app": app})
 
   rpc_request = RPCRequest(op="urn:admin:vars:get_version:1")
@@ -16,10 +21,14 @@ def test_get_version():
   assert response.op == "urn:admin:vars:version:1"
   assert response.payload.version == "9.9.9"
 
-def test_get_hostname():
-  app = FastAPI()
-  app.state.version = "9.9.9"
-  app.state.hostname = "unit-host"
+def test_get_hostname(monkeypatch):
+  monkeypatch.setenv("VERSION", "9.9.9")
+  monkeypatch.setenv("HOSTNAME", "unit-host")
+  monkeypatch.setenv("REPO", "https://repo")
+  monkeypatch.setenv("DISCORD_SECRET", "token")
+  env = EnvironmentProvider(app := FastAPI())
+  app.state.env_provider = env
+  asyncio.run(env.startup())
   request = Request({"type": "http", "app": app})
 
   rpc_request = RPCRequest(op="urn:admin:vars:get_hostname:1")
@@ -28,11 +37,14 @@ def test_get_hostname():
   assert response.op == "urn:admin:vars:hostname:1"
   assert response.payload.hostname == "unit-host"
 
-def test_get_repo():
-  app = FastAPI()
-  app.state.version = "9.9.9"
-  app.state.hostname = "unit-host"
-  app.state.repo = "https://repo"
+def test_get_repo(monkeypatch):
+  monkeypatch.setenv("VERSION", "9.9.9")
+  monkeypatch.setenv("HOSTNAME", "unit-host")
+  monkeypatch.setenv("REPO", "https://repo")
+  monkeypatch.setenv("DISCORD_SECRET", "token")
+  env = EnvironmentProvider(app := FastAPI())
+  app.state.env_provider = env
+  asyncio.run(env.startup())
   request = Request({"type": "http", "app": app})
 
   rpc_request = RPCRequest(op="urn:admin:vars:get_repo:1")
@@ -42,7 +54,13 @@ def test_get_repo():
   assert response.payload.repo == "https://repo"
 
 def test_get_ffmpeg_version(monkeypatch):
-  app = FastAPI()
+  monkeypatch.setenv("VERSION", "9.9.9")
+  monkeypatch.setenv("HOSTNAME", "unit-host")
+  monkeypatch.setenv("REPO", "https://repo")
+  monkeypatch.setenv("DISCORD_SECRET", "token")
+  env = EnvironmentProvider(app := FastAPI())
+  app.state.env_provider = env
+  asyncio.run(env.startup())
   request = Request({"type": "http", "app": app})
 
   async def fake_exec(*args, **kwargs):

--- a/tests/test_rpc_response.py
+++ b/tests/test_rpc_response.py
@@ -12,10 +12,7 @@ def test_rpc_environment_flow(monkeypatch):
   monkeypatch.setenv("VERSION", "9.9.9")
   monkeypatch.setenv("HOSTNAME", "unit-host")
   monkeypatch.setenv("REPO", "https://repo")
-
-  # reload config after setting env vars
-  import server.config as config
-  reload(config)
+  monkeypatch.setenv("DISCORD_SECRET", "token")
   reload(lifespan)
 
   app = FastAPI(lifespan=lifespan.lifespan)


### PR DESCRIPTION
## Summary
- drop per-variable state from lifespan and rely on provider registry
- read configuration values via `EnvironmentProvider`
- fix provider shutdown order
- adjust tests to initialize env provider

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b51b084348325b9621210ef3aad72