### PR TITLE
Normalize users_auth table

### DIFF
--- a/scripts/database_update.py
+++ b/scripts/database_update.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import asyncio
+from scripts.database_cli import connect
+
+async def column_exists(conn, table: str, column: str) -> bool:
+  row = await conn.fetchrow(
+    """
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name=$1 AND column_name=$2;
+    """,
+    table,
+    column,
+  )
+  return row is not None
+
+async def main() -> None:
+  conn = await connect()
+  try:
+    exists = await conn.fetchrow(
+      "SELECT to_regclass('users_auth_old') AS t"
+    )
+    if not exists or not exists['t']:
+      print('users_auth_old not found; nothing to migrate')
+      return
+    providers = await conn.fetch('SELECT id, name FROM auth_provider')
+    for p in providers:
+      col = f"{p['name']}_id"
+      if await column_exists(conn, 'users_auth_old', col):
+        await conn.execute(
+          f"""
+          INSERT INTO users_auth (user_guid, provider_id, provider_user_id)
+          SELECT user_guid, {p['id']}, {col}
+          FROM users_auth_old
+          WHERE {col} IS NOT NULL;
+          """
+        )
+    await conn.execute('DROP TABLE users_auth_old')
+    print('users_auth data migrated')
+  finally:
+    await conn.close()
+
+if __name__ == '__main__':
+  asyncio.run(main())

--- a/scripts/database_upgrade.py
+++ b/scripts/database_upgrade.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import asyncio
+from scripts.database_cli import connect
+
+async def main() -> None:
+  conn = await connect()
+  try:
+    col = await conn.fetchrow(
+      """
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name='users_auth' AND column_name='provider_id';
+      """
+    )
+    if col:
+      print('users_auth already upgraded')
+      return
+    await conn.execute('ALTER TABLE users_auth RENAME TO users_auth_old')
+    await conn.execute(
+      """
+      CREATE TABLE users_auth (
+        user_guid UUID NOT NULL,
+        provider_id INTEGER NOT NULL REFERENCES auth_provider(id),
+        provider_user_id TEXT NOT NULL,
+        PRIMARY KEY (provider_id, provider_user_id)
+      );
+      """
+    )
+    print('users_auth schema upgraded; run database_update.py to migrate data')
+  finally:
+    await conn.close()
+
+if __name__ == '__main__':
+  asyncio.run(main())


### PR DESCRIPTION
## Summary
- add scripts for upgrading/migrating users_auth
- normalize users_auth table schema
- update DB queries for new auth structure
- test that select_user uses new schema

## Testing
- `python scripts/run_tests.py` *(fails: FileNotFoundError: npm)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687946e795408325a4cfcc9a89b86ef0