### PR TITLE
Update tests for new ModuleRegistry

### DIFF
--- a/tests/test_rpc_admin_namespace.py
+++ b/tests/test_rpc_admin_namespace.py
@@ -1,19 +1,37 @@
 import asyncio
 from fastapi import FastAPI, Request
 
-from server.modules import ModuleRegistry
+from server.modules import ModuleRegistry, BaseModule
 from server.modules.env_module import EnvironmentModule
 
 from rpc.handler import handle_rpc_request
 from rpc.models import RPCRequest
+
+
+class DummyModule(BaseModule):
+  async def startup(self):
+    pass
+
+  async def shutdown(self):
+    pass
+
+
+def setup_modules(app: FastAPI) -> ModuleRegistry:
+  app.state.env = EnvironmentModule(app)
+  app.state.discord = DummyModule(app)
+  app.state.database = DummyModule(app)
+  app.state.auth = DummyModule(app)
+  modules = ModuleRegistry(app)
+  app.state.modules = modules
+  return modules
 
 def test_get_version(monkeypatch):
   monkeypatch.setenv("VERSION", "v0.0.0")
   monkeypatch.setenv("HOSTNAME", "unit-host")
   monkeypatch.setenv("REPO", "https://repo")
   monkeypatch.setenv("DISCORD_SECRET", "token")
-  modules = ModuleRegistry(app := FastAPI())
-  app.state.modules = modules
+  app = FastAPI()
+  modules = setup_modules(app)
   asyncio.run(modules.startup())
   request = Request({"type": "http", "app": app})
 
@@ -27,8 +45,8 @@ def test_get_hostname(monkeypatch):
   monkeypatch.setenv("HOSTNAME", "unit-host")
   monkeypatch.setenv("REPO", "https://repo")
   monkeypatch.setenv("DISCORD_SECRET", "token")
-  modules = ModuleRegistry(app := FastAPI())
-  app.state.modules = modules
+  app = FastAPI()
+  modules = setup_modules(app)
   asyncio.run(modules.startup())
   request = Request({"type": "http", "app": app})
 
@@ -42,8 +60,8 @@ def test_get_repo(monkeypatch):
   monkeypatch.setenv("HOSTNAME", "unit-host")
   monkeypatch.setenv("REPO", "https://repo")
   monkeypatch.setenv("DISCORD_SECRET", "token")
-  modules = ModuleRegistry(app := FastAPI())
-  app.state.modules = modules
+  app = FastAPI()
+  modules = setup_modules(app)
   asyncio.run(modules.startup())
   request = Request({"type": "http", "app": app})
 
@@ -57,8 +75,8 @@ def test_get_ffmpeg_version(monkeypatch):
   monkeypatch.setenv("HOSTNAME", "unit-host")
   monkeypatch.setenv("REPO", "https://repo")
   monkeypatch.setenv("DISCORD_SECRET", "token")
-  modules = ModuleRegistry(app := FastAPI())
-  app.state.modules = modules
+  app = FastAPI()
+  modules = setup_modules(app)
   asyncio.run(modules.startup())
   request = Request({"type": "http", "app": app})
 

--- a/tests/test_rpc_response.py
+++ b/tests/test_rpc_response.py
@@ -2,6 +2,15 @@ from importlib import reload
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from server import rpc_router, lifespan
+from server.modules import BaseModule
+
+
+class DummyModule(BaseModule):
+  async def startup(self):
+    pass
+
+  async def shutdown(self):
+    pass
 
 def create_app():
   from main import app
@@ -13,6 +22,21 @@ def test_rpc_environment_flow(monkeypatch):
   monkeypatch.setenv("HOSTNAME", "unit-host")
   monkeypatch.setenv("REPO", "https://repo")
   reload(lifespan)
