### PR TITLE
Refine admin page layout

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -92,7 +92,7 @@ The front-end uses Microsoft OAuth via MSAL. `LoginPage.tsx` prompts the user to
 
 The React application provides several administration pages:
 
- - `AdminUsersPage` lists users. Selecting a user opens `AccountUserPanel` where roles and credits can be modified via the `account:users` RPCs.
+- `AccountUsersPage` lists users. Selecting a user opens `AccountUserPanel` where roles and credits can be modified via the `account:users` RPCs.
 - `SystemRolesPage` manages role definitions using the `system:roles` endpoints.
  - `AccountRoleMembersPage` manages membership for each role through `account:roles` membership operations.
 

--- a/frontend/src/AccountRoleMembersPage.tsx
+++ b/frontend/src/AccountRoleMembersPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Stack, List, ListItemButton, ListItemText, IconButton, Typography } from '@mui/material';
+import { Box, Divider, Stack, List, ListItemButton, ListItemText, IconButton, Typography } from '@mui/material';
 import { ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
 import type { RoleItem, AccountRoleMembers1, UserListItem, AccountRolesList1 } from './shared/RpcModels';
 import { fetchList, fetchMembers, fetchAddMember, fetchRemoveMember } from './rpc/account/roles';
@@ -59,7 +59,10 @@ const AccountRoleMembersPage = (): JSX.Element => {
     };
 
     return (
-        <Stack spacing={4} sx={{ mt: 4 }}>
+        <Box sx={{ p: 2 }}>
+            <Typography variant='h5'>Role Memberships</Typography>
+            <Divider sx={{ mb: 2 }} />
+            <Stack spacing={2}>
             {roles.map((role) => (
                 <Stack key={role.name} spacing={2} direction='column' alignItems='center'>
                     <Typography variant='h6'>{role.name}</Typography>
@@ -85,7 +88,8 @@ const AccountRoleMembersPage = (): JSX.Element => {
                     </Stack>
                 </Stack>
             ))}
-        </Stack>
+            </Stack>
+        </Box>
     );
 };
 

--- a/frontend/src/AccountUserPanel.tsx
+++ b/frontend/src/AccountUserPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Box, Stack, Button, List, ListItemButton, ListItemText, IconButton, Typography, Avatar, TextField } from '@mui/material';
+import { Box, Divider, Stack, Button, List, ListItemButton, ListItemText, IconButton, Typography, Avatar, TextField } from '@mui/material';
 import { ArrowForwardIos, ArrowBackIos, CheckCircle, Cancel } from '@mui/icons-material';
 import type { AccountUserRoles1, AccountUserProfile1 } from './shared/RpcModels';
 import { fetchRoles, fetchSetRoles, fetchListRoles, fetchProfile, fetchSetCredits, fetchEnableStorage } from './rpc/account/users';
@@ -66,7 +66,9 @@ const AccountUserPanel = (): JSX.Element => {
     };
 
     return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mt: 4 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mt: 2, p: 2 }}>
+            <Typography variant='h5'>User Management</Typography>
+            <Divider sx={{ mb: 2 }} />
             {profile && (
                 <Stack spacing={2} sx={{ mb: 4, alignItems: 'center' }}>
                     <Typography variant='h5'>User Profile</Typography>

--- a/frontend/src/AccountUsersPage.tsx
+++ b/frontend/src/AccountUsersPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Table, TableHead, TableRow, TableCell, TableBody, Button, Typography } from '@mui/material';
+import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, Button, Typography } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import type { UserListItem, SystemUsersList1 } from './shared/RpcModels';
 import { fetchList } from './rpc/system/users';
@@ -19,9 +19,10 @@ const AccountUsersPage = (): JSX.Element => {
     }, []);
 
     return (
-        <>
-            <Typography variant='h5' sx={{ mb: 2 }}>User Administration</Typography>
-            <Table>
+        <Box sx={{ p: 2 }}>
+            <Typography variant='h5'>User Accounts</Typography>
+            <Divider sx={{ mb: 2 }} />
+            <Table size='small' sx={{ '& td, & th': { py: 0.5 } }}>
                 <TableHead>
                     <TableRow>
                         <TableCell>Display Name</TableCell>
@@ -39,7 +40,7 @@ const AccountUsersPage = (): JSX.Element => {
                     ))}
                 </TableBody>
             </Table>
