### PR TITLE
Add database schema dump utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ We are building this site primarily using [Codex](https://chatgpt.com/codex). Th
 Several helper scripts in the `scripts` directory manage the project database:
 - `create_or_upgrade_database.py` creates the basic user tables if they do not already exist.
 - `interrogate_database_structure.py` prints the current table, column and index details.
-- `database_cli.py` opens an interactive console with shortcuts for common queries.
+- `database_cli.py` opens an interactive console with shortcuts for common queries. It provides `schema dump` and `schema apply` commands for managing schema snapshots.
+- `data_dump.py` creates a JSON backup containing schema and data.
 These scripts read the `POSTGRES_CONNECTION_STRING` environment variable so they can run against any configured PostgreSQL server.
 
 ### RPC Response Views

--- a/scripts/data_dump.py
+++ b/scripts/data_dump.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+import asyncio, json, datetime
+from database_cli import connect, get_schema
+
+async def main(prefix: str = 'backup') -> None:
+  conn = await connect()
+  try:
+    schema = await get_schema(conn)
+    data: dict[str, list[dict]] = {}
+    for table in [t['name'] for t in schema['tables']]:
+      rows = await conn.fetch(f'SELECT * FROM {table}')
+      data[table] = [dict(r) for r in rows]
+    dump = {'schema': schema, 'data': data}
+    ts = datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S')
+    filename = f'{prefix}_{ts}.json'
+    with open(filename, 'w') as f:
+      json.dump(dump, f, indent=2, default=str)
+    print(f'Data dumped to {filename}')
+  finally:
+    await conn.close()
+
+if __name__ == '__main__':
+  asyncio.run(main())

--- a/scripts/database_cli.py
+++ b/scripts/database_cli.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import os, json, asyncio, asyncpg, dotenv
+import os, json, asyncio, asyncpg, dotenv, datetime
 
 dotenv.load_dotenv()
 
@@ -12,6 +12,8 @@ Available commands:
   list columns <table>               List columns of a table
   list indexes <table>               List indexes on a table
   index all                          Reindex the current database
+  schema dump [name]                 Dump DB schema to name_TIMESTAMP.json
+  schema apply <file>                Apply schema JSON to the database
 """
 
 async def list_tables(conn):
@@ -35,6 +37,142 @@ async def list_indexes(conn, table):
     FROM pg_indexes WHERE tablename=$1;
   """
   return await conn.fetch(query, table)
+
+async def _table_schema(conn, table: str):
+  cols = await conn.fetch(
+    """
+      SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+      WHERE table_name=$1 AND table_schema='public'
+      ORDER BY ordinal_position;
+    """,
+    table,
+  )
+  pk = await conn.fetch(
+    """
+      SELECT a.attname
+      FROM pg_index i
+      JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+      WHERE i.indrelid = $1::regclass AND i.indisprimary;
+    """,
+    table,
+  )
+  fks = await conn.fetch(
+    """
+      SELECT kcu.column_name, ccu.table_name AS foreign_table_name,
+             ccu.column_name AS foreign_column_name
+      FROM information_schema.table_constraints AS tc
+      JOIN information_schema.key_column_usage AS kcu
+        ON tc.constraint_name = kcu.constraint_name
+       AND tc.table_schema = kcu.table_schema
+      JOIN information_schema.constraint_column_usage AS ccu
+        ON ccu.constraint_name = tc.constraint_name
+       AND ccu.table_schema = tc.table_schema
+      WHERE tc.constraint_type='FOREIGN KEY' AND tc.table_name=$1;
+    """,
+    table,
+  )
+  return {
+    'name': table,
+    'columns': [
+      {
+        'name': c['column_name'],
+        'type': c['data_type'],
+        'nullable': c['is_nullable'] == 'YES',
+        'default': c['column_default'],
+      }
+      for c in cols
+    ],
+    'primary_key': [r['attname'] for r in pk],
+    'foreign_keys': [
+      {
+        'column': fk['column_name'],
+        'ref_table': fk['foreign_table_name'],
+        'ref_column': fk['foreign_column_name'],
+      }
+      for fk in fks
+    ],
+  }
+
+async def get_schema(conn):
+  tables = await list_tables(conn)
+  schemas = {}
+  deps: dict[str, set[str]] = {}
+  for t in tables:
+    name = t['table_name']
+    info = await _table_schema(conn, name)
+    schemas[name] = info
+    deps[name] = {fk['ref_table'] for fk in info['foreign_keys']}
+
+  ordered: list[str] = []
+  visited: set[str] = set()
+
+  def visit(n: str):
+    if n in visited:
+      return
+    visited.add(n)
+    for d in deps.get(n, set()):
+      if d in deps:
+        visit(d)
+    ordered.append(n)
+
+  for t in deps.keys():
+    visit(t)
+
+  return {'tables': [schemas[n] for n in ordered]}
+
+def _build_create_sql(table: dict) -> str:
+  parts = []
+  for col in table['columns']:
+    line = f"{col['name']} {col['type']}"
+    if col['default'] is not None:
+      line += f" DEFAULT {col['default']}"
+    if not col['nullable']:
+      line += ' NOT NULL'
+    parts.append(line)
+  if table['primary_key']:
+    parts.append('PRIMARY KEY (' + ', '.join(table['primary_key']) + ')')
+  for fk in table['foreign_keys']:
+    parts.append(
+      f"FOREIGN KEY ({fk['column']}) REFERENCES {fk['ref_table']}({fk['ref_column']})"
+    )
+  cols = ', '.join(parts)
+  return f"CREATE TABLE IF NOT EXISTS {table['name']} ({cols});"
+
+async def dump_schema(conn, prefix: str = 'schema') -> str:
+  schema = await get_schema(conn)
+  ts = datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S')
+  filename = f"{prefix}_{ts}.json"
+  with open(filename, 'w') as f:
+    json.dump(schema, f, indent=2)
+  print(f'Schema dumped to {filename}')
+  return filename
+
+async def apply_schema(conn, path: str):
+  with open(path, 'r') as f:
+    schema = json.load(f)
+  async with conn.transaction():
+    for table in schema.get('tables', []):
+      exists = await conn.fetchval(
+        """SELECT 1 FROM information_schema.tables
+           WHERE table_schema='public' AND table_name=$1""",
+        table['name'],
+      )
+      if not exists:
+        await conn.execute(_build_create_sql(table))
+      else:
+        cols = await list_columns(conn, table['name'])
+        existing = {c['column_name'] for c in cols}
+        for col in table['columns']:
+          if col['name'] not in existing:
+            line = f"ALTER TABLE {table['name']} ADD COLUMN {col['name']} {col['type']}"
+            if col['default'] is not None:
+              line += f" DEFAULT {col['default']}"
+            if not col['nullable']:
+              line += ' NOT NULL'
+            line += ';'
+            await conn.execute(line)
+  print('Schema applied.')
 
 async def connect(dbname=None):
   dsn = os.getenv('POSTGRES_CONNECTION_STRING')
@@ -80,6 +218,15 @@ async def interactive_console(conn):
       case ['index', 'all']:
         await conn.execute('REINDEX DATABASE current_database()')
         print('Reindex complete.')
+      case ['schema', 'dump']:
+        await dump_schema(conn)
+      case ['schema', 'dump', name]:
+        await dump_schema(conn, name)
+      case ['schema', 'apply', file]:
+        try:
+          await apply_schema(conn, file)
+        except Exception as e:
+          print(f'Error applying schema: {e}')
       case _:
         try:
           rows = await conn.fetch(raw)


### PR DESCRIPTION
## Summary
- expand database_cli with schema dump/apply commands
- add helper functions to extract and apply schema
- include data_dump.py for basic backups
- document new utilities in README

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68797d82ebbc832584f82eef16e61422