### PR TITLE
Fix auth module startup call

### DIFF
--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -13,7 +13,7 @@ async def lifespan(app: FastAPI):
   app.state.database = DatabaseModule(app)
   await app.state.database.startup()
   app.state.auth = AuthModule(app)
-  app.state.auth.startup()
+  await app.state.auth.startup()
 
   try:
     yield

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -42,7 +42,9 @@ def test_lifespan_initializes_modules(monkeypatch):
     return {"keys": []}
   monkeypatch.setattr(auth_mod, "fetch_ms_jwks_uri", fake_uri)
   monkeypatch.setattr(auth_mod, "fetch_ms_jwks", fake_jwks)
-  monkeypatch.setattr(auth_mod.AuthModule, "startup", lambda self: None)
+  async def fake_startup(self):
+    return None
+  monkeypatch.setattr(auth_mod.AuthModule, "startup", fake_startup)
 
   app = FastAPI()
 


### PR DESCRIPTION
## Summary
- await auth module startup call
- update lifespan tests for async startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873338cd5448325810c614345362ecd