### PR TITLE
Implement admin user management

### DIFF
--- a/frontend/src/AdminUserPanel.tsx
+++ b/frontend/src/AdminUserPanel.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Box, Stack, Button, List, ListItemButton, ListItemText, IconButton } from '@mui/material';
+import { Box, Stack, Button, List, ListItemButton, ListItemText, IconButton, Typography, Avatar, TextField } from '@mui/material';
 import { ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
-import type { AdminUserRoles1 } from './shared/RpcModels';
-import { fetchRoles, fetchSetRoles, fetchListRoles } from './rpc/admin/users';
+import type { AdminUserRoles1, AdminUserProfile1 } from './shared/RpcModels';
+import { fetchRoles, fetchSetRoles, fetchListRoles, fetchProfile } from './rpc/admin/users';
 
 const AdminUserPanel = (): JSX.Element => {
     const { guid } = useParams();
     const [assigned, setAssigned] = useState<string[]>([]);
     const [available, setAvailable] = useState<string[]>([]);
+    const [profile, setProfile] = useState<AdminUserProfile1 | null>(null);
     const [selectedLeft, setSelectedLeft] = useState<string | null>(null);
     const [selectedRight, setSelectedRight] = useState<string | null>(null);
 
@@ -18,11 +19,14 @@ const AdminUserPanel = (): JSX.Element => {
             try {
                 const roles: AdminUserRoles1 = await fetchRoles({ userGuid: guid });
                 const all: AdminUserRoles1 = await fetchListRoles();
+                const prof: AdminUserProfile1 = await fetchProfile({ userGuid: guid });
                 setAssigned(roles.roles);
                 setAvailable(all.roles.filter(r => !roles.roles.includes(r)));
+                setProfile(prof);
             } catch {
                 setAssigned([]);
                 setAvailable([]);
+                setProfile(null);
             }
         })();
     }, [guid]);
