### PR TITLE
Remove unused discord references

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -27,10 +27,8 @@ class AuthModule(BaseModule):
     self.ms_jwks: Optional[Dict] = None
     if hasattr(app.state, "modules"):
       self.env = app.state.modules.get_module("env")
-      self.discord = app.state.modules.get_module("discord")
     else:
       self.env = None
-      self.discord = None
     self.ms_api_id: Optional[str] = None
     self.jwt_secret: str = "secret"
     self.jwt_algo_ms: str = "RS256"
@@ -46,15 +44,11 @@ class AuthModule(BaseModule):
       jwks_uri = await fetch_ms_jwks_uri()
       self.ms_jwks = await fetch_ms_jwks(jwks_uri)
       logging.info("Auth module loaded")
-      if self.discord:
-        await self.discord.send_sys_message("Auth module loaded")
     except Exception as e:
       print(f"[AuthModule] Failed to load Microsoft JWKS: {e}")
 
   async def shutdown(self):
     logging.info("Auth module shutdown")
-    if self.discord:
-      await self.discord.send_sys_message("Auth module shutdown")
 
   async def verify_ms_id_token(self, id_token: str) -> Dict:
     if not self.ms_jwks:

--- a/server/modules/database_module.py
+++ b/server/modules/database_module.py
@@ -27,10 +27,8 @@ class DatabaseModule(BaseModule):
     self.pool: asyncpg.Pool | None = None
     if hasattr(app.state, "modules"):
       self.env = app.state.modules.get_module("env")
-      self.discord = app.state.modules.get_module("discord")
     else:
       self.env = None
-      self.discord = None
 
   def _db_connection_string(self) -> str | None:
     if self.env:
@@ -42,16 +40,12 @@ class DatabaseModule(BaseModule):
     if dsn:
       self.pool = await asyncpg.create_pool(dsn=dsn)
       logging.info("Database module loaded")
-      if self.discord:
-        await self.discord.send_sys_message("Database module loaded")
 
   async def shutdown(self):
     if self.pool:
       await self.pool.close()
       self.pool = None
     logging.info("Database module shutdown")
-    if self.discord:
-      await self.discord.send_sys_message("Database module shutdown")
 
   async def _fetch_many(self, query: str, *args):
     if not self.pool:


### PR DESCRIPTION
## Summary
- stop referencing Discord module directly in `AuthModule` and `DatabaseModule`
- rely on logging to send messages to Discord

## Testing
- `pytest -q`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6871a773b9188325b5caeceb85cfe53d