### PR TITLE
Add display field to roles

### DIFF
--- a/frontend/src/SystemRolesPage.tsx
+++ b/frontend/src/SystemRolesPage.tsx
@@ -6,7 +6,7 @@ import { fetchList, fetchSet, fetchDelete } from './rpc/system/roles';
 
 const SystemRolesPage = (): JSX.Element => {
     const [roles, setRoles] = useState<RoleItem[]>([]);
-    const [newRole, setNewRole] = useState<RoleItem>({ name: '', bit: 0 });
+    const [newRole, setNewRole] = useState<RoleItem>({ name: '', display: '', bit: 0 });
 
     const load = async (): Promise<void> => {
         try {
@@ -37,7 +37,7 @@ const SystemRolesPage = (): JSX.Element => {
     const handleAdd = async (): Promise<void> => {
         if (!newRole.name) return;
         await fetchSet(newRole);
-        setNewRole({ name: '', bit: 0 });
+        setNewRole({ name: '', display: '', bit: 0 });
         void load();
     };
 
@@ -49,6 +49,7 @@ const SystemRolesPage = (): JSX.Element => {
                 <TableHead>
                     <TableRow>
                         <TableCell>Role</TableCell>
+                        <TableCell>Display</TableCell>
                         <TableCell>Bit</TableCell>
                         <TableCell />
                     </TableRow>
@@ -58,6 +59,9 @@ const SystemRolesPage = (): JSX.Element => {
                         <TableRow key={r.name}>
                             <TableCell>
                                 <TextField value={r.name} onChange={e => updateRole(idx, 'name', e.target.value)} />
+                            </TableCell>
+                            <TableCell>
+                                <TextField value={r.display} onChange={e => updateRole(idx, 'display', e.target.value)} />
                             </TableCell>
                             <TableCell>
                                 <TextField type='number' inputProps={{ min: 0, max: 62 }} value={r.bit} onChange={e => updateRole(idx, 'bit', e.target.value)} />
@@ -70,6 +74,9 @@ const SystemRolesPage = (): JSX.Element => {
                     <TableRow>
                         <TableCell>
                             <TextField value={newRole.name} onChange={e => setNewRole({ ...newRole, name: e.target.value })} />
+                        </TableCell>
+                        <TableCell>
+                            <TextField value={newRole.display} onChange={e => setNewRole({ ...newRole, display: e.target.value })} />
                         </TableCell>
                         <TableCell>
                             <TextField type='number' inputProps={{ min: 0, max: 62 }} value={newRole.bit} onChange={e => setNewRole({ ...newRole, bit: Number(e.target.value) })} />

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,11 +28,11 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
-export interface SystemUserCreditsUpdate1 {
+export interface AccountUserCreditsUpdate1 {
   userGuid: string;
   credits: number;
 }
-export interface SystemUserProfile1 {
+export interface AccountUserProfile1 {
   guid: string;
   defaultProvider: string;
   username: string;
@@ -46,80 +46,43 @@ export interface SystemUserProfile1 {
   rotationToken: any;
   rotationExpires: any;
 }
-export interface SystemUserRoles1 {
+export interface AccountUserRoles1 {
   roles: string[];
 }
-export interface SystemUserRolesUpdate1 {
+export interface AccountUserRolesUpdate1 {
   userGuid: string;
   roles: string[];
 }
-export interface SystemUsersList1 {
+export interface AccountUsersList1 {
   users: UserListItem[];
 }
 export interface UserListItem {
   guid: string;
   displayName: string;
 }
-export interface ConfigItem {
-  key: string;
-  value: string;
-}
-export interface SystemConfigDelete1 {
-  key: string;
-}
-export interface SystemConfigList1 {
-  items: ConfigItem[];
-}
-export interface SystemConfigUpdate1 {
-  key: string;
-  value: string;
-}
-export interface RoleItem {
-  name: string;
-  bit: number;
-}
-export interface SystemRoleDelete1 {
+export interface AccountRoleDelete1 {
   name: string;
 }
-export interface SystemRoleMemberUpdate1 {
+export interface AccountRoleMemberUpdate1 {
   role: string;
   userGuid: string;
 }
-export interface SystemRoleMembers1 {
-  members: any[];
-  nonMembers: any[];
+export interface AccountRoleMembers1 {
+  members: UserListItem[];
+  nonMembers: UserListItem[];
 }
-export interface SystemRoleUpdate1 {
+export interface AccountRoleUpdate1 {
   name: string;
+  display: string;
   bit: number;
 }
-export interface SystemRolesList1 {
+export interface AccountRolesList1 {
   roles: RoleItem[];
 }
-export interface SystemRouteDelete1 {
-  path: string;
-}
-export interface SystemRouteItem {
-  path: string;
+export interface RoleItem {
   name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRouteUpdate1 {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRoutesList1 {
-  routes: SystemRouteItem[];
-}
-export interface AuthSessionTokens1 {
-  bearerToken: string;
-  rotationToken: string;
-  rotationExpires: any;
+  display: string;
+  bit: number;
 }
 export interface AuthMicrosoftLoginData1 {
   bearerToken: string;
@@ -131,6 +94,11 @@ export interface AuthMicrosoftLoginData1 {
   credits: number | null;
   rotationToken: string | null;
   rotationExpires: any | null;
+}
+export interface AuthSessionTokens1 {
+  bearerToken: string;
+  rotationToken: string;
+  rotationExpires: any;
 }
 export interface FrontendLinksHome1 {
   links: LinkItem[];
@@ -180,11 +148,31 @@ export interface FrontendUserSetDisplayName1 {
   bearerToken: string;
   displayName: string;
 }
-export interface AccountUserCreditsUpdate1 {
+export interface SystemRouteDelete1 {
+  path: string;
+}
+export interface SystemRouteItem {
+  path: string;
+  name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
+}
+export interface SystemRouteUpdate1 {
+  path: string;
+  name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
+}
+export interface SystemRoutesList1 {
+  routes: SystemRouteItem[];
+}
+export interface SystemUserCreditsUpdate1 {
   userGuid: string;
   credits: number;
 }
-export interface AccountUserProfile1 {
+export interface SystemUserProfile1 {
   guid: string;
   defaultProvider: string;
   username: string;
@@ -198,32 +186,47 @@ export interface AccountUserProfile1 {
   rotationToken: any;
   rotationExpires: any;
 }
-export interface AccountUserRoles1 {
+export interface SystemUserRoles1 {
   roles: string[];
 }
-export interface AccountUserRolesUpdate1 {
+export interface SystemUserRolesUpdate1 {
   userGuid: string;
   roles: string[];
 }
-export interface AccountUsersList1 {
+export interface SystemUsersList1 {
   users: UserListItem[];
 }
-export interface AccountRoleDelete1 {
+export interface ConfigItem {
+  key: string;
+  value: string;
+}
+export interface SystemConfigDelete1 {
+  key: string;
+}
+export interface SystemConfigList1 {
+  items: ConfigItem[];
+}
+export interface SystemConfigUpdate1 {
+  key: string;
+  value: string;
+}
+export interface SystemRoleDelete1 {
   name: string;
 }
-export interface AccountRoleMemberUpdate1 {
+export interface SystemRoleMemberUpdate1 {
   role: string;
   userGuid: string;
 }
-export interface AccountRoleMembers1 {
-  members: UserListItem[];
-  nonMembers: UserListItem[];
+export interface SystemRoleMembers1 {
+  members: any[];
+  nonMembers: any[];
 }
-export interface AccountRoleUpdate1 {
+export interface SystemRoleUpdate1 {
   name: string;
+  display: string;
   bit: number;
 }
-export interface AccountRolesList1 {
+export interface SystemRolesList1 {
   roles: RoleItem[];
 }
 

--- a/rpc/account/roles/models.py
+++ b/rpc/account/roles/models.py
@@ -3,6 +3,7 @@ from rpc.account.users.models import UserListItem
 
 class RoleItem(BaseModel):
   name: str
+  display: str
   bit: int
 
 class AccountRolesList1(BaseModel):
@@ -10,6 +11,7 @@ class AccountRolesList1(BaseModel):
 
 class AccountRoleUpdate1(BaseModel):
   name: str
+  display: str
   bit: int
 
 class AccountRoleDelete1(BaseModel):

--- a/rpc/system/roles/models.py
+++ b/rpc/system/roles/models.py
@@ -3,6 +3,7 @@ from rpc.system.users.models import UserListItem
 
 class RoleItem(BaseModel):
   name: str
+  display: str
   bit: int
 
 class SystemRolesList1(BaseModel):
@@ -10,6 +11,7 @@ class SystemRolesList1(BaseModel):
 
 class SystemRoleUpdate1(BaseModel):
   name: str
+  display: str
   bit: int
 
 class SystemRoleDelete1(BaseModel):

--- a/rpc/system/roles/services.py
+++ b/rpc/system/roles/services.py
@@ -26,7 +26,10 @@ def bit_to_mask(bit: int) -> int:
 async def list_roles_v1(request: Request) -> RPCResponse:
   db: DatabaseModule = request.app.state.database
   rows = await db.list_roles()
-  roles = [RoleItem(name=r['name'], bit=mask_to_bit(int(r['mask']))) for r in rows]
+  roles = [
+    RoleItem(name=r['name'], display=r['display'], bit=mask_to_bit(int(r['mask'])))
+    for r in rows
+  ]
   roles.sort(key=lambda r: r.bit)
   payload = SystemRolesList1(roles=roles)
   return RPCResponse(op='urn:system:roles:list:1', payload=payload, version=1)
@@ -35,7 +38,7 @@ async def set_role_v1(rpc_request, request: Request) -> RPCResponse:
   data = SystemRoleUpdate1(**(rpc_request.payload or {}))
   db: DatabaseModule = request.app.state.database
   mask = bit_to_mask(data.bit)
-  await db.set_role(data.name, mask)
+  await db.set_role(data.name, mask, data.display)
   await role_helper.load_roles(db)
   return await list_roles_v1(request)
 

--- a/scripts/v0.2.2.0_20250723.json
+++ b/scripts/v0.2.2.0_20250723.json
@@ -1,0 +1,413 @@
+{
+  "tables": [
+    {
+      "name": "routes",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('routes_id_seq'::regclass)"
+        },
+        {
+          "name": "path",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "icon",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "required_roles",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0"
+        },
+        {
+          "name": "sequence",
+          "type": "integer",
+          "nullable": true,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "auth_provider",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "roles",
+      "columns": [
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "display",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "mask",
+          "type": "bigint",
+          "nullable": false,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "name"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "users",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('users_id_seq'::regclass)"
+        },
+        {
+          "name": "guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "email",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "display_name",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "auth_provider",
+          "type": "integer",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "display_email",
+          "type": "boolean",
+          "nullable": true,
+          "default": "false"
+        },
+        {
+          "name": "rotation_token",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "rotation_expires",
+          "type": "timestamp with time zone",
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "auth_provider",
+          "ref_table": "auth_provider",
+          "ref_column": "id"
+        }
+      ]
+    },
+    {
+      "name": "users_profileimg",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "image_b64",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "user_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    },
+    {
+      "name": "config",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('config_id_seq'::regclass)"
+        },
+        {
+          "name": "key",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "value",
+          "type": "text",
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "links",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('links_id_seq'::regclass)"
+        },
+        {
+          "name": "title",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "url",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "required_roles",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "id"
+      ],
+      "foreign_keys": []
+    },
+    {
+      "name": "users_credits",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "credits",
+          "type": "integer",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "user_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    },
+    {
+      "name": "users_roles",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "roles",
+          "type": "bigint",
+          "nullable": false,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "user_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    },
+    {
+      "name": "users_enablements",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "enablements",
+          "type": "bigint",
+          "nullable": false,
+          "default": "0"
+        }
+      ],
+      "primary_key": [
+        "user_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    },
+    {
+      "name": "users_auth",
+      "columns": [
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "provider_id",
+          "type": "integer",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "provider_user_id",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "provider_id",
+        "provider_user_id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "provider_id",
+          "ref_table": "auth_provider",
+          "ref_column": "id"
+        }
+      ]
+    },
+    {
+      "name": "user_sessions",
+      "columns": [
+        {
+          "name": "session_id",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "user_guid",
+          "type": "uuid",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "bearer_token",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "rotation_token",
+          "type": "text",
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "session_id"
+      ],
+      "foreign_keys": [
+        {
+          "column": "user_guid",
+          "ref_table": "users",
+          "ref_column": "guid"
+        }
+      ]
+    }
+  ]
+}

--- a/server/modules/database_module.py
+++ b/server/modules/database_module.py
@@ -169,15 +169,15 @@ class DatabaseModule(BaseModule):
     return row.get('roles', 0) if row else 0
 
   async def list_roles(self) -> list[dict]:
-    query = "SELECT name, mask FROM roles ORDER BY mask;"
+    query = "SELECT name, display, mask FROM roles ORDER BY mask;"
     return await self._fetch_many(query)
 
-  async def set_role(self, name: str, mask: int):
+  async def set_role(self, name: str, mask: int, display: str):
     query = (
-      "INSERT INTO roles(name, mask) VALUES($1, $2) "
-      "ON CONFLICT(name) DO UPDATE SET mask=excluded.mask;"
+      "INSERT INTO roles(name, display, mask) VALUES($1, $2, $3) "
+      "ON CONFLICT(name) DO UPDATE SET display=excluded.display, mask=excluded.mask;"
     )
-    await self._run(query, name, mask)
+    await self._run(query, name, display, mask)
 
   async def delete_role(self, name: str):
     await self._run("DELETE FROM roles WHERE name=$1", name)

--- a/tests/test_rpc_system_namespace.py
+++ b/tests/test_rpc_system_namespace.py
@@ -16,7 +16,7 @@ class DummyDB:
         self.roles = {"ROLE_REGISTERED": 1, "ROLE_SYSTEM_ADMIN": 2}
 
     async def list_roles(self):
-        return [{"name": n, "mask": m} for n, m in self.roles.items()]
+        return [{"name": n, "display": n, "mask": m} for n, m in self.roles.items()]
 
     async def select_routes(self, role_mask=0):
         routes = [

--- a/tests/test_rpc_system_roles.py
+++ b/tests/test_rpc_system_roles.py
@@ -10,7 +10,7 @@ class DummyDB:
     self.users = {'u1': 2, 'u2': 0}
 
   async def list_roles(self):
-    return [{'name': n, 'mask': m} for n, m in self.roles.items()]
+    return [{'name': n, 'display': n, 'mask': m} for n, m in self.roles.items()]
 
   async def select_users_with_role(self, mask):
     return [{'guid': k, 'display_name': k} for k, v in self.users.items() if v & mask]


### PR DESCRIPTION
## Summary
- add 'display' column to roles table schema
- support display name for system/account roles in API and DB
- update SystemRolesPage to edit role display name
- update tests for new role display property
- generate v0.2.2 schema file

## Testing
- `python3 scripts/generate_rpc_library.py`
- `python3 scripts/generate_rpc_client.py`
- `python3 scripts/generate_rpc_metadata.py`
- `python3 scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_688170cdee0083258b756a96d4677db8