### PR TITLE
Add Azure storage module and tests

### DIFF
--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -7,6 +7,7 @@ from server.modules.discord_module import DiscordModule
 from server.modules.database_module import DatabaseModule
 from server.modules.auth_module import AuthModule
 from server.modules.permcap_module import PermCapModule
+from server.modules.storage_module import StorageModule
 from server.helpers.logging import configure_root_logging
 
 @asynccontextmanager
@@ -21,6 +22,8 @@ async def lifespan(app: FastAPI):
   configure_root_logging(debug=str(debug).lower() in ["1", "true"])
 
   app.state.env = EnvironmentModule(app)
+  app.state.storage = StorageModule(app)
+  await app.state.storage.startup()
   app.state.discord = DiscordModule(app)
   await app.state.discord.startup()
   app.state.auth = AuthModule(app)

--- a/server/modules/env_module.py
+++ b/server/modules/env_module.py
@@ -11,6 +11,7 @@ class EnvironmentModule():
     self._getenv("DISCORD_SECRET", "MISSING_ENV_DISCORD_SECRET")
     self._getenv("JWT_SECRET", "MISSING_ENV_JWT_SECRET")
     self._getenv("POSTGRES_CONNECTION_STRING", "MISSING_ENV_POSTGRES_CONNECTION_STRING")
+    self._getenv("AZURE_BLOB_CONNECTION_STRING", "MISSING_ENV_AZURE_BLOB_CONNECTION_STRING")
     
     logging.info("Environment module loaded")
 

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -1,0 +1,43 @@
+from azure.storage.blob.aio import BlobServiceClient
+from azure.core.exceptions import ResourceExistsError
+from fastapi import FastAPI
+from . import BaseModule
+from .env_module import EnvironmentModule
+from .database_module import DatabaseModule
+import io
+
+class StorageModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    try:
+      self.env: EnvironmentModule = app.state.env
+      self.db: DatabaseModule = app.state.database
+    except AttributeError:
+      raise Exception("Env and Database modules must be loaded first")
+    self.client = None
+    self.container = ""
+
+  async def startup(self):
+    conn = self.env.get("AZURE_BLOB_CONNECTION_STRING")
+    container = await self.db.get_config_value("AzureBlobContainerName")
+    bsc = BlobServiceClient.from_connection_string(conn)
+    client = bsc.get_container_client(container)
+    try:
+      await client.create_container()
+    except ResourceExistsError:
+      pass
+    client.container_name = container
+    self.client = client
+    self.container = container
+
+  async def shutdown(self):
+    self.client = None
+
+  async def write_buffer(self, buffer: io.BytesIO, user_guid: str, filename: str):
+    if not self.client:
+      raise RuntimeError("Storage client not initialized")
+    safe = filename.replace(" ", "_")
+    buffer.seek(0)
+    blob_name = f"{user_guid}/{safe}"
+    await self.client.upload_blob(data=buffer, name=blob_name, overwrite=True)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ def app_with_env(monkeypatch):
   monkeypatch.setenv("DISCORD_SYSCHAN", "1")
   monkeypatch.setenv("JWT_SECRET", "jwt")
   monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
+  monkeypatch.setenv("AZURE_BLOB_CONNECTION_STRING", "DefaultEndpointsProtocol=https;AccountName=dev;AccountKey=key;")
   app = FastAPI()
   env = EnvironmentModule(app)
   app.state.env = env

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -16,6 +16,7 @@ def auth_app(monkeypatch):
   monkeypatch.setenv("DISCORD_SYSCHAN", "1")
   monkeypatch.setenv("JWT_SECRET", "jwt")
   monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
+  monkeypatch.setenv("AZURE_BLOB_CONNECTION_STRING", "cs")
   app = FastAPI()
   env = EnvironmentModule(app)
   app.state.env = env

--- a/tests/test_database_module.py
+++ b/tests/test_database_module.py
@@ -11,6 +11,7 @@ def db_app(monkeypatch):
   monkeypatch.setenv("DISCORD_SECRET", "secret")
   monkeypatch.setenv("JWT_SECRET", "jwt")
   monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
+  monkeypatch.setenv("AZURE_BLOB_CONNECTION_STRING", "cs")
   app = FastAPI()
   env = EnvironmentModule(app)
   app.state.env = env

--- a/tests/test_discord_module.py
+++ b/tests/test_discord_module.py
@@ -31,6 +31,7 @@ def discord_app(monkeypatch):
   monkeypatch.setenv("DISCORD_SYSCHAN", "1")
   monkeypatch.setenv("JWT_SECRET", "jwt")
   monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
