### PR TITLE
Enable editing credits in admin panel

### DIFF
--- a/frontend/src/AdminUserPanel.tsx
+++ b/frontend/src/AdminUserPanel.tsx
@@ -3,13 +3,14 @@ import { useParams } from 'react-router-dom';
 import { Box, Stack, Button, List, ListItemButton, ListItemText, IconButton, Typography, Avatar, TextField } from '@mui/material';
 import { ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
 import type { AdminUserRoles1, AdminUserProfile1 } from './shared/RpcModels';
-import { fetchRoles, fetchSetRoles, fetchListRoles, fetchProfile } from './rpc/admin/users';
+import { fetchRoles, fetchSetRoles, fetchListRoles, fetchProfile, fetchSetCredits } from './rpc/admin/users';
 
 const AdminUserPanel = (): JSX.Element => {
     const { guid } = useParams();
     const [assigned, setAssigned] = useState<string[]>([]);
     const [available, setAvailable] = useState<string[]>([]);
     const [profile, setProfile] = useState<AdminUserProfile1 | null>(null);
+    const [credits, setCredits] = useState<number>(0);
     const [selectedLeft, setSelectedLeft] = useState<string | null>(null);
     const [selectedRight, setSelectedRight] = useState<string | null>(null);
 
@@ -23,6 +24,7 @@ const AdminUserPanel = (): JSX.Element => {
                 setAssigned(roles.roles);
                 setAvailable(all.roles.filter(r => !roles.roles.includes(r)));
                 setProfile(prof);
+                setCredits(prof.credits ?? 0);
             } catch {
                 setAssigned([]);
                 setAvailable([]);
@@ -48,6 +50,7 @@ const AdminUserPanel = (): JSX.Element => {
     const handleSave = async (): Promise<void> => {
         if (!guid) return;
         await fetchSetRoles({ userGuid: guid, roles: assigned });
+        await fetchSetCredits({ userGuid: guid, credits });
     };
 
     return (
@@ -58,7 +61,7 @@ const AdminUserPanel = (): JSX.Element => {
                     <Avatar src={profile.profilePicture ?? undefined} sx={{ width: 80, height: 80 }} />
                     <TextField label='Display Name' value={profile.username} InputProps={{ readOnly: true }} />
                     <Typography>Email: {profile.email}</Typography>
-                    <Typography>Credits: {profile.credits ?? 0}</Typography>
+                    <TextField label='Credits' type='number' value={credits} onChange={e => setCredits(Number(e.target.value))} />
                 </Stack>
             )}
             <Stack direction='row' spacing={2}>

--- a/frontend/src/rpc/admin/users/index.ts
+++ b/frontend/src/rpc/admin/users/index.ts
@@ -11,3 +11,4 @@ export const fetchRoles = (payload: any = null): Promise<AdminUserRoles1> => rpc
 export const fetchSetRoles = (payload: any = null): Promise<AdminUserRoles1> => rpcCall('urn:admin:users:set_roles:1', payload);
 export const fetchListRoles = (payload: any = null): Promise<AdminUserRoles1> => rpcCall('urn:admin:users:list_roles:1', payload);
 export const fetchProfile = (payload: any = null): Promise<AdminUserProfile1> => rpcCall('urn:admin:users:get_profile:1', payload);
+export const fetchSetCredits = (payload: any = null): Promise<AdminUserProfile1> => rpcCall('urn:admin:users:set_credits:1', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -23,6 +23,23 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
+export interface FrontendUserProfileData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  storageUsed: number | null;
+  displayEmail: boolean;
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface FrontendUserSetDisplayName1 {
+  bearerToken: string;
+  displayName: string;
+}
 export interface AuthMicrosoftLoginData1 {
   bearerToken: string;
   defaultProvider: string;
@@ -31,6 +48,37 @@ export interface AuthMicrosoftLoginData1 {
   backupEmail: string | null;
   profilePicture: string | null;
   credits: number | null;
+}
+export interface AdminUserCreditsUpdate1 {
+  userGuid: string;
+  credits: number;
+}
+export interface AdminUserProfile1 {
+  guid: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: any;
+  profilePicture: any;
+  credits: any;
+  storageUsed: any;
+  displayEmail: boolean;
+  rotationToken: any;
+  rotationExpires: any;
+}
+export interface AdminUserRoles1 {
+  roles: string[];
+}
+export interface AdminUserRolesUpdate1 {
+  userGuid: string;
+  roles: string[];
+}
+export interface AdminUsersList1 {
+  users: UserListItem[];
+}
+export interface UserListItem {
+  guid: string;
+  displayName: string;
 }
 export interface AdminVarsFfmpegVersion1 {
   ffmpeg_version: string;
@@ -61,50 +109,6 @@ export interface RouteItem {
   path: string;
   name: string;
   icon: string;
-}
-export interface AdminUserProfile1 {
-  guid: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: any;
-  profilePicture: any;
-  credits: any;
-  storageUsed: any;
-  displayEmail: boolean;
-  rotationToken: any;
-  rotationExpires: any;
-}
-export interface AdminUserRoles1 {
-  roles: string[];
-}
-export interface AdminUserRolesUpdate1 {
-  userGuid: string;
-  roles: string[];
-}
-export interface AdminUsersList1 {
-  users: UserListItem[];
-}
-export interface UserListItem {
-  guid: string;
-  displayName: string;
-}
-export interface FrontendUserProfileData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  storageUsed: number | null;
-  displayEmail: boolean;
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
-export interface FrontendUserSetDisplayName1 {
-  bearerToken: string;
-  displayName: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/admin/users/handler.py
+++ b/rpc/admin/users/handler.py
@@ -14,5 +14,7 @@ async def handle_users_request(parts: list[str], rpc_request: RPCRequest | None,
       return await services.list_available_roles_v1(request)
     case ["get_profile", "1"]:
       return await services.get_user_profile_v1(rpc_request, request)
+    case ["set_credits", "1"]:
+      return await services.set_user_credits_v1(rpc_request, request)
     case _:
       raise HTTPException(status_code=404, detail='Unknown RPC operation')

--- a/rpc/admin/users/models.py
+++ b/rpc/admin/users/models.py
@@ -15,6 +15,10 @@ class AdminUserRolesUpdate1(BaseModel):
   userGuid: str
   roles: list[str]
 
+class AdminUserCreditsUpdate1(BaseModel):
+  userGuid: str
+  credits: int
+
 class AdminUserProfile1(BaseModel):
   guid: str
   defaultProvider: str

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -25,6 +25,10 @@
       "capabilities": 0
     },
     {
+      "op": "urn:admin:users:set_credits:1",
+      "capabilities": 0
+    },
+    {
       "op": "urn:admin:users:set_roles:1",
       "capabilities": 0
     },

--- a/server/modules/database_module.py
+++ b/server/modules/database_module.py
@@ -228,3 +228,10 @@ class DatabaseModule(BaseModule):
       "ON CONFLICT(user_guid) DO UPDATE SET roles=excluded.roles;"
     )
     await self._run(query, guid, roles)
+
+  async def set_user_credits(self, guid: str, credits: int):
+    query = (
+      "INSERT INTO users_credits(user_guid, credits) VALUES($1, $2) "
+      "ON CONFLICT(user_guid) DO UPDATE SET credits=excluded.credits;"
+    )
+    await self._run(query, guid, credits)

--- a/tests/test_rpc_admin_namespace.py
+++ b/tests/test_rpc_admin_namespace.py
@@ -45,11 +45,14 @@ class DummyDB:
             "display_name": "User",
             "email": "u@example.com",
             "display_email": False,
-            "credits": 0,
+            "credits": getattr(self, "credits", 0),
             "provider_name": "microsoft",
             "rotation_token": None,
             "rotation_expires": None,
         }
+
+    async def set_user_credits(self, guid, credits):
+        self.credits = credits
 
 class DummyPermCap:
     def filter_routes(self, data, role_mask):
@@ -148,4 +151,12 @@ def test_get_user_profile(app):
 
     assert resp.op == "urn:admin:users:get_profile:1:view:default:1"
     assert resp.payload.email == "u@example.com"
+
+def test_set_user_credits(app):
+    request = Request({"type": "http", "app": app})
+    rpc_request = RPCRequest(op="urn:admin:users:set_credits:1", payload={"userGuid": "uid", "credits": 100})
+    resp = asyncio.run(handle_rpc_request(rpc_request, request))
+
+    assert resp.op == "urn:admin:users:set_credits:1:view:default:1"
+    assert resp.payload.credits == 100
 


### PR DESCRIPTION
## Summary
- allow admins to change user credit amounts
- wire new RPC endpoint and update metadata
- regenerate RPC client and models
- provide editable credits field in the admin user panel
- test the new admin credits flow

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_687dafd477e4832590ab7d0a3f607608