### PR TITLE
Implement capability permissions system

### DIFF
--- a/rpc/admin/links/services.py
+++ b/rpc/admin/links/services.py
@@ -3,13 +3,15 @@ from fastapi import Request
 from rpc.models import RPCResponse
 from rpc.admin.links.models import AdminLinksHome1, LinkItem, AdminLinksRoutes1, RouteItem
 from server.modules.database_module import DatabaseModule
+from server.modules.permcap_module import PermCapModule
 
 async def get_home_v1(request: Request) -> RPCResponse:
     db: DatabaseModule = request.app.state.database
-    data = await db.select_links()
-    links = [
-        LinkItem(title=row["title"], url=row["url"]) for row in data
-    ]
+    permcap: PermCapModule = request.app.state.permcap
+    role_mask = getattr(request.state, 'role_mask', 0)
+    data = await db.select_links(role_mask)
+    data = permcap.filter_routes(data, role_mask)
+    links = [LinkItem(title=row["title"], url=row["url"]) for row in data]
 
     payload = AdminLinksHome1(links=links)
     return RPCResponse(op="urn:admin:links:home:1", payload=payload, version=1)
@@ -17,10 +19,11 @@ async def get_home_v1(request: Request) -> RPCResponse:
 
 async def get_routes_v1(request: Request) -> RPCResponse:
   db: DatabaseModule = request.app.state.database
-  data = await db.select_routes()
-  routes = [
-    RouteItem(path=row['path'], name=row['name'], icon=row['icon']) for row in data
-  ]
+  permcap: PermCapModule = request.app.state.permcap
+  role_mask = getattr(request.state, 'role_mask', 0)
+  data = await db.select_routes(role_mask)
+  data = permcap.filter_routes(data, role_mask)
+  routes = [RouteItem(path=row['path'], name=row['name'], icon=row['icon']) for row in data]
 
   payload = AdminLinksRoutes1(routes=routes)
   return RPCResponse(op="urn:admin:links:routes:1", payload=payload, version=1)

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -1,0 +1,40 @@
+{
+  "rpc": [
+    {
+      "op": "urn:admin:links:get_home:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:admin:links:get_routes:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:admin:vars:get_ffmpeg_version:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:admin:vars:get_hostname:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:admin:vars:get_repo:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:admin:vars:get_version:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:auth:microsoft:user_login:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:frontend:user:get_profile_data:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:frontend:user:set_display_name:1",
+      "capabilities": 0
+    }
+  ]
+}

--- a/scripts/generate_rpc_metadata.py
+++ b/scripts/generate_rpc_metadata.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+import os, json
+from pathlib import Path
+from generate_rpc_client import parse_handler
+from genlib import REPO_ROOT
+
+RPC_ROOT = Path(REPO_ROOT) / 'rpc'
+METADATA_FILE = RPC_ROOT / 'metadata.json'
+
+
+def gather_ops() -> dict[str, int]:
+  metadata: dict[str, int] = {}
+  missing: list[str] = []
+  for root, dirs, files in os.walk(RPC_ROOT):
+    if 'handler.py' not in files:
+      continue
+    handler_path = os.path.join(root, 'handler.py')
+    base_parts, ops = parse_handler(handler_path)
+    for op in ops:
+      urn = ':'.join(['urn'] + base_parts + [op['op'], op['version']])
+      metadata.setdefault(urn, 0)
+  return metadata
+
+
+def load_existing() -> dict[str, int]:
+  if METADATA_FILE.exists():
+    with open(METADATA_FILE, 'r') as f:
+      data = json.load(f)
+    return {item['op']: item.get('capabilities', 0) for item in data.get('rpc', [])}
+  return {}
+
+
+def write_metadata(data: dict[str, int]):
+  out = {'rpc': [{'op': k, 'capabilities': v} for k, v in sorted(data.items())]}
+  METADATA_FILE.write_text(json.dumps(out, indent=2))
+
+
+def main() -> None:
+  ops = gather_ops()
+  existing = load_existing()
+  merged = {op: existing.get(op, cap) for op, cap in ops.items()}
+  missing = [op for op, cap in merged.items() if cap == 0]
+  write_metadata(merged)
+  if missing:
+    print('⚠️ Missing capability metadata for:')
+    for op in missing:
+      print(f'  - {op}')
+  else:
+    print('✅ RPC metadata written')
+
+
+if __name__ == '__main__':
+  main()
+

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -66,6 +66,7 @@ def main() -> None:
 
   subprocess.check_call([sys.executable, 'scripts/generate_rpc_library.py'], cwd=ROOT)
   subprocess.check_call([sys.executable, 'scripts/generate_rpc_client.py'], cwd=ROOT)
+  subprocess.check_call([sys.executable, 'scripts/generate_rpc_metadata.py'], cwd=ROOT)
   
   subprocess.check_call(['npm', 'run', 'lint'], cwd=ROOT / 'frontend')
   subprocess.check_call(['npm', 'run', 'type-check'], cwd=ROOT / 'frontend')

