### PR TITLE
Add icon reference page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import LoginPage from './LoginPage'
 import UserPage from './UserPage'
 import AdminUsersPage from './AdminUsersPage'
 import AdminUserPanel from './AdminUserPanel'
+import Icons from './Icons'
 
 function App(): JSX.Element {
 	return (
@@ -32,8 +33,9 @@ function App(): JSX.Element {
                                                         <Route path='/userpanel' element={<UserPage />} />
                                                         <Route path='/admin_userpanel' element={<AdminUsersPage />} />
                                                         <Route path='/admin_userpanel/:guid' element={<AdminUserPanel />} />
+                                                        <Route path='/icons' element={<Icons />} />
                                                 </Routes>
-					</Container>
+                                        </Container>
 				</Router>
 			</UserContextProvider>
 		</ThemeProvider>

--- a/frontend/src/Icons.tsx
+++ b/frontend/src/Icons.tsx
@@ -1,0 +1,29 @@
+import { Box, Table, TableHead, TableRow, TableCell, TableBody } from '@mui/material';
+import { iconMap } from './icons';
+
+const Icons = (): JSX.Element => {
+    return (
+        <Box sx={{ mt: 2 }}>
+            <Table>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>Icon</TableCell>
+                        <TableCell>Name</TableCell>
+                        <TableCell>Alias</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {Object.entries(iconMap).map(([alias, IconComp]) => (
+                        <TableRow key={alias}>
+                            <TableCell><IconComp /></TableCell>
+                            <TableCell>{alias.charAt(0).toUpperCase() + alias.slice(1) + 'Icon'}</TableCell>
+                            <TableCell>{alias}</TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </Box>
+    );
+};
+
+export default Icons;


### PR DESCRIPTION
## Summary
- add `Icons` page to display icon mappings
- link page to `/icons` route

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_687e5220d144832594ddfdc2f8902612