### PR TITLE
Load routes from database

### DIFF
--- a/rpc/admin/links/services.py
+++ b/rpc/admin/links/services.py
@@ -2,6 +2,7 @@
 from fastapi import Request
 from rpc.models import RPCResponse
 from rpc.admin.links.models import AdminLinksHome1, LinkItem, AdminLinksRoutes1, RouteItem
+from server.modules.database_module import DatabaseModule
 
 async def get_home_v1(request: Request) -> RPCResponse:
   links = [
@@ -17,8 +18,10 @@ async def get_home_v1(request: Request) -> RPCResponse:
   return RPCResponse(op="urn:admin:links:home:1", payload=payload, version=1)
 
 async def get_routes_v1(request: Request) -> RPCResponse:
+  db: DatabaseModule = request.app.state.database
+  data = await db.select_routes()
   routes = [
-    RouteItem(path='/', name='Home', icon='home'),
+    RouteItem(path=r['path'], name=r['name'], icon=r['icon']) for r in data
   ]
 
   payload = AdminLinksRoutes1(routes=routes)

--- a/server/modules/database_module.py
+++ b/server/modules/database_module.py
@@ -54,7 +54,7 @@ class DatabaseModule(BaseModule):
     if not self.pool:
       raise RuntimeError("Database pool not initialized")
     async with self.pool.acquire() as conn:
-      result = await conn.fetchval(query, *args)
+      result = await conn.fetch(query, *args)
     return _maybe_loads_json(result)
 
   async def _fetch_one(self, query: str, *args):
@@ -126,4 +126,9 @@ class DatabaseModule(BaseModule):
           new_guid,
         )
     return await self.select_user(provider, provider_user_id)
+
+  async def select_routes(self):
+    logging.debug("select_routes")
+    query = "SELECT * FROM routes;"
+    return await self._fetch_many(query)
 

--- a/tests/test_rpc_admin_namespace.py
+++ b/tests/test_rpc_admin_namespace.py
@@ -6,6 +6,20 @@ from server.modules.env_module import EnvironmentModule
 from rpc.handler import handle_rpc_request
 from rpc.models import RPCRequest
 
+
+class DummyDB:
+    async def select_routes(self):
+        return [
+            {
+                "id": 1,
+                "path": "/",
+                "name": "Home",
+                "icon": "home",
+                "required_roles": 0,
+                "sequence": 10,
+            }
+        ]
+
 @pytest.fixture(autouse=True)
 def set_env(monkeypatch):
     monkeypatch.setenv("VERSION", "v1.2.3")
@@ -20,6 +34,7 @@ def app():
     env_module = EnvironmentModule(app)
     # services do `request.app.state.env`, so set it here
     app.state.env = env_module
+    app.state.database = DummyDB()
     return app
 
 def test_get_version(app):


### PR DESCRIPTION
## Summary
- read admin links route data from the database
- add `select_routes` query helper
- update tests to stub database routes

## Testing
- `python -m pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687939f6fa508325af37aa0bae798198