### PR TITLE
Improve account user panel username editing

### DIFF
--- a/frontend/src/rpc/account/users/index.ts
+++ b/frontend/src/rpc/account/users/index.ts
@@ -13,3 +13,4 @@ export const fetchListRoles = (payload: any = null): Promise<AccountUserRoles1> 
 export const fetchProfile = (payload: any = null): Promise<AccountUserProfile1> => rpcCall('urn:account:users:get_profile:1', payload);
 export const fetchSetCredits = (payload: any = null): Promise<AccountUserProfile1> => rpcCall('urn:account:users:set_credits:1', payload);
 export const fetchEnableStorage = (payload: any = null): Promise<AccountUserProfile1> => rpcCall('urn:account:users:enable_storage:1', payload);
+export const fetchSetDisplayName = (payload: any = null): Promise<AccountUserProfile1> => rpcCall('urn:account:users:set_display_name:1', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -29,8 +29,12 @@ export interface UserData {
   bearerToken: string;
 }
 export interface AccountUserCreditsUpdate1 {
-  userGuid: string;
-  credits: number;
+    userGuid: string;
+    credits: number;
+}
+export interface AccountUserDisplayNameUpdate1 {
+    userGuid: string;
+    displayName: string;
 }
 export interface AccountUserProfile1 {
   guid: string;

--- a/rpc/account/users/handler.py
+++ b/rpc/account/users/handler.py
@@ -16,6 +16,8 @@ async def handle_users_request(parts: list[str], rpc_request: RPCRequest | None,
       return await services.get_user_profile_v1(rpc_request, request)
     case ["set_credits", "1"]:
       return await services.set_user_credits_v1(rpc_request, request)
+    case ["set_display_name", "1"]:
+      return await services.set_user_display_name_v1(rpc_request, request)
     case ["enable_storage", "1"]:
       return await services.enable_user_storage_v1(rpc_request, request)
     case _:

--- a/rpc/account/users/models.py
+++ b/rpc/account/users/models.py
@@ -19,6 +19,10 @@ class AccountUserCreditsUpdate1(BaseModel):
   userGuid: str
   credits: int
 
+class AccountUserDisplayNameUpdate1(BaseModel):
+  userGuid: str
+  displayName: str
+
 class AccountUserProfile1(BaseModel):
   guid: str
   defaultProvider: str

--- a/rpc/account/users/services.py
+++ b/rpc/account/users/services.py
@@ -6,6 +6,7 @@ from rpc.account.users.models import (
   AccountUserRoles1,
   AccountUserRolesUpdate1,
   AccountUserCreditsUpdate1,
+  AccountUserDisplayNameUpdate1,
   AccountUserProfile1,
 )
 from server.modules.database_module import DatabaseModule, _utos
@@ -100,6 +101,31 @@ async def set_user_credits_v1(rpc_request: RPCRequest, request: Request) -> RPCR
     rotationExpires=user.get('rotation_expires'),
   )
   return RPCResponse(op='urn:account:users:set_credits:1', payload=payload, version=1)
+
+async def set_user_display_name_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
+  payload = rpc_request.payload or {}
+  data = AccountUserDisplayNameUpdate1(**payload)
+  db: DatabaseModule = request.app.state.database
+  storage: StorageModule = request.app.state.storage
+  await db.update_display_name(data.userGuid, data.displayName)
+  user = await db.get_user_profile(data.userGuid)
+  if not user:
+    raise HTTPException(status_code=404, detail='User not found')
+  payload = AccountUserProfile1(
+    guid=_utos(user.get('guid')),
+    defaultProvider=user.get('provider_name', 'microsoft'),
+    username=user.get('display_name', data.displayName),
+    email=user.get('email', ''),
+    backupEmail=None,
+    profilePicture=user.get('profile_image'),
+    credits=user.get('credits', 0),
+    storageUsed=await storage.get_user_folder_size(data.userGuid),
+    storageEnabled=await storage.user_folder_exists(data.userGuid),
+    displayEmail=user.get('display_email', False),
+    rotationToken=_utos(user.get('rotation_token')) if user.get('rotation_token') else None,
+    rotationExpires=user.get('rotation_expires'),
+  )
+  return RPCResponse(op='urn:account:users:set_display_name:1', payload=payload, version=1)
 
 async def enable_user_storage_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   payload = rpc_request.payload or {}

--- a/tests/test_rpc_account_users_service.py
+++ b/tests/test_rpc_account_users_service.py
@@ -1,0 +1,41 @@
+import asyncio
+from fastapi import FastAPI, Request
+from rpc.models import RPCRequest
+from rpc.account.users import services
+
+class DummyDB:
+  async def get_user_profile(self, guid):
+    return {
+      'guid': guid,
+      'display_name': getattr(self, 'name', 'u'),
+      'email': 'e',
+      'profile_image': 'img',
+      'display_email': False,
+      'credits': 0,
+      'provider_name': 'microsoft',
+      'rotation_token': None,
+      'rotation_expires': None,
+    }
+  async def update_display_name(self, guid, name):
+    self.updated = (guid, name)
+    self.name = name
+
+class DummyStorage:
+  async def get_user_folder_size(self, guid):
+    return 0
+  async def user_folder_exists(self, guid):
+    return False
+  async def ensure_user_folder(self, guid):
+    return None
+
+def test_set_user_display_name_v1():
+  app = FastAPI()
+  db = DummyDB()
+  app.state.database = db
+  app.state.storage = DummyStorage()
+  req = Request({'type': 'http', 'app': app, 'headers': []})
+  rpc = RPCRequest(op='op', payload={'userGuid': 'uid', 'displayName': 'n'})
+  resp = asyncio.run(services.set_user_display_name_v1(rpc, req))
+  assert resp.op == 'urn:account:users:set_display_name:1'
+  assert resp.payload.username == 'n'
+  assert db.updated == ('uid', 'n')


### PR DESCRIPTION
## Summary
- fetch role display names for AccountUserPanel
- allow editing username with enter or blur commit
- add backend RPC for account:users:set_display_name
- expose fetchSetDisplayName in generated clients
- cover new service with unit test

## Testing
- `python -m pytest -q`
- `npx vitest run --silent`


------
https://chatgpt.com/codex/tasks/task_e_6881a5fc44c48325978d54f6cce7c204