### PR TITLE
Move token storage to sessions

### DIFF
--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -34,7 +34,6 @@ async def user_login_v1(rpc_request: RPCRequest, request: Request) -> RPCRespons
 
   token = auth.make_bearer_token(_utos(user["guid"]))
   rotation_token, rotation_exp = auth.make_rotation_token(_utos(user["guid"]))
-  await db.set_user_rotation_token(_utos(user["guid"]), rotation_token, rotation_exp)
   await db.create_user_session(_utos(user["guid"]), token, rotation_token, rotation_exp)
 
   discord = getattr(request.app.state, 'discord', None)

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -18,7 +18,6 @@ async def refresh_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   guid = data['guid']
   bearer = auth.make_bearer_token(guid)
   new_rotation, exp = auth.make_rotation_token(guid)
-  await db.set_user_rotation_token(guid, new_rotation, exp)
   await db.update_session_tokens(session['session_id'], bearer, new_rotation, exp)
   payload = AuthSessionTokens1(bearerToken=bearer, rotationToken=new_rotation, rotationExpires=exp)
   return RPCResponse(op='urn:auth:session:refresh:1', payload=payload, version=1)


### PR DESCRIPTION
## Summary
- store rotation token data in `users_sessions`
- refresh session tokens without touching users table

## Testing
- `python scripts/run_tests.py --test`
- `python scripts/database_cli.py <<'EOF'
schema dump new_schema_test
exit
EOF` *(fails: `POSTGRES_CONNECTION_STRING not set`)*

------
https://chatgpt.com/codex/tasks/task_e_6884485ff1dc832587fba01d3772e1c1