### PR TITLE
Add schema upgrade utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ These items were previously implemented and are on the rebuild roadmap.
 - You must configure Always On and enable SCM Basic Auth Publishing Credentials for GitHub Actions.
 - Recommend using the Azure Web App Container Quickstart configuration.
 - Use Deployment Center to configure CI/CD from GitHub Actions post deploy, target build-ready repo.
+- Run `python scripts/upgrade_schema.py` to apply database migrations before deployment.
 
 ### Pull Request Testing
 GitHub Actions run both the Node and Python test suites whenever a pull request targets the `main` branch. The workflow is defined in `.github/workflows/pr-tests.yml`.

--- a/scripts/upgrade_schema.py
+++ b/scripts/upgrade_schema.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+import asyncio, dblib
+
+SCHEMA_FILE = 'scripts/v0.1.4.0_20250718.json'
+
+async def main() -> None:
+  try:
+    conn = await dblib.connect()
+    try:
+      await dblib.apply_schema(conn, SCHEMA_FILE)
+      print(f'Schema {SCHEMA_FILE} applied successfully.')
+    except Exception as e:
+      print(f'Error applying schema: {e}')
+    finally:
+      await conn.close()
+  except Exception as e:
+    print(f'Error connecting to database: {e}')
+
+if __name__ == '__main__':
+  asyncio.run(main())

--- a/scripts/v0.1.4.0_20250718.json
+++ b/scripts/v0.1.4.0_20250718.json
@@ -1,0 +1,260 @@
+{
+  "tables": [
+    {
+      "name": "routes",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('routes_id_seq'::regclass)"
+        },
+        {
+          "name": "path",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "icon",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "required_roles",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0"
+        },
+        {
+          "name": "sequence",
+          "type": "integer",
+          "nullable": true,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "config",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('config_id_seq'::regclass)"
+        },
+        {
+          "name": "key",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "value",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "auth_provider",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "links",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('links_id_seq'::regclass)"
+        },
+        {
+          "name": "title",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "url",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "users",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('users_id_seq'::regclass)"
+        },
+        {
+          "name": "guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "email",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "display_name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "auth_provider",
+          "type": "integer",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "email_verified",
+          "type": "boolean",
+          "nullable": true,
+          "default": "false"
+        },
+        {
+          "name": "primary_provider_id",
+          "type": "integer",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "privacy_flags",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0"
+        },
+        {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "nullable": true,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "nullable": true,
+          "default": "now()"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "auth_provider",
+          "ref_table": "auth_provider",
+          "ref_column": "id"
+        }
+      ]
+    },
+    {
+      "name": "users_credits",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "credits",
+          "type": "integer",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "user_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    },
+    {
+      "name": "users_auth",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "provider_id",
+          "type": "integer",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "provider_user_id",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "provider_id",
+        "provider_user_id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "provider_id",
+          "ref_table": "auth_provider",
+          "ref_column": "id"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add upgrade_schema.py for applying latest migration
- include new database migration v0.1.4.0
- document running upgrade_schema.py in deployment notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a93ed3c8083258f582742bfd4e10b