### PR TITLE
Fix missing auth token for file manager

### DIFF
--- a/frontend/src/FileManager.tsx
+++ b/frontend/src/FileManager.tsx
@@ -1,20 +1,23 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { Box, List, ListItem, Typography, IconButton, Link as MuiLink } from '@mui/material';
 import { Delete, ContentCopy, Link as LinkIcon } from '@mui/icons-material';
 import EditBox from './shared/EditBox';
 import PaginationControls from './shared/PaginationControls';
 import { PageTitle } from './shared/PageTitle';
 import { fetchList, fetchDelete } from './rpc/frontend/files';
+import UserContext from './shared/UserContext';
 import type { FileItem, FrontendFilesList1 } from './shared/RpcModels';
 
 const FileManager = (): JSX.Element => {
+    const { userData } = useContext(UserContext);
+
     const [page, setPage] = useState(0);
     const [itemsPerPage, setItemsPerPage] = useState(10);
     const [files, setFiles] = useState<FileItem[]>([]);
 
     const load = async (): Promise<void> => {
         try {
-            const res: FrontendFilesList1 = await fetchList();
+            const res: FrontendFilesList1 = await fetchList({ bearerToken: userData?.bearerToken });
             setFiles(res.files);
         } catch {
             setFiles([]);
@@ -27,7 +30,7 @@ const FileManager = (): JSX.Element => {
     const paginated = files.slice(page * itemsPerPage, (page + 1) * itemsPerPage);
 
     const handleDelete = async (name: string): Promise<void> => {
-        await fetchDelete({ filename: name });
+        await fetchDelete({ bearerToken: userData?.bearerToken, filename: name });
         void load();
     };
 

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,6 +28,67 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
+export interface FrontendVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface FrontendVarsHostname1 {
+  hostname: string;
+}
+export interface FrontendVarsRepo1 {
+  repo: string;
+}
+export interface FrontendVarsVersion1 {
+  version: string;
+}
+export interface ViewDiscord1 {
+  content: string;
+}
+export interface FrontendLinksHome1 {
+  links: LinkItem[];
+}
+export interface FrontendLinksRoutes1 {
+  routes: RouteItem[];
+}
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+export interface RouteItem {
+  path: string;
+  name: string;
+  icon: string;
+}
+export interface FrontendUserProfileData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  storageUsed: number | null;
+  storageEnabled: boolean | null;
+  displayEmail: boolean;
+  roles: string[];
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface FrontendUserSetDisplayName1 {
+  bearerToken: string;
+  displayName: string;
+}
+export interface FileItem {
+  name: string;
+  url: string;
+  contentType: string | null;
+}
+export interface FrontendFileDelete1 {
+  bearerToken: string;
+  filename: string;
+}
+export interface FrontendFilesList1 {
+  files: FileItem[];
+}
 export interface AccountRoleDelete1 {
   name: string;
 }
@@ -88,82 +149,39 @@ export interface AccountUserRolesUpdate1 {
 export interface AccountUsersList1 {
   users: UserListItem[];
 }
-export interface AuthSessionTokens1 {
-  bearerToken: string;
-  rotationToken: string;
-  rotationExpires: any;
+export interface ConfigItem {
+  key: string;
+  value: string;
 }
-export interface AuthMicrosoftLoginData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  rotationToken: string | null;
-  rotationExpires: any | null;
+export interface SystemConfigDelete1 {
+  key: string;
 }
-export interface FileItem {
-  name: string;
-  url: string;
-  contentType: string | null;
+export interface SystemConfigList1 {
+  items: ConfigItem[];
 }
-export interface FrontendFileDelete1 {
-  bearerToken: string;
-  filename: string;
+export interface SystemConfigUpdate1 {
+  key: string;
+  value: string;
 }
-export interface FrontendFilesList1 {
-  files: FileItem[];
+export interface SystemRouteDelete1 {
+  path: string;
 }
-export interface FrontendUserProfileData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  storageUsed: number | null;
-  storageEnabled: boolean | null;
-  displayEmail: boolean;
-  roles: string[];
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
-export interface FrontendUserSetDisplayName1 {
-  bearerToken: string;
-  displayName: string;
-}
-export interface FrontendLinksHome1 {
-  links: LinkItem[];
-}
-export interface FrontendLinksRoutes1 {
-  routes: RouteItem[];
-}
-export interface LinkItem {
-  title: string;
-  url: string;
-}
-export interface RouteItem {
+export interface SystemRouteItem {
   path: string;
   name: string;
   icon: string;
+  sequence: number;
+  requiredRoles: string[];
 }
-export interface FrontendVarsFfmpegVersion1 {
-  ffmpeg_version: string;
+export interface SystemRouteUpdate1 {
+  path: string;
+  name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
 }
-export interface FrontendVarsHostname1 {
-  hostname: string;
-}
-export interface FrontendVarsRepo1 {
-  repo: string;
-}
-export interface FrontendVarsVersion1 {
-  version: string;
-}
-export interface ViewDiscord1 {
-  content: string;
+export interface SystemRoutesList1 {
+  routes: SystemRouteItem[];
 }
 export interface SystemRoleDelete1 {
   name: string;
@@ -212,39 +230,21 @@ export interface SystemUserRolesUpdate1 {
 export interface SystemUsersList1 {
   users: UserListItem[];
 }
-export interface SystemRouteDelete1 {
-  path: string;
+export interface AuthSessionTokens1 {
+  bearerToken: string;
+  rotationToken: string;
+  rotationExpires: any;
 }
-export interface SystemRouteItem {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRouteUpdate1 {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRoutesList1 {
-  routes: SystemRouteItem[];
-}
-export interface ConfigItem {
-  key: string;
-  value: string;
-}
-export interface SystemConfigDelete1 {
-  key: string;
-}
-export interface SystemConfigList1 {
-  items: ConfigItem[];
-}
-export interface SystemConfigUpdate1 {
-  key: string;
-  value: string;
+export interface AuthMicrosoftLoginData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  rotationToken: string | null;
+  rotationExpires: any | null;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {


### PR DESCRIPTION
## Summary
- use user context in `FileManager` and pass bearer token when listing/deleting files
- update generated RPC models

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68829489d8e08325a2c73c1571fe77b5