### PR TITLE
Add storage status display

### DIFF
--- a/frontend/src/AdminUserPanel.tsx
+++ b/frontend/src/AdminUserPanel.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Box, Stack, Button, List, ListItemButton, ListItemText, IconButton, Typography, Avatar, TextField } from '@mui/material';
-import { ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
+import { ArrowForwardIos, ArrowBackIos, CheckCircle, Cancel } from '@mui/icons-material';
 import type { AdminUserRoles1, AdminUserProfile1 } from './shared/RpcModels';
-import { fetchRoles, fetchSetRoles, fetchListRoles, fetchProfile, fetchSetCredits } from './rpc/admin/users';
+import { fetchRoles, fetchSetRoles, fetchListRoles, fetchProfile, fetchSetCredits, fetchEnableStorage } from './rpc/admin/users';
 
 const AdminUserPanel = (): JSX.Element => {
     const { guid } = useParams();
@@ -11,6 +11,8 @@ const AdminUserPanel = (): JSX.Element => {
     const [available, setAvailable] = useState<string[]>([]);
     const [profile, setProfile] = useState<AdminUserProfile1 | null>(null);
     const [credits, setCredits] = useState<number>(0);
+    const [storageEnabled, setStorageEnabled] = useState<boolean>(false);
+    const [storageUsed, setStorageUsed] = useState<number>(0);
     const [selectedLeft, setSelectedLeft] = useState<string | null>(null);
     const [selectedRight, setSelectedRight] = useState<string | null>(null);
 
@@ -25,6 +27,8 @@ const AdminUserPanel = (): JSX.Element => {
                 setAvailable(all.roles.filter(r => !roles.roles.includes(r)));
                 setProfile(prof);
                 setCredits(prof.credits ?? 0);
+                setStorageEnabled(prof.storageEnabled ?? false);
+                setStorageUsed(prof.storageUsed ?? 0);
             } catch {
                 setAssigned([]);
                 setAvailable([]);
@@ -47,6 +51,14 @@ const AdminUserPanel = (): JSX.Element => {
         setSelectedRight(null);
     };
 
+    const handleEnableStorage = async (): Promise<void> => {
+        if (!guid) return;
+        const prof = await fetchEnableStorage({ userGuid: guid });
+        setProfile(prof);
+        setStorageEnabled(prof.storageEnabled ?? false);
+        setStorageUsed(prof.storageUsed ?? 0);
+    };
+
     const handleSave = async (): Promise<void> => {
         if (!guid) return;
         await fetchSetRoles({ userGuid: guid, roles: assigned });
@@ -62,6 +74,11 @@ const AdminUserPanel = (): JSX.Element => {
                     <TextField label='Display Name' value={profile.username} InputProps={{ readOnly: true }} />
                     <Typography>Email: {profile.email}</Typography>
                     <TextField label='Credits' type='number' value={credits} onChange={e => setCredits(Number(e.target.value))} />
+                    <Stack direction='row' spacing={1} alignItems='center'>
+                        <Typography>Storage Enabled:</Typography>
+                        {storageEnabled ? <CheckCircle color='success' /> : <IconButton onClick={handleEnableStorage}><Cancel color='error' /></IconButton>}
+                    </Stack>
+                    <Typography>Storage Used: {storageUsed} B</Typography>
                 </Stack>
             )}
             <Stack direction='row' spacing={2}>

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -44,6 +44,7 @@ const LoginPage = (): JSX.Element => {
                                 profilePicture: profilePictureBase64,
                                 credits: data.credits ?? 0,
                                 storageUsed: 0,
+                                storageEnabled: false,
                                 displayEmail: false,
                                 rotationToken: data.rotationToken ?? null,
                                 rotationExpires: data.rotationExpires ?? null

--- a/frontend/src/UserPage.tsx
+++ b/frontend/src/UserPage.tsx
@@ -71,6 +71,7 @@ const UserPage = (): JSX.Element => {
                     />
 
                     <Typography>Credits: {userData.credits ?? 0}</Typography>
+                    <Typography>Storage Enabled: {userData.storageEnabled ? 'Yes' : 'No'}</Typography>
                     <Typography>Storage Used: {userData.storageUsed ?? 0} MB</Typography>
                     <Typography>Email: {userData.email}</Typography>
 

--- a/frontend/src/rpc/admin/users/index.ts
+++ b/frontend/src/rpc/admin/users/index.ts
@@ -12,3 +12,4 @@ export const fetchSetRoles = (payload: any = null): Promise<AdminUserRoles1> => 
 export const fetchListRoles = (payload: any = null): Promise<AdminUserRoles1> => rpcCall('urn:admin:users:list_roles:1', payload);
 export const fetchProfile = (payload: any = null): Promise<AdminUserProfile1> => rpcCall('urn:admin:users:get_profile:1', payload);
 export const fetchSetCredits = (payload: any = null): Promise<AdminUserProfile1> => rpcCall('urn:admin:users:set_credits:1', payload);
+export const fetchEnableStorage = (payload: any = null): Promise<AdminUserProfile1> => rpcCall('urn:admin:users:enable_storage:1', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,81 +28,6 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
-export interface AdminVarsFfmpegVersion1 {
-  ffmpeg_version: string;
-}
-export interface AdminVarsHostname1 {
-  hostname: string;
-}
-export interface AdminVarsRepo1 {
-  repo: string;
-}
-export interface AdminVarsVersion1 {
-  version: string;
-}
-export interface ViewDiscord1 {
-  content: string;
-}
-export interface AdminUserCreditsUpdate1 {
-  userGuid: string;
-  credits: number;
-}
-export interface AdminUserProfile1 {
-  guid: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: any;
-  profilePicture: any;
-  credits: any;
-  storageUsed: any;
-  displayEmail: boolean;
-  rotationToken: any;
-  rotationExpires: any;
-}
-export interface AdminUserRoles1 {
-  roles: string[];
-}
-export interface AdminUserRolesUpdate1 {
-  userGuid: string;
-  roles: string[];
-}
-export interface AdminUsersList1 {
-  users: UserListItem[];
-}
-export interface UserListItem {
-  guid: string;
-  displayName: string;
-}
-export interface AdminLinksHome1 {
-  links: LinkItem[];
-}
-export interface AdminLinksRoutes1 {
-  routes: RouteItem[];
-}
-export interface LinkItem {
-  title: string;
-  url: string;
-}
-export interface RouteItem {
-  path: string;
-  name: string;
-  icon: string;
-}
-export interface AdminConfigDelete1 {
-  key: string;
-}
-export interface AdminConfigList1 {
-  items: ConfigItem[];
-}
-export interface AdminConfigUpdate1 {
-  key: string;
-  value: string;
-}
-export interface ConfigItem {
-  key: string;
-  value: string;
-}
 export interface AdminRoleDelete1 {
   name: string;
 }
@@ -124,6 +49,82 @@ export interface AdminRolesList1 {
 export interface RoleItem {
   name: string;
   bit: number;
+}
+export interface UserListItem {
+  guid: string;
+  displayName: string;
+}
+export interface AdminConfigDelete1 {
+  key: string;
+}
+export interface AdminConfigList1 {
+  items: ConfigItem[];
+}
+export interface AdminConfigUpdate1 {
+  key: string;
+  value: string;
+}
+export interface ConfigItem {
+  key: string;
+  value: string;
+}
+export interface AdminVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface AdminVarsHostname1 {
+  hostname: string;
+}
+export interface AdminVarsRepo1 {
+  repo: string;
+}
+export interface AdminVarsVersion1 {
+  version: string;
+}
+export interface ViewDiscord1 {
+  content: string;
+}
+export interface AdminLinksHome1 {
+  links: LinkItem[];
+}
+export interface AdminLinksRoutes1 {
+  routes: RouteItem[];
+}
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+export interface RouteItem {
+  path: string;
+  name: string;
+  icon: string;
+}
+export interface AdminUserCreditsUpdate1 {
+  userGuid: string;
+  credits: number;
+}
+export interface AdminUserProfile1 {
+  guid: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: any;
+  profilePicture: any;
+  credits: any;
+  storageUsed: any;
+  storageEnabled: any;
+  displayEmail: boolean;
+  rotationToken: any;
+  rotationExpires: any;
+}
+export interface AdminUserRoles1 {
+  roles: string[];
+}
+export interface AdminUserRolesUpdate1 {
+  userGuid: string;
+  roles: string[];
+}
+export interface AdminUsersList1 {
+  users: UserListItem[];
 }
 export interface AdminRouteDelete1 {
   path: string;
@@ -170,6 +171,7 @@ export interface FrontendUserProfileData1 {
   profilePicture: string | null;
   credits: number | null;
   storageUsed: number | null;
+  storageEnabled: boolean | null;
   displayEmail: boolean;
   rotationToken: string | null;
   rotationExpires: any | null;

--- a/frontend/src/shared/UserContextProvider.tsx
+++ b/frontend/src/shared/UserContextProvider.tsx
@@ -23,10 +23,11 @@ const UserContextProvider = ({ children }: UserContextProviderProps): JSX.Elemen
                                 username: '',
                                 email: '',
                                 backupEmail: null,
-                                profilePicture: null,
-                                credits: 0,
-                                storageUsed: 0,
-                                displayEmail: false,
+                               profilePicture: null,
+                               credits: 0,
+                               storageUsed: 0,
+                                storageEnabled: false,
+                               displayEmail: false,
                                 rotationToken: stored.rotationToken ?? null,
                                 rotationExpires: stored.rotationExpires ?? null,
                         };
@@ -35,8 +36,8 @@ const UserContextProvider = ({ children }: UserContextProviderProps): JSX.Elemen
                         void (async () => {
                                 try {
                                         const profile = await fetchProfileData({ bearerToken: stored.bearerToken });
-                                        const profilePictureBase64 = profile.profilePicture ? `data:image/png;base64,${profile.profilePicture}` : null;
-                                        setUserData({ ...profile, profilePicture: profilePictureBase64 });
+                                const profilePictureBase64 = profile.profilePicture ? `data:image/png;base64,${profile.profilePicture}` : null;
+                                setUserData({ ...profile, profilePicture: profilePictureBase64 });
                                 } catch (err) {
                                         console.error('Failed to refresh user profile', err);
                                 }

--- a/rpc/admin/users/handler.py
+++ b/rpc/admin/users/handler.py
@@ -16,5 +16,7 @@ async def handle_users_request(parts: list[str], rpc_request: RPCRequest | None,
       return await services.get_user_profile_v1(rpc_request, request)
     case ["set_credits", "1"]:
       return await services.set_user_credits_v1(rpc_request, request)
+    case ["enable_storage", "1"]:
+      return await services.enable_user_storage_v1(rpc_request, request)
     case _:
       raise HTTPException(status_code=404, detail='Unknown RPC operation')

--- a/rpc/admin/users/models.py
+++ b/rpc/admin/users/models.py
@@ -28,6 +28,7 @@ class AdminUserProfile1(BaseModel):
   profilePicture: str | None = None
   credits: int | None = None
   storageUsed: int | None = None
+  storageEnabled: bool | None = None
   displayEmail: bool = False
   rotationToken: str | None = None
   rotationExpires: datetime | None = None

--- a/rpc/frontend/user/models.py
+++ b/rpc/frontend/user/models.py
@@ -11,6 +11,7 @@ class FrontendUserProfileData1(BaseModel):
   profilePicture: Optional[str] = None
   credits: Optional[int] = None
   storageUsed: Optional[int] = None
+  storageEnabled: Optional[bool] = None
   displayEmail: bool = False
   rotationToken: Optional[str] = None
   rotationExpires: Optional[datetime] = None

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -57,6 +57,10 @@
       "capabilities": 0
     },
     {
+      "op": "urn:admin:users:enable_storage:1",
+      "capabilities": 0
+    },
+    {
       "op": "urn:admin:users:get_profile:1",
       "capabilities": 0
     },

--- a/tests/test_rpc_admin_namespace.py
+++ b/tests/test_rpc_admin_namespace.py
@@ -103,6 +103,14 @@ class DummyAuth:
     async def decode_bearer_token(self, token):
         return {"guid": token}
 
+class DummyStorage:
+    async def get_user_folder_size(self, guid):
+        return 0
+    async def user_folder_exists(self, guid):
+        return False
+    async def ensure_user_folder(self, guid):
+        return None
+
 @pytest.fixture(autouse=True)
 def set_env(monkeypatch):
     monkeypatch.setenv("VERSION", "v1.2.3")
@@ -123,6 +131,7 @@ def app():
     app.state.database = db
     app.state.permcap = DummyPermCap()
     app.state.auth = DummyAuth()
+    app.state.storage = DummyStorage()
     return app
 
 def test_get_version(app):

--- a/tests/test_rpc_frontend_user_service.py
+++ b/tests/test_rpc_frontend_user_service.py
@@ -25,10 +25,19 @@ class DummyDB:
     self.updated = (guid, name)
     self.name = name
 
+class DummyStorage:
+  async def get_user_folder_size(self, guid):
+    return 0
+  async def user_folder_exists(self, guid):
+    return False
+  async def ensure_user_folder(self, guid):
+    return None
+
 def test_get_profile_data_v1():
   app = FastAPI()
   app.state.auth = DummyAuth()
   app.state.database = DummyDB()
+  app.state.storage = DummyStorage()
   req = Request({'type': 'http', 'app': app, 'headers': []})
   rpc_req = RPCRequest(op='op', payload={'bearerToken': 'token'})
   resp = asyncio.run(services.get_profile_data_v1(rpc_req, req))
@@ -44,6 +53,7 @@ def test_set_display_name_v1():
   db = DummyDB()
   app.state.auth = auth
   app.state.database = db
+  app.state.storage = DummyStorage()
   req = Request({'type': 'http', 'app': app, 'headers': []})
   rpc_req = RPCRequest(op='op', payload={'bearerToken': 'token', 'displayName': 'n'})
   resp = asyncio.run(services.set_display_name_v1(rpc_req, req))


### PR DESCRIPTION
## Summary
- check whether a user's folder exists in `StorageModule`
- allow folder provisioning
- expose storage information in user RPC models/services
- show storage usage and enablement in the Admin and User panels
- adjust tests for new storage features

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_6880166a9b488325b330ea85671e3923