### PR TITLE
Balance margin and gutter for edit box

### DIFF
--- a/frontend/src/shared/ElideusTheme.tsx
+++ b/frontend/src/shared/ElideusTheme.tsx
@@ -41,6 +41,16 @@ const ElideusTheme: Theme = createTheme({
                                 }
                         }
                 },
+                MuiTextField: {
+                        styleOverrides: {
+                                root: {
+                                        margin: '8px',
+                                        '& .MuiInputBase-input': {
+                                                padding: '8px'
+                                        }
+                                }
+                        }
+                },
                 MuiTypography: {
                         variants: [
                                 {


### PR DESCRIPTION
## Summary
- adjust TextField styles in `ElideusTheme` to add margin and input padding

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6883b591404883258f1beb51610590c3