### PR TITLE
Add login page and widget components

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import ElideusTheme from './shared/ElideusTheme'
 import UserContextProvider from './shared/UserContextProvider'
 import Home from './Home'
 import NavBar from './NavBar'
+import LoginPage from './LoginPage'
 
 function App(): JSX.Element {
 	return (
@@ -22,9 +23,10 @@ function App(): JSX.Element {
 							minHeight: '100vh'
 						}}
 					>
-						<Routes>
-							<Route path='/' element={<Home />} />
-						</Routes>
+                                                <Routes>
+                                                        <Route path='/' element={<Home />} />
+                                                        <Route path='/login' element={<LoginPage />} />
+                                                </Routes>
 					</Container>
 				</Router>
 			</UserContextProvider>

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -1,0 +1,89 @@
+import { useContext, useState } from 'react';
+import { Container, Paper, Typography, Button, Stack } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { PublicClientApplication } from '@azure/msal-browser';
+import { msalConfig, loginRequest } from './config/msal';
+import UserContext from './shared/UserContext';
+import Notification from './shared/Notification';
+import { fetchUserLogin } from './rpc/auth/microsoft';
+
+const pca = new PublicClientApplication(msalConfig);
+
+const LoginPage = (): JSX.Element => {
+	const { setUserData } = useContext(UserContext);
+	const [notification, setNotification] = useState({
+		open: false,
+		severity: 'info' as 'info' | 'success' | 'warning' | 'error',
+		message: ''
+	});
+	const navigate = useNavigate();
+
+	const handleNotificationClose = (): void => {
+		setNotification(prev => ({ ...prev, open: false }));
+	};
+
+	const handleMicrosoftLogin = async (): Promise<void> => {
+		try {
+			await pca.initialize();
+			const loginResponse = await pca.loginPopup(loginRequest);
+			const { idToken, accessToken } = loginResponse;
+
+			const data = await fetchUserLogin({ idToken, accessToken });
+			const profilePictureBase64 = data.profilePicture ? `data:image/png;base64,${data.profilePicture}` : null;
+
+			setUserData({
+				bearerToken: data.bearerToken,
+				defaultProvider: data.defaultProvider,
+				username: data.username,
+				email: data.email,
+				backupEmail: data.backupEmail,
+				profilePicture: profilePictureBase64,
+				credits: data.credits ?? 0
+			});
+
+			setNotification({ open: true, severity: 'success', message: 'Login successful!' });
+			navigate('/');
+		} catch (error: any) {
+			setNotification({ open: true, severity: 'error', message: `Login failed: ${error.message}` });
+		}
+	};
+
+	return (
+		<Container component='main' maxWidth='xs'>
+			<Paper elevation={3} sx={{ marginTop: 8, padding: 4 }}>
+				<Typography component='h1' variant='h5' align='center'>
+					Sign in
+				</Typography>
+				<Typography variant='body2' align='center' sx={{ mt: 2 }}>
+					Only OAuth providers are supported. Please sign in using one of the following services:
+					<br />
+					Microsoft, Discord, Google, or Apple.
+					<br />
+					<strong>Note:</strong> Email-only login is not available.
+				</Typography>
+				<Stack spacing={2} sx={{ mt: 4 }}>
+					<Button variant='contained' fullWidth onClick={handleMicrosoftLogin}>
+						Sign in with Microsoft
+					</Button>
+					<Button variant='outlined' fullWidth disabled>
+						Sign in with Discord (Coming Soon)
+					</Button>
+					<Button variant='outlined' fullWidth disabled>
+						Sign in with Google (Coming Soon)
+					</Button>
+					<Button variant='outlined' fullWidth disabled>
+						Sign in with Apple (Coming Soon)
+					</Button>
+				</Stack>
+			</Paper>
+			<Notification
+				open={notification.open}
+				handleClose={handleNotificationClose}
+				severity={notification.severity}
+				message={notification.message}
+			/>
+		</Container>
+	);
+};
+
+export default LoginPage;

--- a/frontend/src/NavBar.tsx
+++ b/frontend/src/NavBar.tsx
@@ -14,6 +14,7 @@ import { Menu as MenuIcon } from '@mui/icons-material';
 import type { RouteItem, AdminLinksRoutes1 } from './shared/RpcModels';
 import { fetchRoutes } from './rpc/admin/links';
 import { iconMap, defaultIcon } from './icons';
+import Login from './shared/Login';
 
 const DRAWER_OPEN = 240;
 const DRAWER_CLOSED = 60;
@@ -70,10 +71,10 @@ const NavBar = (): JSX.Element => {
 					);
 				})}
 			</List>
-			<Box sx={{ mt: 'auto', p: 1 }}>
-				{/* Login component placeholder */}
-			</Box>
-		</Drawer>
+                        <Box sx={{ mt: 'auto', p: 1 }}>
+                                <Login open={open} />
+                        </Box>
+                </Drawer>
 	);
 };
 

--- a/frontend/src/config/msal.ts
+++ b/frontend/src/config/msal.ts
@@ -1,0 +1,11 @@
+export const msalConfig = {
+       auth: {
+               clientId: '6c725f5b-6a44-4bf0-a0d6-c2cfc15230be',
+               authority: 'https://login.microsoftonline.com/consumers',
+               redirectUri: window.location.origin,
+       },
+};
+
+export const loginRequest = {
+       scopes: ['User.Read'],
+};

