### PR TITLE
Add role member management UI and RPC

### DIFF
--- a/frontend/src/AdminRoleMembersPage.tsx
+++ b/frontend/src/AdminRoleMembersPage.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import { Stack, List, ListItemButton, ListItemText, IconButton, Typography } from '@mui/material';
+import { ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
+import type { RoleItem, AdminRoleMembers1, UserListItem, AdminRolesList1 } from './shared/RpcModels';
+import { fetchList, fetchMembers, fetchAddMember, fetchRemoveMember } from './rpc/admin/roles';
+
+const AdminRoleMembersPage = (): JSX.Element => {
+    const [roles, setRoles] = useState<RoleItem[]>([]);
+    const [members, setMembers] = useState<Record<string, UserListItem[]>>({});
+    const [nonMembers, setNonMembers] = useState<Record<string, UserListItem[]>>({});
+    const [selectedLeft, setSelectedLeft] = useState<Record<string, string>>({});
+    const [selectedRight, setSelectedRight] = useState<Record<string, string>>({});
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                const res: AdminRolesList1 = await fetchList();
+                setRoles(res.roles.sort((a, b) => a.bit - b.bit));
+            } catch {
+                setRoles([]);
+            }
+        })();
+    }, []);
+
+    useEffect(() => {
+        roles.forEach(r => {
+            if (members[r.name]) return;
+            void (async () => {
+                try {
+                    const res: AdminRoleMembers1 = await fetchMembers({ role: r.name });
+                    setMembers(m => ({ ...m, [r.name]: res.members }));
+                    setNonMembers(n => ({ ...n, [r.name]: res.nonMembers }));
+                } catch {
+                    setMembers(m => ({ ...m, [r.name]: [] }));
+                    setNonMembers(n => ({ ...n, [r.name]: [] }));
+                }
+            })();
+        });
+    }, [roles]);
+
+    const moveRight = async (role: string): Promise<void> => {
+        const id = selectedLeft[role];
+        if (!id) return;
+        await fetchAddMember({ role, userGuid: id });
+        const res: AdminRoleMembers1 = await fetchMembers({ role });
+        setMembers(m => ({ ...m, [role]: res.members }));
+        setNonMembers(n => ({ ...n, [role]: res.nonMembers }));
+        setSelectedLeft(s => ({ ...s, [role]: '' }));
+    };
+
+    const moveLeft = async (role: string): Promise<void> => {
+        const id = selectedRight[role];
+        if (!id) return;
+        await fetchRemoveMember({ role, userGuid: id });
+        const res: AdminRoleMembers1 = await fetchMembers({ role });
+        setMembers(m => ({ ...m, [role]: res.members }));
+        setNonMembers(n => ({ ...n, [role]: res.nonMembers }));
+        setSelectedRight(s => ({ ...s, [role]: '' }));
+    };
+
+    return (
+        <Stack spacing={4} sx={{ mt: 4 }}>
+            {roles.map((role) => (
+                <Stack key={role.name} spacing={2} direction='column' alignItems='center'>
+                    <Typography variant='h6'>{role.name}</Typography>
+                    <Stack direction='row' spacing={2}>
+                        <List sx={{ width: 200, border: 1 }}>
+                            {(nonMembers[role.name] || []).map(u => (
+                                <ListItemButton key={u.guid} selected={selectedLeft[role.name] === u.guid} onClick={() => setSelectedLeft({ ...selectedLeft, [role.name]: u.guid })}>
+                                    <ListItemText primary={u.displayName} />
+                                </ListItemButton>
+                            ))}
+                        </List>
+                        <Stack spacing={1} justifyContent='center'>
+                            <IconButton onClick={() => void moveRight(role.name)}><ArrowForwardIos /></IconButton>
+                            <IconButton onClick={() => void moveLeft(role.name)}><ArrowBackIos /></IconButton>
+                        </Stack>
+                        <List sx={{ width: 200, border: 1 }}>
+                            {(members[role.name] || []).map(u => (
+                                <ListItemButton key={u.guid} selected={selectedRight[role.name] === u.guid} onClick={() => setSelectedRight({ ...selectedRight, [role.name]: u.guid })}>
+                                    <ListItemText primary={u.displayName} />
+                                </ListItemButton>
+                            ))}
+                        </List>
+                    </Stack>
+                </Stack>
+            ))}
+        </Stack>
+    );
+};
+
+export default AdminRoleMembersPage;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import UserPage from './UserPage'
 import AdminUsersPage from './AdminUsersPage'
 import AdminUserPanel from './AdminUserPanel'
 import AdminRolesPage from './AdminRolesPage'
