### PR TITLE
Remove unused default role definitions

### DIFF
--- a/rpc/account/users/services.py
+++ b/rpc/account/users/services.py
@@ -13,7 +13,6 @@ from server.modules.storage_module import StorageModule
 from server.helpers.roles import (
   mask_to_names,
   names_to_mask,
-  ROLE_NAMES,
   ROLE_REGISTERED,
 )
 

--- a/rpc/system/users/services.py
+++ b/rpc/system/users/services.py
@@ -13,7 +13,6 @@ from server.modules.storage_module import StorageModule
 from server.helpers.roles import (
   mask_to_names,
   names_to_mask,
-  ROLE_NAMES,
   ROLE_REGISTERED,
 )
 

--- a/server/helpers/roles.py
+++ b/server/helpers/roles.py
@@ -1,25 +1,13 @@
-# The role bitmasks must fit in a signed 64-bit integer as they are stored using
-# the Postgres ``BIGINT`` type. Using ``0x8000000000000000`` would flip the sign
-# bit, so the highest role begins at ``0x4000000000000000`` and the remaining
-# roles shift down from there.
-DEFAULT_ROLES = {
-  'ROLE_SERVICE_ADMIN': 0x4000000000000000,
-  'ROLE_SYSTEM_ADMIN': 0x2000000000000000,
-  'ROLE_ACCOUNT_ADMIN': 0x1000000000000000,
-  'ROLE_MODERATOR': 0x0800000000000000,
-  'ROLE_SUPPORT': 0x0400000000000000,
-  'ROLE_REGISTERED': 0x0000000000000001,
-}
+# Mapping of role names to their masks loaded from the database.
+ROLES: dict[str, int] = {}
 
-ROLES = DEFAULT_ROLES.copy()
-ROLE_NAMES = [name for name in ROLES.keys() if name != 'ROLE_REGISTERED']
+# List of all roles except ``ROLE_REGISTERED`` for convenience.
+ROLE_NAMES: list[str] = []
 
-ROLE_SERVICE_ADMIN = ROLES['ROLE_SERVICE_ADMIN']
-ROLE_SYSTEM_ADMIN = ROLES['ROLE_SYSTEM_ADMIN']
-ROLE_ACCOUNT_ADMIN = ROLES.get('ROLE_ACCOUNT_ADMIN', 0)
-ROLE_MODERATOR = ROLES['ROLE_MODERATOR']
-ROLE_SUPPORT = ROLES['ROLE_SUPPORT']
-ROLE_REGISTERED = ROLES['ROLE_REGISTERED']
+# ``ROLE_REGISTERED`` is used frequently so expose it directly.  It will be
+# updated when ``load_roles`` is called.  Default to ``1`` so code using the
+# constant before roles are loaded behaves as expected.
+ROLE_REGISTERED: int = 1
 
 async def load_roles(db) -> None:
   rows = await db.list_roles()
@@ -28,13 +16,8 @@ async def load_roles(db) -> None:
   ROLES.clear()
   for r in rows:
     ROLES[r['name']] = int(r['mask'])
-  global ROLE_NAMES, ROLE_SERVICE_ADMIN, ROLE_SYSTEM_ADMIN, ROLE_ACCOUNT_ADMIN, ROLE_MODERATOR, ROLE_SUPPORT, ROLE_REGISTERED
+  global ROLE_NAMES, ROLE_REGISTERED
   ROLE_NAMES = [n for n in ROLES.keys() if n != 'ROLE_REGISTERED']
-  ROLE_SERVICE_ADMIN = ROLES.get('ROLE_SERVICE_ADMIN', 0)
-  ROLE_SYSTEM_ADMIN = ROLES.get('ROLE_SYSTEM_ADMIN', 0)
-  ROLE_ACCOUNT_ADMIN = ROLES.get('ROLE_ACCOUNT_ADMIN', 0)
-  ROLE_MODERATOR = ROLES.get('ROLE_MODERATOR', 0)
-  ROLE_SUPPORT = ROLES.get('ROLE_SUPPORT', 0)
   ROLE_REGISTERED = ROLES.get('ROLE_REGISTERED', 0)
 
 def mask_to_names(mask: int) -> list[str]:


### PR DESCRIPTION
## Summary
- simplify `roles` helper by removing static role constants
- adjust services to drop unused `ROLE_NAMES`
- update namespace test to load roles dynamically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881429b598c83258fb48830f5c89a33