### PR TITLE
Fix config list when values aren't strings

### DIFF
--- a/rpc/admin/config/services.py
+++ b/rpc/admin/config/services.py
@@ -6,14 +6,14 @@ from server.modules.database_module import DatabaseModule
 async def list_config_v1(request: Request) -> RPCResponse:
   db: DatabaseModule = request.app.state.database
   rows = await db.list_config()
-  items = [ConfigItem(key=r['key'], value=r['value']) for r in rows]
+  items = [ConfigItem(key=r['key'], value=str(r['value'])) for r in rows]
   payload = AdminConfigList1(items=items)
   return RPCResponse(op='urn:admin:config:list:1', payload=payload, version=1)
 
 async def set_config_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   data = AdminConfigUpdate1(**(rpc_request.payload or {}))
   db: DatabaseModule = request.app.state.database
-  await db.set_config_value(data.key, data.value)
+  await db.set_config_value(data.key, str(data.value))
   return await list_config_v1(request)
 
 async def delete_config_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:


### PR DESCRIPTION
## Summary
- avoid pydantic failure when non-string values exist in the config table

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_687ff345e6308325bac08754677d17e5