### PR TITLE
Clean up ModuleRegistry usage

### DIFF
--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -1,6 +1,5 @@
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
-from server.modules import ModuleRegistry
 
 from server.modules.env_module import EnvironmentModule   # Explicit manual import
 from server.modules.discord_module import DiscordModule   # Explicit manual import

--- a/server/modules/__init__.py
+++ b/server/modules/__init__.py
@@ -1,20 +1,6 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 from fastapi import FastAPI
 
 class BaseModule(ABC):
   def __init__(self, app: FastAPI):
     self.app = app
-
-class ModuleRegistry:
-  def __init__(self, app: FastAPI):
-    self.app = app
-    self.modules: dict[str, BaseModule] = {}
-    
-  def get_module(self, key: str) -> BaseModule:
-    if key not in self.modules:
-      raise KeyError(f"Module '{key}' not registered")
-    return self.modules[key]
-
-  #def register_module(self, key: str) -> BaseModule:
-
-  #def unregister_module(self, key: str): # consider Pydantic model for return contract


### PR DESCRIPTION
## Summary
- remove `ModuleRegistry` class and unused import
- drop stale import from lifespan

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6872c0e3f4fc8325be038481ec8398e5