### PR TITLE
Add detailed logging for auth RPC workflow

### DIFF
--- a/rpc/auth/handler.py
+++ b/rpc/auth/handler.py
@@ -1,8 +1,15 @@
 from fastapi import Request, HTTPException
+import logging
 from rpc.auth.microsoft.handler import handle_ms_request
 from rpc.models import RPCRequest, RPCResponse
 
 async def handle_auth_request(parts: list[str], rpc_request: RPCRequest, request: Request) -> RPCResponse:
+  logging.info(
+    "handle_auth_request parts=%s op=%s payload=%s",
+    parts,
+    rpc_request.op,
+    rpc_request.payload,
+  )
   match parts:
     case ["microsoft", *rest]:
       return await handle_ms_request(rest, rpc_request, request)

--- a/rpc/auth/microsoft/handler.py
+++ b/rpc/auth/microsoft/handler.py
@@ -1,8 +1,15 @@
 from fastapi import Request, HTTPException
+import logging
 from rpc.auth.microsoft import services
 from rpc.models import RPCRequest, RPCResponse
 
 async def handle_ms_request(parts: list[str], rpc_request: RPCRequest, request: Request) -> RPCResponse:
+  logging.info(
+    "handle_ms_request parts=%s op=%s payload=%s",
+    parts,
+    rpc_request.op,
+    rpc_request.payload,
+  )
   match parts:
     case ["user_login", "1"]:
       return await services.user_login_v1(rpc_request, request)

--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -8,6 +8,12 @@ from rpc.suffix import split_suffix, apply_suffixes
 
 async def handle_rpc_request(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   parts = rpc_request.op.split(":")
+  logging.info(
+    "handle_rpc_request op=%s parts=%s payload=%s",
+    rpc_request.op,
+    parts,
+    rpc_request.payload,
+  )
 
   if parts[:1] != ["urn"]:
     raise HTTPException(400, "Invalid URN prefix")

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -54,6 +54,7 @@ class AuthModule(BaseModule):
     logging.info("Auth module shutdown")
 
   async def verify_ms_id_token(self, id_token: str) -> Dict:
+    logging.info("verify_ms_id_token id_token=%s", id_token)
     if not self.ms_jwks:
       raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Microsoft keys unavailable")
     try:
@@ -80,6 +81,7 @@ class AuthModule(BaseModule):
         audience=self.ms_api_id,
         issuer="https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
       )
+      logging.info("verify_ms_id_token payload=%s", payload)
       return payload
     except jwt.ExpiredSignatureError:
       raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired.")
@@ -89,6 +91,7 @@ class AuthModule(BaseModule):
       raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token validation failed.")
 
   async def fetch_ms_user_profile(self, access_token: str) -> Dict:
+    logging.info("fetch_ms_user_profile access_token=%s", access_token)
     async with aiohttp.ClientSession() as session:
       headers = {"Authorization": f"Bearer {access_token}"}
       async with session.get("https://graph.microsoft.com/v1.0/me", headers=headers) as response:
@@ -108,6 +111,12 @@ class AuthModule(BaseModule):
       }
 
   async def handle_auth_login(self, provider: str, id_token: str, access_token: str):
+    logging.info(
+      "handle_auth_login provider=%s id_token=%s access_token=%s",
+      provider,
+      id_token,
+      access_token,
+    )
     if provider == "microsoft":
       payload = await self.verify_ms_id_token(id_token)
       guid = payload.get("sub")

--- a/server/modules/database_module.py
+++ b/server/modules/database_module.py
@@ -83,6 +83,11 @@ class DatabaseModule(BaseModule):
     await self._run(query, sub_uuid, *args)
 
   async def select_user(self, provider: str, provider_user_id: str):
+    logging.info(
+      "select_user provider=%s provider_user_id=%s",
+      provider,
+      provider_user_id,
+    )
     query = """
       SELECT
         u.guid,
@@ -105,6 +110,13 @@ class DatabaseModule(BaseModule):
     return result
 
   async def insert_user(self, provider: str, provider_user_id: str, email: str, username: str):
+    logging.info(
+      "insert_user provider=%s provider_user_id=%s email=%s username=%s",
+      provider,
+      provider_user_id,
+      email,
+      username,
+    )
     if not self.pool:
       raise RuntimeError("Database pool not initialized")
     new_guid = _utos(uuid4())


### PR DESCRIPTION
## Summary
- add granular logging of RPC steps for auth pipeline
- record provider details through auth flow to debug provider issues

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6878207117808325a5e502cd14366913