### PR TITLE
Fix provider validation on login

### DIFF
--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -28,7 +28,11 @@ const LoginPage = (): JSX.Element => {
 			const loginResponse = await pca.loginPopup(loginRequest);
 			const { idToken, accessToken } = loginResponse;
 
-			const data = await fetchUserLogin({ idToken, accessToken });
+			const data = await fetchUserLogin({
+				idToken,
+				accessToken,
+				provider: 'microsoft',
+			});
 			const profilePictureBase64 = data.profilePicture ? `data:image/png;base64,${data.profilePicture}` : null;
 
 			setUserData({


### PR DESCRIPTION
## Summary
- only allow known providers in DatabaseModule
- update frontend to send provider value when logging in
- adjust tests for provider check

## Testing
- `npm --prefix frontend test -- --run`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68780954741483259aa681892f24cd2c