### PR TITLE
Enable Discord-based logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,13 +6,17 @@
 ################################################################################
 
 # External imports
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+import logging
 from fastapi.staticfiles import StaticFiles
 
 # Internal imports
 from server import lifespan
 from server.routers import rpc_router
 from server.routers import web_router
+
+logging.basicConfig(level=logging.INFO)
 
 # Create the FastAPI app
 app = FastAPI(lifespan=lifespan.lifespan)
@@ -28,3 +32,9 @@ app.include_router(web_router.router)
 @app.get("/")
 async def get_root():
   return {"message": "If you are seeing this the React app is misconfigured."}
+
+
+@app.exception_handler(Exception)
+async def log_exceptions(request: Request, exc: Exception):
+  logging.exception("Unhandled exception")
+  return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})

--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -1,4 +1,5 @@
 from fastapi import Request, HTTPException
+import logging
 from rpc.admin.handler import handle_admin_request
 from rpc.auth.handler import handle_auth_request
 from rpc.models import RPCRequest, RPCResponse
@@ -9,10 +10,16 @@ async def handle_rpc_request(rpc_request: RPCRequest, request: Request) -> RPCRe
   if parts[:1] != ["urn"]:
     raise HTTPException(400, "Invalid URN prefix")
 
-  match parts[1:]:
-    case ["admin", *rest]:
-      return await handle_admin_request(rest, request)
-    case ["auth", *rest]:
-      return await handle_auth_request(rest, rpc_request, request)
-    case _:
-      raise HTTPException(status_code=404, detail="Unknown RPC domain")
+  try:
+    match parts[1:]:
+      case ["admin", *rest]:
+        response = await handle_admin_request(rest, request)
+      case ["auth", *rest]:
+        response = await handle_auth_request(rest, rpc_request, request)
+      case _:
+        raise HTTPException(status_code=404, detail="Unknown RPC domain")
+    logging.info(f"RPC completed: {rpc_request.op}")
+    return response
+  except Exception:
+    logging.exception(f"RPC failed: {rpc_request.op}")
+    raise

--- a/server/helpers/logging.py
+++ b/server/helpers/logging.py
@@ -1,0 +1,27 @@
+import logging
+
+class DiscordHandler(logging.Handler):
+  def __init__(self, discord_module):
+    super().__init__()
+    self.discord = discord_module
+
+  def emit(self, record):
+    msg = self.format(record)
+    try:
+      chan = self.discord.bot.get_channel(self.discord.syschan)
+      if chan:
+        self.discord.bot.loop.create_task(chan.send(msg))
+    except Exception:
+      pass
+
+def configure_discord_logging(discord_module):
+  handler = DiscordHandler(discord_module)
+  handler.setFormatter(logging.Formatter('[%(levelname)s] %(message)s'))
+  logging.getLogger().addHandler(handler)
+
+
+def remove_discord_logging(discord_module):
+  logger = logging.getLogger()
+  for h in list(logger.handlers):
+    if isinstance(h, DiscordHandler) and h.discord is discord_module:
+      logger.removeHandler(h)

--- a/server/modules/__init__.py
+++ b/server/modules/__init__.py
@@ -1,4 +1,4 @@
-import pkgutil, importlib, inspect
+import pkgutil, importlib, inspect, logging
 from abc import ABC, abstractmethod
 from fastapi import FastAPI
 
@@ -51,7 +51,9 @@ class ModuleRegistry:
   async def startup(self):
     for key, module in self.modules.items():
       await module.startup()
+      logging.info(f"Module '{key}' started")
 
   async def shutdown(self):
     for key, module in reversed(list(self.modules.items())):
       await module.shutdown()
+      logging.info(f"Module '{key}' shutdown")

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -1,4 +1,4 @@
-import os, aiohttp, base64
+import os, aiohttp, base64, logging
 from datetime import datetime, timedelta, timezone
 from fastapi import FastAPI, HTTPException, Request, status, Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -34,11 +34,12 @@ class AuthModule(BaseModule):
     try:
       jwks_uri = await fetch_ms_jwks_uri()
       self.ms_jwks = await fetch_ms_jwks(jwks_uri)
+      logging.info("Auth module loaded")
     except Exception as e:
       print(f"[AuthModule] Failed to load Microsoft JWKS: {e}")
 
   async def shutdown(self):
-    pass
+    logging.info("Auth module shutdown")
 
   async def verify_ms_id_token(self, id_token: str) -> Dict:
     if not self.ms_jwks:

--- a/server/modules/database_module.py
+++ b/server/modules/database_module.py
@@ -1,4 +1,4 @@
-import os, json, asyncpg
+import os, json, asyncpg, logging
 from uuid import UUID, uuid4
 from fastapi import FastAPI
 from . import BaseModule
@@ -33,11 +33,13 @@ class DatabaseModule(BaseModule):
     dsn = self._db_connection_string()
     if dsn:
       self.pool = await asyncpg.create_pool(dsn=dsn)
+      logging.info("Database module loaded")
 
   async def shutdown(self):
     if self.pool:
       await self.pool.close()
       self.pool = None
+    logging.info("Database module shutdown")
 
   async def _fetch_many(self, query: str, *args):
     if not self.pool:

--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI
 from . import BaseModule
+from server.helpers.logging import configure_discord_logging, remove_discord_logging
+import logging
 
 """Discord provider using environment variables from EnvironmentProvider."""
 
@@ -32,6 +34,7 @@ class DiscordModule(BaseModule):
       channel = bot.get_channel(syschan)
       if channel:
         await channel.send("TheOracleRPC Online.")
+        logging.info("Discord bot ready")
       else:
         print("[DiscordProvider] System channel not found on ready.")
 
@@ -40,6 +43,7 @@ class DiscordModule(BaseModule):
       channel = bot.get_channel(syschan)
       if channel:
         await channel.send(f"Joined {guild.name} ({guild.id})")
+        logging.info(f"Joined guild {guild.name} ({guild.id})")
       else:
         print(f"[DiscordProvider] System channel not found when joining {guild.name}.")
 
@@ -50,9 +54,12 @@ class DiscordModule(BaseModule):
     self.secret = self.env.get("DISCORD_SECRET")
     self.syschan = self.env.get_int("DISCORD_SYSCHAN")
     self._init_bot_routes()
+    configure_discord_logging(self)
+    logging.info("Discord module loaded")
     self.task = asyncio.create_task(self._start_discord_bot())
 
   async def shutdown(self):
     await self.bot.close()
     if self.task:
       self.task.cancel()
+    remove_discord_logging(self)

--- a/server/modules/env_module.py
+++ b/server/modules/env_module.py
@@ -1,4 +1,4 @@
-import os, dotenv
+import os, dotenv, logging
 from fastapi import FastAPI
 from server.modules import BaseModule
 
@@ -18,6 +18,7 @@ class EnvironmentModule(BaseModule):
     self._load_required("REPO", "MISSING_ENV_REPO")
     self._load_required("DISCORD_SECRET", "MISSING_ENV_DISCORD_SECRET")
     self._load_required("DISCORD_SYSCHAN", 0)
+    logging.info("Environment module loaded")
 
   async def shutdown(self):
     # Nothing to clean up, but defined for interface compliance


### PR DESCRIPTION
## Summary
- add Discord logging handler
- log major module events and RPC calls
- forward uncaught exceptions to log handler

## Testing
- `python3 scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_686fda19b8a88325a4fd394c7d1993c7