### PR TITLE
Fix schema dump error handling null lengths

### DIFF
--- a/scripts/msdblib.py
+++ b/scripts/msdblib.py
@@ -17,8 +17,8 @@ async def list_columns(conn, table):
     await cur.execute(
       """SELECT COLUMN_NAME AS column_name, DATA_TYPE AS data_type,
                 CHARACTER_MAXIMUM_LENGTH AS max_length
-         FROM INFORMATION_SCHEMA.COLUMNS
-         WHERE TABLE_NAME=? ORDER BY ORDINAL_POSITION FOR JSON PATH""",
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_NAME=? ORDER BY ORDINAL_POSITION FOR JSON PATH, INCLUDE_NULL_VALUES""",
       (table,),
     )
     row = await cur.fetchone()
@@ -69,8 +69,8 @@ async def _table_schema(conn, table: str):
                 CHARACTER_MAXIMUM_LENGTH AS length,
                 IS_NULLABLE AS nullable,
                 COLUMN_DEFAULT AS [default]
-         FROM INFORMATION_SCHEMA.COLUMNS
-         WHERE TABLE_NAME=? ORDER BY ORDINAL_POSITION FOR JSON PATH""",
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_NAME=? ORDER BY ORDINAL_POSITION FOR JSON PATH, INCLUDE_NULL_VALUES""",
       (table,),
     )
     row = await cur.fetchone()


### PR DESCRIPTION
## Summary
- ensure column length info is preserved even when null
- fix `_table_schema` query to include null values
- update `list_columns` for consistency

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_6885b55bdef483259ed51aad28ba11ed