### PR TITLE
Add column header component

### DIFF
--- a/frontend/src/AccountUsersPage.tsx
+++ b/frontend/src/AccountUsersPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Box, Table, TableHead, TableRow, TableCell, TableBody, Button } from '@mui/material';
+import ColumnHeader from './shared/ColumnHeader';
 import { PageTitle } from './shared/PageTitle';
 import { Link as RouterLink } from 'react-router-dom';
 import type { UserListItem, SystemUsersList1 } from './shared/RpcModels';
@@ -25,8 +26,8 @@ const AccountUsersPage = (): JSX.Element => {
             <Table size='small' sx={{ '& td, & th': { py: 0.5 } }}>
                 <TableHead>
                     <TableRow>
-                        <TableCell>Display Name</TableCell>
-                        <TableCell>Actions</TableCell>
+                        <ColumnHeader title='Display Name' />
+                        <ColumnHeader title='Actions' />
                     </TableRow>
                 </TableHead>
                 <TableBody>

--- a/frontend/src/SystemConfigPage.tsx
+++ b/frontend/src/SystemConfigPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Box, Table, TableHead, TableRow, TableCell, TableBody, IconButton, TextField } from '@mui/material';
+import ColumnHeader from './shared/ColumnHeader';
 import { PageTitle } from './shared/PageTitle';
 import { Delete, Add } from '@mui/icons-material';
 import type { ConfigItem, SystemConfigList1 } from './shared/RpcModels';
@@ -52,8 +53,8 @@ const SystemConfigPage = (): JSX.Element => {
             <Table size='small' sx={{ '& td, & th': { py: 0.5 } }}>
                 <TableHead>
                     <TableRow>
-                        <TableCell>Key</TableCell>
-                        <TableCell>Value</TableCell>
+                        <ColumnHeader title='Key' />
+                        <ColumnHeader title='Value' />
                         <TableCell />
                     </TableRow>
                 </TableHead>

--- a/frontend/src/SystemRolesPage.tsx
+++ b/frontend/src/SystemRolesPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Box, Table, TableHead, TableRow, TableCell, TableBody, IconButton, TextField } from '@mui/material';
+import ColumnHeader from './shared/ColumnHeader';
 import { PageTitle } from './shared/PageTitle';
 import { Delete, Add } from '@mui/icons-material';
 import type { RoleItem, SystemRolesList1 } from './shared/RpcModels';
@@ -55,9 +56,9 @@ const SystemRolesPage = (): JSX.Element => {
             <Table size='small' sx={{ '& td, & th': { py: 0.5 } }}>
                 <TableHead>
                     <TableRow>
-                        <TableCell>Role</TableCell>
-                        <TableCell>Display</TableCell>
-                        <TableCell>Bit</TableCell>
+                        <ColumnHeader title='Role' />
+                        <ColumnHeader title='Display' />
+                        <ColumnHeader title='Bit' />
                         <TableCell />
                     </TableRow>
                 </TableHead>

--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Box, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Stack, List, ListItemButton, ListItemText } from '@mui/material';
+import ColumnHeader from './shared/ColumnHeader';
 import { PageTitle } from './shared/PageTitle';
 import { Delete, Add, ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
 import type { SystemRouteItem, SystemRoutesList1, SystemUserRoles1 } from './shared/RpcModels';
@@ -97,11 +98,11 @@ const SystemRoutesPage = (): JSX.Element => {
             <Table size='small' sx={{ '& td, & th': { py: 0.5 } }}>
                 <TableHead>
                     <TableRow>
-                        <TableCell>Path</TableCell>
-                        <TableCell>Name</TableCell>
-                        <TableCell>Icon</TableCell>
-                        <TableCell>Sequence</TableCell>
-                        <TableCell>Roles</TableCell>
+                        <ColumnHeader title='Path' />
+                        <ColumnHeader title='Name' />
+                        <ColumnHeader title='Icon' />
+                        <ColumnHeader title='Sequence' />
+                        <ColumnHeader title='Roles' />
                         <TableCell />
                     </TableRow>
                 </TableHead>

--- a/frontend/src/shared/ColumnHeader.tsx
+++ b/frontend/src/shared/ColumnHeader.tsx
@@ -1,0 +1,9 @@
+import { TableCell, Typography } from '@mui/material';
+
+const ColumnHeader = ({ title }: { title: string }): JSX.Element => (
+    <TableCell>
+        <Typography variant='columnHeader'>{title}</Typography>
+    </TableCell>
+);
+
+export default ColumnHeader;

--- a/frontend/src/shared/ElideusTheme.tsx
+++ b/frontend/src/shared/ElideusTheme.tsx
@@ -50,6 +50,15 @@ const ElideusTheme: Theme = createTheme({
                                                 fontWeight: 700,
                                                 marginBottom: '16px'
                                         }
+                                },
+                                {
+                                        props: { variant: 'columnHeader' },
+                                        style: {
+                                                fontSize: '0.75rem',
+                                                fontWeight: 700,
+                                                fontFamily: 'Georgia, Times, "Times New Roman", serif',
+                                                fontVariant: 'small-caps'
+                                        }
                                 }
                         ]
                 }

--- a/frontend/src/shared/theme.d.ts
+++ b/frontend/src/shared/theme.d.ts
@@ -5,14 +5,17 @@ import '@mui/material/Typography';
 declare module '@mui/material/styles' {
     interface TypographyVariants {
         pageTitle: CSSProperties;
+        columnHeader: CSSProperties;
     }
     interface TypographyVariantsOptions {
         pageTitle?: CSSProperties;
+        columnHeader?: CSSProperties;
     }
 }
 
 declare module '@mui/material/Typography' {
     interface TypographyPropsVariantOverrides {
         pageTitle: true;
+        columnHeader: true;
     }
 }

--- a/frontend/tests/columnHeader.test.tsx
+++ b/frontend/tests/columnHeader.test.tsx
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { isValidElement } from 'react';
+import ColumnHeader from '../src/shared/ColumnHeader';
+
+describe('ColumnHeader', () => {
+    it('creates a valid React element', () => {
+        const el = <ColumnHeader title='Test' />;
+        expect(isValidElement(el)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- provide a ColumnHeader React component
- support `columnHeader` typography variant in the theme
- add serif, small-caps styling for column headers
- use ColumnHeader component across tables
- document component with a simple test

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_6883a8c81c708325addd07ed09d1eb81