--- a/frontend/src/shared/Login.tsx
+++ b/frontend/src/shared/Login.tsx
@@ -1,0 +1,90 @@
+import { useState, useContext } from 'react';
+import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import { Login as LoginIcon } from '@mui/icons-material';
+import { Typography, Box, Tooltip, IconButton, ListItemText } from '@mui/material';
+import { PublicClientApplication } from '@azure/msal-browser';
+import { msalConfig } from '../config/msal';
+import Notification from './Notification';
+import UserContext from './UserContext';
+
+const pca = new PublicClientApplication(msalConfig);
+
+interface LoginProps {
+	open: boolean;
+}
+
+const Login = ({ open }: LoginProps): JSX.Element => {
+	const { userData, clearUserData } = useContext(UserContext);
+	const [notification, setNotification] = useState({
+		open: false,
+		severity: 'info' as 'info' | 'success' | 'warning' | 'error',
+		message: ''
+	});
+	const navigate = useNavigate();
+
+	const handleNotificationClose = (): void => {
+		setNotification(prev => ({ ...prev, open: false }));
+	};
+
+	const handleLoginNavigation = (): void => {
+		navigate('/login');
+	};
+
+	const handleLogout = async (): Promise<void> => {
+		try {
+			await pca.initialize();
+			await pca.logoutPopup();
+			clearUserData();
+			setNotification({ open: true, severity: 'info', message: 'Logged out successfully.' });
+		} catch (error: any) {
+			setNotification({ open: true, severity: 'error', message: `Logout failed: ${error.message}` });
+		}
+	};
+
+	return (
+		<Box sx={{ display: 'flex', alignItems: 'center' }}>
+			{userData ? (
+				<Tooltip title='Logout'>
+					<IconButton onClick={handleLogout}>
+						<img src={userData.profilePicture ?? ''} alt={userData.username} style={{ width: '28px', height: '28px', borderRadius: '50%', border: '1px solid #000' }} />
+					</IconButton>
+				</Tooltip>
+			) : (
+				<Tooltip title='Login'>
+					<IconButton onClick={handleLoginNavigation}>
+						<LoginIcon />
+					</IconButton>
+				</Tooltip>
+			)}
+
+			{open && (
+				<ListItemText
+					primary={
+						userData ? (
+							<Box>
+								<Typography component={RouterLink} to='/userpanel' variant='body1' sx={{ fontWeight: 'bold', color: 'gray', textDecoration: 'none' }}>
+									{userData.username}
+								</Typography>
+								<Typography component='span' variant='body2' sx={{ display: 'block', fontSize: '0.9em', color: 'gray' }}>
+									{new Intl.NumberFormat(navigator.language).format(Number(userData.credits ?? 0))}
+								</Typography>
+							</Box>
+							) : (
+								'Login'
+							)
+					}
+					sx={{ marginLeft: '8px' }}
+				/>
+			)}
+
+			<Notification
+				open={notification.open}
+				handleClose={handleNotificationClose}
+				severity={notification.severity}
+				message={notification.message}
+			/>
+		</Box>
+	);
+};
+
+export default Login;

--- a/frontend/src/shared/Notification.tsx
+++ b/frontend/src/shared/Notification.tsx
@@ -1,0 +1,19 @@
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+
+interface NotificationProps {
+	open: boolean;
+	handleClose: () => void;
+	severity: 'success' | 'info' | 'warning' | 'error';
+	message: string;
+}
+
+const Notification = ({ open, handleClose, severity, message }: NotificationProps): JSX.Element => (
+	<Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
+		<Alert onClose={handleClose} severity={severity} sx={{ width: '100%' }}>
+			{message}
+		</Alert>
+	</Snackbar>
+);
+
+export default Notification;

--- a/frontend/src/shared/UserContext.tsx
+++ b/frontend/src/shared/UserContext.tsx
@@ -1,15 +1,15 @@
 import { createContext } from 'react';
-import type { UserData } from './RpcModels';
+import type { AuthMicrosoftLoginData1 } from './RpcModels';
 
 export interface UserContext {
-  userData: UserData | null;
-  setUserData: (data: UserData | null) => void;
-  clearUserData: () => void;
+	userData: AuthMicrosoftLoginData1 | null;
+	setUserData: (data: AuthMicrosoftLoginData1 | null) => void;
+	clearUserData: () => void;
 }
 const defaultContext: UserContext = {
-  userData: null,
-  setUserData: () => {},
-  clearUserData: () => {},
+	userData: null,
+	setUserData: () => {},
+	clearUserData: () => {},
 };
 
 const UserContextObject = createContext<UserContext>(defaultContext);

--- a/frontend/src/shared/UserContextProvider.tsx
+++ b/frontend/src/shared/UserContextProvider.tsx
@@ -1,13 +1,13 @@
 import { useState, ReactNode } from 'react';
 import UserContext from './UserContext';
-import { UserData } from './RpcModels';
+import type { AuthMicrosoftLoginData1 } from './RpcModels';
 
 interface UserContextProviderProps {
   	children: ReactNode;
 }
 
 const UserContextProvider = ({ children }: UserContextProviderProps): JSX.Element => {
-  	const [userData, setUserData] = useState<UserData | null>(null);
+        const [userData, setUserData] = useState<AuthMicrosoftLoginData1 | null>(null);
 
   	const clearUserData = () => {
     	setUserData(null);


### PR DESCRIPTION
## Summary
- convert prior login components to TypeScript
- add notification helper component
- hook login widget to sidebar and create login page
- integrate msal config and RPC login
- update user context typing
- update msal config per request

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687423e893e08325a9efc7cd865fa807