-        </>
+        </Box>
     );
 };
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,7 @@ function App(): JSX.Element {
 			<UserContextProvider>
 				<Router>
 					<NavBar />
-					<Container sx={{ width: '100%', display: 'block', bgcolor: 'background.paper', color: 'text.primary', minHeight: '100vh' }}>
+                                        <Container maxWidth='lg' disableGutters sx={{ bgcolor: 'background.paper', color: 'text.primary', minHeight: '100vh', py: 2 }}>
 						<Routes>
 							<Route path='/' element={<Home />} />
 							<Route path='/userpage' element={<UserPage />} />

--- a/frontend/src/SystemConfigPage.tsx
+++ b/frontend/src/SystemConfigPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Table, TableHead, TableRow, TableCell, TableBody, TextField, IconButton, Typography } from '@mui/material';
+import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, TextField, IconButton, Typography } from '@mui/material';
 import { Delete, Add } from '@mui/icons-material';
 import type { ConfigItem, SystemConfigList1 } from './shared/RpcModels';
 import { fetchList, fetchSet, fetchDelete } from './rpc/system/config';
@@ -39,9 +39,10 @@ const SystemConfigPage = (): JSX.Element => {
     };
 
     return (
-        <>
-            <Typography variant='h5' sx={{ mb: 2 }}>Config Management</Typography>
-            <Table>
+        <Box sx={{ p: 2 }}>
+            <Typography variant='h5'>System Configuration</Typography>
+            <Divider sx={{ mb: 2 }} />
+            <Table size='small' sx={{ '& td, & th': { py: 0.5 } }}>
                 <TableHead>
                     <TableRow>
                         <TableCell>Key</TableCell>
@@ -76,7 +77,7 @@ const SystemConfigPage = (): JSX.Element => {
                     </TableRow>
                 </TableBody>
             </Table>
-        </>
+        </Box>
     );
 };
 

--- a/frontend/src/SystemRolesPage.tsx
+++ b/frontend/src/SystemRolesPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Table, TableHead, TableRow, TableCell, TableBody, TextField, IconButton, Typography } from '@mui/material';
+import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, TextField, IconButton, Typography } from '@mui/material';
 import { Delete, Add } from '@mui/icons-material';
 import type { RoleItem, SystemRolesList1 } from './shared/RpcModels';
 import { fetchList, fetchSet, fetchDelete } from './rpc/system/roles';
@@ -42,9 +42,10 @@ const SystemRolesPage = (): JSX.Element => {
     };
 
     return (
-        <>
-            <Typography variant='h5' sx={{ mb: 2 }}>Role Management</Typography>
-            <Table>
+        <Box sx={{ p: 2 }}>
+            <Typography variant='h5'>System Roles</Typography>
+            <Divider sx={{ mb: 2 }} />
+            <Table size='small' sx={{ '& td, & th': { py: 0.5 } }}>
                 <TableHead>
                     <TableRow>
                         <TableCell>Role</TableCell>
@@ -79,7 +80,7 @@ const SystemRolesPage = (): JSX.Element => {
                     </TableRow>
                 </TableBody>
             </Table>
-        </>
+        </Box>
     );
 };
 

