### PR TITLE
Fix model names for storage files

### DIFF
--- a/frontend/src/FileManager.tsx
+++ b/frontend/src/FileManager.tsx
@@ -7,7 +7,7 @@ import PaginationControls from './shared/PaginationControls';
 import { PageTitle } from './shared/PageTitle';
 import { fetchList, fetchDelete, fetchUpload } from './rpc/storage/files';
 import UserContext from './shared/UserContext';
-import type { FileItem, FrontendFilesList1 } from './shared/RpcModels';
+import type { FileItem, StorageFilesList1 } from './shared/RpcModels';
 
 const FileManager = (): JSX.Element => {
     const { userData } = useContext(UserContext);
@@ -18,7 +18,7 @@ const FileManager = (): JSX.Element => {
 
     const load = async (): Promise<void> => {
         try {
-            const res: FrontendFilesList1 = await fetchList({ bearerToken: userData?.bearerToken });
+            const res: StorageFilesList1 = await fetchList({ bearerToken: userData?.bearerToken });
             setFiles(res.files);
         } catch {
             setFiles([]);

--- a/frontend/src/rpc/storage/files/index.ts
+++ b/frontend/src/rpc/storage/files/index.ts
@@ -4,8 +4,8 @@
 // overwritten the next time the generator runs.
 // ================================================
 
-import { rpcCall, FrontendFilesList1 } from '../../../shared/RpcModels';
+import { rpcCall, StorageFilesList1 } from '../../../shared/RpcModels';
 
-export const fetchList = (payload: any = null): Promise<FrontendFilesList1> => rpcCall('urn:storage:files:list:1', payload);
-export const fetchDelete = (payload: any = null): Promise<FrontendFilesList1> => rpcCall('urn:storage:files:delete:1', payload);
-export const fetchUpload = (payload: any = null): Promise<FrontendFilesList1> => rpcCall('urn:storage:files:upload:1', payload);
+export const fetchList = (payload: any = null): Promise<StorageFilesList1> => rpcCall('urn:storage:files:list:1', payload);
+export const fetchDelete = (payload: any = null): Promise<StorageFilesList1> => rpcCall('urn:storage:files:delete:1', payload);
+export const fetchUpload = (payload: any = null): Promise<StorageFilesList1> => rpcCall('urn:storage:files:upload:1', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,6 +28,73 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
+export interface FileItem {
+  name: string;
+  url: string;
+  contentType: string | null;
+}
+export interface StorageFileDelete1 {
+  bearerToken: string;
+  filename: string;
+}
+export interface StorageFileUpload1 {
+  bearerToken: string;
+  filename: string;
+  dataUrl: string;
+  contentType: string;
+}
+export interface StorageFilesList1 {
+  files: FileItem[];
+}
+export interface FrontendUserProfileData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  storageUsed: number | null;
+  storageEnabled: boolean | null;
+  displayEmail: boolean;
+  roles: string[];
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface FrontendUserSetDisplayName1 {
+  bearerToken: string;
+  displayName: string;
+}
+export interface FrontendVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface FrontendVarsHostname1 {
+  hostname: string;
+}
+export interface FrontendVarsRepo1 {
+  repo: string;
+}
+export interface FrontendVarsVersion1 {
+  version: string;
+}
+export interface ViewDiscord1 {
+  content: string;
+}
+export interface FrontendLinksHome1 {
+  links: LinkItem[];
+}
+export interface FrontendLinksRoutes1 {
+  routes: RouteItem[];
+}
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+export interface RouteItem {
+  path: string;
+  name: string;
+  icon: string;
+}
 export interface AccountUserCreditsUpdate1 {
   userGuid: string;
   credits: number;
@@ -88,73 +155,6 @@ export interface RoleItem {
   display: string;
   bit: number;
 }
-export interface FileItem {
-  name: string;
-  url: string;
-  contentType: string | null;
-}
-export interface FrontendFileDelete1 {
-  bearerToken: string;
-  filename: string;
-}
-export interface FrontendFileUpload1 {
-  bearerToken: string;
-  filename: string;
-  dataUrl: string;
-  contentType: string;
-}
-export interface FrontendFilesList1 {
-  files: FileItem[];
-}
-export interface FrontendLinksHome1 {
-  links: LinkItem[];
-}
-export interface FrontendLinksRoutes1 {
-  routes: RouteItem[];
-}
-export interface LinkItem {
-  title: string;
-  url: string;
-}
-export interface RouteItem {
-  path: string;
-  name: string;
-  icon: string;
-}
-export interface FrontendVarsFfmpegVersion1 {
-  ffmpeg_version: string;
-}
-export interface FrontendVarsHostname1 {
-  hostname: string;
-}
-export interface FrontendVarsRepo1 {
-  repo: string;
-}
-export interface FrontendVarsVersion1 {
-  version: string;
-}
-export interface ViewDiscord1 {
-  content: string;
-}
-export interface FrontendUserProfileData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  storageUsed: number | null;
-  storageEnabled: boolean | null;
-  displayEmail: boolean;
-  roles: string[];
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
-export interface FrontendUserSetDisplayName1 {
-  bearerToken: string;
-  displayName: string;
-}
 export interface AuthSessionTokens1 {
   bearerToken: string;
   rotationToken: string;
@@ -170,26 +170,6 @@ export interface AuthMicrosoftLoginData1 {
   credits: number | null;
   rotationToken: string | null;
   rotationExpires: any | null;
-}
-export interface SystemRouteDelete1 {
-  path: string;
-}
-export interface SystemRouteItem {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRouteUpdate1 {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRoutesList1 {
-  routes: SystemRouteItem[];
 }
 export interface SystemUserCreditsUpdate1 {
   userGuid: string;
@@ -218,6 +198,26 @@ export interface SystemUserRolesUpdate1 {
 }
 export interface SystemUsersList1 {
   users: UserListItem[];
+}
+export interface SystemRouteDelete1 {
+  path: string;
+}
+export interface SystemRouteItem {
+  path: string;
+  name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
+}
+export interface SystemRouteUpdate1 {
+  path: string;
+  name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
+}
+export interface SystemRoutesList1 {
+  routes: SystemRouteItem[];
 }
 export interface SystemRoleDelete1 {
   name: string;

--- a/rpc/storage/files/models.py
+++ b/rpc/storage/files/models.py
@@ -6,14 +6,14 @@ class FileItem(BaseModel):
   url: str
   contentType: Optional[str] = None
 
-class FrontendFilesList1(BaseModel):
+class StorageFilesList1(BaseModel):
   files: list[FileItem]
 
-class FrontendFileDelete1(BaseModel):
+class StorageFileDelete1(BaseModel):
   bearerToken: str
   filename: str
 
-class FrontendFileUpload1(BaseModel):
+class StorageFileUpload1(BaseModel):
   bearerToken: str
   filename: str
   dataUrl: str

--- a/rpc/storage/files/services.py
+++ b/rpc/storage/files/services.py
@@ -1,6 +1,6 @@
 from fastapi import Request, HTTPException
 from rpc.models import RPCRequest, RPCResponse
-from rpc.storage.files.models import FrontendFilesList1, FileItem, FrontendFileDelete1, FrontendFileUpload1
+from rpc.storage.files.models import StorageFilesList1, FileItem, StorageFileDelete1, StorageFileUpload1
 from server.helpers.buffers import AsyncBufferWriter
 import base64, re
 from server.modules.auth_module import AuthModule
@@ -17,7 +17,7 @@ async def list_files_v1(rpc_request: RPCRequest, request: Request) -> RPCRespons
   guid = data['guid']
   files = await storage.list_user_files(guid)
   items = [FileItem(name=f['name'], url=f['url'], contentType=f.get('content_type')) for f in files]
-  payload = FrontendFilesList1(files=items)
+  payload = StorageFilesList1(files=items)
   return RPCResponse(op='urn:storage:files:list:1', payload=payload, version=1)
 
 async def delete_file_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
@@ -33,11 +33,11 @@ async def delete_file_v1(rpc_request: RPCRequest, request: Request) -> RPCRespon
   await storage.delete_user_file(guid, filename)
   files = await storage.list_user_files(guid)
   items = [FileItem(name=f['name'], url=f['url'], contentType=f.get('content_type')) for f in files]
-  payload = FrontendFilesList1(files=items)
+  payload = StorageFilesList1(files=items)
   return RPCResponse(op='urn:storage:files:delete:1', payload=payload, version=1)
 
 async def upload_file_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
-  data = FrontendFileUpload1(**(rpc_request.payload or {}))
+  data = StorageFileUpload1(**(rpc_request.payload or {}))
   auth: AuthModule = request.app.state.auth
   storage: StorageModule = request.app.state.storage
   token_data = await auth.decode_bearer_token(data.bearerToken)
@@ -52,5 +52,5 @@ async def upload_file_v1(rpc_request: RPCRequest, request: Request) -> RPCRespon
 
   files = await storage.list_user_files(guid)
   items = [FileItem(name=f['name'], url=f['url'], contentType=f.get('content_type')) for f in files]
-  payload = FrontendFilesList1(files=items)
+  payload = StorageFilesList1(files=items)
   return RPCResponse(op='urn:storage:files:upload:1', payload=payload, version=1)


### PR DESCRIPTION
## Summary
- rename `FrontendFile*` models to `StorageFile*`
- regenerate RPC client and models
- update frontend usage for storage file types

## Testing
- `python3 scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68859527e46c8325b77fb969b2688ce0