### PR TITLE
Refactor module registry

### DIFF
--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -63,3 +63,8 @@ class DiscordModule(BaseModule):
     if self.task:
       self.task.cancel()
     remove_discord_logging(self)
+
+  async def send_sys_message(self, message: str):
+    channel = self.bot.get_channel(self.syschan)
+    if channel:
+      await channel.send(message)

--- a/server/modules/env_module.py
+++ b/server/modules/env_module.py
@@ -9,7 +9,7 @@ class EnvironmentModule(BaseModule):
     super().__init__(app)
 
     # Use internal dict to store all loaded values
-    self._env: dict[str, str] = {}
+    self._env: dict[str, str | None] = {}
     self._version: dict[str, str] = {}
 
   async def startup(self):
@@ -18,6 +18,9 @@ class EnvironmentModule(BaseModule):
     self._load_required("REPO", "MISSING_ENV_REPO")
     self._load_required("DISCORD_SECRET", "MISSING_ENV_DISCORD_SECRET")
     self._load_required("DISCORD_SYSCHAN", 0)
+    self._load_optional("JWT_SECRET")
+    self._load_optional("MS_API_ID")
+    self._load_optional("POSTGRES_CONNECTION_STRING")
     logging.info("Environment module loaded")
 
   async def shutdown(self):
@@ -30,7 +33,11 @@ class EnvironmentModule(BaseModule):
       raise RuntimeError(f"ERROR: {var_name} missing.")
     self._env[var_name] = value
 
-  def get(self, var_name: str) -> str:
+  def _load_optional(self, var_name: str, default: str | None = None):
+    value = os.getenv(var_name, default)
+    self._env[var_name] = value
+
+  def get(self, var_name: str) -> str | None:
     if var_name not in self._env:
       raise RuntimeError(f"ERROR: {var_name} not initialized in EnvironmentProvider.")
     return self._env[var_name]


### PR DESCRIPTION
## Summary
- remove dynamic module discovery
- register env, discord, database and auth modules explicitly
- let modules pull config from `EnvironmentModule`
- add Discord helpers so other modules can post status messages
- adjust database and auth modules to use env and discord

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687085b03fa083258a0d88650c9a405e