### PR TITLE
Switch frontend to MSSQL-backed RPC v2

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -3,12 +3,12 @@ import { useEffect, useState } from 'react';
 import type { LinkItem } from './shared/RpcModels';
 import Logo from './assets/elideus_group_green.png';
 import {
-	fetchHostname,
-	fetchVersion,
-	fetchRepo,
-	fetchFfmpegVersion,
+        fetchHostname2 as fetchHostname,
+        fetchVersion2 as fetchVersion,
+        fetchRepo2 as fetchRepo,
+        fetchFfmpegVersion,
 } from './rpc/frontend/vars';
-import { fetchHome } from './rpc/frontend/links';
+import { fetchHome2 as fetchHome } from './rpc/frontend/links';
 
 const Home = (): JSX.Element => {
 	const [hostname, setHostname] = useState('');

--- a/frontend/src/NavBar.tsx
+++ b/frontend/src/NavBar.tsx
@@ -11,8 +11,8 @@ import {
 	ListItemText,
 } from '@mui/material';
 import { Menu as MenuIcon } from '@mui/icons-material';
-import type { RouteItem, FrontendLinksRoutes1 } from './shared/RpcModels';
-import { fetchRoutes } from './rpc/frontend/links';
+import type { RouteItem, FrontendLinksRoutes2 } from './shared/RpcModels';
+import { fetchRoutes2 as fetchRoutes } from './rpc/frontend/links';
 import { iconMap, defaultIcon } from './icons';
 import Login from './shared/Login';
 import UserContext from './shared/UserContext';
@@ -28,7 +28,7 @@ const NavBar = (): JSX.Element => {
         useEffect(() => {
                 void (async () => {
                         try {
-                                const res: FrontendLinksRoutes1 = await fetchRoutes();
+                                const res: FrontendLinksRoutes2 = await fetchRoutes();
                                 setRoutes(res.routes);
                         } catch {
                                 setRoutes([]);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,139 +28,6 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
-export interface FrontendUserProfileData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  storageUsed: number | null;
-  storageEnabled: boolean | null;
-  displayEmail: boolean;
-  roles: string[];
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
-export interface FrontendUserSetDisplayName1 {
-  bearerToken: string;
-  displayName: string;
-}
-export interface FrontendVarsFfmpegVersion1 {
-  ffmpeg_version: string;
-}
-export interface FrontendVarsHostname1 {
-  hostname: string;
-}
-export interface FrontendVarsHostname2 {
-  hostname: string;
-}
-export interface FrontendVarsRepo1 {
-  repo: string;
-}
-export interface FrontendVarsRepo2 {
-  repo: string;
-}
-export interface FrontendVarsVersion1 {
-  version: string;
-}
-export interface FrontendVarsVersion2 {
-  version: string;
-}
-export interface ViewDiscord1 {
-  content: string;
-}
-export interface ViewDiscord2 {
-  content: string;
-}
-export interface FrontendLinksHome1 {
-  links: LinkItem[];
-}
-export interface FrontendLinksHome2 {
-  links: LinkItem[];
-}
-export interface FrontendLinksRoutes1 {
-  routes: RouteItem[];
-}
-export interface FrontendLinksRoutes2 {
-  routes: RouteItem[];
-}
-export interface LinkItem {
-  title: string;
-  url: string;
-}
-export interface RouteItem {
-  path: string;
-  name: string;
-  icon: string;
-}
-export interface FileItem {
-  name: string;
-  url: string;
-  contentType: string | null;
-}
-export interface StorageFileDelete1 {
-  bearerToken: string;
-  filename: string;
-}
-export interface StorageFileUpload1 {
-  bearerToken: string;
-  filename: string;
-  dataUrl: string;
-  contentType: string;
-}
-export interface StorageFilesList1 {
-  files: FileItem[];
-}
-export interface SystemRouteDelete1 {
-  path: string;
-}
-export interface SystemRouteItem {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRouteUpdate1 {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRoutesList1 {
-  routes: SystemRouteItem[];
-}
-export interface RoleItem {
-  name: string;
-  display: string;
-  bit: number;
-}
-export interface SystemRoleDelete1 {
-  name: string;
-}
-export interface SystemRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface SystemRoleMembers1 {
-  members: any[];
-  nonMembers: any[];
-}
-export interface SystemRoleUpdate1 {
-  name: string;
-  display: string;
-  bit: number;
-}
-export interface SystemRolesList1 {
-  roles: RoleItem[];
-}
-export interface UserListItem {
-  guid: string;
-  displayName: string;
-}
 export interface SystemUserCreditsUpdate1 {
   userGuid: string;
   credits: number;
@@ -189,6 +56,34 @@ export interface SystemUserRolesUpdate1 {
 export interface SystemUsersList1 {
   users: UserListItem[];
 }
+export interface UserListItem {
+  guid: string;
+  displayName: string;
+}
+export interface RoleItem {
+  name: string;
+  display: string;
+  bit: number;
+}
+export interface SystemRoleDelete1 {
+  name: string;
+}
+export interface SystemRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
+}
+export interface SystemRoleMembers1 {
+  members: any[];
+  nonMembers: any[];
+}
+export interface SystemRoleUpdate1 {
+  name: string;
+  display: string;
+  bit: number;
+}
+export interface SystemRolesList1 {
+  roles: RoleItem[];
+}
 export interface ConfigItem {
   key: string;
   value: string;
@@ -203,40 +98,25 @@ export interface SystemConfigUpdate1 {
   key: string;
   value: string;
 }
-export interface AuthMicrosoftLoginData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  rotationToken: string | null;
-  rotationExpires: any | null;
+export interface SystemRouteDelete1 {
+  path: string;
 }
-export interface AuthSessionTokens1 {
-  bearerToken: string;
-  rotationToken: string;
-  rotationExpires: any;
-}
-export interface AccountRoleDelete1 {
+export interface SystemRouteItem {
+  path: string;
   name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
 }
-export interface AccountRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface AccountRoleMembers1 {
-  members: UserListItem[];
-  nonMembers: UserListItem[];
-}
-export interface AccountRoleUpdate1 {
+export interface SystemRouteUpdate1 {
+  path: string;
   name: string;
-  display: string;
-  bit: number;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
 }
-export interface AccountRolesList1 {
-  roles: RoleItem[];
+export interface SystemRoutesList1 {
+  routes: SystemRouteItem[];
 }
 export interface AccountUserCreditsUpdate1 {
   userGuid: string;
@@ -269,6 +149,126 @@ export interface AccountUserRolesUpdate1 {
 }
 export interface AccountUsersList1 {
   users: UserListItem[];
+}
+export interface AccountRoleDelete1 {
+  name: string;
+}
+export interface AccountRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
+}
+export interface AccountRoleMembers1 {
+  members: UserListItem[];
+  nonMembers: UserListItem[];
+}
+export interface AccountRoleUpdate1 {
+  name: string;
+  display: string;
+  bit: number;
+}
+export interface AccountRolesList1 {
+  roles: RoleItem[];
+}
+export interface FileItem {
+  name: string;
+  url: string;
+  contentType: string | null;
+}
+export interface StorageFileDelete1 {
+  bearerToken: string;
+  filename: string;
+}
+export interface StorageFileUpload1 {
+  bearerToken: string;
+  filename: string;
+  dataUrl: string;
+  contentType: string;
+}
+export interface StorageFilesList1 {
+  files: FileItem[];
+}
+export interface FrontendLinksHome1 {
+  links: LinkItem[];
+}
+export interface FrontendLinksHome2 {
+  links: LinkItem[];
+}
+export interface FrontendLinksRoutes1 {
+  routes: RouteItem[];
+}
+export interface FrontendLinksRoutes2 {
+  routes: RouteItem[];
+}
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+export interface RouteItem {
+  path: string;
+  name: string;
+  icon: string;
+}
+export interface FrontendVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface FrontendVarsHostname1 {
+  hostname: string;
+}
+export interface FrontendVarsHostname2 {
+  hostname: string;
+}
+export interface FrontendVarsRepo1 {
+  repo: string;
+}
+export interface FrontendVarsRepo2 {
+  repo: string;
+}
+export interface FrontendVarsVersion1 {
+  version: string;
+}
+export interface FrontendVarsVersion2 {
+  version: string;
+}
+export interface ViewDiscord1 {
+  content: string;
+}
+export interface ViewDiscord2 {
+  content: string;
+}
+export interface FrontendUserProfileData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  storageUsed: number | null;
+  storageEnabled: boolean | null;
+  displayEmail: boolean;
+  roles: string[];
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface FrontendUserSetDisplayName1 {
+  bearerToken: string;
+  displayName: string;
+}
+export interface AuthSessionTokens1 {
+  bearerToken: string;
+  rotationToken: string;
+  rotationExpires: any;
+}
+export interface AuthMicrosoftLoginData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  rotationToken: string | null;
+  rotationExpires: any | null;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/frontend/tests/rpcClient.test.ts
+++ b/frontend/tests/rpcClient.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import axios from 'axios';
-import { fetchVersion, fetchHostname, fetchRepo, fetchFfmpegVersion } from '../src/rpc/frontend/vars';
-import { fetchHome, fetchRoutes } from '../src/rpc/frontend/links';
+import { fetchVersion2 as fetchVersion, fetchHostname2 as fetchHostname, fetchRepo2 as fetchRepo, fetchFfmpegVersion } from '../src/rpc/frontend/vars';
+import { fetchHome2 as fetchHome, fetchRoutes2 as fetchRoutes } from '../src/rpc/frontend/links';
 import { fetchList as fetchFileList, fetchDelete as fetchFileDelete, fetchUpload as fetchFileUpload } from '../src/rpc/storage/files';
 import { fetchList as fetchUsers, fetchProfile } from '../src/rpc/system/users';
 import { fetchList as fetchConfigList, fetchSet as fetchConfigSet, fetchDelete as fetchConfigDelete } from '../src/rpc/system/config';
@@ -13,21 +13,21 @@ describe('rpcClient', () => {
     it('fetchVersion posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { version: 'v9.9.9' } } });
         const res = await fetchVersion();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:vars:get_version:1' }), expect.anything());
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:vars:get_version:2' }), expect.anything());
         expect(res.version).toBe('v9.9.9');
     });
 
     it('fetchHostname posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { hostname: 'unit-host' } } });
         const res = await fetchHostname();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:vars:get_hostname:1' }), expect.anything());
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:vars:get_hostname:2' }), expect.anything());
         expect(res.hostname).toBe('unit-host');
     });
 
     it('fetchRepo posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { repo: 'https://repo' } } });
         const res = await fetchRepo();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:vars:get_repo:1' }), expect.anything());
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:vars:get_repo:2' }), expect.anything());
         expect(res.repo).toBe('https://repo');
     });
 
@@ -41,14 +41,14 @@ describe('rpcClient', () => {
     it('fetchHome posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { links: [] } } });
         const res = await fetchHome();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:links:get_home:1' }), expect.anything());
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:links:get_home:2' }), expect.anything());
         expect(Array.isArray(res.links)).toBe(true);
     });
 
     it('fetchRoutes posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { routes: [] } } });
         const res = await fetchRoutes();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:links:get_routes:1' }), expect.anything());
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:links:get_routes:2' }), expect.anything());
         expect(Array.isArray(res.routes)).toBe(true);
     });
 

--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -10,6 +10,7 @@ from server.modules.storage_module import StorageModule
 from server.modules.discord_module import DiscordModule
 from server.modules.auth_module import AuthModule
 from server.modules.permcap_module import PermCapModule
+from server.modules.mssql_module import MSSQLModule
 
 from server.helpers import roles as role_helper
 
@@ -23,6 +24,10 @@ async def lifespan(app: FastAPI):
 
   debug = await app.state.database.get_config_value("DebugLogging")
   configure_root_logging(debug=str(debug).lower() in ["1", "true"])
+
+  mssql_dsn = os.getenv("AZURE_SQL_CONNECTION_STRING")
+  app.state.mssql = MSSQLModule(app, dsn=mssql_dsn)
+  await app.state.mssql.startup()
 
   app.state.env = EnvironmentModule(app)
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -2,6 +2,7 @@ import asyncio
 from fastapi import FastAPI
 import server.modules.discord_module as discord_mod
 import server.modules.database_module as db_mod
+import server.modules.mssql_module as mssql_mod
 import server.modules.auth_module as auth_mod
 import server.modules.storage_module as storage_mod
 from server.modules.discord_module import DiscordModule
@@ -22,6 +23,7 @@ def test_lifespan_initializes_modules(monkeypatch):
   monkeypatch.setenv("DISCORD_SECRET", "secret")
   monkeypatch.setenv("JWT_SECRET", "jwt")
   monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgres://user@host/db")
+  monkeypatch.setenv("AZURE_SQL_CONNECTION_STRING", "sql://cs")
   monkeypatch.setenv("AZURE_BLOB_CONNECTION_STRING", "cs")
 
   monkeypatch.setattr(discord_mod, "configure_discord_logging", lambda m: None)
@@ -44,6 +46,10 @@ def test_lifespan_initializes_modules(monkeypatch):
   async def fake_pool(**kwargs):
     return "pool"
   monkeypatch.setattr(db_mod.asyncpg, "create_pool", fake_pool)
+
+  async def fake_mssql_pool(**kwargs):
+    return "mssql_pool"
+  monkeypatch.setattr(mssql_mod.aioodbc, "create_pool", fake_mssql_pool)
 
   async def fake_list_roles(self):
     return []
@@ -72,6 +78,7 @@ def test_lifespan_initializes_modules(monkeypatch):
       assert app.state.env is not None
       assert app.state.discord is not None
       assert app.state.database is not None
+      assert app.state.mssql is not None
       assert app.state.auth is not None
 
   asyncio.run(run())


### PR DESCRIPTION
## Summary
- initialize MSSQL module during FastAPI startup
- query v2 frontend RPC endpoints in Home and NavBar
- update vitest coverage to expect v2 RPC calls
- generate fresh RPC models
- validate MSSQL module in startup tests

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68866457cd34832594f3ccf5c1b836ac