### PR TITLE
Fix Discord oversize messages

### DIFF
--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -23,6 +23,27 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
+export interface AuthMicrosoftLoginData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+}
+export interface AdminVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface AdminVarsHostname1 {
+  hostname: string;
+}
+export interface AdminVarsRepo1 {
+  repo: string;
+}
+export interface AdminVarsVersion1 {
+  version: string;
+}
 export interface AdminLinksHome1 {
   links: LinkItem[];
 }
@@ -37,27 +58,6 @@ export interface RouteItem {
   path: string;
   name: string;
   icon: string;
-}
-export interface AdminVarsFfmpegVersion1 {
-  ffmpeg_version: string;
-}
-export interface AdminVarsHostname1 {
-  hostname: string;
-}
-export interface AdminVarsRepo1 {
-  repo: string;
-}
-export interface AdminVarsVersion1 {
-  version: string;
-}
-export interface AuthMicrosoftLoginData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -34,7 +34,9 @@ class DiscordModule():
   async def send_sys_message(self, message: str):
     channel = self.bot.get_channel(self.syschan)
     if channel:
-      await channel.send(message)
+      from server.helpers.logging import split_message
+      for part in split_message(message):
+        await channel.send(part)
 
   # This will be moved to discord_router at a later time
   def _init_bot_routes(self):

--- a/tests/test_discord_module.py
+++ b/tests/test_discord_module.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import server.modules.discord_module as discord_mod
 from server.modules.env_module import EnvironmentModule
 from server.modules.discord_module import DiscordModule
+from server.helpers.logging import MAX_DISCORD_MESSAGE_LEN
 
 class DummyBot:
   def __init__(self):
@@ -77,6 +78,13 @@ def test_send_sys_message(monkeypatch, discord_app):
 def test_send_sys_message_no_channel(monkeypatch, discord_app):
   mod = _setup(monkeypatch, discord_app, None)
   asyncio.run(mod.send_sys_message("hi"))
+
+def test_send_sys_message_long(monkeypatch, discord_app):
+  chan = Chan()
+  mod = _setup(monkeypatch, discord_app, chan)
+  long_msg = "a" * 3000
+  asyncio.run(mod.send_sys_message(long_msg))
+  assert chan.messages == ["a" * MAX_DISCORD_MESSAGE_LEN, "a" * (3000 - MAX_DISCORD_MESSAGE_LEN)]
 
 
 def test_rpc_command(monkeypatch, discord_app):


### PR DESCRIPTION
## Summary
- chunk messages before sending to Discord
- split system messages to respect Discord size limit
- update tests for new chunking behavior
- regenerate RpcModels

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`
- `npm run build`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_687455b27a24832589bf4b7a56c4647b