### PR TITLE
Move version info to database config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,5 @@
-VERSION="v0.0.0"
-HOSTNAME="localhost"
-REPO="https://github.com/username/repository"
 MS_API_ID=
 JWT_SECRET=""
 DISCORD_SECRET=0123456789
-DISCORD_SYSCHAN=0123456789
 POSTGRES_CONNECTION_STRING="postgresql://user:pass@server:port/database?sslmode=require"
-DEBUG_LOGGING=1
+# Configuration values such as VERSION and HOSTNAME are stored in the database

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from server.routers import rpc_router
 from server.routers import web_router
 from server.helpers.logging import configure_root_logging
 
-configure_root_logging(debug=lifespan.DEBUG_LOGGING)
+configure_root_logging()
 
 # Create the FastAPI app
 app = FastAPI(lifespan=lifespan.lifespan)

--- a/rpc/admin/vars/services.py
+++ b/rpc/admin/vars/services.py
@@ -4,20 +4,20 @@ from rpc.admin.vars.models import AdminVarsVersion1, AdminVarsHostname1, AdminVa
 from rpc.models import RPCResponse
 
 async def get_version_v1(request: Request):
-  env = request.app.state.env
-  version = env.get("VERSION")
+  db = request.app.state.database
+  version = await db.get_config_value("Version")
   payload = AdminVarsVersion1(version=version)
   return RPCResponse(op="urn:admin:vars:version:1", payload=payload, version=1)
 
 async def get_hostname_v1(request: Request):
-  env = request.app.state.env
-  hostname = env.get("HOSTNAME")
+  db = request.app.state.database
+  hostname = await db.get_config_value("Hostname")
   payload = AdminVarsHostname1(hostname=hostname)
   return RPCResponse(op="urn:admin:vars:hostname:1", payload=payload, version=1)
 
 async def get_repo_v1(request: Request):
-  env = request.app.state.env
-  repo = env.get("REPO")
+  db = request.app.state.database
+  repo = await db.get_config_value("Repo")
   payload = AdminVarsRepo1(repo=repo)
   return RPCResponse(op="urn:admin:vars:repo:1", payload=payload, version=1)
 

--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -2,19 +2,24 @@ from fastapi import FastAPI
 from contextlib import asynccontextmanager
 import os
 
-DEBUG_LOGGING = os.getenv("DEBUG_LOGGING", "0") == "1"
-
 from server.modules.env_module import EnvironmentModule
 from server.modules.discord_module import DiscordModule
 from server.modules.database_module import DatabaseModule
 from server.modules.auth_module import AuthModule
+from server.helpers.logging import configure_root_logging
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+  dsn = os.getenv("POSTGRES_CONNECTION_STRING")
+  app.state.database = DatabaseModule(app, dsn=dsn)
+  await app.state.database.startup()
+
+  debug = await app.state.database.get_config_value("DebugLogging")
+  configure_root_logging(debug=str(debug).lower() in ["1", "true"])
+
   app.state.env = EnvironmentModule(app)
   app.state.discord = DiscordModule(app)
-  app.state.database = DatabaseModule(app)
-  await app.state.database.startup()
+  await app.state.discord.startup()
   app.state.auth = AuthModule(app)
   await app.state.auth.startup()
 

--- a/server/modules/env_module.py
+++ b/server/modules/env_module.py
@@ -8,11 +8,7 @@ class EnvironmentModule():
     self.app = app
 
     self._env: dict[str, str | None] = {}
-    self._getenv("VERSION", "MISSING_ENV_VERSION")
-    self._getenv("HOSTNAME", "MISSING_ENV_HOSTNAME")
-    self._getenv("REPO", "MISSING_ENV_REPO")
     self._getenv("DISCORD_SECRET", "MISSING_ENV_DISCORD_SECRET")
-    self._getenv("DISCORD_SYSCHAN", 0)
     self._getenv("JWT_SECRET", "MISSING_ENV_JWT_SECRET")
     self._getenv("MS_API_ID", "MISSING_ENV_MS_API_ID")
     self._getenv("POSTGRES_CONNECTION_STRING", "MISSING_ENV_POSTGRES_CONNECTION_STRING")

--- a/tests/test_database_module.py
+++ b/tests/test_database_module.py
@@ -8,11 +8,7 @@ from server.modules.env_module import EnvironmentModule
 
 @pytest.fixture
 def db_app(monkeypatch):
-  monkeypatch.setenv("VERSION", "1")
-  monkeypatch.setenv("HOSTNAME", "host")
-  monkeypatch.setenv("REPO", "repo")
   monkeypatch.setenv("DISCORD_SECRET", "secret")
-  monkeypatch.setenv("DISCORD_SYSCHAN", "1")
   monkeypatch.setenv("JWT_SECRET", "jwt")
   monkeypatch.setenv("MS_API_ID", "msid")
   monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
@@ -26,12 +22,12 @@ def test_db_startup(monkeypatch, db_app):
   async def fake_pool(**kwargs):
     return "pool"
   monkeypatch.setattr(db_mod.asyncpg, "create_pool", fake_pool)