+  monkeypatch.setenv("AZURE_BLOB_CONNECTION_STRING", "cs")
   app = FastAPI()
   env = EnvironmentModule(app)
   app.state.env = env

--- a/tests/test_env_module.py
+++ b/tests/test_env_module.py
@@ -7,6 +7,7 @@ def test_env_loads(app_with_env):
   env = app_with_env.state.env
   assert env.get("DISCORD_SECRET") == "secret"
   assert env.get("JWT_SECRET") == "jwt"
+  assert env.get("AZURE_BLOB_CONNECTION_STRING") == "DefaultEndpointsProtocol=https;AccountName=dev;AccountKey=key;"
 
 def test_env_missing_key(app_with_env):
   env = app_with_env.state.env
@@ -15,12 +16,14 @@ def test_env_missing_key(app_with_env):
 
 def test_env_defaults(monkeypatch):
   monkeypatch.delenv("MS_API_ID", raising=False)
+  monkeypatch.setenv("AZURE_BLOB_CONNECTION_STRING", "cs")
   app = FastAPI()
   env = EnvironmentModule(app)
   with pytest.raises(RuntimeError):
     env.get("MS_API_ID")
 
 def test_getenv_required(monkeypatch):
+  monkeypatch.setenv("AZURE_BLOB_CONNECTION_STRING", "cs")
   app = FastAPI()
   env = EnvironmentModule(app)
   with pytest.raises(RuntimeError):

--- a/tests/test_rpc_admin_namespace.py
+++ b/tests/test_rpc_admin_namespace.py
@@ -109,6 +109,7 @@ def set_env(monkeypatch):
     monkeypatch.setenv("HOSTNAME", "unit-host")
     monkeypatch.setenv("REPO", "https://repo")
     monkeypatch.setenv("DISCORD_SECRET", "token")
+    monkeypatch.setenv("AZURE_BLOB_CONNECTION_STRING", "cs")
 
 @pytest.fixture
 def app():

--- a/tests/test_rpc_response_views.py
+++ b/tests/test_rpc_response_views.py
@@ -10,6 +10,10 @@ from rpc.models import RPCRequest
 @pytest.fixture(autouse=True)
 def set_env(monkeypatch):
   monkeypatch.setenv("HOSTNAME", "unit-host")
+  monkeypatch.setenv("DISCORD_SECRET", "token")
+  monkeypatch.setenv("JWT_SECRET", "jwt")
+  monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
+  monkeypatch.setenv("AZURE_BLOB_CONNECTION_STRING", "cs")
 
 
 @pytest.fixture

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -1,0 +1,57 @@
+import asyncio, io
+from fastapi import FastAPI
+import server.modules.storage_module as storage_mod
+from server.modules.storage_module import StorageModule
+from server.modules.env_module import EnvironmentModule
+
+class DummyContainerClient:
+  def __init__(self):
+    self.created = False
+    self.uploaded = []
+    self.container_name = ""
+  async def create_container(self):
+    self.created = True
+  async def upload_blob(self, data, name, overwrite=False):
+    self.uploaded.append((name, data.read()))
+
+class DummyBSC:
+  def __init__(self, client):
+    self.client = client
+  def get_container_client(self, name):
+    self.client.container_name = name
+    return self.client
+
+
+def _make_app(monkeypatch):
+  monkeypatch.setenv("DISCORD_SECRET", "secret")
+  monkeypatch.setenv("JWT_SECRET", "jwt")
+  monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
+  monkeypatch.setenv("AZURE_BLOB_CONNECTION_STRING", "cs")
+  app = FastAPI()
+  env = EnvironmentModule(app)
+  app.state.env = env
+  class DB:
+    async def get_config_value(self, key):
+      if key == "AzureBlobContainerName":
+        return "elideus-group"
+      return None
+  app.state.database = DB()
+  return app
+
+
+def test_storage_startup_and_write(monkeypatch):
+  app = _make_app(monkeypatch)
+  container = DummyContainerClient()
+  monkeypatch.setattr(
+    storage_mod.BlobServiceClient,
+    "from_connection_string",
+    lambda cs: DummyBSC(container),
+  )
+  sm = StorageModule(app)
+  asyncio.run(sm.startup())
+  assert sm.container == "elideus-group"
+  assert container.created
+  buf = io.BytesIO(b"data")
+  asyncio.run(sm.write_buffer(buf, "uid", "file.txt"))
+  assert container.uploaded == [("uid/file.txt", b"data")]
+


### PR DESCRIPTION
## Summary
- add `StorageModule` for Azure blob uploads
- load `AZURE_BLOB_CONNECTION_STRING` env var
- initialize `StorageModule` during startup
- provide tests for new storage logic
- update existing tests for new environment requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ffdd09eb48325949a373f6ad939ca