### PR TITLE
Update database queries for new schema

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -107,14 +107,16 @@ class AuthModule(BaseModule):
         "profilePicture": profile_picture_base64,
       }
 
-  async def handle_ms_auth_login(self, id_token: str, access_token: str):
-    payload = await self.verify_ms_id_token(id_token)
-    guid = payload.get("sub")
-    if not guid:
-      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload.")
-    profile = await self.fetch_ms_user_profile(access_token)
-    logging.info(f"Processing login for: {profile['username']}, {profile['email']}")
-    return guid, profile
+  async def handle_auth_login(self, provider: str, id_token: str, access_token: str):
+    if provider == "microsoft":
+      payload = await self.verify_ms_id_token(id_token)
+      guid = payload.get("sub")
+      if not guid:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload.")
+      profile = await self.fetch_ms_user_profile(access_token)
+      logging.info(f"Processing login for: {profile['username']}, {profile['email']}")
+      return guid, profile
+    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported auth provider")
 
   def make_bearer_token(self, guid: str) -> str:
     exp = datetime.now(timezone.utc) + timedelta(hours=24)

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -61,7 +61,7 @@ def test_decode_expired_token(auth_app):
     asyncio.run(am.decode_bearer_token(bad))
 
 
-def test_handle_ms_auth_login(monkeypatch, auth_app):
+def test_handle_auth_login(monkeypatch, auth_app):
   am = AuthModule(auth_app)
   async def fake_verify(idt):
     return {"sub": "guid"}
@@ -69,7 +69,7 @@ def test_handle_ms_auth_login(monkeypatch, auth_app):
     return {"email": "e", "username": "u", "profilePicture": None}
   monkeypatch.setattr(am, "verify_ms_id_token", fake_verify)
   monkeypatch.setattr(am, "fetch_ms_user_profile", fake_profile)
-  guid, profile = asyncio.run(am.handle_ms_auth_login("id", "ac"))
+  guid, profile = asyncio.run(am.handle_auth_login("microsoft", "id", "ac"))
   assert guid == "guid"
   assert profile["email"] == "e"
 

--- a/tests/test_rpc_microsoft_service.py
+++ b/tests/test_rpc_microsoft_service.py
@@ -5,24 +5,23 @@ from rpc.auth.microsoft import services
 
 
 class DummyAuth:
-  async def handle_ms_auth_login(self, idt, act):
+  async def handle_auth_login(self, provider, idt, act):
     return 'g', {'email': 'e', 'username': 'u', 'profilePicture': None}
   def make_bearer_token(self, guid):
     return 'token'
 
 class DummyDB:
-  async def select_ms_user(self, mid):
+  async def select_user(self, provider, mid):
     return {
       'guid': 'uid',
       'provider_name': 'microsoft',
-      'username': 'u',
+      'display_name': 'u',
       'email': 'e',
-      'backup_email': None,
       'credits': 0,
     }
 
-  async def insert_ms_user(self, mid, email, username):
-    return await self.select_ms_user(mid)
+  async def insert_user(self, provider, mid, email, username):
+    return await self.select_user(provider, mid)
 
 
 def test_user_login_v1():
@@ -30,7 +29,7 @@ def test_user_login_v1():
   app.state.auth = DummyAuth()
   app.state.database = DummyDB()
   req = Request({'type': 'http', 'app': app})
-  rpc_req = RPCRequest(op='op', payload={'idToken': 'id', 'accessToken': 'ac'})
+  rpc_req = RPCRequest(op='op', payload={'idToken': 'id', 'accessToken': 'ac', 'provider': 'microsoft'})
   resp = asyncio.run(services.user_login_v1(rpc_req, req))
   assert resp.op == 'urn:auth:microsoft:login_data:1'
   assert resp.payload.bearerToken == 'token'


### PR DESCRIPTION
## Summary
- support provider-based login in auth service
- refactor database module queries for new schema
- drop unused credit update helpers and routes queries
- update auth module to use generic login handler
- adjust tests for new APIs

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6877ffdb9e4c83258d171a6a8789aba6