+
+  def sync_env_startup(self):
+    self._load_required("VERSION", "MISSING_ENV_VERSION")
+    self._load_required("HOSTNAME", "MISSING_ENV_HOSTNAME")
+    self._load_required("REPO", "MISSING_ENV_REPO")
+    self._load_required("DISCORD_SECRET", "MISSING_ENV_DISCORD_SECRET")
+    self._load_required("DISCORD_SYSCHAN", 0)
+    self._load_optional("JWT_SECRET")
+    self._load_optional("MS_API_ID")
+    self._load_optional("POSTGRES_CONNECTION_STRING")
+
+  monkeypatch.setattr(lifespan.EnvironmentModule, "startup", sync_env_startup)
+  monkeypatch.setattr(lifespan, "DiscordModule", DummyModule)
+  monkeypatch.setattr(lifespan, "DatabaseModule", DummyModule)
+  monkeypatch.setattr(lifespan, "AuthModule", DummyModule)
 
   app = FastAPI(lifespan=lifespan.lifespan)
   app.include_router(rpc_router.router, prefix="/rpc")

--- a/tests/test_server_components.py
+++ b/tests/test_server_components.py
@@ -3,11 +3,29 @@ from importlib import reload
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
 from server import lifespan
-from server.modules import ModuleRegistry
+from server.modules import ModuleRegistry, BaseModule
 from server.modules.env_module import EnvironmentModule
 from rpc.handler import handle_rpc_request
 from rpc.admin.vars.handler import handle_vars_request
 from rpc.admin.vars.services import get_version_v1, get_hostname_v1, get_repo_v1, get_ffmpeg_version_v1
+
+
+class DummyModule(BaseModule):
+  async def startup(self):
+    pass
+
+  async def shutdown(self):
+    pass
+
+
+def setup_modules(app: FastAPI) -> ModuleRegistry:
+  app.state.env = EnvironmentModule(app)
+  app.state.discord = DummyModule(app)
+  app.state.database = DummyModule(app)
+  app.state.auth = DummyModule(app)
+  modules = ModuleRegistry(app)
+  app.state.modules = modules
+  return modules
 from rpc.models import RPCRequest
 
 def test_get_missing_environment_variable(monkeypatch):
@@ -21,6 +39,21 @@ def test_lifespan_sets_state(monkeypatch):
   monkeypatch.setenv("HOSTNAME", "unit-host")
   monkeypatch.setenv("REPO", "https://repo")
   reload(lifespan)
+
+  def sync_env_startup(self):
+    self._load_required("VERSION", "MISSING_ENV_VERSION")
+    self._load_required("HOSTNAME", "MISSING_ENV_HOSTNAME")
+    self._load_required("REPO", "MISSING_ENV_REPO")
+    self._load_required("DISCORD_SECRET", "MISSING_ENV_DISCORD_SECRET")
+    self._load_required("DISCORD_SYSCHAN", 0)
+    self._load_optional("JWT_SECRET")
+    self._load_optional("MS_API_ID")
+    self._load_optional("POSTGRES_CONNECTION_STRING")
+
+  monkeypatch.setattr(lifespan.EnvironmentModule, "startup", sync_env_startup)
+  monkeypatch.setattr(lifespan, "DiscordModule", DummyModule)
+  monkeypatch.setattr(lifespan, "DatabaseModule", DummyModule)
+  monkeypatch.setattr(lifespan, "AuthModule", DummyModule)
   app = FastAPI(lifespan=lifespan.lifespan)
   with TestClient(app) as client:
     env = client.app.state.modules.get_module("env")
@@ -33,8 +66,7 @@ def test_services_read_from_state(monkeypatch):
   monkeypatch.setenv("HOSTNAME", "unit-host")
   monkeypatch.setenv("REPO", "https://repo")
   app = FastAPI()
-  modules = ModuleRegistry(app)
-  app.state.modules = modules
+  modules = setup_modules(app)
   asyncio.run(modules.startup())
   request = Request({'type': 'http', 'app': app})
   version_res = asyncio.run(get_version_v1(request))


### PR DESCRIPTION
## Summary
- adapt tests for new `ModuleRegistry` initialization
- patch lifespan modules in test cases to avoid side effects

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6871d84fafb88325a3e3e91dc839d47a