### PR TITLE
Add database roles table

### DIFF
--- a/scripts/load_roles.py
+++ b/scripts/load_roles.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+import asyncio
+from dblib import connect
+from server.helpers.roles import ROLE_DEFAULTS
+
+async def main() -> None:
+  conn = await connect()
+  async with conn.transaction():
+    for name, mask in ROLE_DEFAULTS.items():
+      await conn.execute(
+        "INSERT INTO roles(name, mask) VALUES($1, $2) "
+        "ON CONFLICT(name) DO UPDATE SET mask=excluded.mask;",
+        name,
+        mask,
+      )
+  await conn.close()
+  print("Roles loaded.")
+
+if __name__ == '__main__':
+  asyncio.run(main())

--- a/scripts/v0.2.1.0_20250722.json
+++ b/scripts/v0.2.1.0_20250722.json
@@ -1,0 +1,407 @@
+{
+  "tables": [
+    {
+      "name": "routes",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('routes_id_seq'::regclass)"
+        },
+        {
+          "name": "path",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "icon",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "required_roles",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0"
+        },
+        {
+          "name": "sequence",
+          "type": "integer",
+          "nullable": true,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "auth_provider",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+    "foreign_keys": []
+  },
+    {
+      "name": "roles",
+      "columns": [
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "mask",
+          "type": "bigint",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "name"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "users",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('users_id_seq'::regclass)"
+        },
+        {
+          "name": "guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "email",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "display_name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "auth_provider",
+          "type": "integer",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "display_email",
+          "type": "boolean",
+          "nullable": true,
+          "default": "false"
+        },
+        {
+          "name": "rotation_token",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "rotation_expires",
+          "type": "timestamp with time zone",
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "auth_provider",
+          "ref_table": "auth_provider",
+          "ref_column": "id"
+        }
+      ]
+    },
+    {
+      "name": "users_profileimg",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "image_b64",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "user_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    },
+    {
+      "name": "config",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('config_id_seq'::regclass)"
+        },
+        {
+          "name": "key",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "value",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "links",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('links_id_seq'::regclass)"
+        },
+        {
+          "name": "title",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "url",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "required_roles",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "users_credits",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "credits",
+          "type": "integer",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "user_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    },
+    {
+      "name": "users_roles",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "roles",
+          "type": "bigint",
+          "nullable": false,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "user_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    },
+    {
+      "name": "users_enablements",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "enablements",
+          "type": "bigint",
+          "nullable": false,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "user_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    },
+    {
+      "name": "users_auth",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "provider_id",
+          "type": "integer",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "provider_user_id",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "provider_id",
+        "provider_user_id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "provider_id",
+          "ref_table": "auth_provider",
+          "ref_column": "id"
+        }
+      ]
+    },
+    {
+      "name": "user_sessions",
+      "columns": [
+        {
+          "name": "session_id",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "bearer_token",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "rotation_token",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "session_id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    }
+  ]
+}

--- a/server/helpers/roles.py
+++ b/server/helpers/roles.py
@@ -2,21 +2,38 @@
 # the Postgres ``BIGINT`` type. Using ``0x8000000000000000`` would flip the sign
 # bit, so the highest role begins at ``0x4000000000000000`` and the remaining
 # roles shift down from there.
-ROLE_SERVICE_ADMIN = 0x4000000000000000
-ROLE_SYSTEM_ADMIN = 0x2000000000000000
-ROLE_MODERATOR = 0x0800000000000000
-ROLE_SUPPORT = 0x0400000000000000
-ROLE_REGISTERED = 0x0000000000000001
+from typing import TYPE_CHECKING
 
-ROLES = {
-  'ROLE_SERVICE_ADMIN': ROLE_SERVICE_ADMIN,
-  'ROLE_SYSTEM_ADMIN': ROLE_SYSTEM_ADMIN,
-  'ROLE_MODERATOR': ROLE_MODERATOR,
-  'ROLE_SUPPORT': ROLE_SUPPORT,
-  'ROLE_REGISTERED': ROLE_REGISTERED,
+if TYPE_CHECKING:
+  from server.modules.database_module import DatabaseModule
+
+ROLE_DEFAULTS = {
+  'ROLE_SERVICE_ADMIN': 0x4000000000000000,
+  'ROLE_SYSTEM_ADMIN': 0x2000000000000000,
+  'ROLE_MODERATOR': 0x0800000000000000,
+  'ROLE_SUPPORT': 0x0400000000000000,
+  'ROLE_REGISTERED': 0x0000000000000001,
 }
 
+ROLES = ROLE_DEFAULTS.copy()
+
+ROLE_SERVICE_ADMIN = ROLES['ROLE_SERVICE_ADMIN']
+ROLE_SYSTEM_ADMIN = ROLES['ROLE_SYSTEM_ADMIN']
+ROLE_MODERATOR = ROLES['ROLE_MODERATOR']
+ROLE_SUPPORT = ROLES['ROLE_SUPPORT']
+ROLE_REGISTERED = ROLES['ROLE_REGISTERED']
+
 ROLE_NAMES = [name for name in ROLES.keys() if name != 'ROLE_REGISTERED']
+
+def _refresh_globals():
+  globals().update({
+    'ROLE_SERVICE_ADMIN': ROLES.get('ROLE_SERVICE_ADMIN', 0),
+    'ROLE_SYSTEM_ADMIN': ROLES.get('ROLE_SYSTEM_ADMIN', 0),
+    'ROLE_MODERATOR': ROLES.get('ROLE_MODERATOR', 0),
+    'ROLE_SUPPORT': ROLES.get('ROLE_SUPPORT', 0),
+    'ROLE_REGISTERED': ROLES.get('ROLE_REGISTERED', 0),
+    'ROLE_NAMES': [n for n in ROLES.keys() if n != 'ROLE_REGISTERED'],
+  })
 
 def mask_to_names(mask: int) -> list[str]:
   return [name for name, bit in ROLES.items() if mask & bit]
@@ -26,3 +43,11 @@ def names_to_mask(names: list[str]) -> int:
   for name in names:
     mask |= ROLES.get(name, 0)
   return mask
+
+async def load_from_db(db: 'DatabaseModule') -> None:
+  rows = await db._fetch_many('SELECT name, mask FROM roles;')
+  if rows:
+    ROLES.clear()
+    for r in rows:
+      ROLES[r['name']] = int(r['mask'])
+    _refresh_globals()

--- a/server/modules/database_module.py
+++ b/server/modules/database_module.py
@@ -41,6 +41,12 @@ class DatabaseModule(BaseModule):
     dsn = self._db_connection_string()
     if dsn:
       self.pool = await asyncpg.create_pool(dsn=dsn)
+      from server.helpers import roles as role_helper
+      if hasattr(self.pool, 'acquire'):
+        try:
+          await role_helper.load_from_db(self)
+        except Exception:
+          logging.exception('Failed loading roles from database')
       logging.info("Database module loaded")
 
   async def shutdown(self):


### PR DESCRIPTION
## Summary
- add `roles` table to database schema
- expose defaults and async loading API in `server.helpers.roles`
- load roles during DB module startup
- add data loading script `load_roles.py`

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_687eccc48700832586cf522c34cd5c64