### PR TITLE
Add MSSQL-backed system routes v2

### DIFF
--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -3,8 +3,8 @@ import { Box, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Stac
 import ColumnHeader from './shared/ColumnHeader';
 import { PageTitle } from './shared/PageTitle';
 import { Delete, Add, ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
-import type { SystemRouteItem, SystemRoutesList1, SystemUserRoles1 } from './shared/RpcModels';
-import { fetchList as fetchRoutes, fetchSet, fetchDelete } from './rpc/system/routes';
+import type { SystemRouteItem, SystemRoutesList2, SystemUserRoles1 } from './shared/RpcModels';
+import { fetchList2 as fetchRoutes, fetchSet2 as fetchSet, fetchDelete2 as fetchDelete } from './rpc/system/routes';
 import EditBox from './shared/EditBox';
 import Notification from './shared/Notification';
 import { fetchListRoles } from './rpc/system/users';
@@ -24,7 +24,7 @@ const SystemRoutesPage = (): JSX.Element => {
 
     const load = async (): Promise<void> => {
         try {
-            const res: SystemRoutesList1 = await fetchRoutes();
+            const res: SystemRoutesList2 = await fetchRoutes();
             setRoutes(res.routes.sort((a, b) => a.sequence - b.sequence));
         } catch {
             setRoutes([]);

--- a/frontend/src/rpc/system/routes/index.ts
+++ b/frontend/src/rpc/system/routes/index.ts
@@ -4,8 +4,11 @@
 // overwritten the next time the generator runs.
 // ================================================
 
-import { rpcCall, SystemRoutesList1 } from '../../../shared/RpcModels';
+import { rpcCall, SystemRoutesList1, SystemRoutesList2 } from '../../../shared/RpcModels';
 
 export const fetchList = (payload: any = null): Promise<SystemRoutesList1> => rpcCall('urn:system:routes:list:1', payload);
 export const fetchSet = (payload: any = null): Promise<any> => rpcCall('urn:system:routes:set:1', payload);
 export const fetchDelete = (payload: any = null): Promise<any> => rpcCall('urn:system:routes:delete:1', payload);
+export const fetchList2 = (payload: any = null): Promise<SystemRoutesList2> => rpcCall('urn:system:routes:list:2', payload);
+export const fetchSet2 = (payload: any = null): Promise<any> => rpcCall('urn:system:routes:set:2', payload);
+export const fetchDelete2 = (payload: any = null): Promise<any> => rpcCall('urn:system:routes:delete:2', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,107 +28,6 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
-export interface FrontendUserProfileData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  storageUsed: number | null;
-  storageEnabled: boolean | null;
-  displayEmail: boolean;
-  roles: string[];
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
-export interface FrontendUserSetDisplayName1 {
-  bearerToken: string;
-  displayName: string;
-}
-export interface FrontendLinksHome1 {
-  links: LinkItem[];
-}
-export interface FrontendLinksHome2 {
-  links: LinkItem[];
-}
-export interface FrontendLinksRoutes1 {
-  routes: RouteItem[];
-}
-export interface FrontendLinksRoutes2 {
-  routes: RouteItem[];
-}
-export interface LinkItem {
-  title: string;
-  url: string;
-}
-export interface RouteItem {
-  path: string;
-  name: string;
-  icon: string;
-}
-export interface FrontendVarsFfmpegVersion1 {
-  ffmpeg_version: string;
-}
-export interface FrontendVarsHostname1 {
-  hostname: string;
-}
-export interface FrontendVarsHostname2 {
-  hostname: string;
-}
-export interface FrontendVarsRepo1 {
-  repo: string;
-}
-export interface FrontendVarsRepo2 {
-  repo: string;
-}
-export interface FrontendVarsVersion1 {
-  version: string;
-}
-export interface FrontendVarsVersion2 {
-  version: string;
-}
-export interface ViewDiscord1 {
-  content: string;
-}
-export interface ViewDiscord2 {
-  content: string;
-}
-export interface FileItem {
-  name: string;
-  url: string;
-  contentType: string | null;
-}
-export interface StorageFileDelete1 {
-  bearerToken: string;
-  filename: string;
-}
-export interface StorageFileUpload1 {
-  bearerToken: string;
-  filename: string;
-  dataUrl: string;
-  contentType: string;
-}
-export interface StorageFilesList1 {
-  files: FileItem[];
-}
-export interface AuthSessionTokens1 {
-  bearerToken: string;
-  rotationToken: string;
-  rotationExpires: any;
-}
-export interface AuthMicrosoftLoginData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
 export interface AccountUserCreditsUpdate1 {
   userGuid: string;
   credits: number;
@@ -217,21 +116,10 @@ export interface SystemUserRolesUpdate1 {
 export interface SystemUsersList1 {
   users: UserListItem[];
 }
-export interface ConfigItem {
-  key: string;
-  value: string;
-}
-export interface SystemConfigDelete1 {
-  key: string;
-}
-export interface SystemConfigList1 {
-  items: ConfigItem[];
-}
-export interface SystemConfigUpdate1 {
-  key: string;
-  value: string;
-}
 export interface SystemRouteDelete1 {
+  path: string;
+}
+export interface SystemRouteDelete2 {
   path: string;
 }
 export interface SystemRouteItem {
@@ -248,8 +136,32 @@ export interface SystemRouteUpdate1 {
   sequence: number;
   requiredRoles: string[];
 }
+export interface SystemRouteUpdate2 {
+  path: string;
+  name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
+}
 export interface SystemRoutesList1 {
   routes: SystemRouteItem[];
+}
+export interface SystemRoutesList2 {
+  routes: SystemRouteItem[];
+}
+export interface ConfigItem {
+  key: string;
+  value: string;
+}
+export interface SystemConfigDelete1 {
+  key: string;
+}
+export interface SystemConfigList1 {
+  items: ConfigItem[];
+}
+export interface SystemConfigUpdate1 {
+  key: string;
+  value: string;
 }
 export interface SystemRoleDelete1 {
   name: string;
@@ -269,6 +181,107 @@ export interface SystemRoleUpdate1 {
 }
 export interface SystemRolesList1 {
   roles: RoleItem[];
+}
+export interface AuthMicrosoftLoginData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface AuthSessionTokens1 {
+  bearerToken: string;
+  rotationToken: string;
+  rotationExpires: any;
+}
+export interface FileItem {
+  name: string;
+  url: string;
+  contentType: string | null;
+}
+export interface StorageFileDelete1 {
+  bearerToken: string;
+  filename: string;
+}
+export interface StorageFileUpload1 {
+  bearerToken: string;
+  filename: string;
+  dataUrl: string;
+  contentType: string;
+}
+export interface StorageFilesList1 {
+  files: FileItem[];
+}
+export interface FrontendVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface FrontendVarsHostname1 {
+  hostname: string;
+}
+export interface FrontendVarsHostname2 {
+  hostname: string;
+}
+export interface FrontendVarsRepo1 {
+  repo: string;
+}
+export interface FrontendVarsRepo2 {
+  repo: string;
+}
+export interface FrontendVarsVersion1 {
+  version: string;
+}
+export interface FrontendVarsVersion2 {
+  version: string;
+}
+export interface ViewDiscord1 {
+  content: string;
+}
+export interface ViewDiscord2 {
+  content: string;
+}
+export interface FrontendLinksHome1 {
+  links: LinkItem[];
+}
+export interface FrontendLinksHome2 {
+  links: LinkItem[];
+}
+export interface FrontendLinksRoutes1 {
+  routes: RouteItem[];
+}
+export interface FrontendLinksRoutes2 {
+  routes: RouteItem[];
+}
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+export interface RouteItem {
+  path: string;
+  name: string;
+  icon: string;
+}
+export interface FrontendUserProfileData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  storageUsed: number | null;
+  storageEnabled: boolean | null;
+  displayEmail: boolean;
+  roles: string[];
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface FrontendUserSetDisplayName1 {
+  bearerToken: string;
+  displayName: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -161,11 +161,23 @@
       "capabilities": 0
     },
     {
+      "op": "urn:system:routes:delete:2",
+      "capabilities": 0
+    },
+    {
       "op": "urn:system:routes:list:1",
       "capabilities": 0
     },
     {
+      "op": "urn:system:routes:list:2",
+      "capabilities": 0
+    },
+    {
       "op": "urn:system:routes:set:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:system:routes:set:2",
       "capabilities": 0
     },
     {

--- a/rpc/system/routes/handler.py
+++ b/rpc/system/routes/handler.py
@@ -14,5 +14,15 @@ async def handle_routes_request(parts: list[str], rpc_request: RPCRequest | None
       if rpc_request is None:
         raise HTTPException(status_code=400, detail='Missing payload')
       return await services.delete_route_v1(rpc_request, request)
+    case ["list", "2"]:
+      return await services.list_routes_v2(request)
+    case ["set", "2"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.set_route_v2(rpc_request, request)
+    case ["delete", "2"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.delete_route_v2(rpc_request, request)
     case _:
       raise HTTPException(status_code=404, detail='Unknown RPC operation')

--- a/rpc/system/routes/models.py
+++ b/rpc/system/routes/models.py
@@ -15,3 +15,15 @@ class SystemRouteUpdate1(SystemRouteItem):
 
 class SystemRouteDelete1(BaseModel):
   path: str
+
+
+class SystemRoutesList2(BaseModel):
+  routes: list[SystemRouteItem]
+
+
+class SystemRouteUpdate2(SystemRouteItem):
+  pass
+
+
+class SystemRouteDelete2(BaseModel):
+  path: str

--- a/rpc/system/routes/services.py
+++ b/rpc/system/routes/services.py
@@ -1,7 +1,16 @@
 from fastapi import Request
 from rpc.models import RPCRequest, RPCResponse
-from rpc.system.routes.models import SystemRoutesList1, SystemRouteItem, SystemRouteUpdate1, SystemRouteDelete1
+from rpc.system.routes.models import (
+  SystemRoutesList1,
+  SystemRoutesList2,
+  SystemRouteItem,
+  SystemRouteUpdate1,
+  SystemRouteUpdate2,
+  SystemRouteDelete1,
+  SystemRouteDelete2,
+)
 from server.modules.database_module import DatabaseModule
+from server.modules.mssql_module import MSSQLModule
 from server.helpers.roles import mask_to_names, names_to_mask
 
 async def list_routes_v1(request: Request) -> RPCResponse:
@@ -32,3 +41,35 @@ async def delete_route_v1(rpc_request: RPCRequest, request: Request) -> RPCRespo
   db: DatabaseModule = request.app.state.database
   await db.delete_route(data.path)
   return await list_routes_v1(request)
+
+
+async def list_routes_v2(request: Request) -> RPCResponse:
+  db: MSSQLModule = request.app.state.mssql
+  rows = await db.list_routes()
+  routes = [
+    SystemRouteItem(
+      path=r['element_path'],
+      name=r['element_name'],
+      icon=r['element_icon'],
+      sequence=r['element_sequence'],
+      requiredRoles=mask_to_names(int(r.get('element_roles') or 0)),
+    )
+    for r in rows
+  ]
+  payload = SystemRoutesList2(routes=routes)
+  return RPCResponse(op='urn:system:routes:list:2', payload=payload, version=2)
+
+
+async def set_route_v2(rpc_request: RPCRequest, request: Request) -> RPCResponse:
+  data = SystemRouteUpdate2(**(rpc_request.payload or {}))
+  db: MSSQLModule = request.app.state.mssql
+  mask = names_to_mask(data.requiredRoles)
+  await db.set_route(data.path, data.name, data.icon, mask, data.sequence)
+  return await list_routes_v2(request)
+
+
+async def delete_route_v2(rpc_request: RPCRequest, request: Request) -> RPCResponse:
+  data = SystemRouteDelete2(**(rpc_request.payload or {}))
+  db: MSSQLModule = request.app.state.mssql
+  await db.delete_route(data.path)
+  return await list_routes_v2(request)

--- a/tests/test_rpc_system_routes.py
+++ b/tests/test_rpc_system_routes.py
@@ -34,6 +34,37 @@ class DummyDB:
   async def delete_route(self, path):
     self.routes.pop(path, None)
 
+
+class DummyMSSQL:
+  def __init__(self):
+    self.routes = {
+      '/a': {
+        'element_path': '/a',
+        'element_name': 'A',
+        'element_icon': 'home',
+        'element_roles': 0,
+        'element_sequence': 10,
+      }
+    }
+
+  async def list_routes(self):
+    return list(self.routes.values())
+
+  async def list_roles(self):
+    return []
+
+  async def set_route(self, path, name, icon, required_roles, sequence):
+    self.routes[path] = {
+      'element_path': path,
+      'element_name': name,
+      'element_icon': icon,
+      'element_roles': required_roles,
+      'element_sequence': sequence,
+    }
+
+  async def delete_route(self, path):
+    self.routes.pop(path, None)
+
 async def make_app():
   app = FastAPI()
   app.state.database = DummyDB()
@@ -41,6 +72,16 @@ async def make_app():
   app.state.permcap = None
   app.state.env = None
   await role_helper.load_roles(app.state.database)
+  return app
+
+
+async def make_app2():
+  app = FastAPI()
+  app.state.mssql = DummyMSSQL()
+  app.state.auth = None
+  app.state.permcap = None
+  app.state.env = None
+  await role_helper.load_roles(app.state.mssql)
   return app
 
 
@@ -62,5 +103,28 @@ def test_route_flow():
   assert any(r.path == '/b' for r in resp.payload.routes)
 
   rpc = RPCRequest(op='urn:system:routes:delete:1', payload={'path': '/a'})
+  resp = asyncio.run(handle_rpc_request(rpc, req))
+  assert all(r.path != '/a' for r in resp.payload.routes)
+
+
+def test_route_flow_v2():
+  app = asyncio.run(make_app2())
+  req = Request({'type': 'http', 'app': app, 'headers': []})
+
+  rpc = RPCRequest(op='urn:system:routes:list:2')
+  resp = asyncio.run(handle_rpc_request(rpc, req))
+  assert len(resp.payload.routes) == 1
+
+  rpc = RPCRequest(op='urn:system:routes:set:2', payload={
+    'path': '/b',
+    'name': 'B',
+    'icon': 'menu',
+    'sequence': 20,
+    'requiredRoles': []
+  })
+  resp = asyncio.run(handle_rpc_request(rpc, req))
+  assert any(r.path == '/b' for r in resp.payload.routes)
+
+  rpc = RPCRequest(op='urn:system:routes:delete:2', payload={'path': '/a'})
   resp = asyncio.run(handle_rpc_request(rpc, req))
   assert all(r.path != '/a' for r in resp.payload.routes)


### PR DESCRIPTION
## Summary
- add v2 models for system routes
- implement MSSQL-backed system routes services and handler cases
- regenerate RPC library/clients and update metadata
- switch frontend SystemRoutesPage to use v2 RPC functions
- test both v1 and new v2 route operations

## Testing
- `npm run lint --silent --prefix frontend`
- `npm run type-check --silent --prefix frontend`
- `frontend/node_modules/.bin/vitest run`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e90a80e48325a04f3f6390b2aaf7