### PR TITLE
Fix discord RPC view injection and response formatting

### DIFF
--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -63,10 +63,20 @@ class DiscordModule():
       req = Request({"type": "http", "app": self.app})
       from rpc.handler import handle_rpc_request
       from rpc.models import RPCRequest
+
+      parts = op.split(":")
+      if "view" not in parts:
+        op = f"{op}:view:discord:1"
+
       rpc_req = RPCRequest(op=op)
       try:
         resp = await handle_rpc_request(rpc_req, req)
         payload = resp.payload
+
+        if hasattr(payload, "content"):
+          await ctx.send(payload.content)
+          return
+
         if hasattr(payload, "model_dump"):
           data = json.dumps(payload.model_dump())
         else:

--- a/tests/test_discord_module.py
+++ b/tests/test_discord_module.py
@@ -108,5 +108,5 @@ def test_rpc_command(monkeypatch, discord_app):
   ctx = Ctx()
   asyncio.run(mod.bot.cmd(ctx, op="urn:admin:vars:get_hostname:1"))
 
-  assert messages == ['{"hostname": "host"}']
+  assert messages == ['Hostname: host']
 


### PR DESCRIPTION
## Summary
- improve `!rpc` command to inject Discord view request automatically
- show Discord-friendly content from RPC responses
- update tests for new Discord RPC behavior

## Testing
- `pytest tests/test_discord_module.py::test_rpc_command -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877d7a5d5e48325b7e97ede164709c1