### PR TITLE
Use shared PageTitle in all pages

### DIFF
--- a/frontend/src/AccountRoleMembersPage.tsx
+++ b/frontend/src/AccountRoleMembersPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Box, Divider, Stack, List, ListItemButton, ListItemText, IconButton, Typography } from '@mui/material';
+import { Box, Stack, List, ListItemButton, ListItemText, IconButton, Typography } from '@mui/material';
+import { PageTitle } from './shared/PageTitle';
 import { ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
 import type { RoleItem, AccountRoleMembers1, UserListItem, AccountRolesList1 } from './shared/RpcModels';
 import { fetchList, fetchMembers, fetchAddMember, fetchRemoveMember } from './rpc/account/roles';
@@ -60,8 +61,7 @@ const AccountRoleMembersPage = (): JSX.Element => {
 
     return (
         <Box sx={{ p: 2 }}>
-            <Typography variant='h5'>Role Memberships</Typography>
-            <Divider sx={{ mb: 2 }} />
+            <PageTitle title='Role Memberships' />
             <Stack spacing={2}>
             {roles.map((role) => (
                 <Stack key={role.name} spacing={2} direction='column' alignItems='center'>

--- a/frontend/src/AccountUserPanel.tsx
+++ b/frontend/src/AccountUserPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Box, Divider, Stack, Button, List, ListItemButton, ListItemText, IconButton, Typography, Avatar } from '@mui/material';
+import { Box, Stack, Button, List, ListItemButton, ListItemText, IconButton, Typography, Avatar } from '@mui/material';
+import { PageTitle } from './shared/PageTitle';
 import { ArrowForwardIos, ArrowBackIos, CheckCircle, Cancel } from '@mui/icons-material';
 import type { AccountUserRoles1, AccountUserProfile1, RoleItem } from './shared/RpcModels';
 import { fetchRoles, fetchSetRoles, fetchProfile, fetchSetCredits, fetchEnableStorage, fetchSetDisplayName } from './rpc/account/users';
@@ -85,11 +86,10 @@ const AccountUserPanel = (): JSX.Element => {
 
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mt: 2, p: 2 }}>
-            <Typography variant='h5'>User Management</Typography>
-            <Divider sx={{ mb: 2 }} />
+            <PageTitle title='User Management' />
             {profile && (
                 <Stack spacing={2} sx={{ mb: 4, alignItems: 'center' }}>
-                    <Typography variant='h5'>User Profile</Typography>
+                    <PageTitle title='User Profile' />
                     <Avatar
                         src={profile.profilePicture ? `data:image/png;base64,${profile.profilePicture}` : undefined}
                         sx={{ width: 80, height: 80 }}

--- a/frontend/src/AccountUsersPage.tsx
+++ b/frontend/src/AccountUsersPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, Button, Typography } from '@mui/material';
+import { Box, Table, TableHead, TableRow, TableCell, TableBody, Button } from '@mui/material';
+import { PageTitle } from './shared/PageTitle';
 import { Link as RouterLink } from 'react-router-dom';
 import type { UserListItem, SystemUsersList1 } from './shared/RpcModels';
 import { fetchList } from './rpc/system/users';
@@ -20,8 +21,7 @@ const AccountUsersPage = (): JSX.Element => {
 
     return (
         <Box sx={{ p: 2 }}>
-            <Typography variant='h5'>User Accounts</Typography>
-            <Divider sx={{ mb: 2 }} />
+            <PageTitle title='User Accounts' />
             <Table size='small' sx={{ '& td, & th': { py: 0.5 } }}>
                 <TableHead>
                     <TableRow>

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useContext, useState } from 'react';
 import { Container, Paper, Typography, Button, Stack } from '@mui/material';
+import { PageTitle } from './shared/PageTitle';
 import { useNavigate } from 'react-router-dom';
 import { PublicClientApplication } from '@azure/msal-browser';
 import { msalConfig, loginRequest } from './config/msal';
@@ -65,11 +66,9 @@ const LoginPage = (): JSX.Element => {
 
 	return (
 		<Container component='main' maxWidth='xs'>
-			<Paper elevation={3} sx={{ marginTop: 8, padding: 4 }}>
-				<Typography component='h1' variant='h5' align='center'>
-					Sign in
-				</Typography>
-				<Typography variant='body2' align='center' sx={{ mt: 2 }}>
+                        <Paper elevation={3} sx={{ marginTop: 8, padding: 4 }}>
+                                <PageTitle title='Sign in' />
+                                <Typography variant='body2' align='center' sx={{ mt: 2 }}>
 					Only OAuth providers are supported. Please sign in using one of the following services:
 					<br />
 					Microsoft, Discord, Google, or Apple.

--- a/frontend/src/SystemConfigPage.tsx
+++ b/frontend/src/SystemConfigPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Typography, TextField } from '@mui/material';
+import { Box, Table, TableHead, TableRow, TableCell, TableBody, IconButton, TextField } from '@mui/material';
+import { PageTitle } from './shared/PageTitle';
 import { Delete, Add } from '@mui/icons-material';
 import type { ConfigItem, SystemConfigList1 } from './shared/RpcModels';
 import { fetchList, fetchSet, fetchDelete } from './rpc/system/config';
@@ -47,8 +48,7 @@ const SystemConfigPage = (): JSX.Element => {
 
     return (
         <Box sx={{ p: 2 }}>
-            <Typography variant='h5'>System Configuration</Typography>
-            <Divider sx={{ mb: 2 }} />
+            <PageTitle title='System Configuration' />
             <Table size='small' sx={{ '& td, & th': { py: 0.5 } }}>
                 <TableHead>
                     <TableRow>

--- a/frontend/src/SystemRolesPage.tsx
+++ b/frontend/src/SystemRolesPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Typography, TextField } from '@mui/material';
+import { Box, Table, TableHead, TableRow, TableCell, TableBody, IconButton, TextField } from '@mui/material';
+import { PageTitle } from './shared/PageTitle';
 import { Delete, Add } from '@mui/icons-material';
 import type { RoleItem, SystemRolesList1 } from './shared/RpcModels';
 import { fetchList, fetchSet, fetchDelete } from './rpc/system/roles';
@@ -50,8 +51,7 @@ const SystemRolesPage = (): JSX.Element => {
 
     return (
         <Box sx={{ p: 2 }}>
-            <Typography variant='h5'>System Roles</Typography>
-            <Divider sx={{ mb: 2 }} />
+            <PageTitle title='System Roles' />
             <Table size='small' sx={{ '& td, & th': { py: 0.5 } }}>
                 <TableHead>
                     <TableRow>

--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Box, Divider, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Stack, List, ListItemButton, ListItemText, Typography } from '@mui/material';
+import { Box, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Stack, List, ListItemButton, ListItemText } from '@mui/material';
+import { PageTitle } from './shared/PageTitle';
 import { Delete, Add, ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
 import type { SystemRouteItem, SystemRoutesList1, SystemUserRoles1 } from './shared/RpcModels';
 import { fetchList as fetchRoutes, fetchSet, fetchDelete } from './rpc/system/routes';
@@ -92,8 +93,7 @@ const SystemRoutesPage = (): JSX.Element => {
 
     return (
         <Box sx={{ p: 2 }}>
-            <Typography variant='h5'>System Routes</Typography>
-            <Divider sx={{ mb: 2 }} />
+            <PageTitle title='System Routes' />
             <Table size='small' sx={{ '& td, & th': { py: 0.5 } }}>
                 <TableHead>
                     <TableRow>

--- a/frontend/src/UserPage.tsx
+++ b/frontend/src/UserPage.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useEffect, useRef } from 'react';
 import { Box, Typography, FormControlLabel, Switch, Avatar, Button, Stack, RadioGroup, Radio } from '@mui/material';
+import { PageTitle } from './shared/PageTitle';
 import UserContext from './shared/UserContext';
 import { fetchSetDisplayName } from './rpc/frontend/user';
 import EditBox, { EditBoxHandle } from './shared/EditBox';
@@ -77,7 +78,7 @@ const UserPage = (): JSX.Element => {
                 spacing={2}
                 sx={{ mt: 2, display: 'flex', alignItems: 'flex-end', textAlign: 'right' }}
                 >
-                <Typography variant='h5' gutterBottom>User Profile</Typography>
+                <PageTitle title='User Profile' />
 
                 {userData && (
                     <Stack spacing={2} sx={{ mt: 2, alignItems: 'flex-end', width: '100%' }}>

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,66 +28,95 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
-export interface FrontendVarsFfmpegVersion1 {
-  ffmpeg_version: string;
+export interface ConfigItem {
+  key: string;
+  value: string;
 }
-export interface FrontendVarsHostname1 {
-  hostname: string;
+export interface SystemConfigDelete1 {
+  key: string;
 }
-export interface FrontendVarsRepo1 {
-  repo: string;
+export interface SystemConfigList1 {
+  items: ConfigItem[];
 }
-export interface FrontendVarsVersion1 {
-  version: string;
+export interface SystemConfigUpdate1 {
+  key: string;
+  value: string;
 }
-export interface ViewDiscord1 {
-  content: string;
+export interface RoleItem {
+  name: string;
+  display: string;
+  bit: number;
 }
-export interface FrontendLinksHome1 {
-  links: LinkItem[];
+export interface SystemRoleDelete1 {
+  name: string;
 }
-export interface FrontendLinksRoutes1 {
-  routes: RouteItem[];
+export interface SystemRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
 }
-export interface LinkItem {
-  title: string;
-  url: string;
+export interface SystemRoleMembers1 {
+  members: any[];
+  nonMembers: any[];
 }
-export interface RouteItem {
+export interface SystemRoleUpdate1 {
+  name: string;
+  display: string;
+  bit: number;
+}
+export interface SystemRolesList1 {
+  roles: RoleItem[];
+}
+export interface UserListItem {
+  guid: string;
+  displayName: string;
+}
+export interface SystemRouteDelete1 {
+  path: string;
+}
+export interface SystemRouteItem {
   path: string;
   name: string;
   icon: string;
+  sequence: number;
+  requiredRoles: string[];
 }
-export interface FrontendUserProfileData1 {
-  bearerToken: string;
+export interface SystemRouteUpdate1 {
+  path: string;
+  name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
+}
+export interface SystemRoutesList1 {
+  routes: SystemRouteItem[];
+}
+export interface SystemUserCreditsUpdate1 {
+  userGuid: string;
+  credits: number;
+}
+export interface SystemUserProfile1 {
+  guid: string;
   defaultProvider: string;
   username: string;
   email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  storageUsed: number | null;
-  storageEnabled: boolean | null;
+  backupEmail: any;
+  profilePicture: any;
+  credits: any;
+  storageUsed: any;
+  storageEnabled: any;
   displayEmail: boolean;
+  rotationToken: any;
+  rotationExpires: any;
+}
+export interface SystemUserRoles1 {
   roles: string[];
-  rotationToken: string | null;
-  rotationExpires: any | null;
 }
-export interface FrontendUserSetDisplayName1 {
-  bearerToken: string;
-  displayName: string;
+export interface SystemUserRolesUpdate1 {
+  userGuid: string;
+  roles: string[];
 }
-export interface FileItem {
-  name: string;
-  url: string;
-  contentType: string | null;
-}
-export interface FrontendFileDelete1 {
-  bearerToken: string;
-  filename: string;
-}
-export interface FrontendFilesList1 {
-  files: FileItem[];
+export interface SystemUsersList1 {
+  users: UserListItem[];
 }
 export interface AccountRoleDelete1 {
   name: string;
@@ -107,15 +136,6 @@ export interface AccountRoleUpdate1 {
 }
 export interface AccountRolesList1 {
   roles: RoleItem[];
-}
-export interface RoleItem {
-  name: string;
-  display: string;
-  bit: number;
-}
-export interface UserListItem {
-  guid: string;
-  displayName: string;
 }
 export interface AccountUserCreditsUpdate1 {
   userGuid: string;
@@ -149,91 +169,66 @@ export interface AccountUserRolesUpdate1 {
 export interface AccountUsersList1 {
   users: UserListItem[];
 }
-export interface ConfigItem {
-  key: string;
-  value: string;
-}
-export interface SystemConfigDelete1 {
-  key: string;
-}
-export interface SystemConfigList1 {
-  items: ConfigItem[];
-}
-export interface SystemConfigUpdate1 {
-  key: string;
-  value: string;
-}
-export interface SystemRouteDelete1 {
-  path: string;
-}
-export interface SystemRouteItem {
-  path: string;
+export interface FileItem {
   name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
+  url: string;
+  contentType: string | null;
 }
-export interface SystemRouteUpdate1 {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
+export interface FrontendFileDelete1 {
+  bearerToken: string;
+  filename: string;
 }
-export interface SystemRoutesList1 {
-  routes: SystemRouteItem[];
+export interface FrontendFilesList1 {
+  files: FileItem[];
 }
-export interface SystemRoleDelete1 {
-  name: string;
-}
-export interface SystemRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface SystemRoleMembers1 {
-  members: any[];
-  nonMembers: any[];
-}
-export interface SystemRoleUpdate1 {
-  name: string;
-  display: string;
-  bit: number;
-}
-export interface SystemRolesList1 {
-  roles: RoleItem[];
-}
-export interface SystemUserCreditsUpdate1 {
-  userGuid: string;
-  credits: number;
-}
-export interface SystemUserProfile1 {
-  guid: string;
+export interface FrontendUserProfileData1 {
+  bearerToken: string;
   defaultProvider: string;
   username: string;
   email: string;
-  backupEmail: any;
-  profilePicture: any;
-  credits: any;
-  storageUsed: any;
-  storageEnabled: any;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  storageUsed: number | null;
+  storageEnabled: boolean | null;
   displayEmail: boolean;
-  rotationToken: any;
-  rotationExpires: any;
-}
-export interface SystemUserRoles1 {
   roles: string[];
+  rotationToken: string | null;
+  rotationExpires: any | null;
 }
-export interface SystemUserRolesUpdate1 {
-  userGuid: string;
-  roles: string[];
-}
-export interface SystemUsersList1 {
-  users: UserListItem[];
-}
-export interface AuthSessionTokens1 {
+export interface FrontendUserSetDisplayName1 {
   bearerToken: string;
-  rotationToken: string;
-  rotationExpires: any;
+  displayName: string;
+}
+export interface FrontendLinksHome1 {
+  links: LinkItem[];
+}
+export interface FrontendLinksRoutes1 {
+  routes: RouteItem[];
+}
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+export interface RouteItem {
+  path: string;
+  name: string;
+  icon: string;
+}
+export interface FrontendVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface FrontendVarsHostname1 {
+  hostname: string;
+}
+export interface FrontendVarsRepo1 {
+  repo: string;
+}
+export interface FrontendVarsVersion1 {
+  version: string;
+}
+export interface ViewDiscord1 {
+  content: string;
 }
 export interface AuthMicrosoftLoginData1 {
   bearerToken: string;
@@ -245,6 +240,11 @@ export interface AuthMicrosoftLoginData1 {
   credits: number | null;
   rotationToken: string | null;
   rotationExpires: any | null;
+}
+export interface AuthSessionTokens1 {
+  bearerToken: string;
+  rotationToken: string;
+  rotationExpires: any;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {


### PR DESCRIPTION
## Summary
- use the PageTitle component for page headers across the frontend
- regenerate RPC models

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c8cc7df88325a737c785c0ecdbb8