### PR TITLE
Fix logout session clearing and fetch invalidate

### DIFF
--- a/frontend/src/shared/Login.tsx
+++ b/frontend/src/shared/Login.tsx
@@ -4,6 +4,7 @@ import { Login as LoginIcon } from '@mui/icons-material';
 import { Typography, Box, Tooltip, IconButton, ListItemText } from '@mui/material';
 import { PublicClientApplication } from '@azure/msal-browser';
 import { msalConfig } from '../config/msal';
+import { fetchInvalidate } from '../rpc/auth/session';
 import Notification from './Notification';
 import UserContext from './UserContext';
 
@@ -30,16 +31,23 @@ const Login = ({ open }: LoginProps): JSX.Element => {
 		navigate('/login');
 	};
 
-	const handleLogout = async (): Promise<void> => {
-		try {
-			await pca.initialize();
-			await pca.logoutPopup();
-			clearUserData();
-			setNotification({ open: true, severity: 'info', message: 'Logged out successfully.' });
-		} catch (error: any) {
-			setNotification({ open: true, severity: 'error', message: `Logout failed: ${error.message}` });
-		}
-	};
+        const handleLogout = async (): Promise<void> => {
+                try {
+                        await pca.initialize();
+                        await pca.logoutPopup();
+                        if (userData?.rotationToken) {
+                                try {
+                                        await fetchInvalidate({ rotationToken: userData.rotationToken });
+                                } catch (err) {
+                                        console.error('Failed to invalidate session', err);
+                                }
+                        }
+                        clearUserData();
+                        setNotification({ open: true, severity: 'info', message: 'Logged out successfully.' });
+                } catch (error: any) {
+                        setNotification({ open: true, severity: 'error', message: `Logout failed: ${error.message}` });
+                }
+        };
 
 	return (
 		<Box sx={{ display: 'flex', alignItems: 'center' }}>

--- a/frontend/src/shared/UserContextProvider.tsx
+++ b/frontend/src/shared/UserContextProvider.tsx
@@ -47,7 +47,8 @@ const UserContextProvider = ({ children }: UserContextProviderProps): JSX.Elemen
         }, []);
 
         const clearUserData = () => {
-        setUserData(null);
+                localStorage.removeItem('authTokens');
+                setUserData(null);
         };
 
   	return (


### PR DESCRIPTION
## Summary
- improve logout to invalidate session and remove auth tokens
- ensure clearUserData removes stored session data

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_687e846b2f688325a9077f96a213d23a