### PR TITLE
Implement debug flag and reduce logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from server.routers import rpc_router
 from server.routers import web_router
 from server.helpers.logging import configure_root_logging
 
-configure_root_logging()
+configure_root_logging(debug=lifespan.DEBUG_LOGGING)
 
 # Create the FastAPI app
 app = FastAPI(lifespan=lifespan.lifespan)

--- a/rpc/auth/handler.py
+++ b/rpc/auth/handler.py
@@ -4,7 +4,7 @@ from rpc.auth.microsoft.handler import handle_ms_request
 from rpc.models import RPCRequest, RPCResponse
 
 async def handle_auth_request(parts: list[str], rpc_request: RPCRequest, request: Request) -> RPCResponse:
-  logging.info(
+  logging.debug(
     "handle_auth_request parts=%s op=%s payload=%s",
     parts,
     rpc_request.op,

--- a/rpc/auth/microsoft/handler.py
+++ b/rpc/auth/microsoft/handler.py
@@ -4,7 +4,7 @@ from rpc.auth.microsoft import services
 from rpc.models import RPCRequest, RPCResponse
 
 async def handle_ms_request(parts: list[str], rpc_request: RPCRequest, request: Request) -> RPCResponse:
-  logging.info(
+  logging.debug(
     "handle_ms_request parts=%s op=%s payload=%s",
     parts,
     rpc_request.op,

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -9,19 +9,19 @@ async def user_login_v1(rpc_request: RPCRequest, request: Request) -> RPCRespons
   req_payload = rpc_request.payload or {}
   auth: AuthModule = request.app.state.auth
   db: DatabaseModule = request.app.state.database
-  logging.info(
+  logging.debug(
     "user_login_v1 payload=%s",
     req_payload,
   )
 
   provider = req_payload.get("provider", "microsoft")
-  logging.info("user_login_v1 provider=%s", provider)
+  logging.debug("user_login_v1 provider=%s", provider)
   guid, profile = await auth.handle_auth_login(
     provider,
     req_payload.get("idToken"),
     req_payload.get("accessToken"),
   )
-  logging.info(
+  logging.debug(
     "user_login_v1 guid=%s profile=%s",
     guid,
     profile,
@@ -30,7 +30,7 @@ async def user_login_v1(rpc_request: RPCRequest, request: Request) -> RPCRespons
   user = await db.select_user(provider, guid)
   # if not user:
   #   user = await db.insert_user(provider, guid, profile["email"], profile["username"])
-  logging.info("user_login_v1 user=%s", user)
+  logging.debug("user_login_v1 user=%s", user)
 
   #token = auth.make_bearer_token(user["guid"])
   token = auth.make_bearer_token(_utos(user["guid"]))

--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -8,7 +8,7 @@ from rpc.suffix import split_suffix, apply_suffixes
 
 async def handle_rpc_request(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   parts = rpc_request.op.split(":")
-  logging.info(
+  logging.debug(
     "handle_rpc_request op=%s parts=%s payload=%s",
     rpc_request.op,
     parts,

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -30,5 +30,7 @@ class RPCResponse(BaseModel):
     description="Optional metadata like processing time or status notes"
   )
 
+# ###REVIEW### Unused model, verify necessity
 class UserData(BaseModel):
- bearerToken: str
+  bearerToken: str
+

--- a/server/helpers/buffers.py
+++ b/server/helpers/buffers.py
@@ -1,6 +1,7 @@
 import aiohttp, io
 
-# Async Context Manager for buffer
+# ###REVIEW### This helper is only used in tests and is not
+# referenced by the application runtime.
 class AsyncBufferWriter():
   def __init__(self, url):
     self.buffer = None
@@ -22,3 +23,4 @@ class AsyncBufferWriter():
   async def __aexit__(self, exc_type, exc_val, exc_tb):
     if self.buffer:
       self.buffer.close()
+

--- a/server/helpers/logging.py
+++ b/server/helpers/logging.py
@@ -58,14 +58,14 @@ def configure_discord_logging(discord_module):
   logging.getLogger().addHandler(handler)
 
 
-def configure_root_logging():
+def configure_root_logging(debug: bool = False):
   logger = logging.getLogger()
   if logger.handlers:
     logger.handlers.clear()
   handler = logging.StreamHandler(sys.stdout)
   handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
   logger.addHandler(handler)
-  logger.setLevel(logging.INFO)
+  logger.setLevel(logging.DEBUG if debug else logging.INFO)
 
 
 def remove_discord_logging(discord_module):

--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -1,5 +1,9 @@
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
+import os
+
+# Toggle debug logging globally
+DEBUG_LOGGING = os.getenv("DEBUG_LOGGING", "0") == "1"
 
 from server.modules.env_module import EnvironmentModule   # Explicit manual import
 from server.modules.discord_module import DiscordModule   # Explicit manual import

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -54,7 +54,7 @@ class AuthModule(BaseModule):
     logging.info("Auth module shutdown")
 
   async def verify_ms_id_token(self, id_token: str) -> Dict:
-    logging.info("verify_ms_id_token id_token=%s", id_token)
+    logging.debug("verify_ms_id_token id_token=%s", id_token)
     if not self.ms_jwks:
       raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Microsoft keys unavailable")
     try:
@@ -81,7 +81,7 @@ class AuthModule(BaseModule):
         audience=self.ms_api_id,
         issuer="https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
       )
-      logging.info("verify_ms_id_token payload=%s", payload)
+      logging.debug("verify_ms_id_token payload=%s", payload)
       return payload
     except jwt.ExpiredSignatureError:
       raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired.")
@@ -91,7 +91,7 @@ class AuthModule(BaseModule):
       raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token validation failed.")
 
   async def fetch_ms_user_profile(self, access_token: str) -> Dict:
-    logging.info("fetch_ms_user_profile access_token=%s", access_token)
+    logging.debug("fetch_ms_user_profile access_token=%s", access_token)
     async with aiohttp.ClientSession() as session:
       headers = {"Authorization": f"Bearer {access_token}"}
       async with session.get("https://graph.microsoft.com/v1.0/me", headers=headers) as response:
@@ -111,7 +111,7 @@ class AuthModule(BaseModule):
       }
 
   async def handle_auth_login(self, provider: str, id_token: str, access_token: str):
-    logging.info(
+    logging.debug(
       "handle_auth_login provider=%s id_token=%s access_token=%s",
       provider,
       id_token,

--- a/server/modules/database_module.py
+++ b/server/modules/database_module.py
@@ -70,20 +70,23 @@ class DatabaseModule(BaseModule):
     async with self.pool.acquire() as conn:
       await conn.execute(query, *args)
 
+  # ###REVIEW### currently unused utility for scoped fetch
   async def _secure_fetch_many(self, query: str, sub: str, *args):
     sub_uuid = _stou(sub)
     return await self._fetch_many(query, sub_uuid, *args)
 
+  # ###REVIEW### currently unused utility for scoped fetch
   async def _secure_fetch_one(self, query: str, sub: str, *args):
     sub_uuid = _stou(sub)
     return await self._fetch_one(query, sub_uuid, *args)
 
+  # ###REVIEW### currently unused utility for scoped execution
   async def _secure_run(self, query: str, sub: str, *args):
     sub_uuid = _stou(sub)
     await self._run(query, sub_uuid, *args)
 
   async def select_user(self, provider: str, provider_user_id: str):
-    logging.info(
+    logging.debug(
       "select_user provider=%s provider_user_id=%s",
       provider,
       provider_user_id,
@@ -102,14 +105,14 @@ class DatabaseModule(BaseModule):
     """
     result = await self._fetch_one(query, provider_user_id, provider)
     if result:
-      logging.info(
+      logging.debug(
         f"Found {result['provider_name']} user for {result['guid']}: "
         f"{result.get('display_name')}, {result['email']}, Credits: {result['credits']}"
       )
     return result
 
   async def insert_user(self, provider: str, provider_user_id: str, email: str, username: str):
-    logging.info(
+    logging.debug(
       "insert_user provider=%s provider_user_id=%s email=%s username=%s",
       provider,
       provider_user_id,


### PR DESCRIPTION
## Summary
- add global `DEBUG_LOGGING` flag
- make root logging configurable for debug mode
- quiet RPC and auth logging by moving noisy calls to `logging.debug`
- mark unused helpers with `###REVIEW###`
- keep buffer helper newline and adjust root logging usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785de6f27c83259d439087ba5b5a3e