### PR TITLE
Add reusable edit box component

### DIFF
--- a/frontend/src/AccountUserPanel.tsx
+++ b/frontend/src/AccountUserPanel.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Box, Divider, Stack, Button, List, ListItemButton, ListItemText, IconButton, Typography, Avatar, TextField } from '@mui/material';
+import { Box, Divider, Stack, Button, List, ListItemButton, ListItemText, IconButton, Typography, Avatar } from '@mui/material';
 import { ArrowForwardIos, ArrowBackIos, CheckCircle, Cancel } from '@mui/icons-material';
 import type { AccountUserRoles1, AccountUserProfile1, RoleItem } from './shared/RpcModels';
 import { fetchRoles, fetchSetRoles, fetchProfile, fetchSetCredits, fetchEnableStorage, fetchSetDisplayName } from './rpc/account/users';
+import EditBox from './shared/EditBox';
+import Notification from './shared/Notification';
 import { fetchList as fetchRoleList } from './rpc/account/roles';
 
 const AccountUserPanel = (): JSX.Element => {
@@ -11,6 +13,7 @@ const AccountUserPanel = (): JSX.Element => {
     const [assigned, setAssigned] = useState<string[]>([]);
     const [available, setAvailable] = useState<string[]>([]);
     const [profile, setProfile] = useState<AccountUserProfile1 | null>(null);
+    const [notification, setNotification] = useState(false);
     const [username, setUsername] = useState<string>('');
     const [roles, setRoles] = useState<RoleItem[]>([]);
     const [credits, setCredits] = useState<number>(0);
@@ -64,17 +67,20 @@ const AccountUserPanel = (): JSX.Element => {
         setStorageUsed(prof.storageUsed ?? 0);
     };
 
-    const handleNameCommit = async (): Promise<void> => {
-        if (!guid || !profile) return;
-        if (username === profile.username) return;
-        const updated = await fetchSetDisplayName({ userGuid: guid, displayName: username });
+    const commitName = async (val: string | number): Promise<void> => {
+        if (!guid) return;
+        const updated = await fetchSetDisplayName({ userGuid: guid, displayName: String(val) });
         setProfile(updated);
+        setUsername(updated.username);
     };
+
+    const handleNotificationClose = (): void => { setNotification(false); };
 
     const handleSave = async (): Promise<void> => {
         if (!guid) return;
         await fetchSetRoles({ userGuid: guid, roles: assigned });
         await fetchSetCredits({ userGuid: guid, credits });
+        setNotification(true);
     };
 
     return (
@@ -88,15 +94,9 @@ const AccountUserPanel = (): JSX.Element => {
                         src={profile.profilePicture ? `data:image/png;base64,${profile.profilePicture}` : undefined}
                         sx={{ width: 80, height: 80 }}
                     />
-                    <TextField
-                        label='Display Name'
-                        value={username}
-                        onChange={e => setUsername(e.target.value)}
-                        onBlur={() => void handleNameCommit()}
-                        onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); void handleNameCommit(); } }}
-                    />
+                    <EditBox label='Display Name' value={username} onCommit={commitName} />
                     <Typography>Email: {profile.email}</Typography>
-                    <TextField label='Credits' type='number' value={credits} onChange={e => setCredits(Number(e.target.value))} />
+                    <EditBox label='Credits' type='number' value={credits} onCommit={val => setCredits(Number(val))} />
                     <Stack direction='row' spacing={1} alignItems='center'>
                         <Typography>Storage Enabled:</Typography>
                         {storageEnabled ? <CheckCircle color='success' /> : <IconButton onClick={handleEnableStorage}><Cancel color='error' /></IconButton>}
@@ -127,6 +127,12 @@ const AccountUserPanel = (): JSX.Element => {
             <Box sx={{ ml: 2 }}>
                 <Button variant='contained' onClick={handleSave}>Save</Button>
             </Box>
+            <Notification
+                open={notification}
+                handleClose={handleNotificationClose}
+                severity='success'
+                message='Saved'
+            />
         </Box>
     );
 };

--- a/frontend/src/SystemConfigPage.tsx
+++ b/frontend/src/SystemConfigPage.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useState } from 'react';
-import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, TextField, IconButton, Typography } from '@mui/material';
+import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Typography } from '@mui/material';
 import { Delete, Add } from '@mui/icons-material';
 import type { ConfigItem, SystemConfigList1 } from './shared/RpcModels';
 import { fetchList, fetchSet, fetchDelete } from './rpc/system/config';
