### PR TITLE
Update NavBar to refresh routes on login

### DIFF
--- a/frontend/src/NavBar.tsx
+++ b/frontend/src/NavBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
 import {
 	Drawer,
@@ -15,24 +15,26 @@ import type { RouteItem, AdminLinksRoutes1 } from './shared/RpcModels';
 import { fetchRoutes } from './rpc/admin/links';
 import { iconMap, defaultIcon } from './icons';
 import Login from './shared/Login';
+import UserContext from './shared/UserContext';
 
 const DRAWER_OPEN = 240;
 const DRAWER_CLOSED = 60;
 
 const NavBar = (): JSX.Element => {
-	const [open, setOpen] = useState(false);
-	const [routes, setRoutes] = useState<RouteItem[]>([]);
+        const [open, setOpen] = useState(false);
+        const [routes, setRoutes] = useState<RouteItem[]>([]);
+        const { userData } = useContext(UserContext);
 
-	useEffect(() => {
-		void (async () => {
-			try {
-				const res: AdminLinksRoutes1 = await fetchRoutes();
-				setRoutes(res.routes);
-			} catch {
-				setRoutes([]);
-			}
-		})();
-	}, []);
+        useEffect(() => {
+                void (async () => {
+                        try {
+                                const res: AdminLinksRoutes1 = await fetchRoutes();
+                                setRoutes(res.routes);
+                        } catch {
+                                setRoutes([]);
+                        }
+                })();
+        }, [userData]);
 
 	return (
 		<Drawer

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -131,6 +131,16 @@ export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {
         timestamp: Date.now(),
         metadata: null,
     };
-    const response = await axios.post<RPCResponse>('/rpc', request);
+    const headers: Record<string, string> = {};
+    if (typeof localStorage !== 'undefined') {
+        try {
+            const raw = localStorage.getItem('authTokens');
+            if (raw) {
+                const { bearerToken } = JSON.parse(raw);
+                if (bearerToken) headers.Authorization = `Bearer ${bearerToken}`;
+            }
+        } catch {}
+    }
+    const response = await axios.post<RPCResponse>('/rpc', request, { headers });
     return response.data.payload as T;
 }

--- a/frontend/tests/rpcClient.test.ts
+++ b/frontend/tests/rpcClient.test.ts
@@ -11,56 +11,56 @@ describe('rpcClient', () => {
     it('fetchVersion posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { version: 'v9.9.9' } } });
         const res = await fetchVersion();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_version:1' }));
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_version:1' }), expect.anything());
         expect(res.version).toBe('v9.9.9');
     });
 
     it('fetchHostname posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { hostname: 'unit-host' } } });
         const res = await fetchHostname();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_hostname:1' }));
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_hostname:1' }), expect.anything());
         expect(res.hostname).toBe('unit-host');
     });
 
     it('fetchRepo posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { repo: 'https://repo' } } });
         const res = await fetchRepo();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_repo:1' }));
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_repo:1' }), expect.anything());
         expect(res.repo).toBe('https://repo');
     });
 
     it('fetchFfmpegVersion posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { ffmpeg_version: 'ffmpeg version 6.0' } } });
         const res = await fetchFfmpegVersion();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_ffmpeg_version:1' }));
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:vars:get_ffmpeg_version:1' }), expect.anything());
         expect(res.ffmpeg_version).toBe('ffmpeg version 6.0');
     });
 
     it('fetchHome posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { links: [] } } });
         const res = await fetchHome();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:links:get_home:1' }));
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:links:get_home:1' }), expect.anything());
         expect(Array.isArray(res.links)).toBe(true);
     });
 
     it('fetchRoutes posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { routes: [] } } });
         const res = await fetchRoutes();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:links:get_routes:1' }));
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:links:get_routes:1' }), expect.anything());
         expect(Array.isArray(res.routes)).toBe(true);
     });
 
     it('fetchUsers posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { users: [] } } });
         const res = await fetchUsers();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:users:list:1' }));
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:users:list:1' }), expect.anything());
         expect(Array.isArray(res.users)).toBe(true);
     });
 
     it('fetchProfile posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { email: 'e' } } });
         const res = await fetchProfile({ userGuid: 'uid' });
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:users:get_profile:1' }));
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:admin:users:get_profile:1' }), expect.anything());
         expect(res.email).toBe('e');
     });
 });


### PR DESCRIPTION
## Summary
- expose user context to NavBar and re-fetch routes when it changes
- include Authorization header in rpc calls from browser
- adjust rpcClient tests for axios config parameter

## Testing
- `npm test --silent --run`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f044077b8832593bca3ef3601d28c