### PR TITLE
Add DB integration and payload support for Microsoft login RPC

### DIFF
--- a/frontend/src/rpc/admin/links/index.ts
+++ b/frontend/src/rpc/admin/links/index.ts
@@ -7,10 +7,10 @@
 import axios from 'axios';
 import { RPCRequest, RPCResponse, AdminLinksHome1, AdminLinksRoutes1 } from '../../../shared/RpcModels';
 
-const rpcCall = async <T>(op: string): Promise<T> => {
+const rpcCall = async <T>(op: string, payload: any = null): Promise<T> => {
     const request: RPCRequest = {
         op,
-        payload: null,
+        payload,
         version: 1,
         timestamp: Date.now(),
         metadata: null,
@@ -19,5 +19,5 @@ const rpcCall = async <T>(op: string): Promise<T> => {
     return response.data.payload as T;
 };
 
-export const fetchHome = (): Promise<AdminLinksHome1> => rpcCall('urn:admin:links:get_home:1');
-export const fetchRoutes = (): Promise<AdminLinksRoutes1> => rpcCall('urn:admin:links:get_routes:1');
+export const fetchHome = (payload: any = null): Promise<AdminLinksHome1> => rpcCall('urn:admin:links:get_home:1', payload);
+export const fetchRoutes = (payload: any = null): Promise<AdminLinksRoutes1> => rpcCall('urn:admin:links:get_routes:1', payload);

--- a/frontend/src/rpc/admin/vars/index.ts
+++ b/frontend/src/rpc/admin/vars/index.ts
@@ -7,10 +7,10 @@
 import axios from 'axios';
 import { RPCRequest, RPCResponse, AdminVarsFfmpegVersion1, AdminVarsHostname1, AdminVarsRepo1, AdminVarsVersion1 } from '../../../shared/RpcModels';
 
-const rpcCall = async <T>(op: string): Promise<T> => {
+const rpcCall = async <T>(op: string, payload: any = null): Promise<T> => {
     const request: RPCRequest = {
         op,
-        payload: null,
+        payload,
         version: 1,
         timestamp: Date.now(),
         metadata: null,
@@ -19,7 +19,7 @@ const rpcCall = async <T>(op: string): Promise<T> => {
     return response.data.payload as T;
 };
 
-export const fetchVersion = (): Promise<AdminVarsVersion1> => rpcCall('urn:admin:vars:get_version:1');
-export const fetchHostname = (): Promise<AdminVarsHostname1> => rpcCall('urn:admin:vars:get_hostname:1');
-export const fetchRepo = (): Promise<AdminVarsRepo1> => rpcCall('urn:admin:vars:get_repo:1');
-export const fetchFfmpegVersion = (): Promise<AdminVarsFfmpegVersion1> => rpcCall('urn:admin:vars:get_ffmpeg_version:1');
+export const fetchVersion = (payload: any = null): Promise<AdminVarsVersion1> => rpcCall('urn:admin:vars:get_version:1', payload);
+export const fetchHostname = (payload: any = null): Promise<AdminVarsHostname1> => rpcCall('urn:admin:vars:get_hostname:1', payload);
+export const fetchRepo = (payload: any = null): Promise<AdminVarsRepo1> => rpcCall('urn:admin:vars:get_repo:1', payload);
+export const fetchFfmpegVersion = (payload: any = null): Promise<AdminVarsFfmpegVersion1> => rpcCall('urn:admin:vars:get_ffmpeg_version:1', payload);

--- a/frontend/src/rpc/auth/microsoft/index.ts
+++ b/frontend/src/rpc/auth/microsoft/index.ts
@@ -5,12 +5,12 @@
 // ================================================
 
 import axios from 'axios';
-import { RPCRequest, RPCResponse } from '../../../shared/RpcModels';
+import { RPCRequest, RPCResponse, AuthMicrosoftLoginData1 } from '../../../shared/RpcModels';
 
-const rpcCall = async <T>(op: string): Promise<T> => {
+const rpcCall = async <T>(op: string, payload: any = null): Promise<T> => {
     const request: RPCRequest = {
         op,
-        payload: null,
+        payload,
         version: 1,
         timestamp: Date.now(),
         metadata: null,
@@ -19,4 +19,4 @@ const rpcCall = async <T>(op: string): Promise<T> => {
     return response.data.payload as T;
 };
 
-export const fetchUserLogin = (): Promise<any> => rpcCall('urn:auth:microsoft:user_login:1');
+export const fetchUserLogin = (payload: any = null): Promise<AuthMicrosoftLoginData1> => rpcCall('urn:auth:microsoft:user_login:1', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -21,6 +21,18 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
+export interface AdminVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface AdminVarsHostname1 {
+  hostname: string;
+}
+export interface AdminVarsRepo1 {
+  repo: string;
+}
+export interface AdminVarsVersion1 {
+  version: string;
+}
 export interface AdminLinksHome1 {
   links: LinkItem[];
 }
@@ -35,18 +47,6 @@ export interface RouteItem {
   path: string;
   name: string;
   icon: string;
-}
-export interface AdminVarsFfmpegVersion1 {
-  ffmpeg_version: string;
-}
-export interface AdminVarsHostname1 {
-  hostname: string;
-}
-export interface AdminVarsRepo1 {
-  repo: string;
-}
-export interface AdminVarsVersion1 {
-  version: string;
 }
 export interface AuthMicrosoftLoginData1 {
   bearerToken: string;

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -2,26 +2,31 @@ from fastapi import Request
 from rpc.models import RPCResponse, RPCRequest
 from rpc.auth.microsoft.models import AuthMicrosoftLoginData1
 from server.modules.auth_module import AuthModule
+from server.modules.database_module import DatabaseModule
 
 async def user_login_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
-  payload = rpc_request.payload or {}
-  auth: AuthModule = request.app.state.modules.get_module("auth")
+  req_payload = rpc_request.payload or {}
+  auth: AuthModule = request.app.state.auth
+  db: DatabaseModule = request.app.state.database
 
   guid, profile = await auth.handle_ms_auth_login(
-    payload.get("idToken"),
-    payload.get("accessToken"),
+    req_payload.get("idToken"),
+    req_payload.get("accessToken"),
   )
 
-  token = auth.make_bearer_token(guid)
+  user = await db.select_ms_user(guid)
+  if not user:
+    user = await db.insert_ms_user(guid, profile["email"], profile["username"])
 
-  login_data = AuthMicrosoftLoginData1(
+  token = auth.make_bearer_token(user["guid"])
+
+  payload = AuthMicrosoftLoginData1(
     bearerToken=token,
-    defaultProvider="microsoft",
-    username=profile["username"],
-    email=profile["email"],
-    backupEmail=payload.get("backupEmail"),
+    defaultProvider=user.get("provider_name", "microsoft"),
+    username=user.get("username", profile["username"]),
+    email=user.get("email", profile["email"]),
+    backupEmail=user.get("backup_email"),
     profilePicture=profile.get("profilePicture"),
-    credits=0,
+    credits=user.get("credits", 0),
   )
-
-  return RPCResponse(op="urn:auth:microsoft:login_data:1", payload=login_data, version=1)
+  return RPCResponse(op="urn:auth:microsoft:login_data:1", payload=payload, version=1)

--- a/scripts/generate_rpc_client.py
+++ b/scripts/generate_rpc_client.py
@@ -65,10 +65,10 @@ def generate_ts(base: list[str], ops: list[dict[str, str]], service_models: dict
     lines.append("import { RPCRequest, RPCResponse } from '../../../shared/RpcModels';")
 
   lines.append('')
-  lines.append('const rpcCall = async <T>(op: string): Promise<T> => {')
+  lines.append('const rpcCall = async <T>(op: string, payload: any = null): Promise<T> => {')
   lines.append('    const request: RPCRequest = {')
   lines.append('        op,')
-  lines.append('        payload: null,')
+  lines.append('        payload,')
   lines.append('        version: 1,')
   lines.append('        timestamp: Date.now(),')
   lines.append('        metadata: null,')
@@ -83,7 +83,7 @@ def generate_ts(base: list[str], ops: list[dict[str, str]], service_models: dict
     func_name = urn_to_func(o['op'])
     model = service_models.get(o['func'], 'any')
     urn = f"{base_urn}:{o['op']}:{o['version']}"
-    lines.append(f"export const {func_name} = (): Promise<{model}> => rpcCall('{urn}');")
+    lines.append(f"export const {func_name} = (payload: any = null): Promise<{model}> => rpcCall('{urn}', payload);")
 
   lines.append('')
   return "\n".join(lines)


### PR DESCRIPTION
## Summary
- connect Microsoft login service to the DatabaseModule
- generate bearer token using database user guid
- send payloads from generated RPC client functions
- regenerate TypeScript RPC models and clients
- adjust Microsoft login service test

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68732aab7b2483258c460f08190e5a2e