### PR TITLE
Fix navbar menu alignment

### DIFF
--- a/frontend/src/NavBar.tsx
+++ b/frontend/src/NavBar.tsx
@@ -50,7 +50,7 @@ const NavBar = (): JSX.Element => {
 				},
 			}}
 		>
-			<Box sx={{ display: 'flex', justifyContent: 'center', p: 1 }}>
+			<Box sx={{ display: 'flex', justifyContent: 'flex-start', pl: 2, py: 1 }}>
 				<Tooltip title="Toggle Menu">
 					<IconButton onClick={() => setOpen(!open)}>
 						<MenuIcon />


### PR DESCRIPTION
## Summary
- keep hamburger menu left-aligned when drawer opens

## Testing
- `npm --prefix frontend test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b62b862608325826037fb20745a73