### PR TITLE
Add RPC view routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ Several helper scripts in the `scripts` directory manage the project database:
 - `interrogate_database_structure.py` prints the current table, column and index details.
 - `database_cli.py` opens an interactive console with shortcuts for common queries.
 These scripts read the `POSTGRES_CONNECTION_STRING` environment variable so they can run against any configured PostgreSQL server.
+
+### RPC Response Views
+RPC methods can return alternate representations using URN suffixes of the form
+`urn:{domain}:{subdomain}:{function}:{version}:view:{context}:{variant}`. When a
+view suffix is provided, the core method executes and the response is formatted
+for the requested context and variant. Requests without a view suffix continue
+to return the default models.
+
+The available mappings are exposed via `rpc.get_view_registry()`.
+For example, `urn:admin:vars:get_hostname:1:view:discord:1` will return a
+Discord-friendly hostname message.

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -23,20 +23,14 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
-export interface AuthMicrosoftLoginData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-}
 export interface AdminVarsFfmpegVersion1 {
   ffmpeg_version: string;
 }
 export interface AdminVarsHostname1 {
   hostname: string;
+}
+export interface AdminVarsHostnameViewDiscord1 {
+  content: string;
 }
 export interface AdminVarsRepo1 {
   repo: string;
@@ -58,6 +52,15 @@ export interface RouteItem {
   path: string;
   name: string;
   icon: string;
+}
+export interface AuthMicrosoftLoginData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/__init__.py
+++ b/rpc/__init__.py
@@ -1,1 +1,9 @@
+"""RPC package initializer."""
 
+# Import view registrations so that handlers are available
+from . import admin  # noqa: F401
+from .admin.vars import views as _admin_vars_views  # noqa: F401
+
+from .views import format_response, register_formatter, get_view_registry
+
+__all__ = ["format_response", "register_formatter", "get_view_registry"]

--- a/rpc/admin/vars/__init__.py
+++ b/rpc/admin/vars/__init__.py
@@ -1,1 +1,1 @@
-
+from . import views  # noqa: F401

--- a/rpc/admin/vars/models.py
+++ b/rpc/admin/vars/models.py
@@ -12,3 +12,7 @@ class AdminVarsRepo1(BaseModel):
 class AdminVarsFfmpegVersion1(BaseModel):
   ffmpeg_version: str
 
+
+class AdminVarsHostnameViewDiscord1(BaseModel):
+  content: str
+

--- a/rpc/admin/vars/views.py
+++ b/rpc/admin/vars/views.py
@@ -1,0 +1,17 @@
+from rpc.models import RPCResponse
+from rpc.views import register_formatter
+from .models import AdminVarsHostname1, AdminVarsHostnameViewDiscord1
+
+
+@register_formatter("urn:admin:vars:hostname:1", "discord", "1")
+def hostname_discord_v1(response: RPCResponse) -> RPCResponse:
+  assert isinstance(response.payload, AdminVarsHostname1)
+  payload = AdminVarsHostnameViewDiscord1(content=f"Hostname: {response.payload.hostname}")
+  return RPCResponse(
+    op=response.op,
+    payload=payload,
+    version=response.version,
+    timestamp=response.timestamp,
+    metadata=response.metadata,
+  )
+

--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -3,6 +3,7 @@ import logging
 from rpc.admin.handler import handle_admin_request
 from rpc.auth.handler import handle_auth_request
 from rpc.models import RPCRequest, RPCResponse
+from rpc.views import format_response
 
 async def handle_rpc_request(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   parts = rpc_request.op.split(":")
@@ -10,14 +11,29 @@ async def handle_rpc_request(rpc_request: RPCRequest, request: Request) -> RPCRe
   if parts[:1] != ["urn"]:
     raise HTTPException(400, "Invalid URN prefix")
 
+  context = None
+  variant = None
+  if len(parts) >= 4 and parts[-3] == "view":
+    context = parts[-2]
+    variant = parts[-1]
+    core_parts = parts[:-3]
+  elif len(parts) >= 3 and parts[-2] == "view":
+    context = parts[-1]
+    core_parts = parts[:-2]
+  else:
+    core_parts = parts
+
   try:
-    match parts[1:]:
+    match core_parts[1:]:
       case ["admin", *rest]:
         response = await handle_admin_request(rest, request)
       case ["auth", *rest]:
         response = await handle_auth_request(rest, rpc_request, request)
       case _:
         raise HTTPException(status_code=404, detail="Unknown RPC domain")
+    response = format_response(response, context, variant)
+    if context:
+      response.op = rpc_request.op
     logging.info(f"RPC completed: {rpc_request.op}")
     return response
   except Exception:

--- a/rpc/views.py
+++ b/rpc/views.py
@@ -1,0 +1,7 @@
+from server.modules.views_module import (
+  register_formatter,
+  format_response,
+  get_view_registry,
+)
+
+__all__ = ["register_formatter", "format_response", "get_view_registry"]

--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -5,6 +5,7 @@ from server.modules.env_module import EnvironmentModule   # Explicit manual impo
 from server.modules.discord_module import DiscordModule   # Explicit manual import
 from server.modules.database_module import DatabaseModule # Explicit manual import
 from server.modules.auth_module import AuthModule         # Explicit manual import
+from server.modules.views_module import ViewsModule       # Explicit manual import
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -14,6 +15,7 @@ async def lifespan(app: FastAPI):
   await app.state.database.startup()
   app.state.auth = AuthModule(app)
   await app.state.auth.startup()
+  app.state.views = ViewsModule(app)
 
   try:
     yield

--- a/server/modules/views_module.py
+++ b/server/modules/views_module.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+import logging
+from typing import Callable, Dict, Optional, TYPE_CHECKING
+from fastapi import FastAPI
+from . import BaseModule
+
+if TYPE_CHECKING:
+  from rpc.models import RPCResponse
+
+FormatFunc = Callable[["RPCResponse"], "RPCResponse"]
+
+# Global registry mapping base RPC op -> context -> variant -> formatter
+VIEW_REGISTRY: Dict[str, Dict[str, Dict[str, FormatFunc]]] = {}
+
+
+class ViewsModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    logging.info("Views module loaded")
+
+
+def register_formatter(op: str, context: str, variant: Optional[str] = None):
+  def decorator(func: FormatFunc) -> FormatFunc:
+    ctx_map = VIEW_REGISTRY.setdefault(op, {}).setdefault(context, {})
+    ctx_map[str(variant or "")] = func
+    return func
+  return decorator
+
+
+def format_response(response: RPCResponse, context: Optional[str], variant: Optional[str]) -> RPCResponse:
+  if not context:
+    return response
+  ctx_map = VIEW_REGISTRY.get(response.op, {})
+  var_map = ctx_map.get(context, {})
+  fmt = var_map.get(str(variant or "")) or var_map.get("")
+  if fmt:
+    return fmt(response)
+  return response
+
+
+def get_view_registry() -> Dict[str, Dict[str, list[str]]]:
+  return {
+    op: {ctx: list(vars.keys()) for ctx, vars in ctxs.items()}
+    for op, ctxs in VIEW_REGISTRY.items()
+  }

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -54,5 +54,6 @@ def test_lifespan_initializes_modules(monkeypatch):
       assert app.state.discord is not None
       assert app.state.database is not None
       assert app.state.auth is not None
+      assert app.state.views is not None
 
   asyncio.run(run())

--- a/tests/test_rpc_response_views.py
+++ b/tests/test_rpc_response_views.py
@@ -1,0 +1,31 @@
+import asyncio
+import pytest
+from fastapi import FastAPI, Request
+
+from server.modules.env_module import EnvironmentModule
+from server.modules.views_module import ViewsModule
+from rpc.handler import handle_rpc_request
+from rpc.models import RPCRequest
+
+
+@pytest.fixture(autouse=True)
+def set_env(monkeypatch):
+  monkeypatch.setenv("HOSTNAME", "unit-host")
+
+
+@pytest.fixture
+def app():
+  app = FastAPI()
+  env_module = EnvironmentModule(app)
+  app.state.env = env_module
+  app.state.views = ViewsModule(app)
+  return app
+
+
+def test_hostname_discord_view(app):
+  request = Request({"type": "http", "app": app})
+  urn = "urn:admin:vars:get_hostname:1:view:discord:1"
+  rpc_request = RPCRequest(op=urn)
+  resp = asyncio.run(handle_rpc_request(rpc_request, request))
+  assert resp.op == urn
+  assert resp.payload.content == "Hostname: unit-host"


### PR DESCRIPTION
## Summary
- implement new URN view parsing and formatting logic
- add global registry for response view handlers
- create Discord view formatter for `admin.vars.get_hostname`
- update TypeScript RPC models
- document RPC view usage
- test Discord view routing
- move view registry into server `ViewsModule` and wire into lifespan

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68747fa7a9ac8325a417711c6e70ce77