+import AdminRoleMembersPage from './AdminRoleMembersPage'
 import Icons from './Icons'
 
 function App(): JSX.Element {
@@ -35,6 +36,7 @@ function App(): JSX.Element {
                                                         <Route path='/admin_userpanel' element={<AdminUsersPage />} />
                                                         <Route path='/admin_userpanel/:guid' element={<AdminUserPanel />} />
                                                         <Route path='/admin_roles' element={<AdminRolesPage />} />
+                                                        <Route path='/admin_role_members' element={<AdminRoleMembersPage />} />
                                                         <Route path='/icons' element={<Icons />} />
                                                 </Routes>
                                         </Container>

--- a/frontend/src/rpc/admin/roles/index.ts
+++ b/frontend/src/rpc/admin/roles/index.ts
@@ -4,11 +4,11 @@
 // overwritten the next time the generator runs.
 // ================================================
 
-import { rpcCall, AdminRolesList1, AdminRoleMembers1 } from '../../../shared/RpcModels';
+import { rpcCall, AdminRolesList1 } from '../../../shared/RpcModels';
 
 export const fetchList = (payload: any = null): Promise<AdminRolesList1> => rpcCall('urn:admin:roles:list:1', payload);
 export const fetchSet = (payload: any = null): Promise<any> => rpcCall('urn:admin:roles:set:1', payload);
 export const fetchDelete = (payload: any = null): Promise<any> => rpcCall('urn:admin:roles:delete:1', payload);
-export const fetchMembers = (payload: any = null): Promise<AdminRoleMembers1> => rpcCall('urn:admin:roles:get_members:1', payload);
-export const fetchAddMember = (payload: any = null): Promise<AdminRoleMembers1> => rpcCall('urn:admin:roles:add_member:1', payload);
-export const fetchRemoveMember = (payload: any = null): Promise<AdminRoleMembers1> => rpcCall('urn:admin:roles:remove_member:1', payload);
+export const fetchMembers = (payload: any = null): Promise<any> => rpcCall('urn:admin:roles:get_members:1', payload);
+export const fetchAddMember = (payload: any = null): Promise<any> => rpcCall('urn:admin:roles:add_member:1', payload);
+export const fetchRemoveMember = (payload: any = null): Promise<any> => rpcCall('urn:admin:roles:remove_member:1', payload);

--- a/frontend/src/rpc/admin/roles/index.ts
+++ b/frontend/src/rpc/admin/roles/index.ts
@@ -4,8 +4,11 @@
 // overwritten the next time the generator runs.
 // ================================================
 
-import { rpcCall, AdminRolesList1 } from '../../../shared/RpcModels';
+import { rpcCall, AdminRolesList1, AdminRoleMembers1 } from '../../../shared/RpcModels';
 
 export const fetchList = (payload: any = null): Promise<AdminRolesList1> => rpcCall('urn:admin:roles:list:1', payload);
 export const fetchSet = (payload: any = null): Promise<any> => rpcCall('urn:admin:roles:set:1', payload);
 export const fetchDelete = (payload: any = null): Promise<any> => rpcCall('urn:admin:roles:delete:1', payload);
+export const fetchMembers = (payload: any = null): Promise<AdminRoleMembers1> => rpcCall('urn:admin:roles:get_members:1', payload);
+export const fetchAddMember = (payload: any = null): Promise<AdminRoleMembers1> => rpcCall('urn:admin:roles:add_member:1', payload);
+export const fetchRemoveMember = (payload: any = null): Promise<AdminRoleMembers1> => rpcCall('urn:admin:roles:remove_member:1', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,6 +28,23 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
+export interface FrontendUserProfileData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  storageUsed: number | null;
+  displayEmail: boolean;
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface FrontendUserSetDisplayName1 {
+  bearerToken: string;
+  displayName: string;
+}
 export interface AuthMicrosoftLoginData1 {
   bearerToken: string;
   defaultProvider: string;
@@ -75,28 +92,6 @@ export interface UserListItem {
   guid: string;
   displayName: string;
 }
-export interface AdminRoleDelete1 {
-  name: string;
-}
-export interface AdminRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface AdminRoleMembers1 {
-  members: UserListItem[];
-  nonMembers: UserListItem[];
-}
-export interface AdminRoleUpdate1 {
-  name: string;
-  bit: number;
-}
-export interface AdminRolesList1 {
-  roles: RoleItem[];
-}
-export interface RoleItem {
-  name: string;
-  bit: number;
-}
 export interface AdminVarsFfmpegVersion1 {
   ffmpeg_version: string;
 }
@@ -127,22 +122,27 @@ export interface RouteItem {
   name: string;
   icon: string;
 }
-export interface FrontendUserProfileData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  storageUsed: number | null;
-  displayEmail: boolean;
-  rotationToken: string | null;
-  rotationExpires: any | null;
+export interface AdminRoleDelete1 {
+  name: string;
 }
-export interface FrontendUserSetDisplayName1 {
-  bearerToken: string;
-  displayName: string;
+export interface AdminRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
+}
+export interface AdminRoleMembers1 {
+  members: any[];
+  nonMembers: any[];
+}
+export interface AdminRoleUpdate1 {
+  name: string;
+  bit: number;
+}
+export interface AdminRolesList1 {
+  roles: RoleItem[];
+}
+export interface RoleItem {
+  name: string;
+  bit: number;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -78,6 +78,14 @@ export interface UserListItem {
 export interface AdminRoleDelete1 {
   name: string;
 }
+export interface AdminRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
+}
+export interface AdminRoleMembers1 {
+  members: UserListItem[];
+  nonMembers: UserListItem[];
+}
 export interface AdminRoleUpdate1 {
   name: string;
   bit: number;

--- a/rpc/admin/roles/handler.py
+++ b/rpc/admin/roles/handler.py
@@ -14,6 +14,18 @@ async def handle_roles_request(parts: list[str], rpc_request: RPCRequest | None,
       if rpc_request is None:
         raise HTTPException(status_code=400, detail='Missing payload')
       return await services.delete_role_v1(rpc_request, request)
+    case ["get_members", "1"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.get_role_members_v1(rpc_request, request)
+    case ["add_member", "1"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.add_role_member_v1(rpc_request, request)
+    case ["remove_member", "1"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.remove_role_member_v1(rpc_request, request)
     case _:
       raise HTTPException(status_code=404, detail='Unknown RPC operation')
 

--- a/rpc/admin/roles/models.py
+++ b/rpc/admin/roles/models.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from rpc.admin.users.models import UserListItem
 
 class RoleItem(BaseModel):
   name: str
@@ -13,3 +14,11 @@ class AdminRoleUpdate1(BaseModel):
 
 class AdminRoleDelete1(BaseModel):
   name: str
+
+class AdminRoleMemberUpdate1(BaseModel):
+  role: str
+  userGuid: str
+
+class AdminRoleMembers1(BaseModel):
+  members: list['UserListItem']
+  nonMembers: list['UserListItem']

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -9,15 +9,11 @@
       "capabilities": 0
     },
     {
+      "op": "urn:admin:roles:add_member:1",
+      "capabilities": 0
+    },
+    {
       "op": "urn:admin:roles:delete:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:admin:roles:list:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:admin:roles:set:1",
       "capabilities": 0
     },
     {
@@ -25,11 +21,15 @@
       "capabilities": 0
     },
     {
-      "op": "urn:admin:roles:add_member:1",
+      "op": "urn:admin:roles:list:1",
       "capabilities": 0
     },
     {
       "op": "urn:admin:roles:remove_member:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:admin:roles:set:1",
       "capabilities": 0
     },
     {

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -21,6 +21,18 @@
       "capabilities": 0
     },
     {
+      "op": "urn:admin:roles:get_members:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:admin:roles:add_member:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:admin:roles:remove_member:1",
+      "capabilities": 0
+    },
+    {
       "op": "urn:admin:users:get_profile:1",
       "capabilities": 0
     },

--- a/scripts/add_admin_role_members_route.sql
+++ b/scripts/add_admin_role_members_route.sql
@@ -1,0 +1,2 @@
+INSERT INTO routes(path, name, icon, required_roles, sequence)
+VALUES ('/admin_role_members', 'Role Members', 'group', (SELECT mask FROM roles WHERE name='ROLE_SYSTEM_ADMIN') | (SELECT mask FROM roles WHERE name='ROLE_REGISTERED'), (SELECT COALESCE(MAX(sequence),0)+10 FROM routes));

--- a/server/modules/database_module.py
+++ b/server/modules/database_module.py
@@ -241,6 +241,23 @@ class DatabaseModule(BaseModule):
     query = "SELECT guid, display_name FROM users ORDER BY display_name;"
     return await self._fetch_many(query)
 
+  async def select_users_with_role(self, mask: int):
+    query = (
+      "SELECT u.guid, u.display_name FROM users u "
+      "JOIN users_roles ur ON u.guid = ur.user_guid "
+      "WHERE (ur.roles & $1) = $1 ORDER BY u.display_name;"
+    )
+    return await self._fetch_many(query, mask)
+
+  async def select_users_without_role(self, mask: int):
+    query = (
+      "SELECT u.guid, u.display_name FROM users u "
+      "LEFT JOIN users_roles ur ON u.guid = ur.user_guid "
+      "WHERE ur.roles IS NULL OR (ur.roles & $1) = 0 "
+      "ORDER BY u.display_name;"
+    )
+    return await self._fetch_many(query, mask)
+
   async def set_user_roles(self, guid: str, roles: int):
     query = (
       "INSERT INTO users_roles(user_guid, roles) VALUES($1, $2) "

--- a/tests/test_rpc_admin_roles.py
+++ b/tests/test_rpc_admin_roles.py
@@ -1,0 +1,45 @@
+import asyncio
+from fastapi import FastAPI, Request
+from rpc.handler import handle_rpc_request
+from rpc.models import RPCRequest
+from server.helpers import roles as role_helper
+
+class DummyDB:
+    def __init__(self):
+        self.roles = {'ROLE_TEST': 2}
+        self.users = {'u1': 2, 'u2': 0}
+    async def list_roles(self):
+        return [{'name': n, 'mask': m} for n, m in self.roles.items()]
+    async def select_users_with_role(self, mask):
+        return [{'guid': k, 'display_name': k} for k, v in self.users.items() if v & mask]
+    async def select_users_without_role(self, mask):
+        return [{'guid': k, 'display_name': k} for k, v in self.users.items() if not (v & mask)]
+    async def get_user_roles(self, guid):
+        return self.users.get(guid, 0)
+    async def set_user_roles(self, guid, roles):
+        self.users[guid] = roles
+
+class DummyAuth:
+    async def decode_bearer_token(self, token):
+        return {'guid': token}
+
+async def make_app():
+    app = FastAPI()
+    app.state.database = DummyDB()
+    app.state.auth = DummyAuth()
+    app.state.permcap = None
+    app.state.env = None
+    return app
+
+def test_role_member_flow():
+    app = asyncio.run(make_app())
+    req = Request({'type': 'http', 'app': app, 'headers': []})
+    rpc = RPCRequest(op='urn:admin:roles:get_members:1', payload={'role': 'ROLE_TEST'})
+    resp = asyncio.run(handle_rpc_request(rpc, req))
+    assert len(resp.payload.members) == 1
+    rpc = RPCRequest(op='urn:admin:roles:add_member:1', payload={'role': 'ROLE_TEST', 'userGuid': 'u2'})
+    resp = asyncio.run(handle_rpc_request(rpc, req))
+    assert any(u.guid == 'u2' for u in resp.payload.members)
+    rpc = RPCRequest(op='urn:admin:roles:remove_member:1', payload={'role': 'ROLE_TEST', 'userGuid': 'u1'})
+    resp = asyncio.run(handle_rpc_request(rpc, req))
+    assert all(u.guid != 'u1' for u in resp.payload.members)


### PR DESCRIPTION
## Summary
- query role membership in DatabaseModule
- support role member management RPC endpoints
- expose new role member operations in metadata and TS client
- add React page for editing role membership
- add route insert script
- test role member RPC

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f942153688325a386c85b76eba270