### PR TITLE
Add PageTitle variant

### DIFF
--- a/frontend/src/shared/ElideusTheme.tsx
+++ b/frontend/src/shared/ElideusTheme.tsx
@@ -24,24 +24,36 @@ const ElideusTheme: Theme = createTheme({
 				}
 			}
 		},
-		MuiLink: {
-			styleOverrides: {
-				root: {
-					display: 'block',
-					padding: '12px',
-					margin: '10px 0',
-					borderRadius: '5px',
-					transition: 'background 0.3s',
-					color: '#ffffff',
-					backgroundColor: '#111',
-					textDecoration: 'none',
-					'&:hover': {
-						backgroundColor: '#222'
-					}
-				}
-			}
-		}
-	}
+                MuiLink: {
+                        styleOverrides: {
+                                root: {
+                                        display: 'block',
+                                        padding: '12px',
+                                        margin: '10px 0',
+                                        borderRadius: '5px',
+                                        transition: 'background 0.3s',
+                                        color: '#ffffff',
+                                        backgroundColor: '#111',
+                                        textDecoration: 'none',
+                                        '&:hover': {
+                                                backgroundColor: '#222'
+                                        }
+                                }
+                        }
+                },
+                MuiTypography: {
+                        variants: [
+                                {
+                                        props: { variant: 'pageTitle' },
+                                        style: {
+                                                fontSize: '1.5rem',
+                                                fontWeight: 700,
+                                                marginBottom: '16px'
+                                        }
+                                }
+                        ]
+                }
+        }
 });
 
 export default ElideusTheme;

--- a/frontend/src/shared/PageTitle.tsx
+++ b/frontend/src/shared/PageTitle.tsx
@@ -2,7 +2,7 @@ import { Typography, Divider } from '@mui/material';
 
 export const PageTitle = ({ title }: { title: string }): JSX.Element => (
     <>
-        <Typography variant='h4'>{title}</Typography>
-        <Divider sx={{ mb: 2 }} />
+        <Typography variant='pageTitle'>{title}</Typography>
+        <Divider />
     </>
 );

--- a/frontend/src/shared/theme.d.ts
+++ b/frontend/src/shared/theme.d.ts
@@ -1,0 +1,18 @@
+import type { CSSProperties } from 'react';
+import '@mui/material/styles';
+import '@mui/material/Typography';
+
+declare module '@mui/material/styles' {
+    interface TypographyVariants {
+        pageTitle: CSSProperties;
+    }
+    interface TypographyVariantsOptions {
+        pageTitle?: CSSProperties;
+    }
+}
+
+declare module '@mui/material/Typography' {
+    interface TypographyPropsVariantOverrides {
+        pageTitle: true;
+    }
+}


### PR DESCRIPTION
## Summary
- centralize PageTitle styling in ElideusTheme
- define MUI variant for PageTitle
- type augment Typography to allow pageTitle variant

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_6883a20b8bcc83258bea89f8f26992cc