### PR TITLE
Add key and constraint listing in MSSQL CLI

### DIFF
--- a/scripts/msdblib.py
+++ b/scripts/msdblib.py
@@ -31,6 +31,43 @@ async def list_indexes(conn, table):
     rows = await cur.fetchall()
   return [{'indexname': r[0], 'indexdef': r[1]} for r in rows]
 
+async def list_keys(conn, table):
+  async with conn.cursor() as cur:
+    await cur.execute(
+      """SELECT k.CONSTRAINT_NAME, k.COLUMN_NAME, tc.CONSTRAINT_TYPE
+         FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE k
+         JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
+           ON k.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+         WHERE k.TABLE_NAME=?""",
+      (table,),
+    )
+    rows = await cur.fetchall()
+  return [
+    {
+      'constraint_name': r[0],
+      'column_name': r[1],
+      'constraint_type': r[2],
+    }
+    for r in rows
+  ]
+
+async def list_constraints(conn, table):
+  async with conn.cursor() as cur:
+    await cur.execute(
+      """SELECT CONSTRAINT_NAME, CONSTRAINT_TYPE
+         FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+         WHERE TABLE_NAME=?""",
+      (table,),
+    )
+    rows = await cur.fetchall()
+  return [
+    {
+      'constraint_name': r[0],
+      'constraint_type': r[1],
+    }
+    for r in rows
+  ]
+
 async def _table_schema(conn, table: str):
   async with conn.cursor() as cur:
     await cur.execute(

--- a/scripts/mssql_cli.py
+++ b/scripts/mssql_cli.py
@@ -42,6 +42,8 @@ Available commands:
   list tables                        List all tables
   list columns <table>               List columns of a table
   list indexes <table>               List indexes on a table
+  list keys <table>                  List key columns and constraint types
+  list constraints <table>           List constraints on a table
   index all                          Reindex the current database
   schema dump [name]                 Dump DB schema to <name>_YYYYMMDD.json
   schema apply <file>                Apply schema JSON to the database
@@ -81,6 +83,14 @@ async def interactive_console(conn):
         rows = await db.list_indexes(conn, table)
         for r in rows:
           print(f"{r['indexname']} ({r['indexdef']})")
+      case ['list', 'keys', table]:
+        rows = await db.list_keys(conn, table)
+        for r in rows:
+          print(f"{r['column_name']} -> {r['constraint_name']} ({r['constraint_type']})")
+      case ['list', 'constraints', table]:
+        rows = await db.list_constraints(conn, table)
+        for r in rows:
+          print(f"{r['constraint_name']} ({r['constraint_type']})")
       case ['index', 'all']:
         try:
           async with conn.cursor() as cur:


### PR DESCRIPTION
## Summary
- extend `msdblib` with helpers to query key and constraint info
- expose new `list keys` and `list constraints` commands in `mssql_cli`

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68857fa74c288325b35a41de12d886a1