### PR TITLE
fix menu icon alignment

### DIFF
--- a/frontend/src/NavBar.tsx
+++ b/frontend/src/NavBar.tsx
@@ -50,7 +50,7 @@ const NavBar = (): JSX.Element => {
 				},
 			}}
 		>
-			<Box sx={{ display: 'flex', justifyContent: 'flex-start', pl: 2, py: 1 }}>
+                       <Box sx={{ display: 'flex', justifyContent: 'flex-start', pl: 1, py: 1 }}>
 				<Tooltip title="Toggle Menu">
 					<IconButton onClick={() => setOpen(!open)}>
 						<MenuIcon />


### PR DESCRIPTION
## Summary
- tweak NavBar hamburger menu padding so it lines up with the icons

## Testing
- `npm test --silent` in `frontend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cbbd7d7d883258bdd8f0e85ef63db