### PR TITLE
Update admin roles to apply ROLE_REGISTERED

### DIFF
--- a/rpc/admin/users/services.py
+++ b/rpc/admin/users/services.py
@@ -9,7 +9,12 @@ from rpc.admin.users.models import (
   AdminUserProfile1,
 )
 from server.modules.database_module import DatabaseModule, _utos
-from server.helpers.roles import mask_to_names, names_to_mask, ROLE_NAMES
+from server.helpers.roles import (
+  mask_to_names,
+  names_to_mask,
+  ROLE_NAMES,
+  ROLE_REGISTERED,
+)
 
 async def get_users_v1(request: Request) -> RPCResponse:
   db: DatabaseModule = request.app.state.database
@@ -33,13 +38,16 @@ async def set_user_roles_v1(rpc_request: RPCRequest, request: Request) -> RPCRes
   payload = rpc_request.payload or {}
   data = AdminUserRolesUpdate1(**payload)
   db: DatabaseModule = request.app.state.database
-  mask = names_to_mask(data.roles)
+  mask = names_to_mask(data.roles) | ROLE_REGISTERED
   await db.set_user_roles(data.userGuid, mask)
-  payload = AdminUserRoles1(roles=data.roles)
+  payload = AdminUserRoles1(roles=mask_to_names(mask))
   return RPCResponse(op='urn:admin:users:set_roles:1', payload=payload, version=1)
 
 async def list_available_roles_v1(request: Request) -> RPCResponse:
-  payload = AdminUserRoles1(roles=ROLE_NAMES)
+  db: DatabaseModule = request.app.state.database
+  rows = await db.list_roles()
+  names = [r['name'] for r in rows]
+  payload = AdminUserRoles1(roles=names)
   return RPCResponse(op='urn:admin:users:list_roles:1', payload=payload, version=1)
 
 async def get_user_profile_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:


### PR DESCRIPTION
## Summary
- always include ROLE_REGISTERED when assigning user roles
- list all roles, including ROLE_REGISTERED, when populating admin role options

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_687efb33ba308325b6be49f5217c650f