### PR TITLE
Fix Discord log spam

### DIFF
--- a/server/helpers/logging.py
+++ b/server/helpers/logging.py
@@ -7,6 +7,10 @@ class DiscordHandler(logging.Handler):
 
   def emit(self, record):
     msg = self.format(record)
+
+    if not msg or msg == "None":
+      return
+
     try:
       chan = self.discord.bot.get_channel(self.discord.syschan)
       if chan:


### PR DESCRIPTION
## Summary
- skip sending blank log messages to Discord

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68714253352c83259746488374b3881a