@@ -47,7 +51,16 @@ const AdminUserPanel = (): JSX.Element => {
     };
 
     return (
-        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mt: 4 }}>
+            {profile && (
+                <Stack spacing={2} sx={{ mb: 4, alignItems: 'center' }}>
+                    <Typography variant='h5'>User Profile</Typography>
+                    <Avatar src={profile.profilePicture ?? undefined} sx={{ width: 80, height: 80 }} />
+                    <TextField label='Display Name' value={profile.username} InputProps={{ readOnly: true }} />
+                    <Typography>Email: {profile.email}</Typography>
+                    <Typography>Credits: {profile.credits ?? 0}</Typography>
+                </Stack>
+            )}
             <Stack direction='row' spacing={2}>
                 <List sx={{ width: 200, border: 1 }}>
                     {available.map((r) => (

--- a/frontend/src/AdminUsersPage.tsx
+++ b/frontend/src/AdminUsersPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Table, TableHead, TableRow, TableCell, TableBody, Button } from '@mui/material';
+import { Table, TableHead, TableRow, TableCell, TableBody, Button, Typography } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import type { UserListItem, AdminUsersList1 } from './shared/RpcModels';
 import { fetchList } from './rpc/admin/users';
@@ -19,24 +19,27 @@ const AdminUsersPage = (): JSX.Element => {
     }, []);
 
     return (
-        <Table>
-            <TableHead>
-                <TableRow>
-                    <TableCell>Display Name</TableCell>
-                    <TableCell>Actions</TableCell>
-                </TableRow>
-            </TableHead>
-            <TableBody>
-                {users.map((u) => (
-                    <TableRow key={u.guid}>
-                        <TableCell>{u.displayName}</TableCell>
-                        <TableCell>
-                            <Button component={RouterLink} to={`/admin_userpanel/${u.guid}`} variant='contained'>Edit</Button>
-                        </TableCell>
+        <>
+            <Typography variant='h5' sx={{ mb: 2 }}>User Administration</Typography>
+            <Table>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>Display Name</TableCell>
+                        <TableCell>Actions</TableCell>
                     </TableRow>
-                ))}
-            </TableBody>
-        </Table>
+                </TableHead>
+                <TableBody>
+                    {users.map((u) => (
+                        <TableRow key={u.guid}>
+                            <TableCell>{u.displayName}</TableCell>
+                            <TableCell>
+                                <Button component={RouterLink} to={`/admin_userpanel/${u.guid}`} variant='contained'>Edit</Button>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </>
     );
 };
 

--- a/frontend/src/rpc/admin/users/index.ts
+++ b/frontend/src/rpc/admin/users/index.ts
@@ -4,9 +4,10 @@
 // overwritten the next time the generator runs.
 // ================================================
 
-import { rpcCall, AdminUserRoles1, AdminUsersList1 } from '../../../shared/RpcModels';
+import { rpcCall, AdminUserProfile1, AdminUserRoles1, AdminUsersList1 } from '../../../shared/RpcModels';
 
 export const fetchList = (payload: any = null): Promise<AdminUsersList1> => rpcCall('urn:admin:users:list:1', payload);
 export const fetchRoles = (payload: any = null): Promise<AdminUserRoles1> => rpcCall('urn:admin:users:get_roles:1', payload);
 export const fetchSetRoles = (payload: any = null): Promise<AdminUserRoles1> => rpcCall('urn:admin:users:set_roles:1', payload);
 export const fetchListRoles = (payload: any = null): Promise<AdminUserRoles1> => rpcCall('urn:admin:users:list_roles:1', payload);
+export const fetchProfile = (payload: any = null): Promise<AdminUserProfile1> => rpcCall('urn:admin:users:get_profile:1', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -23,23 +23,6 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
-export interface FrontendUserProfileData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  storageUsed: number | null;
-  displayEmail: boolean;
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
-export interface FrontendUserSetDisplayName1 {
-  bearerToken: string;
-  displayName: string;
-}
 export interface AuthMicrosoftLoginData1 {
   bearerToken: string;
   defaultProvider: string;
@@ -48,21 +31,6 @@ export interface AuthMicrosoftLoginData1 {
   backupEmail: string | null;
   profilePicture: string | null;
   credits: number | null;
-}
-export interface AdminLinksHome1 {
-  links: LinkItem[];
-}
-export interface AdminLinksRoutes1 {
-  routes: RouteItem[];
-}
-export interface LinkItem {
-  title: string;
-  url: string;
-}
-export interface RouteItem {
-  path: string;
-  name: string;
-  icon: string;
 }
 export interface AdminVarsFfmpegVersion1 {
   ffmpeg_version: string;
@@ -79,6 +47,34 @@ export interface AdminVarsVersion1 {
 export interface ViewDiscord1 {
   content: string;
 }
+export interface AdminLinksHome1 {
+  links: LinkItem[];
+}
+export interface AdminLinksRoutes1 {
+  routes: RouteItem[];
+}
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+export interface RouteItem {
+  path: string;
+  name: string;
+  icon: string;
+}
+export interface AdminUserProfile1 {
+  guid: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: any;
+  profilePicture: any;
+  credits: any;
+  storageUsed: any;
+  displayEmail: boolean;
+  rotationToken: any;
+  rotationExpires: any;
+}
 export interface AdminUserRoles1 {
   roles: string[];
 }
@@ -91,6 +87,23 @@ export interface AdminUsersList1 {
 }
 export interface UserListItem {
   guid: string;
+  displayName: string;
+}
+export interface FrontendUserProfileData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  storageUsed: number | null;
+  displayEmail: boolean;
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface FrontendUserSetDisplayName1 {
+  bearerToken: string;
   displayName: string;
 }
 

--- a/frontend/tests/rpcClient.test.ts
+++ b/frontend/tests/rpcClient.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import axios from 'axios';
 import { fetchVersion, fetchHostname, fetchRepo, fetchFfmpegVersion } from '../src/rpc/admin/vars';
 import { fetchHome, fetchRoutes } from '../src/rpc/admin/links';
+import { fetchList as fetchUsers, fetchProfile } from '../src/rpc/admin/users';
 
 vi.mock('axios');
 const mockedPost = axios.post as unknown as ReturnType<typeof vi.fn>;
@@ -47,5 +48,19 @@ describe('rpcClient', () => {
         const res = await fetchRoutes();
         expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:links:get_routes:1' }));
         expect(Array.isArray(res.routes)).toBe(true);
+    });
+
+    it('fetchUsers posts correct request', async () => {
+        mockedPost.mockResolvedValueOnce({ data: { payload: { users: [] } } });
+        const res = await fetchUsers();
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:users:list:1' }));
+        expect(Array.isArray(res.users)).toBe(true);
+    });
+
+    it('fetchProfile posts correct request', async () => {
+        mockedPost.mockResolvedValueOnce({ data: { payload: { email: 'e' } } });
+        const res = await fetchProfile({ userGuid: 'uid' });
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:users:get_profile:1' }));
+        expect(res.email).toBe('e');
     });
 });

--- a/migrations/20250720_add_admin_userpanel_route.sql
+++ b/migrations/20250720_add_admin_userpanel_route.sql
@@ -1,3 +1,0 @@
-INSERT INTO routes (path, name, icon, required_roles, sequence)
-VALUES ('/admin_userpanel', 'User Admin', 'menu', 0, 50)
-ON CONFLICT (path) DO NOTHING;

--- a/rpc/admin/users/handler.py
+++ b/rpc/admin/users/handler.py
@@ -12,5 +12,7 @@ async def handle_users_request(parts: list[str], rpc_request: RPCRequest | None,
       return await services.set_user_roles_v1(rpc_request, request)
     case ["list_roles", "1"]:
       return await services.list_available_roles_v1(request)
+    case ["get_profile", "1"]:
+      return await services.get_user_profile_v1(rpc_request, request)
     case _:
       raise HTTPException(status_code=404, detail='Unknown RPC operation')

--- a/rpc/admin/users/models.py
+++ b/rpc/admin/users/models.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from datetime import datetime
 
 class UserListItem(BaseModel):
   guid: str
@@ -13,3 +14,16 @@ class AdminUserRoles1(BaseModel):
 class AdminUserRolesUpdate1(BaseModel):
   userGuid: str
   roles: list[str]
+
+class AdminUserProfile1(BaseModel):
+  guid: str
+  defaultProvider: str
+  username: str
+  email: str
+  backupEmail: str | None = None
+  profilePicture: str | None = None
+  credits: int | None = None
+  storageUsed: int | None = None
+  displayEmail: bool = False
+  rotationToken: str | None = None
+  rotationExpires: datetime | None = None

--- a/rpc/admin/users/services.py
+++ b/rpc/admin/users/services.py
@@ -1,13 +1,19 @@
 from fastapi import Request, HTTPException
 from rpc.models import RPCRequest, RPCResponse
-from rpc.admin.users.models import AdminUsersList1, UserListItem, AdminUserRoles1, AdminUserRolesUpdate1
+from rpc.admin.users.models import (
+  AdminUsersList1,
+  UserListItem,
+  AdminUserRoles1,
+  AdminUserRolesUpdate1,
+  AdminUserProfile1,
+)
 from server.modules.database_module import DatabaseModule
 from server.helpers.roles import mask_to_names, names_to_mask, ROLE_NAMES
 
 async def get_users_v1(request: Request) -> RPCResponse:
   db: DatabaseModule = request.app.state.database
   rows = await db.select_users()
-  users = [UserListItem(guid=r['guid'], displayName=r['display_name']) for r in rows]
+  users = [UserListItem(guid=str(r['guid']), displayName=r['display_name']) for r in rows]
   payload = AdminUsersList1(users=users)
   return RPCResponse(op='urn:admin:users:list:1', payload=payload, version=1)
 
@@ -34,3 +40,27 @@ async def set_user_roles_v1(rpc_request: RPCRequest, request: Request) -> RPCRes
 async def list_available_roles_v1(request: Request) -> RPCResponse:
   payload = AdminUserRoles1(roles=ROLE_NAMES)
   return RPCResponse(op='urn:admin:users:list_roles:1', payload=payload, version=1)
+
+async def get_user_profile_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
+  payload = rpc_request.payload or {}
+  guid = payload.get('userGuid')
+  if not guid:
+    raise HTTPException(status_code=400, detail='Missing userGuid')
+  db: DatabaseModule = request.app.state.database
+  user = await db.get_user_profile(guid)
+  if not user:
+    raise HTTPException(status_code=404, detail='User not found')
+  payload = AdminUserProfile1(
+    guid=str(user.get('guid')),
+    defaultProvider=user.get('provider_name', 'microsoft'),
+    username=user.get('display_name', ''),
+    email=user.get('email', ''),
+    backupEmail=None,
+    profilePicture=None,
+    credits=user.get('credits', 0),
+    storageUsed=user.get('storage_used', 0),
+    displayEmail=user.get('display_email', False),
+    rotationToken=user.get('rotation_token'),
+    rotationExpires=user.get('rotation_expires'),
+  )
+  return RPCResponse(op='urn:admin:users:get_profile:1', payload=payload, version=1)

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -9,6 +9,10 @@
       "capabilities": 0
     },
     {
+      "op": "urn:admin:users:get_profile:1",
+      "capabilities": 0
+    },
+    {
       "op": "urn:admin:users:get_roles:1",
       "capabilities": 0
     },

--- a/tests/test_rpc_admin_namespace.py
+++ b/tests/test_rpc_admin_namespace.py
@@ -36,6 +36,21 @@ class DummyDB:
             "Repo": "https://repo",
         }.get(key)
 
+    async def select_users(self):
+        return [{"guid": "uid", "display_name": "User"}]
+
+    async def get_user_profile(self, guid):
+        return {
+            "guid": guid,
+            "display_name": "User",
+            "email": "u@example.com",
+            "display_email": False,
+            "credits": 0,
+            "provider_name": "microsoft",
+            "rotation_token": None,
+            "rotation_expires": None,
+        }
+
 class DummyPermCap:
     def filter_routes(self, data, role_mask):
         return data
@@ -116,4 +131,21 @@ def test_get_routes(app):
     assert resp.op == "urn:admin:links:routes:1:view:default:1"
     assert len(resp.payload.routes) == 1
     assert resp.payload.routes[0].path == "/"
+
+def test_get_users(app):
+    request = Request({"type": "http", "app": app})
+    rpc_request = RPCRequest(op="urn:admin:users:list:1")
+    resp = asyncio.run(handle_rpc_request(rpc_request, request))
+
+    assert resp.op == "urn:admin:users:list:1:view:default:1"
+    assert len(resp.payload.users) == 1
+    assert resp.payload.users[0].displayName == "User"
+
+def test_get_user_profile(app):
+    request = Request({"type": "http", "app": app})
+    rpc_request = RPCRequest(op="urn:admin:users:get_profile:1", payload={"userGuid": "uid"})
+    resp = asyncio.run(handle_rpc_request(rpc_request, request))
+
+    assert resp.op == "urn:admin:users:get_profile:1:view:default:1"
+    assert resp.payload.email == "u@example.com"
 


### PR DESCRIPTION
## Summary
- add user profile models and service routes under admin
- generate metadata and TS client code
- show admin user list with title and profile editor
- support viewing profile info with role boxes
- clean up obsolete migrations
- expand tests for new rpc routes
- fix string conversion of user GUID in admin services

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_687d8d8b65ec832584408cb03a9ae952