--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Table, TableHead, TableRow, TableCell, TableBody, TextField, IconButton, Stack, List, ListItemButton, ListItemText, Typography } from '@mui/material';
+import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, TextField, IconButton, Stack, List, ListItemButton, ListItemText, Typography } from '@mui/material';
 import { Delete, Add, ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
 import type { SystemRouteItem, SystemRoutesList1, SystemUserRoles1 } from './shared/RpcModels';
 import { fetchList as fetchRoutes, fetchSet, fetchDelete } from './rpc/system/routes';
@@ -84,9 +84,10 @@ const SystemRoutesPage = (): JSX.Element => {
     };
 
     return (
-        <>
-            <Typography variant='h5' sx={{ mb: 2 }}>Route Management</Typography>
-            <Table>
+        <Box sx={{ p: 2 }}>
+            <Typography variant='h5'>System Routes</Typography>
+            <Divider sx={{ mb: 2 }} />
+            <Table size='small' sx={{ '& td, & th': { py: 0.5 } }}>
                 <TableHead>
                     <TableRow>
                         <TableCell>Path</TableCell>
@@ -183,7 +184,7 @@ const SystemRoutesPage = (): JSX.Element => {
                     </TableRow>
                 </TableBody>
             </Table>
-        </>
+        </Box>
     );
 };
 

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,88 +28,6 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
-export interface FrontendVarsFfmpegVersion1 {
-  ffmpeg_version: string;
-}
-export interface FrontendVarsHostname1 {
-  hostname: string;
-}
-export interface FrontendVarsRepo1 {
-  repo: string;
-}
-export interface FrontendVarsVersion1 {
-  version: string;
-}
-export interface ViewDiscord1 {
-  content: string;
-}
-export interface FrontendLinksHome1 {
-  links: LinkItem[];
-}
-export interface FrontendLinksRoutes1 {
-  routes: RouteItem[];
-}
-export interface LinkItem {
-  title: string;
-  url: string;
-}
-export interface RouteItem {
-  path: string;
-  name: string;
-  icon: string;
-}
-export interface FrontendUserProfileData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  storageUsed: number | null;
-  storageEnabled: boolean | null;
-  displayEmail: boolean;
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
-export interface FrontendUserSetDisplayName1 {
-  bearerToken: string;
-  displayName: string;
-}
-export interface SystemRouteDelete1 {
-  path: string;
-}
-export interface SystemRouteItem {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRouteUpdate1 {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRoutesList1 {
-  routes: SystemRouteItem[];
-}
-export interface ConfigItem {
-  key: string;
-  value: string;
-}
-export interface SystemConfigDelete1 {
-  key: string;
-}
-export interface SystemConfigList1 {
-  items: ConfigItem[];
-}
-export interface SystemConfigUpdate1 {
-  key: string;
-  value: string;
-}
 export interface SystemUserCreditsUpdate1 {
   userGuid: string;
   credits: number;
@@ -142,6 +60,20 @@ export interface UserListItem {
   guid: string;
   displayName: string;
 }
+export interface ConfigItem {
+  key: string;
+  value: string;
+}
+export interface SystemConfigDelete1 {
+  key: string;
+}
+export interface SystemConfigList1 {
+  items: ConfigItem[];
+}
+export interface SystemConfigUpdate1 {
+  key: string;
+  value: string;
+}
 export interface RoleItem {
   name: string;
   bit: number;
@@ -163,6 +95,90 @@ export interface SystemRoleUpdate1 {
 }
 export interface SystemRolesList1 {
   roles: RoleItem[];
+}
+export interface SystemRouteDelete1 {
+  path: string;
+}
+export interface SystemRouteItem {
+  path: string;
+  name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
+}
+export interface SystemRouteUpdate1 {
+  path: string;
+  name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
+}
+export interface SystemRoutesList1 {
+  routes: SystemRouteItem[];
+}
+export interface AuthSessionTokens1 {
+  bearerToken: string;
+  rotationToken: string;
+  rotationExpires: any;
+}
+export interface AuthMicrosoftLoginData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface FrontendLinksHome1 {
+  links: LinkItem[];
+}
+export interface FrontendLinksRoutes1 {
+  routes: RouteItem[];
+}
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+export interface RouteItem {
+  path: string;
+  name: string;
+  icon: string;
+}
+export interface FrontendVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface FrontendVarsHostname1 {
+  hostname: string;
+}
+export interface FrontendVarsRepo1 {
+  repo: string;
+}
+export interface FrontendVarsVersion1 {
+  version: string;
+}
+export interface ViewDiscord1 {
+  content: string;
+}
+export interface FrontendUserProfileData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  storageUsed: number | null;
+  storageEnabled: boolean | null;
+  displayEmail: boolean;
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface FrontendUserSetDisplayName1 {
+  bearerToken: string;
+  displayName: string;
 }
 export interface AccountUserCreditsUpdate1 {
   userGuid: string;
@@ -209,22 +225,6 @@ export interface AccountRoleUpdate1 {
 }
 export interface AccountRolesList1 {
   roles: RoleItem[];
-}
-export interface AuthMicrosoftLoginData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
-export interface AuthSessionTokens1 {
-  bearerToken: string;
-  rotationToken: string;
-  rotationExpires: any;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {


### PR DESCRIPTION
## Summary
- center main container and add vertical padding
- update System pages with tighter table padding, consistent headers, and new dividers
- cleanup Account pages layout and titles
- regenerate RPC models
- refresh docs on page names

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6881513a412c83259b32005c90fa6399