### PR TITLE
Ensure RPC model generation before tests

### DIFF
--- a/.github/workflows/main_elideus-group.yml
+++ b/.github/workflows/main_elideus-group.yml
@@ -29,10 +29,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt
 
-    - name: Generate TypeScript libraries
-      run: |
-        python scripts/generate_rpc_library.py
-        python scripts/generate_rpc_client.py
 
     - name: Setup Node
       uses: actions/setup-node@v3
@@ -44,13 +40,8 @@ jobs:
         cd frontend
         npm ci
 
-    - name: Run frontend tests
-      run: |
-        cd frontend
-        npx vitest run
-
-    - name: Run backend tests
-      run: pytest -q
+    - name: Run tests
+      run: python scripts/run_tests.py
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -17,10 +17,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
-      - name: Generate TypeScript libraries
-        run: |
-          python scripts/generate_rpc_library.py
-          python scripts/generate_rpc_client.py
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -30,8 +26,5 @@ jobs:
       - name: Install Node dependencies
         working-directory: frontend
         run: npm ci
-      - name: Run frontend tests
-        working-directory: frontend
-        run: npx vitest run
-      - name: Run backend tests
-        run: pytest -q
+      - name: Run tests
+        run: python scripts/run_tests.py

--- a/README.md
+++ b/README.md
@@ -53,5 +53,11 @@ To require these tests before merging you will need to enable branch protection 
 3. Enable **Require status checks to pass before merging** and select **Pull Request Tests**.
 4. Save the rule.
 
+### Running Tests Locally
+Run `python scripts/run_tests.py` before committing changes. This script
+generates the RPC TypeScript libraries and then executes both the frontend and
+backend test suites. Keeping the generated files in sync ensures that any
+inconsistencies are caught by the tests.
+
 ### AI Usage Details
 We are building this site primarily using [Codex](https://chatgpt.com/codex). This is the OpenAI coding agent that integrates directly into your repository. It features agentified tools that it can use on a virtual command line where it can search your code with grep, list file names with ls and execute build and test steps during its research phase. This does require some additional configuration, I effectively duplicated the build script for the Codex agent so that it is working even with the live output from the build in the virtual workspace. The advanced integration and agentification of the coding tool greatly improves the results, but it does require very careful prompting because it can take upwards of 7-10 minutes to execute each prompt. This is no chat bot, this thing performs a deep research activity for each task you give it, and can even run multiple scenarios if you desire, and you can also run several tasks at the same time.

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+import subprocess, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def main() -> None:
+  subprocess.check_call([sys.executable, 'scripts/generate_rpc_library.py'], cwd=ROOT)
+  subprocess.check_call([sys.executable, 'scripts/generate_rpc_client.py'], cwd=ROOT)
+  subprocess.check_call(['npx', 'vitest', 'run'], cwd=ROOT / 'frontend')
+  subprocess.check_call(['pytest', '-q'], cwd=ROOT)
+
+
+if __name__ == '__main__':
+  main()
+


### PR DESCRIPTION
## Summary
- create `run_tests.py` helper script that generates RPC libraries and runs all tests
- update CI workflows to use the helper script
- document local test workflow in README

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_686da66ac1a08325a4920a59ed29b613