--- a/scripts/v0.1.5.0_20250719.json
+++ b/scripts/v0.1.5.0_20250719.json
@@ -1,0 +1,308 @@
+{
+  "tables": [
+    {
+      "name": "routes",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('routes_id_seq'::regclass)"
+        },
+        {
+          "name": "path",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "icon",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "required_roles",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0"
+        },
+        {
+          "name": "sequence",
+          "type": "integer",
+          "nullable": true,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "config",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('config_id_seq'::regclass)"
+        },
+        {
+          "name": "key",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "value",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "auth_provider",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "links",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('links_id_seq'::regclass)"
+        },
+        {
+          "name": "title",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "url",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "required_roles",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "users",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('users_id_seq'::regclass)"
+        },
+        {
+          "name": "guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "email",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "display_name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "display_email",
+          "type": "boolean",
+          "nullable": true,
+          "default": "false"
+        },
+        {
+          "name": "rotation_token",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "rotation_expires",
+          "type": "timestamp with time zone",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "auth_provider",
+          "type": "integer",
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "auth_provider",
+          "ref_table": "auth_provider",
+          "ref_column": "id"
+        }
+      ]
+    },
+    {
+      "name": "users_credits",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "credits",
+          "type": "integer",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "user_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    },
+    {
+      "name": "users_auth",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "provider_id",
+          "type": "integer",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "provider_user_id",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "provider_id",
+        "provider_user_id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "provider_id",
+          "ref_table": "auth_provider",
+          "ref_column": "id"
+        }
+      ]
+    },
+    {
+      "name": "users_roles",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "roles",
+          "type": "bigint",
+          "nullable": false,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "user_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    },
+    {
+      "name": "users_enablements",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "enablements",
+          "type": "bigint",
+          "nullable": false,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "user_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    }
+  ]
+}

--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -6,6 +6,7 @@ from server.modules.env_module import EnvironmentModule
 from server.modules.discord_module import DiscordModule
 from server.modules.database_module import DatabaseModule
 from server.modules.auth_module import AuthModule
+from server.modules.permcap_module import PermCapModule
 from server.helpers.logging import configure_root_logging
 
 @asynccontextmanager
@@ -22,6 +23,8 @@ async def lifespan(app: FastAPI):
   await app.state.discord.startup()
   app.state.auth = AuthModule(app)
   await app.state.auth.startup()
+  app.state.permcap = PermCapModule(app)
+  await app.state.permcap.startup()
 
   try:
     yield

--- a/server/modules/permcap_module.py
+++ b/server/modules/permcap_module.py
@@ -1,0 +1,37 @@
+import json, os
+from pathlib import Path
+from fastapi import FastAPI
+from . import BaseModule
+
+class PermCapModule(BaseModule):
+  def __init__(self, app: FastAPI, metadata_file: str | None = None):
+    super().__init__(app)
+    root = Path(__file__).resolve().parents[1]
+    self.metadata_file = metadata_file or os.path.join(root, 'rpc', 'metadata.json')
+    self.capabilities: dict[str, int] = {}
+
+  async def startup(self):
+    await self.load()
+
+  async def shutdown(self):
+    return
+
+  async def load(self):
+    try:
+      with open(self.metadata_file, 'r') as f:
+        data = json.load(f)
+      self.capabilities = {i['op']: i.get('capabilities', 0) for i in data.get('rpc', [])}
+    except FileNotFoundError:
+      self.capabilities = {}
+
+  def get_capabilities(self, op: str) -> int:
+    return self.capabilities.get(op, 0)
+
+  def filter_routes(self, routes: list[dict], role_mask: int) -> list[dict]:
+    allowed: list[dict] = []
+    for r in routes:
+      req_mask = r.get('required_roles') or 0
+      if req_mask == 0 or req_mask & role_mask == req_mask:
+        allowed.append(r)
+    return allowed
+

--- a/tests/test_rpc_admin_namespace.py
+++ b/tests/test_rpc_admin_namespace.py
@@ -8,7 +8,7 @@ from rpc.models import RPCRequest
 
 
 class DummyDB:
-    async def select_routes(self):
+    async def select_routes(self, role_mask=0):
         return [
             {
                 "id": 1,
@@ -19,12 +19,13 @@ class DummyDB:
                 "sequence": 10,
             }
         ]
-    async def select_links(self):
+    async def select_links(self, role_mask=0):
         return [
             {
                 "id": 1,
                 "title": "Discord",
                 "url": "https://link",
+                "required_roles": 0,
             }
         ]
 
@@ -34,6 +35,10 @@ class DummyDB:
             "Hostname": "unit-host",
             "Repo": "https://repo",
         }.get(key)
+
+class DummyPermCap:
+    def filter_routes(self, data, role_mask):
+        return data
 
 @pytest.fixture(autouse=True)
 def set_env(monkeypatch):
@@ -50,6 +55,7 @@ def app():
     # services do `request.app.state.env`, so set it here
     app.state.env = env_module
     app.state.database = DummyDB()
+    app.state.permcap = DummyPermCap()
     return app
 
 def test_get_version(app):
@@ -110,3 +116,4 @@ def test_get_routes(app):
     assert resp.op == "urn:admin:links:routes:1:view:default:1"
     assert len(resp.payload.routes) == 1
     assert resp.payload.routes[0].path == "/"
+


### PR DESCRIPTION
## Summary
- add new `users_roles` and `users_enablements` tables and expand `links`
- generate RPC metadata for capability checks
- add `PermCapModule` for permissions filtering
- filter admin links/routes by role mask
- record RPC metadata on generation
- include new tables in DB schema
- update tests

## Testing
- `pytest -q`
- `python scripts/generate_rpc_metadata.py`

------
https://chatgpt.com/codex/tasks/task_e_687c20fafb6883259a054ed030d3cffb