+import EditBox from './shared/EditBox';
+import Notification from './shared/Notification';
 
 const SystemConfigPage = (): JSX.Element => {
     const [items, setItems] = useState<ConfigItem[]>([]);
     const [newItem, setNewItem] = useState<ConfigItem>({ key: '', value: '' });
+    const [notification, setNotification] = useState(false);
+    const handleNotificationClose = (): void => { setNotification(false); };
 
     const load = async (): Promise<void> => {
         try {
@@ -24,11 +28,13 @@ const SystemConfigPage = (): JSX.Element => {
         (updated[index] as any)[field] = value;
         setItems(updated);
         await fetchSet(updated[index]);
+        setNotification(true);
     };
 
     const handleDelete = async (key: string): Promise<void> => {
         await fetchDelete({ key });
         void load();
+        setNotification(true);
     };
 
     const handleAdd = async (): Promise<void> => {
@@ -36,6 +42,7 @@ const SystemConfigPage = (): JSX.Element => {
         await fetchSet(newItem);
         setNewItem({ key: '', value: '' });
         void load();
+        setNotification(true);
     };
 
     return (
@@ -54,10 +61,10 @@ const SystemConfigPage = (): JSX.Element => {
                     {items.map((i, idx) => (
                         <TableRow key={i.key}>
                             <TableCell>
-                                <TextField value={i.key} onChange={e => updateItem(idx, 'key', e.target.value)} />
+                                <EditBox value={i.key} onCommit={val => updateItem(idx, 'key', String(val))} />
                             </TableCell>
                             <TableCell>
-                                <TextField value={i.value} onChange={e => updateItem(idx, 'value', e.target.value)} />
+                                <EditBox value={i.value} onCommit={val => updateItem(idx, 'value', String(val))} />
                             </TableCell>
                             <TableCell>
                                 <IconButton onClick={() => handleDelete(i.key)}><Delete /></IconButton>
@@ -77,6 +84,12 @@ const SystemConfigPage = (): JSX.Element => {
                     </TableRow>
                 </TableBody>
             </Table>
+            <Notification
+                open={notification}
+                handleClose={handleNotificationClose}
+                severity='success'
+                message='Saved'
+            />
         </Box>
     );
 };

--- a/frontend/src/SystemRolesPage.tsx
+++ b/frontend/src/SystemRolesPage.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useState } from 'react';
-import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, TextField, IconButton, Typography } from '@mui/material';
+import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Typography } from '@mui/material';
 import { Delete, Add } from '@mui/icons-material';
 import type { RoleItem, SystemRolesList1 } from './shared/RpcModels';
 import { fetchList, fetchSet, fetchDelete } from './rpc/system/roles';
+import EditBox from './shared/EditBox';
+import Notification from './shared/Notification';
 
 const SystemRolesPage = (): JSX.Element => {
     const [roles, setRoles] = useState<RoleItem[]>([]);
     const [newRole, setNewRole] = useState<RoleItem>({ name: '', display: '', bit: 0 });
+    const [notification, setNotification] = useState(false);
+    const handleNotificationClose = (): void => { setNotification(false); };
 
     const load = async (): Promise<void> => {
         try {
@@ -27,11 +31,13 @@ const SystemRolesPage = (): JSX.Element => {
         setRoles(updated);
         await fetchSet(updated[index]);
         void load();
+        setNotification(true);
     };
 
     const handleDelete = async (name: string): Promise<void> => {
         await fetchDelete({ name });
         void load();
+        setNotification(true);
     };
 
     const handleAdd = async (): Promise<void> => {
@@ -39,6 +45,7 @@ const SystemRolesPage = (): JSX.Element => {
         await fetchSet(newRole);
         setNewRole({ name: '', display: '', bit: 0 });
         void load();
+        setNotification(true);
     };
 
     return (
@@ -58,13 +65,13 @@ const SystemRolesPage = (): JSX.Element => {
                     {roles.map((r, idx) => (
                         <TableRow key={r.name}>
                             <TableCell>
-                                <TextField value={r.name} onChange={e => updateRole(idx, 'name', e.target.value)} />
+                                <EditBox value={r.name} onCommit={val => updateRole(idx, 'name', String(val))} />
                             </TableCell>
                             <TableCell>
-                                <TextField value={r.display} onChange={e => updateRole(idx, 'display', e.target.value)} />
+                                <EditBox value={r.display} onCommit={val => updateRole(idx, 'display', String(val))} />
                             </TableCell>
                             <TableCell>
-                                <TextField type='number' inputProps={{ min: 0, max: 62 }} value={r.bit} onChange={e => updateRole(idx, 'bit', e.target.value)} />
+                                <EditBox type='number' inputProps={{ min: 0, max: 62 }} value={r.bit} onCommit={val => updateRole(idx, 'bit', Number(val))} />
                             </TableCell>
                             <TableCell>
                                 <IconButton onClick={() => handleDelete(r.name)}><Delete /></IconButton>
@@ -87,6 +94,12 @@ const SystemRolesPage = (): JSX.Element => {
                     </TableRow>
                 </TableBody>
             </Table>
+            <Notification
+                open={notification}
+                handleClose={handleNotificationClose}
+                severity='success'
+                message='Saved'
+            />
         </Box>
     );
 };

--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
-import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, TextField, IconButton, Stack, List, ListItemButton, ListItemText, Typography } from '@mui/material';
+import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Stack, List, ListItemButton, ListItemText, Typography } from '@mui/material';
 import { Delete, Add, ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
 import type { SystemRouteItem, SystemRoutesList1, SystemUserRoles1 } from './shared/RpcModels';
 import { fetchList as fetchRoutes, fetchSet, fetchDelete } from './rpc/system/routes';
+import EditBox from './shared/EditBox';
+import Notification from './shared/Notification';
 import { fetchListRoles } from './rpc/system/users';
 
 const MAX_HEIGHT = 120;
@@ -15,6 +17,8 @@ const SystemRoutesPage = (): JSX.Element => {
     const [newRoute, setNewRoute] = useState<SystemRouteItem>({ path: '', name: '', icon: '', sequence: 0, requiredRoles: [] });
     const [newLeft, setNewLeft] = useState<string | null>(null);
     const [newRight, setNewRight] = useState<string | null>(null);
+    const [notification, setNotification] = useState(false);
+    const handleNotificationClose = (): void => { setNotification(false); };
 
     const load = async (): Promise<void> => {
         try {
@@ -39,6 +43,7 @@ const SystemRoutesPage = (): JSX.Element => {
         setRoutes(updated);
         await fetchSet(updated[index]);
         void load();
+        setNotification(true);
     };
 
     const moveRight = async (idx: number): Promise<void> => {
@@ -60,6 +65,7 @@ const SystemRoutesPage = (): JSX.Element => {
     const handleDelete = async (path: string): Promise<void> => {
         await fetchDelete({ path });
         void load();
+        setNotification(true);
     };
 
     const addMoveRight = (role: string | null): void => {
@@ -81,6 +87,7 @@ const SystemRoutesPage = (): JSX.Element => {
         setNewLeft(null);
         setNewRight(null);
         void load();
+        setNotification(true);
     };
 
     return (
@@ -104,16 +111,16 @@ const SystemRoutesPage = (): JSX.Element => {
                         return (
                             <TableRow key={r.path}>
                                 <TableCell>
-                                    <TextField value={r.path} onChange={e => updateRoute(idx, 'path', e.target.value)} />
+                                    <EditBox value={r.path} onCommit={val => updateRoute(idx, 'path', String(val))} />
                                 </TableCell>
                                 <TableCell>
-                                    <TextField value={r.name} onChange={e => updateRoute(idx, 'name', e.target.value)} />
+                                    <EditBox value={r.name} onCommit={val => updateRoute(idx, 'name', String(val))} />
                                 </TableCell>
                                 <TableCell>
-                                    <TextField value={r.icon} onChange={e => updateRoute(idx, 'icon', e.target.value)} />
+                                    <EditBox value={r.icon} onCommit={val => updateRoute(idx, 'icon', String(val))} />
                                 </TableCell>
                                 <TableCell>
-                                    <TextField type='number' value={r.sequence} onChange={e => updateRoute(idx, 'sequence', Number(e.target.value))} />
+                                    <EditBox type='number' value={r.sequence} onCommit={val => updateRoute(idx, 'sequence', Number(val))} />
                                 </TableCell>
                                 <TableCell>
                                     <Stack direction='row' spacing={1}>
@@ -184,6 +191,12 @@ const SystemRoutesPage = (): JSX.Element => {
                     </TableRow>
                 </TableBody>
             </Table>
+            <Notification
+                open={notification}
+                handleClose={handleNotificationClose}
+                severity='success'
+                message='Saved'
+            />
         </Box>
     );
 };

--- a/frontend/src/UserPage.tsx
+++ b/frontend/src/UserPage.tsx
@@ -1,7 +1,9 @@
-import React, { useContext, useState, useEffect } from 'react';
-import { Box, Typography, FormControlLabel, Switch, Avatar, TextField, Button, Stack, RadioGroup, Radio } from '@mui/material';
+import React, { useContext, useState, useEffect, useRef } from 'react';
+import { Box, Typography, FormControlLabel, Switch, Avatar, Button, Stack, RadioGroup, Radio } from '@mui/material';
 import UserContext from './shared/UserContext';
 import { fetchSetDisplayName } from './rpc/frontend/user';
+import EditBox, { EditBoxHandle } from './shared/EditBox';
+import Notification from './shared/Notification';
 import { fetchList as fetchRoleList } from './rpc/system/roles';
 import type { SystemRolesList1 } from './shared/RpcModels';
 
@@ -12,6 +14,10 @@ const UserPage = (): JSX.Element => {
     const [dirty, setDirty] = useState<boolean>(false);
     const [provider, setProvider] = useState<string>(userData?.defaultProvider ?? 'microsoft');
     const [roleMap, setRoleMap] = useState<Record<string, string>>({});
+    const [notification, setNotification] = useState(false);
+    const nameRef = useRef<EditBoxHandle>(null);
+
+    const handleNotificationClose = (): void => { setNotification(false); };
 
     useEffect(() => {
         void (async () => {
@@ -53,9 +59,11 @@ const UserPage = (): JSX.Element => {
 
     const handleApply = async (): Promise<void> => {
         if (!userData) return;
+        await nameRef.current?.commit();
         const updated = await fetchSetDisplayName({ bearerToken: userData.bearerToken, displayName });
         setUserData({ ...userData, username: updated.username, displayEmail });
         setDirty(false);
+        setNotification(true);
     };
 
     return (
@@ -74,16 +82,14 @@ const UserPage = (): JSX.Element => {
                         sx={{ width: 80, height: 80 }}
                     />
 
-                    <TextField
+                    <EditBox
+                        ref={nameRef}
                         label='Display Name'
                         value={displayName}
-                        onChange={handleNameChange}
+                        onCommit={val => { setDisplayName(String(val)); setDirty(true); }}
+                        manual
                         fullWidth
-                        slotProps={{
-                            input: {
-                                style: { textAlign: 'right' }
-                            }
-                        }}
+                        slotProps={{ input: { style: { textAlign: 'right' } } }}
                     />
 
                     <Typography>Credits: {userData.credits ?? 0}</Typography>
@@ -131,6 +137,12 @@ const UserPage = (): JSX.Element => {
                 )}
                 </Stack>
             </Box>
+            <Notification
+                open={notification}
+                handleClose={handleNotificationClose}
+                severity='success'
+                message='Saved'
+            />
         </Box>
     );
 };

--- a/frontend/src/shared/EditBox.tsx
+++ b/frontend/src/shared/EditBox.tsx
@@ -1,0 +1,64 @@
+import { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
+import TextField from '@mui/material/TextField';
+import Notification from './Notification';
+
+interface EditBoxProps {
+    label?: string;
+    value: string | number;
+    type?: string;
+    onCommit: (value: string | number) => Promise<void> | void;
+    manual?: boolean;
+    [key: string]: any;
+}
+
+export interface EditBoxHandle {
+    commit: () => Promise<void>;
+}
+
+const EditBox = forwardRef<EditBoxHandle, EditBoxProps>(({ label, value, type = 'text', onCommit, manual = false, ...rest }, ref) => {
+    const [internal, setInternal] = useState<string | number>(value);
+    const [notify, setNotify] = useState(false);
+
+    useEffect(() => { setInternal(value); }, [value]);
+
+    const commit = async (): Promise<void> => {
+        if (internal !== value) {
+            await onCommit(internal);
+            setNotify(true);
+        }
+    };
+
+    useImperativeHandle(ref, () => ({ commit }));
+
+    const handleKeyDown = (e: React.KeyboardEvent): void => {
+        if (!manual && (e.key === 'Enter' || e.key === 'Tab')) {
+            void commit();
+        }
+    };
+
+    const handleBlur = (): void => { if (!manual) void commit(); };
+
+    const handleClose = (): void => { setNotify(false); };
+
+    return (
+        <>
+            <TextField
+                label={label}
+                type={type}
+                value={internal}
+                onChange={e => setInternal(type === 'number' ? Number((e.target as HTMLInputElement).value) : (e.target as HTMLInputElement).value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleBlur}
+                {...rest}
+            />
+            <Notification
+                open={notify}
+                handleClose={handleClose}
+                severity='success'
+                message='Saved'
+            />
+        </>
+    );
+});
+
+export default EditBox;


### PR DESCRIPTION
## Summary
- implement generic `EditBox` component
- wire edit box into user management panel
- use edit box across system config, roles and routes pages
- show a "Saved" notification on RPC completion

## Testing
- `npm test` in `frontend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882462418d48325b7b4e56e4eaa6fea