### PR TITLE
Fix profile picture not caching

### DIFF
--- a/tests/test_rpc_microsoft_service.py
+++ b/tests/test_rpc_microsoft_service.py
@@ -49,3 +49,20 @@ def test_user_login_v1():
   assert resp.payload.bearerToken == 'token'
   assert resp.payload.rotationToken == 'rtoken'
 
+
+class DummyAuthImage(DummyAuth):
+  async def fetch_ms_user_profile(self, act):
+    return {'email': 'e', 'username': 'u', 'profilePicture': 'img'}
+
+
+def test_user_login_profile_update():
+  app = FastAPI()
+  auth = DummyAuthImage()
+  db = DummyDB()
+  app.state.auth = auth
+  app.state.database = db
+  req = Request({'type': 'http', 'app': app})
+  rpc_req = RPCRequest(op='op', payload={'idToken': 'id', 'accessToken': 'ac', 'provider': 'microsoft'})
+  asyncio.run(services.user_login_v1(rpc_req, req))
+  assert db.image == ('uid', 'img')
+


### PR DESCRIPTION
## Summary
- update Microsoft login service to always fetch and store the user's profile picture
- test that profile picture data is stored on login

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_687e907d3fd883258f0c14c5280e840f