### PR TITLE
Centralize rpcCall helper

### DIFF
--- a/frontend/src/rpc/admin/links/index.ts
+++ b/frontend/src/rpc/admin/links/index.ts
@@ -4,20 +4,7 @@
 // overwritten the next time the generator runs.
 // ================================================
 
-import axios from 'axios';
-import { RPCRequest, RPCResponse, AdminLinksHome1, AdminLinksRoutes1 } from '../../../shared/RpcModels';
-
-const rpcCall = async <T>(op: string, payload: any = null): Promise<T> => {
-    const request: RPCRequest = {
-        op,
-        payload,
-        version: 1,
-        timestamp: Date.now(),
-        metadata: null,
-    };
-    const response = await axios.post<RPCResponse>('/rpc', request);
-    return response.data.payload as T;
-};
+import { rpcCall, AdminLinksHome1, AdminLinksRoutes1 } from '../../../shared/RpcModels';
 
 export const fetchHome = (payload: any = null): Promise<AdminLinksHome1> => rpcCall('urn:admin:links:get_home:1', payload);
 export const fetchRoutes = (payload: any = null): Promise<AdminLinksRoutes1> => rpcCall('urn:admin:links:get_routes:1', payload);

--- a/frontend/src/rpc/admin/vars/index.ts
+++ b/frontend/src/rpc/admin/vars/index.ts
@@ -4,20 +4,7 @@
 // overwritten the next time the generator runs.
 // ================================================
 
-import axios from 'axios';
-import { RPCRequest, RPCResponse, AdminVarsFfmpegVersion1, AdminVarsHostname1, AdminVarsRepo1, AdminVarsVersion1 } from '../../../shared/RpcModels';
-
-const rpcCall = async <T>(op: string, payload: any = null): Promise<T> => {
-    const request: RPCRequest = {
-        op,
-        payload,
-        version: 1,
-        timestamp: Date.now(),
-        metadata: null,
-    };
-    const response = await axios.post<RPCResponse>('/rpc', request);
-    return response.data.payload as T;
-};
+import { rpcCall, AdminVarsFfmpegVersion1, AdminVarsHostname1, AdminVarsRepo1, AdminVarsVersion1 } from '../../../shared/RpcModels';
 
 export const fetchVersion = (payload: any = null): Promise<AdminVarsVersion1> => rpcCall('urn:admin:vars:get_version:1', payload);
 export const fetchHostname = (payload: any = null): Promise<AdminVarsHostname1> => rpcCall('urn:admin:vars:get_hostname:1', payload);

--- a/frontend/src/rpc/auth/microsoft/index.ts
+++ b/frontend/src/rpc/auth/microsoft/index.ts
@@ -4,19 +4,6 @@
 // overwritten the next time the generator runs.
 // ================================================
 
-import axios from 'axios';
-import { RPCRequest, RPCResponse, AuthMicrosoftLoginData1 } from '../../../shared/RpcModels';
-
-const rpcCall = async <T>(op: string, payload: any = null): Promise<T> => {
-    const request: RPCRequest = {
-        op,
-        payload,
-        version: 1,
-        timestamp: Date.now(),
-        metadata: null,
-    };
-    const response = await axios.post<RPCResponse>('/rpc', request);
-    return response.data.payload as T;
-};
+import { rpcCall, AuthMicrosoftLoginData1 } from '../../../shared/RpcModels';
 
 export const fetchUserLogin = (payload: any = null): Promise<AuthMicrosoftLoginData1> => rpcCall('urn:auth:microsoft:user_login:1', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -4,6 +4,8 @@
 // overwritten the next time the generator runs.
 // ================================================
 
+import axios from "axios";
+
 export interface RPCRequest {
   op: string;
   payload: any | null;
@@ -56,4 +58,16 @@ export interface AuthMicrosoftLoginData1 {
   backupEmail: string | null;
   profilePicture: string | null;
   credits: number | null;
+}
+
+export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {
+    const request: RPCRequest = {
+        op,
+        payload,
+        version: 1,
+        timestamp: Date.now(),
+        metadata: null,
+    };
+    const response = await axios.post<RPCResponse>('/rpc', request);
+    return response.data.payload as T;
 }

--- a/scripts/generate_rpc_client.py
+++ b/scripts/generate_rpc_client.py
@@ -57,25 +57,13 @@ def generate_ts(base: list[str], ops: list[dict[str, str]], service_models: dict
   models = {service_models.get(o['func'], 'any') for o in ops}
   model_imports = ', '.join(sorted(m for m in models if m != 'any'))
 
-  lines = HEADER_COMMENT + ["import axios from 'axios';"]
+  lines = HEADER_COMMENT.copy()
 
   if model_imports:
-    lines.append(f"import {{ RPCRequest, RPCResponse, {model_imports} }} from '../../../shared/RpcModels';")
+    lines.append(f"import {{ rpcCall, {model_imports} }} from '../../../shared/RpcModels';")
   else:
-    lines.append("import { RPCRequest, RPCResponse } from '../../../shared/RpcModels';")
+    lines.append("import { rpcCall } from '../../../shared/RpcModels';")
 
-  lines.append('')
-  lines.append('const rpcCall = async <T>(op: string, payload: any = null): Promise<T> => {')
-  lines.append('    const request: RPCRequest = {')
-  lines.append('        op,')
-  lines.append('        payload,')
-  lines.append('        version: 1,')
-  lines.append('        timestamp: Date.now(),')
-  lines.append('        metadata: null,')
-  lines.append('    };')
-  lines.append("    const response = await axios.post<RPCResponse>('/rpc', request);")
-  lines.append('    return response.data.payload as T;')
-  lines.append('};')
   lines.append('')
 
   base_urn = ':'.join(['urn'] + base)

--- a/scripts/generate_rpc_library.py
+++ b/scripts/generate_rpc_library.py
@@ -6,6 +6,20 @@ from typing import List
 from pydantic import BaseModel
 from genlib import REPO_ROOT, HEADER_COMMENT, load_module, model_to_ts
 
+RPC_CALL_FUNC = [
+  "export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {",
+  "    const request: RPCRequest = {",
+  "        op,",
+  "        payload,",
+  "        version: 1,",
+  "        timestamp: Date.now(),",
+  "        metadata: null,",
+  "    };",
+  "    const response = await axios.post<RPCResponse>('/rpc', request);",
+  "    return response.data.payload as T;",
+  "}",
+]
+
 ROOT = os.path.join(REPO_ROOT, 'rpc')
 FRONTEND_SRC = os.path.join(REPO_ROOT, 'frontend', 'src', 'shared')
 
@@ -31,7 +45,9 @@ def write_interfaces_to_file(interfaces: List[str], output_dir: str) -> None:
   os.makedirs(output_dir, exist_ok=True)
   out_path = os.path.join(output_dir, 'RpcModels.tsx')
   with open(out_path, 'w') as f:
-    f.write("\n".join(HEADER_COMMENT + interfaces))
+    lines = HEADER_COMMENT + ['import axios from \"axios\";', '']
+    lines += interfaces + [''] + RPC_CALL_FUNC + ['']
+    f.write("\n".join(lines))
   print(f"✅ Wrote {len(interfaces)} TypeScript interfaces to '{out_path}'")
 
 


### PR DESCRIPTION
## Summary
- move `rpcCall` helper into shared `RpcModels.tsx`
- update RPC client generator to import the helper
- regenerate RPC client stubs and models

## Testing
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68740b89351483258b89eabe587dd7a4