### PR TITLE
Use role display names on membership page

### DIFF
--- a/frontend/src/AccountRoleMembersPage.tsx
+++ b/frontend/src/AccountRoleMembersPage.tsx
@@ -65,7 +65,7 @@ const AccountRoleMembersPage = (): JSX.Element => {
             <Stack spacing={2}>
             {roles.map((role) => (
                 <Stack key={role.name} spacing={2} direction='column' alignItems='center'>
-                    <Typography variant='h6'>{role.name}</Typography>
+                    <Typography variant='h6'>{role.display}</Typography>
                     <Stack direction='row' spacing={2}>
                         <List sx={{ width: 200, border: 1 }}>
                             {(nonMembers[role.name] || []).map(u => (


### PR DESCRIPTION
## Summary
- display role display names instead of internal role names on Role Memberships page

## Testing
- `python3 scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68819c8ee3188325a3702976f03b4004