### PR TITLE
Refactor Discord provider env lookup

### DIFF
--- a/server/providers/__init__.py
+++ b/server/providers/__init__.py
@@ -20,6 +20,7 @@ class ProviderRegistry:
   def __init__(self, app: FastAPI):
     self.app = app
     self.providers: dict[str, Provider] = {}
+    setattr(self.app.state, "providers", self)
 
     # Step 1: Manually register 'env' first
     env_provider = EnvironmentProvider(app)
@@ -28,6 +29,11 @@ class ProviderRegistry:
 
     # Step 2: Dynamically register all other providers
     self._discover_and_register_providers(exclude={"env_provider"})
+
+  def get_provider(self, key: str) -> Provider:
+    if key not in self.providers:
+      raise KeyError(f"Provider '{key}' not registered")
+    return self.providers[key]
 
   def _discover_and_register_providers(self, exclude: set[str] = set()):
     for _, module_name, _ in pkgutil.iter_modules(__path__):

--- a/server/providers/discord_provider.py
+++ b/server/providers/discord_provider.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 class DiscordProvider(Provider):
   def __init__(self, app: FastAPI):
     super().__init__(app)
-    self.env = app.state.env_provider
+    self.env = app.state.providers.get_provider("env")
     self.secret: str | None = None
     self.syschan: int | None = None
     self.bot = self._init_discord_bot('!')


### PR DESCRIPTION
## Summary
- add a provider accessor on `ProviderRegistry`
- register registry on app state earlier
- use new accessor in `DiscordProvider`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d7fed0ae08325a87b5af70ba043ca