### PR TITLE
Fix column names for v2 RPC

### DIFF
--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,87 +28,6 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
-export interface AccountRoleDelete1 {
-  name: string;
-}
-export interface AccountRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface AccountRoleMembers1 {
-  members: UserListItem[];
-  nonMembers: UserListItem[];
-}
-export interface AccountRoleUpdate1 {
-  name: string;
-  display: string;
-  bit: number;
-}
-export interface AccountRolesList1 {
-  roles: RoleItem[];
-}
-export interface RoleItem {
-  name: string;
-  display: string;
-  bit: number;
-}
-export interface UserListItem {
-  guid: string;
-  displayName: string;
-}
-export interface AccountUserCreditsUpdate1 {
-  userGuid: string;
-  credits: number;
-}
-export interface AccountUserDisplayNameUpdate1 {
-  userGuid: string;
-  displayName: string;
-}
-export interface AccountUserProfile1 {
-  guid: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: any;
-  profilePicture: any;
-  credits: any;
-  storageUsed: any;
-  storageEnabled: any;
-  displayEmail: boolean;
-  rotationToken: any;
-  rotationExpires: any;
-}
-export interface AccountUserRoles1 {
-  roles: string[];
-}
-export interface AccountUserRolesUpdate1 {
-  userGuid: string;
-  roles: string[];
-}
-export interface AccountUsersList1 {
-  users: UserListItem[];
-}
-export interface FrontendLinksHome1 {
-  links: LinkItem[];
-}
-export interface FrontendLinksHome2 {
-  links: LinkItem[];
-}
-export interface FrontendLinksRoutes1 {
-  routes: RouteItem[];
-}
-export interface FrontendLinksRoutes2 {
-  routes: RouteItem[];
-}
-export interface LinkItem {
-  title: string;
-  url: string;
-}
-export interface RouteItem {
-  path: string;
-  name: string;
-  icon: string;
-}
 export interface FrontendUserProfileData1 {
   bearerToken: string;
   defaultProvider: string;
@@ -155,6 +74,27 @@ export interface ViewDiscord1 {
 export interface ViewDiscord2 {
   content: string;
 }
+export interface FrontendLinksHome1 {
+  links: LinkItem[];
+}
+export interface FrontendLinksHome2 {
+  links: LinkItem[];
+}
+export interface FrontendLinksRoutes1 {
+  routes: RouteItem[];
+}
+export interface FrontendLinksRoutes2 {
+  routes: RouteItem[];
+}
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+export interface RouteItem {
+  path: string;
+  name: string;
+  icon: string;
+}
 export interface FileItem {
   name: string;
   url: string;
@@ -172,41 +112,6 @@ export interface StorageFileUpload1 {
 }
 export interface StorageFilesList1 {
   files: FileItem[];
-}
-export interface AuthMicrosoftLoginData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
-export interface AuthSessionTokens1 {
-  bearerToken: string;
-  rotationToken: string;
-  rotationExpires: any;
-}
-export interface SystemRoleDelete1 {
-  name: string;
-}
-export interface SystemRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface SystemRoleMembers1 {
-  members: any[];
-  nonMembers: any[];
-}
-export interface SystemRoleUpdate1 {
-  name: string;
-  display: string;
-  bit: number;
-}
-export interface SystemRolesList1 {
-  roles: RoleItem[];
 }
 export interface SystemRouteDelete1 {
   path: string;
@@ -228,19 +133,33 @@ export interface SystemRouteUpdate1 {
 export interface SystemRoutesList1 {
   routes: SystemRouteItem[];
 }
-export interface ConfigItem {
-  key: string;
-  value: string;
+export interface RoleItem {
+  name: string;
+  display: string;
+  bit: number;
 }
-export interface SystemConfigDelete1 {
-  key: string;
+export interface SystemRoleDelete1 {
+  name: string;
 }
-export interface SystemConfigList1 {
-  items: ConfigItem[];
+export interface SystemRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
 }
-export interface SystemConfigUpdate1 {
-  key: string;
-  value: string;
+export interface SystemRoleMembers1 {
+  members: any[];
+  nonMembers: any[];
+}
+export interface SystemRoleUpdate1 {
+  name: string;
+  display: string;
+  bit: number;
+}
+export interface SystemRolesList1 {
+  roles: RoleItem[];
+}
+export interface UserListItem {
+  guid: string;
+  displayName: string;
 }
 export interface SystemUserCreditsUpdate1 {
   userGuid: string;
@@ -268,6 +187,87 @@ export interface SystemUserRolesUpdate1 {
   roles: string[];
 }
 export interface SystemUsersList1 {
+  users: UserListItem[];
+}
+export interface ConfigItem {
+  key: string;
+  value: string;
+}
+export interface SystemConfigDelete1 {
+  key: string;
+}
+export interface SystemConfigList1 {
+  items: ConfigItem[];
+}
+export interface SystemConfigUpdate1 {
+  key: string;
+  value: string;
+}
+export interface AuthMicrosoftLoginData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface AuthSessionTokens1 {
+  bearerToken: string;
+  rotationToken: string;
+  rotationExpires: any;
+}
+export interface AccountRoleDelete1 {
+  name: string;
+}
+export interface AccountRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
+}
+export interface AccountRoleMembers1 {
+  members: UserListItem[];
+  nonMembers: UserListItem[];
+}
+export interface AccountRoleUpdate1 {
+  name: string;
+  display: string;
+  bit: number;
+}
+export interface AccountRolesList1 {
+  roles: RoleItem[];
+}
+export interface AccountUserCreditsUpdate1 {
+  userGuid: string;
+  credits: number;
+}
+export interface AccountUserDisplayNameUpdate1 {
+  userGuid: string;
+  displayName: string;
+}
+export interface AccountUserProfile1 {
+  guid: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: any;
+  profilePicture: any;
+  credits: any;
+  storageUsed: any;
+  storageEnabled: any;
+  displayEmail: boolean;
+  rotationToken: any;
+  rotationExpires: any;
+}
+export interface AccountUserRoles1 {
+  roles: string[];
+}
+export interface AccountUserRolesUpdate1 {
+  userGuid: string;
+  roles: string[];
+}
+export interface AccountUsersList1 {
   users: UserListItem[];
 }
 

--- a/rpc/frontend/links/services.py
+++ b/rpc/frontend/links/services.py
@@ -42,7 +42,9 @@ async def get_home_v2(request: Request) -> RPCResponse:
   role_mask = getattr(request.state, 'role_mask', 0)
   data = await db.select_links(role_mask)
   data = permcap.filter_routes(data, role_mask)
-  links = [LinkItem(title=row["title"], url=row["url"]) for row in data]
+  links = [
+    LinkItem(title=row["element_title"], url=row["element_url"]) for row in data
+  ]
 
   payload = FrontendLinksHome2(links=links)
   return RPCResponse(op="urn:frontend:links:home:2", payload=payload, version=2)
@@ -53,7 +55,14 @@ async def get_routes_v2(request: Request) -> RPCResponse:
   role_mask = getattr(request.state, 'role_mask', 0)
   data = await db.select_routes(role_mask)
   data = permcap.filter_routes(data, role_mask)
-  routes = [RouteItem(path=row['path'], name=row['name'], icon=row['icon']) for row in data]
+  routes = [
+    RouteItem(
+      path=row['element_path'],
+      name=row['element_name'],
+      icon=row['element_icon']
+    )
+    for row in data
+  ]
 
   payload = FrontendLinksRoutes2(routes=routes)
   return RPCResponse(op="urn:frontend:links:routes:2", payload=payload, version=2)

--- a/server/modules/mssql_module.py
+++ b/server/modules/mssql_module.py
@@ -91,18 +91,18 @@ class MSSQLModule(BaseModule):
     )
     query = """
       SELECT
-        u.guid,
-        u.display_name,
-        u.email,
-        COALESCE(uc.credits, 0) AS credits,
-        ap.name AS provider_name,
-        upi.image_b64 AS profile_image
-      FROM users u
-      JOIN users_auth ua ON ua.user_guid = u.guid
-      JOIN auth_provider ap ON ap.id = ua.provider_id
-      LEFT JOIN users_credits uc ON uc.user_guid = u.guid
-      LEFT JOIN users_profileimg upi ON upi.user_guid = u.guid
-      WHERE ap.name = ? AND ua.provider_user_id = ?;
+        u.element_guid AS guid,
+        u.element_display AS display_name,
+        u.element_email AS email,
+        COALESCE(uc.element_credits, 0) AS credits,
+        ap.element_name AS provider_name,
+        upi.element_base64 AS profile_image
+      FROM account_users u
+      JOIN users_auth ua ON ua.users_guid = u.element_guid
+      JOIN auth_providers ap ON ap.recid = ua.providers_recid
+      LEFT JOIN users_credits uc ON uc.users_guid = u.element_guid
+      LEFT JOIN users_profileimg upi ON upi.users_guid = u.element_guid
+      WHERE ap.element_name = ? AND ua.element_identifier = ?;
     """
     result = await self._fetch_one(query, provider, provider_user_id)
     if result:
@@ -126,7 +126,7 @@ class MSSQLModule(BaseModule):
     async with self.pool.acquire() as conn:
       async with conn.cursor() as cur:
         await cur.execute(
-          "SELECT id FROM auth_provider WHERE name = ?",
+          "SELECT recid FROM auth_providers WHERE element_name = ?",
           (provider,)
         )
         row = await cur.fetchone()
@@ -135,17 +135,17 @@ class MSSQLModule(BaseModule):
           raise ValueError(f"Unknown auth provider: {provider}")
 
         await cur.execute(
-          "INSERT INTO users (guid, email, display_name, auth_provider) VALUES (?, ?, ?, ?)",
+          "INSERT INTO account_users (element_guid, element_email, element_display, providers_recid) VALUES (?, ?, ?, ?)",
           (new_guid, email, username, auth_provider_id),
         )
 
         await cur.execute(
-          "INSERT INTO users_auth (user_guid, provider_id, provider_user_id) VALUES (?, ?, ?)",
+          "INSERT INTO users_auth (users_guid, providers_recid, element_identifier) VALUES (?, ?, ?)",
           (new_guid, auth_provider_id, provider_user_id),
         )
 
         await cur.execute(
-          "INSERT INTO users_credits (user_guid, credits) VALUES (?, 50)",
+          "INSERT INTO users_credits (users_guid, element_credits) VALUES (?, 50)",
           (new_guid,),
         )
     return await self.select_user(provider, provider_user_id)
@@ -154,34 +154,34 @@ class MSSQLModule(BaseModule):
     logging.debug("get_user_profile guid=%s", guid)
     query = """
       SELECT
-        u.guid,
-        u.display_name,
-        u.email,
-        u.display_email,
-        us.rotation_token,
-        us.expires_at AS rotation_expires,
-        COALESCE(uc.credits, 0) AS credits,
-        ap.name AS provider_name,
-        upi.image_b64 AS profile_image
-      FROM users u
-      LEFT JOIN users_credits uc ON uc.user_guid = u.guid
-      LEFT JOIN users_auth ua ON ua.user_guid = u.guid
-      LEFT JOIN auth_provider ap ON ap.id = ua.provider_id
-      LEFT JOIN users_profileimg upi ON upi.user_guid = u.guid
-      LEFT JOIN users_sessions us ON us.user_guid = u.guid
-      WHERE u.guid = ?
+        u.element_guid AS guid,
+        u.element_display AS display_name,
+        u.element_email AS email,
+        u.element_optin AS display_email,
+        us.element_token AS rotation_token,
+        us.element_token_exp AS rotation_expires,
+        COALESCE(uc.element_credits, 0) AS credits,
+        ap.element_name AS provider_name,
+        upi.element_base64 AS profile_image
+      FROM account_users u
+      LEFT JOIN users_credits uc ON uc.users_guid = u.element_guid
+      LEFT JOIN users_auth ua ON ua.users_guid = u.element_guid
+      LEFT JOIN auth_providers ap ON ap.recid = ua.providers_recid
+      LEFT JOIN users_profileimg upi ON upi.users_guid = u.element_guid
+      LEFT JOIN users_sessions us ON us.users_guid = u.element_guid
+      WHERE u.element_guid = ?
       LIMIT 1;
     """
     result = await self._fetch_one(query, guid)
     return result
 
   async def get_user_roles(self, guid: str) -> int:
-    query = "SELECT roles FROM users_roles WHERE user_guid=?;"
+    query = "SELECT element_roles FROM users_roles WHERE users_guid=?;"
     row = await self._fetch_one(query, guid)
-    return row.get('roles', 0) if row else 0
+    return row.get('element_roles', 0) if row else 0
 
   async def list_roles(self) -> list[dict]:
-    query = "SELECT name, display, mask FROM roles ORDER BY mask;"
+    query = "SELECT element_name AS name, element_display AS display, element_mask AS mask FROM system_roles ORDER BY element_mask;"
     return await self._fetch_many(query)
 
   async def set_role(self, name: str, mask: int, display: str):
@@ -189,33 +189,33 @@ class MSSQLModule(BaseModule):
       raise RuntimeError("Database pool not initialized")
     async with self.pool.acquire() as conn:
       result = await conn.execute(
-        "UPDATE roles SET display=?, mask=? WHERE name=?",
+        "UPDATE system_roles SET element_display=?, element_mask=? WHERE element_name=?",
         name,
         display,
         mask,
       )
       if result.startswith("UPDATE 0"):
         await conn.execute(
-          "INSERT INTO roles(name, display, mask) VALUES(?, ?, ?)",
+          "INSERT INTO system_roles(element_name, element_display, element_mask) VALUES(?, ?, ?)",
           name,
           display,
           mask,
         )
 
   async def delete_role(self, name: str):
-    await self._run("DELETE FROM roles WHERE name=?", name)
+    await self._run("DELETE FROM system_roles WHERE element_name=?", name)
 
   async def get_user_enablements(self, guid: str) -> int:
-    query = "SELECT enablements FROM users_enablements WHERE user_guid=?;"
+    query = "SELECT element_enablements FROM users_enablements WHERE users_guid=?;"
     row = await self._fetch_one(query, guid)
-    return row.get('enablements', 0) if row else 0
+    return row.get('element_enablements', 0) if row else 0
 
   async def select_routes(self, role_mask: int = 0):
     logging.debug("select_routes role_mask=%s", role_mask)
     query = (
-      "SELECT * FROM routes "
-      "WHERE required_roles = 0 OR (required_roles & ?) = required_roles "
-      "ORDER BY sequence ASC;"
+      "SELECT * FROM frontend_routes "
+      "WHERE element_roles = 0 OR (element_roles & ?) = element_roles "
+      "ORDER BY element_sequence ASC;"
     )
     result = await self._fetch_many(query, role_mask)
     if result:
@@ -226,7 +226,7 @@ class MSSQLModule(BaseModule):
     return result
 
   async def list_routes(self) -> list[dict]:
-    query = "SELECT * FROM routes ORDER BY sequence;"
+    query = "SELECT * FROM frontend_routes ORDER BY element_sequence;"
     return await self._fetch_many(query)
 
   async def set_route(self, path: str, name: str, icon: str, required_roles: int, sequence: int):
@@ -234,31 +234,31 @@ class MSSQLModule(BaseModule):
       raise RuntimeError("Database pool not initialized")
     async with self.pool.acquire() as conn:
       async with conn.cursor() as cur:
-        await cur.execute("SELECT 1 FROM routes WHERE path=?", (path,))
+        await cur.execute("SELECT 1 FROM frontend_routes WHERE element_path=?", (path,))
         row = await cur.fetchone()
         if row:
           await cur.execute(
-            "UPDATE routes SET name=?, icon=?, required_roles=?, sequence=? WHERE path=?",
+            "UPDATE frontend_routes SET element_name=?, element_icon=?, element_roles=?, element_sequence=? WHERE element_path=?",
             (name, icon, required_roles, sequence, path),
           )
         else:
           await cur.execute(
-            "INSERT INTO routes(path, name, icon, required_roles, sequence) VALUES(?, ?, ?, ?, ?)",
+            "INSERT INTO frontend_routes(element_path, element_name, element_icon, element_roles, element_sequence) VALUES(?, ?, ?, ?, ?)",
             (path, name, icon, required_roles, sequence),
           )
 
   async def delete_route(self, path: str):
-    await self._run("DELETE FROM routes WHERE path=?", path)
+    await self._run("DELETE FROM frontend_routes WHERE element_path=?", path)
 
   async def select_links(self, role_mask: int = 0):
     logging.debug("select_links role_mask=%s", role_mask)
     query = (
-      "SELECT * FROM links "
-      "WHERE required_roles = 0 OR (required_roles & ?) = required_roles;"
+      "SELECT * FROM frontend_links "
+      "WHERE element_roles = 0 OR (element_roles & ?) = element_roles;"
     )
     result = await self._fetch_many(query, role_mask)
     if result:
-      titles = ", ".join(link.get("title", "Untitled") for link in result)
+      titles = ", ".join(link.get("element_title", "Untitled") for link in result)
       logging.info(
         "Returning %d routes: %s", len(result), titles
       )
@@ -266,10 +266,10 @@ class MSSQLModule(BaseModule):
 
   async def get_config_value(self, key: str) -> str | None:
     logging.debug("get_config_value key=%s", key)
-    query = "SELECT value FROM config WHERE key=?;"
+    query = "SELECT element_value FROM system_config WHERE element_key=?;"
     row = await self._fetch_one(query, key)
     if row:
-      return row.get("value")
+      return row.get("element_value")
     return None
 
   async def set_config_value(self, key: str, value: str):
@@ -279,45 +279,45 @@ class MSSQLModule(BaseModule):
     async with self.pool.acquire() as conn:
       async with conn.cursor() as cur:
         await cur.execute(
-          "UPDATE config SET value=? WHERE key=?",
+          "UPDATE system_config SET element_value=? WHERE element_key=?",
           (value, key),
         )
         if cur.rowcount == 0:
           await cur.execute(
-            "INSERT INTO config(key, value) VALUES(?, ?)",
+            "INSERT INTO system_config(element_key, element_value) VALUES(?, ?)",
             (key, value),
           )
 
   async def list_config(self) -> list[dict]:
-    query = "SELECT key, value FROM config ORDER BY key;"
+    query = "SELECT element_key, element_value FROM system_config ORDER BY element_key;"
     return await self._fetch_many(query)
 
   async def delete_config_value(self, key: str):
-    await self._run("DELETE FROM config WHERE key=?", key)
+    await self._run("DELETE FROM system_config WHERE element_key=?", key)
 
   async def update_display_name(self, guid: str, display_name: str):
     logging.debug("update_display_name guid=%s display_name=%s", guid, display_name)
-    query = "UPDATE users SET display_name=? WHERE guid=?;"
+    query = "UPDATE account_users SET element_display=? WHERE element_guid=?;"
     await self._run(query, display_name, guid)
 
   async def select_users(self):
-    query = "SELECT guid, display_name FROM users ORDER BY display_name;"
+    query = "SELECT element_guid AS guid, element_display AS display_name FROM account_users ORDER BY element_display;"
     return await self._fetch_many(query)
 
   async def select_users_with_role(self, mask: int):
     query = (
-      "SELECT u.guid, u.display_name FROM users u "
-      "JOIN users_roles ur ON u.guid = ur.user_guid "
-      "WHERE (ur.roles & ?) = ? ORDER BY u.display_name;"
+      "SELECT u.element_guid AS guid, u.element_display AS display_name FROM account_users u "
+      "JOIN users_roles ur ON u.element_guid = ur.users_guid "
+      "WHERE (ur.element_roles & ?) = ? ORDER BY u.element_display;"
     )
     return await self._fetch_many(query, mask, mask)
 
   async def select_users_without_role(self, mask: int):
     query = (
-      "SELECT u.guid, u.display_name FROM users u "
-      "LEFT JOIN users_roles ur ON u.guid = ur.user_guid "
-      "WHERE ur.roles IS NULL OR (ur.roles & ?) = 0 "
-      "ORDER BY u.display_name;"
+      "SELECT u.element_guid AS guid, u.element_display AS display_name FROM account_users u "
+      "LEFT JOIN users_roles ur ON u.element_guid = ur.users_guid "
+      "WHERE ur.element_roles IS NULL OR (ur.element_roles & ?) = 0 "
+      "ORDER BY u.element_display;"
     )
     return await self._fetch_many(query, mask)
 
@@ -326,16 +326,16 @@ class MSSQLModule(BaseModule):
       raise RuntimeError("Database pool not initialized")
     async with self.pool.acquire() as conn:
       async with conn.cursor() as cur:
-        await cur.execute("SELECT 1 FROM users_roles WHERE user_guid=?", (guid,))
+        await cur.execute("SELECT 1 FROM users_roles WHERE users_guid=?", (guid,))
         row = await cur.fetchone()
         if row:
           await cur.execute(
-            "UPDATE users_roles SET roles=? WHERE user_guid=?",
+            "UPDATE users_roles SET element_roles=? WHERE users_guid=?",
             (roles, guid),
           )
         else:
           await cur.execute(
-            "INSERT INTO users_roles(user_guid, roles) VALUES(?, ?)",
+            "INSERT INTO users_roles(users_guid, element_roles) VALUES(?, ?)",
             (guid, roles),
           )
 
@@ -344,55 +344,55 @@ class MSSQLModule(BaseModule):
       raise RuntimeError("Database pool not initialized")
     async with self.pool.acquire() as conn:
       async with conn.cursor() as cur:
-        await cur.execute("SELECT 1 FROM users_credits WHERE user_guid=?", (guid,))
+        await cur.execute("SELECT 1 FROM users_credits WHERE users_guid=?", (guid,))
         row = await cur.fetchone()
         if row:
           await cur.execute(
-            "UPDATE users_credits SET credits=? WHERE user_guid=?",
+            "UPDATE users_credits SET element_credits=? WHERE users_guid=?",
             (credits, guid),
           )
         else:
           await cur.execute(
-            "INSERT INTO users_credits(user_guid, credits) VALUES(?, ?)",
+            "INSERT INTO users_credits(users_guid, element_credits) VALUES(?, ?)",
             (guid, credits),
           )
 
   async def set_user_rotation_token(self, guid: str, token: str, expires: datetime):
     query = (
-      "UPDATE users_sessions SET rotation_token=?, expires_at=? "
-      "WHERE user_guid=?;"
+      "UPDATE users_sessions SET element_token=?, element_token_exp=? "
+      "WHERE users_guid=?;"
     )
     await self._run(query, token, expires, guid)
 
   async def create_user_session(self, user_guid: str, bearer: str, rotation: str, expires: datetime) -> str:
     session_id = _utos(uuid4())
-    await self._run("DELETE FROM users_sessions WHERE user_guid=?", user_guid)
+    await self._run("DELETE FROM users_sessions WHERE users_guid=?", user_guid)
     query = (
-      "INSERT INTO users_sessions(session_id, user_guid, bearer_token, rotation_token, created_at, expires_at) "
-      "VALUES(?, ?, ?, ?, GETDATE(), ?);"
+      "INSERT INTO users_sessions(element_guid, users_guid, element_token, element_token_iat, element_token_exp) "
+      "VALUES(?, ?, ?, GETDATE(), ?);"
     )
-    await self._run(query, session_id, user_guid, bearer, rotation, expires)
+    await self._run(query, session_id, user_guid, rotation, expires)
     return session_id
 
   async def get_session_by_rotation(self, rotation_token: str):
-    query = "SELECT * FROM users_sessions WHERE rotation_token=?;"
+    query = "SELECT * FROM users_sessions WHERE element_token=?;"
     return await self._fetch_one(query, rotation_token)
 
   async def update_session_tokens(self, session_id: str, bearer: str, rotation: str, expires: datetime):
     query = (
-      "UPDATE users_sessions SET bearer_token=?, rotation_token=?, expires_at=? "
-      "WHERE session_id=?;"
+      "UPDATE users_sessions SET element_token=?, element_token_exp=? "
+      "WHERE element_guid=?;"
     )
-    await self._run(query, session_id, bearer, rotation, expires)
+    await self._run(query, rotation, expires, session_id)
 
   async def delete_session(self, session_id: str):
-    await self._run("DELETE FROM users_sessions WHERE session_id=?", session_id)
+    await self._run("DELETE FROM users_sessions WHERE element_guid=?", session_id)
 
   async def get_user_profile_image(self, guid: str) -> str | None:
-    query = "SELECT image_b64 FROM users_profileimg WHERE user_guid=?;"
+    query = "SELECT element_base64 FROM users_profileimg WHERE users_guid=?;"
     row = await self._fetch_one(query, guid)
     if row:
-      return row.get('image_b64')
+      return row.get('element_base64')
     return None
 
   async def set_user_profile_image(self, guid: str, image_b64: str):
@@ -400,15 +400,15 @@ class MSSQLModule(BaseModule):
       raise RuntimeError("Database pool not initialized")
     async with self.pool.acquire() as conn:
       async with conn.cursor() as cur:
-        await cur.execute("SELECT 1 FROM users_profileimg WHERE user_guid=?", (guid,))
+        await cur.execute("SELECT 1 FROM users_profileimg WHERE users_guid=?", (guid,))
         row = await cur.fetchone()
         if row:
           await cur.execute(
-            "UPDATE users_profileimg SET image_b64=? WHERE user_guid=?",
+            "UPDATE users_profileimg SET element_base64=? WHERE users_guid=?",
             (image_b64, guid),
           )
         else:
           await cur.execute(
-            "INSERT INTO users_profileimg(user_guid, image_b64) VALUES(?, ?)",
+            "INSERT INTO users_profileimg(users_guid, element_base64) VALUES(?, ?)",
             (guid, image_b64),
           )

--- a/server/modules/permcap_module.py
+++ b/server/modules/permcap_module.py
@@ -30,7 +30,7 @@ class PermCapModule(BaseModule):
   def filter_routes(self, routes: list[dict], role_mask: int) -> list[dict]:
     allowed: list[dict] = []
     for r in routes:
-      req_mask = r.get('required_roles') or 0
+      req_mask = r.get('required_roles') or r.get('element_roles') or 0
       if req_mask == 0 or req_mask & role_mask == req_mask:
         allowed.append(r)
     return allowed

--- a/tests/test_mssql_module.py
+++ b/tests/test_mssql_module.py
@@ -87,12 +87,12 @@ class DummyPool:
 
 def test_mssql_get_config_value(mssql_app):
   dbm = MSSQLModule(mssql_app, dsn="sql://cs")
-  dbm.pool = DummyPool(('v',), column="value")
+  dbm.pool = DummyPool(('v',), column="element_value")
   result = asyncio.run(dbm.get_config_value('Version'))
   assert result == 'v'
 
 def test_mssql_profile_image_ops(mssql_app):
-  conn = DummyConn(('img',), column="image_b64")
+  conn = DummyConn(('img',), column="element_base64")
   class Pool(DummyPool):
     def __init__(self, c):
       self.c = c

--- a/tests/test_rpc_system_namespace.py
+++ b/tests/test_rpc_system_namespace.py
@@ -22,35 +22,59 @@ class DummyDB:
         routes = [
             {
                 "id": 1,
+                "recid": 1,
                 "path": "/",
+                "element_path": "/",
                 "name": "Home",
+                "element_name": "Home",
                 "icon": "home",
+                "element_icon": "home",
                 "required_roles": 0,
+                "element_roles": 0,
                 "sequence": 10,
+                "element_sequence": 10,
             },
             {
                 "id": 2,
+                "recid": 2,
                 "path": "/gallery",
+                "element_path": "/gallery",
                 "name": "Gallery",
+                "element_name": "Gallery",
                 "icon": "gallery",
+                "element_icon": "gallery",
                 "required_roles": 0,
+                "element_roles": 0,
                 "sequence": 20,
+                "element_sequence": 20,
             },
             {
                 "id": 3,
+                "recid": 3,
                 "path": "/file-manager",
+                "element_path": "/file-manager",
                 "name": "File Manager",
+                "element_name": "File Manager",
                 "icon": "files",
+                "element_icon": "files",
                 "required_roles": self.roles["ROLE_REGISTERED"],
+                "element_roles": self.roles["ROLE_REGISTERED"],
                 "sequence": 30,
+                "element_sequence": 30,
             },
             {
                 "id": 4,
+                "recid": 4,
                 "path": "/user-admin",
+                "element_path": "/user-admin",
                 "name": "User Admin",
+                "element_name": "User Admin",
                 "icon": "admin",
+                "element_icon": "admin",
                 "required_roles": self.roles["ROLE_SYSTEM_ADMIN"] | self.roles["ROLE_REGISTERED"],
+                "element_roles": self.roles["ROLE_SYSTEM_ADMIN"] | self.roles["ROLE_REGISTERED"],
                 "sequence": 40,
+                "element_sequence": 40,
             },
         ]
         return [
@@ -66,9 +90,13 @@ class DummyDB:
         return [
             {
                 "id": 1,
+                "recid": 1,
                 "title": "Discord",
+                "element_title": "Discord",
                 "url": "https://link",
+                "element_url": "https://link",
                 "required_roles": 0,
+                "element_roles": 0,
             }
         ]
 


### PR DESCRIPTION
## Summary
- update MSSQL module queries for new schema
- use new column names in v2 links RPC
- support element_roles in permcap filter
- adjust tests for new schema
- regenerate RPC client

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_6885d537894c83258da1433c834c6f09