### PR TITLE
Add lifespan initialization test

### DIFF
--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,0 +1,56 @@
+import asyncio
+from fastapi import FastAPI
+import server.modules.discord_module as discord_mod
+import server.modules.database_module as db_mod
+import server.modules.auth_module as auth_mod
+from server.modules.discord_module import DiscordModule
+from server.lifespan import lifespan
+
+class DummyBot:
+  def __init__(self):
+    self.loop = asyncio.new_event_loop()
+  def start(self, secret):
+    self.started = secret
+  def get_channel(self, chan):
+    return None
+  def event(self, fn):
+    return fn
+
+
+def test_lifespan_initializes_modules(monkeypatch):
+  monkeypatch.setenv("VERSION", "1")
+  monkeypatch.setenv("HOSTNAME", "host")
+  monkeypatch.setenv("REPO", "repo")
+  monkeypatch.setenv("DISCORD_SECRET", "secret")
+  monkeypatch.setenv("DISCORD_SYSCHAN", "1")
+  monkeypatch.setenv("JWT_SECRET", "jwt")
+  monkeypatch.setenv("MS_API_ID", "msid")
+  monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
+
+  monkeypatch.setattr(discord_mod, "configure_discord_logging", lambda m: None)
+  monkeypatch.setattr(discord_mod.asyncio, "create_task", lambda coro: None)
+  monkeypatch.setattr(DiscordModule, "_init_bot_routes", lambda self: None)
+  monkeypatch.setattr(DiscordModule, "_init_discord_bot", lambda self, p: DummyBot())
+
+  async def fake_pool(**kwargs):
+    return "pool"
+  monkeypatch.setattr(db_mod.asyncpg, "create_pool", fake_pool)
+
+  async def fake_uri():
+    return "url"
+  async def fake_jwks(uri):
+    return {"keys": []}
+  monkeypatch.setattr(auth_mod, "fetch_ms_jwks_uri", fake_uri)
+  monkeypatch.setattr(auth_mod, "fetch_ms_jwks", fake_jwks)
+  monkeypatch.setattr(auth_mod.AuthModule, "startup", lambda self: None)
+
+  app = FastAPI()
+
+  async def run():
+    async with lifespan(app):
+      assert app.state.env is not None
+      assert app.state.discord is not None
+      assert app.state.database is not None
+      assert app.state.auth is not None
+
+  asyncio.run(run())


### PR DESCRIPTION
## Summary
- add unit test for server lifespan

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68730621d2d883258d44d1fa676cc637