### PR TITLE
Move MS_API_ID to DB configuration

### DIFF
--- a/server/modules/env_module.py
+++ b/server/modules/env_module.py
@@ -10,7 +10,6 @@ class EnvironmentModule():
     self._env: dict[str, str | None] = {}
     self._getenv("DISCORD_SECRET", "MISSING_ENV_DISCORD_SECRET")
     self._getenv("JWT_SECRET", "MISSING_ENV_JWT_SECRET")
-    self._getenv("MS_API_ID", "MISSING_ENV_MS_API_ID")
     self._getenv("POSTGRES_CONNECTION_STRING", "MISSING_ENV_POSTGRES_CONNECTION_STRING")
     
     logging.info("Environment module loaded")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ def app_with_env(monkeypatch):
   monkeypatch.setenv("DISCORD_SECRET", "secret")
   monkeypatch.setenv("DISCORD_SYSCHAN", "1")
   monkeypatch.setenv("JWT_SECRET", "jwt")
-  monkeypatch.setenv("MS_API_ID", "msid")
   monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
   app = FastAPI()
   env = EnvironmentModule(app)

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -15,12 +15,17 @@ def auth_app(monkeypatch):
   monkeypatch.setenv("DISCORD_SECRET", "secret")
   monkeypatch.setenv("DISCORD_SYSCHAN", "1")
   monkeypatch.setenv("JWT_SECRET", "jwt")
-  monkeypatch.setenv("MS_API_ID", "msid")
   monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
   app = FastAPI()
   env = EnvironmentModule(app)
   app.state.env = env
   app.state.discord = SimpleNamespace()
+  class DB:
+    async def get_config_value(self, key):
+      if key == "MsApiId":
+        return "msid"
+      return None
+  app.state.database = DB()
   return app
 
 def test_auth_startup(monkeypatch, auth_app):

--- a/tests/test_database_module.py
+++ b/tests/test_database_module.py
@@ -10,7 +10,6 @@ from server.modules.env_module import EnvironmentModule
 def db_app(monkeypatch):
   monkeypatch.setenv("DISCORD_SECRET", "secret")
   monkeypatch.setenv("JWT_SECRET", "jwt")
-  monkeypatch.setenv("MS_API_ID", "msid")
   monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
   app = FastAPI()
   env = EnvironmentModule(app)

--- a/tests/test_discord_module.py
+++ b/tests/test_discord_module.py
@@ -30,7 +30,6 @@ def discord_app(monkeypatch):
   monkeypatch.setenv("DISCORD_SECRET", "secret")
   monkeypatch.setenv("DISCORD_SYSCHAN", "1")
   monkeypatch.setenv("JWT_SECRET", "jwt")
-  monkeypatch.setenv("MS_API_ID", "msid")
   monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
   app = FastAPI()
   env = EnvironmentModule(app)

--- a/tests/test_env_module.py
+++ b/tests/test_env_module.py
@@ -17,7 +17,8 @@ def test_env_defaults(monkeypatch):
   monkeypatch.delenv("MS_API_ID", raising=False)
   app = FastAPI()
   env = EnvironmentModule(app)
-  assert env.get("MS_API_ID") == "MISSING_ENV_MS_API_ID"
+  with pytest.raises(RuntimeError):
+    env.get("MS_API_ID")
 
 def test_getenv_required(monkeypatch):
   app = FastAPI()

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -20,7 +20,6 @@ class DummyBot:
 def test_lifespan_initializes_modules(monkeypatch):
   monkeypatch.setenv("DISCORD_SECRET", "secret")
   monkeypatch.setenv("JWT_SECRET", "jwt")
-  monkeypatch.setenv("MS_API_ID", "msid")
   monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
 
   monkeypatch.setattr(discord_mod, "configure_discord_logging", lambda m: None)


### PR DESCRIPTION
## Summary
- read `MsApiId` from the configuration table instead of an env var
- drop `MS_API_ID` from `EnvironmentModule`
- update tests for new behaviour

## Testing
- `npm --prefix frontend test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879751790608325a2a5249f13ee9622