-  dbm = DatabaseModule(db_app)
+  dbm = DatabaseModule(db_app, dsn="postgres://user@host/db")
   asyncio.run(dbm.startup())
   assert dbm.pool == "pool"
 
 def test_db_fetch_one_without_pool(db_app):
-  dbm = DatabaseModule(db_app)
+  dbm = DatabaseModule(db_app, dsn="postgres://user@host/db")
   with pytest.raises(RuntimeError):
     asyncio.run(dbm._fetch_one("SELECT 1"))
 
@@ -93,11 +89,24 @@ def test_select_user_new_schema(db_app):
     def acquire(self):
       return DummyAcquire(Conn())
 
-  dbm = DatabaseModule(db_app)
+  dbm = DatabaseModule(db_app, dsn="postgres://user@host/db")
   dbm.pool = Pool()
   result = asyncio.run(dbm.select_user('microsoft', 'pid'))
   assert captured['args'] == ('microsoft', 'pid')
   assert result['provider_name'] == 'microsoft'
+
+
+def test_get_config_value(db_app):
+  class Pool(DummyPool):
+    def __init__(self):
+      self.row = {'value': 'v'}
+    def acquire(self):
+      return DummyAcquire(DummyConn(self.row))
+
+  dbm = DatabaseModule(db_app, dsn="postgres://user@host/db")
+  dbm.pool = Pool()
+  result = asyncio.run(dbm.get_config_value('Version'))
+  assert result == 'v'
 
 
 #def test_secure_fetch_one(monkeypatch, db_app):

--- a/tests/test_env_module.py
+++ b/tests/test_env_module.py
@@ -5,19 +5,19 @@ from fastapi import FastAPI
 
 def test_env_loads(app_with_env):
   env = app_with_env.state.env
-  assert env.get("VERSION") == "1"
-  assert env.get_as_int("DISCORD_SYSCHAN") == 1
+  assert env.get("DISCORD_SECRET") == "secret"
+  assert env.get("JWT_SECRET") == "jwt"
 
 def test_env_missing_key(app_with_env):
   env = app_with_env.state.env
   with pytest.raises(RuntimeError):
-    env.get("NOPE")
+    env.get("VERSION")
 
 def test_env_defaults(monkeypatch):
-  monkeypatch.delenv("HOSTNAME", raising=False)
+  monkeypatch.delenv("MS_API_ID", raising=False)
   app = FastAPI()
   env = EnvironmentModule(app)
-  assert env.get("HOSTNAME") == "MISSING_ENV_HOSTNAME"
+  assert env.get("MS_API_ID") == "MISSING_ENV_MS_API_ID"
 
 def test_getenv_required(monkeypatch):
   app = FastAPI()

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -18,11 +18,7 @@ class DummyBot:
 
 
 def test_lifespan_initializes_modules(monkeypatch):
-  monkeypatch.setenv("VERSION", "1")
-  monkeypatch.setenv("HOSTNAME", "host")
-  monkeypatch.setenv("REPO", "repo")
   monkeypatch.setenv("DISCORD_SECRET", "secret")
-  monkeypatch.setenv("DISCORD_SYSCHAN", "1")
   monkeypatch.setenv("JWT_SECRET", "jwt")
   monkeypatch.setenv("MS_API_ID", "msid")
   monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
@@ -35,6 +31,12 @@ def test_lifespan_initializes_modules(monkeypatch):
   async def fake_pool(**kwargs):
     return "pool"
   monkeypatch.setattr(db_mod.asyncpg, "create_pool", fake_pool)
+
+  async def fake_get_config(self, key):
+    if key == "DiscordSyschan":
+      return "1"
+    return "0"
+  monkeypatch.setattr(db_mod.DatabaseModule, "get_config_value", fake_get_config)
 
   async def fake_uri():
     return "url"

--- a/tests/test_rpc_admin_namespace.py
+++ b/tests/test_rpc_admin_namespace.py
@@ -20,6 +20,13 @@ class DummyDB:
             }
         ]
 
+    async def get_config_value(self, key):
+        return {
+            "Version": "v1.2.3",
+            "Hostname": "unit-host",
+            "Repo": "https://repo",
+        }.get(key)
+
 @pytest.fixture(autouse=True)
 def set_env(monkeypatch):
     monkeypatch.setenv("VERSION", "v1.2.3")

--- a/tests/test_rpc_response_views.py
+++ b/tests/test_rpc_response_views.py
@@ -17,6 +17,11 @@ def app():
   app = FastAPI()
   env_module = EnvironmentModule(app)
   app.state.env = env_module
+  class DB:
+    async def get_config_value(self, key):
+      if key == "Hostname":
+        return "unit-host"
+  app.state.database = DB()
   return app
 
 


### PR DESCRIPTION
## Summary
- move VERSION, HOSTNAME, REPO, DISCORD_SYSCHAN and DEBUG_LOGGING into a new config table
- adjust startup ordering so the database module is ready before discord
- fetch configuration values from the database instead of environment variables
- update tests to match new startup order and configuration source

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795d4d7afc83259635b72afd3035cf