### PR TITLE
Add MSSQL system roles v2

### DIFF
--- a/frontend/src/SystemRolesPage.tsx
+++ b/frontend/src/SystemRolesPage.tsx
@@ -3,8 +3,8 @@ import { Box, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Text
 import ColumnHeader from './shared/ColumnHeader';
 import { PageTitle } from './shared/PageTitle';
 import { Delete, Add } from '@mui/icons-material';
-import type { RoleItem, SystemRolesList1 } from './shared/RpcModels';
-import { fetchList, fetchSet, fetchDelete } from './rpc/system/roles';
+import type { RoleItem, SystemRolesList2 } from './shared/RpcModels';
+import { fetchList2 as fetchList, fetchSet2 as fetchSet, fetchDelete2 as fetchDelete } from './rpc/system/roles';
 import EditBox from './shared/EditBox';
 import Notification from './shared/Notification';
 
@@ -16,7 +16,7 @@ const SystemRolesPage = (): JSX.Element => {
 
     const load = async (): Promise<void> => {
         try {
-            const res: SystemRolesList1 = await fetchList();
+            const res: SystemRolesList2 = await fetchList();
             setRoles(res.roles.sort((a, b) => a.bit - b.bit));
         } catch {
             setRoles([]);

--- a/frontend/src/UserPage.tsx
+++ b/frontend/src/UserPage.tsx
@@ -5,8 +5,8 @@ import UserContext from './shared/UserContext';
 import { fetchSetDisplayName } from './rpc/frontend/user';
 import EditBox, { EditBoxHandle } from './shared/EditBox';
 import Notification from './shared/Notification';
-import { fetchList as fetchRoleList } from './rpc/system/roles';
-import type { SystemRolesList1 } from './shared/RpcModels';
+import { fetchList2 as fetchRoleList } from './rpc/system/roles';
+import type { SystemRolesList2 } from './shared/RpcModels';
 
 const UserPage = (): JSX.Element => {
     const { userData, setUserData } = useContext(UserContext);
@@ -25,7 +25,7 @@ const UserPage = (): JSX.Element => {
     useEffect(() => {
         void (async () => {
             try {
-                const res: SystemRolesList1 = await fetchRoleList();
+                const res: SystemRolesList2 = await fetchRoleList();
                 const map: Record<string, string> = {};
                 res.roles.forEach(r => { map[r.name] = r.display; });
                 setRoleMap(map);

--- a/frontend/src/rpc/system/roles/index.ts
+++ b/frontend/src/rpc/system/roles/index.ts
@@ -4,8 +4,17 @@
 // overwritten the next time the generator runs.
 // ================================================
 
-import { rpcCall, SystemRolesList1 } from '../../../shared/RpcModels';
+import { rpcCall, SystemRolesList1, SystemRolesList2 } from '../../../shared/RpcModels';
 
 export const fetchList = (payload: any = null): Promise<SystemRolesList1> => rpcCall('urn:system:roles:list:1', payload);
 export const fetchSet = (payload: any = null): Promise<any> => rpcCall('urn:system:roles:set:1', payload);
 export const fetchDelete = (payload: any = null): Promise<any> => rpcCall('urn:system:roles:delete:1', payload);
+export const fetchMembers = (payload: any = null): Promise<any> => rpcCall('urn:system:roles:get_members:1', payload);
+export const fetchAddMember = (payload: any = null): Promise<any> => rpcCall('urn:system:roles:add_member:1', payload);
+export const fetchRemoveMember = (payload: any = null): Promise<any> => rpcCall('urn:system:roles:remove_member:1', payload);
+export const fetchList2 = (payload: any = null): Promise<SystemRolesList2> => rpcCall('urn:system:roles:list:2', payload);
+export const fetchSet2 = (payload: any = null): Promise<any> => rpcCall('urn:system:roles:set:2', payload);
+export const fetchDelete2 = (payload: any = null): Promise<any> => rpcCall('urn:system:roles:delete:2', payload);
+export const fetchMembers2 = (payload: any = null): Promise<any> => rpcCall('urn:system:roles:get_members:2', payload);
+export const fetchAddMember2 = (payload: any = null): Promise<any> => rpcCall('urn:system:roles:add_member:2', payload);
+export const fetchRemoveMember2 = (payload: any = null): Promise<any> => rpcCall('urn:system:roles:remove_member:2', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,160 +28,6 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
-export interface AccountUserCreditsUpdate1 {
-  userGuid: string;
-  credits: number;
-}
-export interface AccountUserDisplayNameUpdate1 {
-  userGuid: string;
-  displayName: string;
-}
-export interface AccountUserProfile1 {
-  guid: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: any;
-  profilePicture: any;
-  credits: any;
-  storageUsed: any;
-  storageEnabled: any;
-  displayEmail: boolean;
-  rotationToken: any;
-  rotationExpires: any;
-}
-export interface AccountUserRoles1 {
-  roles: string[];
-}
-export interface AccountUserRolesUpdate1 {
-  userGuid: string;
-  roles: string[];
-}
-export interface AccountUsersList1 {
-  users: UserListItem[];
-}
-export interface UserListItem {
-  guid: string;
-  displayName: string;
-}
-export interface AccountRoleDelete1 {
-  name: string;
-}
-export interface AccountRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface AccountRoleMembers1 {
-  members: UserListItem[];
-  nonMembers: UserListItem[];
-}
-export interface AccountRoleUpdate1 {
-  name: string;
-  display: string;
-  bit: number;
-}
-export interface AccountRolesList1 {
-  roles: RoleItem[];
-}
-export interface RoleItem {
-  name: string;
-  display: string;
-  bit: number;
-}
-export interface SystemUserCreditsUpdate1 {
-  userGuid: string;
-  credits: number;
-}
-export interface SystemUserProfile1 {
-  guid: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: any;
-  profilePicture: any;
-  credits: any;
-  storageUsed: any;
-  storageEnabled: any;
-  displayEmail: boolean;
-  rotationToken: any;
-  rotationExpires: any;
-}
-export interface SystemUserRoles1 {
-  roles: string[];
-}
-export interface SystemUserRolesUpdate1 {
-  userGuid: string;
-  roles: string[];
-}
-export interface SystemUsersList1 {
-  users: UserListItem[];
-}
-export interface SystemRouteDelete1 {
-  path: string;
-}
-export interface SystemRouteDelete2 {
-  path: string;
-}
-export interface SystemRouteItem {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRouteUpdate1 {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRouteUpdate2 {
-  path: string;
-  name: string;
-  icon: string;
-  sequence: number;
-  requiredRoles: string[];
-}
-export interface SystemRoutesList1 {
-  routes: SystemRouteItem[];
-}
-export interface SystemRoutesList2 {
-  routes: SystemRouteItem[];
-}
-export interface ConfigItem {
-  key: string;
-  value: string;
-}
-export interface SystemConfigDelete1 {
-  key: string;
-}
-export interface SystemConfigList1 {
-  items: ConfigItem[];
-}
-export interface SystemConfigUpdate1 {
-  key: string;
-  value: string;
-}
-export interface SystemRoleDelete1 {
-  name: string;
-}
-export interface SystemRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface SystemRoleMembers1 {
-  members: any[];
-  nonMembers: any[];
-}
-export interface SystemRoleUpdate1 {
-  name: string;
-  display: string;
-  bit: number;
-}
-export interface SystemRolesList1 {
-  roles: RoleItem[];
-}
 export interface AuthMicrosoftLoginData1 {
   bearerToken: string;
   defaultProvider: string;
@@ -282,6 +128,179 @@ export interface FrontendUserProfileData1 {
 export interface FrontendUserSetDisplayName1 {
   bearerToken: string;
   displayName: string;
+}
+export interface RoleItem {
+  name: string;
+  display: string;
+  bit: number;
+}
+export interface SystemRoleDelete1 {
+  name: string;
+}
+export interface SystemRoleDelete2 {
+  name: string;
+}
+export interface SystemRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
+}
+export interface SystemRoleMemberUpdate2 {
+  role: string;
+  userGuid: string;
+}
+export interface SystemRoleMembers1 {
+  members: any[];
+  nonMembers: any[];
+}
+export interface SystemRoleMembers2 {
+  members: any[];
+  nonMembers: any[];
+}
+export interface SystemRoleUpdate1 {
+  name: string;
+  display: string;
+  bit: number;
+}
+export interface SystemRoleUpdate2 {
+  name: string;
+  display: string;
+  bit: number;
+}
+export interface SystemRolesList1 {
+  roles: RoleItem[];
+}
+export interface SystemRolesList2 {
+  roles: RoleItem[];
+}
+export interface UserListItem {
+  guid: string;
+  displayName: string;
+}
+export interface SystemRouteDelete1 {
+  path: string;
+}
+export interface SystemRouteDelete2 {
+  path: string;
+}
+export interface SystemRouteItem {
+  path: string;
+  name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
+}
+export interface SystemRouteUpdate1 {
+  path: string;
+  name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
+}
+export interface SystemRouteUpdate2 {
+  path: string;
+  name: string;
+  icon: string;
+  sequence: number;
+  requiredRoles: string[];
+}
+export interface SystemRoutesList1 {
+  routes: SystemRouteItem[];
+}
+export interface SystemRoutesList2 {
+  routes: SystemRouteItem[];
+}
+export interface ConfigItem {
+  key: string;
+  value: string;
+}
+export interface SystemConfigDelete1 {
+  key: string;
+}
+export interface SystemConfigList1 {
+  items: ConfigItem[];
+}
+export interface SystemConfigUpdate1 {
+  key: string;
+  value: string;
+}
+export interface SystemUserCreditsUpdate1 {
+  userGuid: string;
+  credits: number;
+}
+export interface SystemUserProfile1 {
+  guid: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: any;
+  profilePicture: any;
+  credits: any;
+  storageUsed: any;
+  storageEnabled: any;
+  displayEmail: boolean;
+  rotationToken: any;
+  rotationExpires: any;
+}
+export interface SystemUserRoles1 {
+  roles: string[];
+}
+export interface SystemUserRolesUpdate1 {
+  userGuid: string;
+  roles: string[];
+}
+export interface SystemUsersList1 {
+  users: UserListItem[];
+}
+export interface AccountRoleDelete1 {
+  name: string;
+}
+export interface AccountRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
+}
+export interface AccountRoleMembers1 {
+  members: UserListItem[];
+  nonMembers: UserListItem[];
+}
+export interface AccountRoleUpdate1 {
+  name: string;
+  display: string;
+  bit: number;
+}
+export interface AccountRolesList1 {
+  roles: RoleItem[];
+}
+export interface AccountUserCreditsUpdate1 {
+  userGuid: string;
+  credits: number;
+}
+export interface AccountUserDisplayNameUpdate1 {
+  userGuid: string;
+  displayName: string;
+}
+export interface AccountUserProfile1 {
+  guid: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: any;
+  profilePicture: any;
+  credits: any;
+  storageUsed: any;
+  storageEnabled: any;
+  displayEmail: boolean;
+  rotationToken: any;
+  rotationExpires: any;
+}
+export interface AccountUserRoles1 {
+  roles: string[];
+}
+export interface AccountUserRolesUpdate1 {
+  userGuid: string;
+  roles: string[];
+}
+export interface AccountUsersList1 {
+  users: UserListItem[];
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -145,7 +145,27 @@
       "capabilities": 0
     },
     {
+      "op": "urn:system:roles:add_member:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:system:roles:add_member:2",
+      "capabilities": 0
+    },
+    {
       "op": "urn:system:roles:delete:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:system:roles:delete:2",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:system:roles:get_members:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:system:roles:get_members:2",
       "capabilities": 0
     },
     {
@@ -153,7 +173,23 @@
       "capabilities": 0
     },
     {
+      "op": "urn:system:roles:list:2",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:system:roles:remove_member:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:system:roles:remove_member:2",
+      "capabilities": 0
+    },
+    {
       "op": "urn:system:roles:set:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:system:roles:set:2",
       "capabilities": 0
     },
     {

--- a/rpc/system/roles/handler.py
+++ b/rpc/system/roles/handler.py
@@ -14,5 +14,39 @@ async def handle_roles_request(parts: list[str], rpc_request: RPCRequest | None,
       if rpc_request is None:
         raise HTTPException(status_code=400, detail='Missing payload')
       return await services.delete_role_v1(rpc_request, request)
+    case ["get_members", "1"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.get_role_members_v1(rpc_request, request)
+    case ["add_member", "1"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.add_role_member_v1(rpc_request, request)
+    case ["remove_member", "1"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.remove_role_member_v1(rpc_request, request)
+    case ["list", "2"]:
+      return await services.list_roles_v2(request)
+    case ["set", "2"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.set_role_v2(rpc_request, request)
+    case ["delete", "2"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.delete_role_v2(rpc_request, request)
+    case ["get_members", "2"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.get_role_members_v2(rpc_request, request)
+    case ["add_member", "2"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.add_role_member_v2(rpc_request, request)
+    case ["remove_member", "2"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.remove_role_member_v2(rpc_request, request)
     case _:
       raise HTTPException(status_code=404, detail='Unknown RPC operation')

--- a/rpc/system/roles/models.py
+++ b/rpc/system/roles/models.py
@@ -24,3 +24,22 @@ class SystemRoleMemberUpdate1(BaseModel):
 class SystemRoleMembers1(BaseModel):
   members: list['UserListItem']
   nonMembers: list['UserListItem']
+
+class SystemRolesList2(BaseModel):
+  roles: list[RoleItem]
+
+class SystemRoleUpdate2(BaseModel):
+  name: str
+  display: str
+  bit: int
+
+class SystemRoleDelete2(BaseModel):
+  name: str
+
+class SystemRoleMemberUpdate2(BaseModel):
+  role: str
+  userGuid: str
+
+class SystemRoleMembers2(BaseModel):
+  members: list['UserListItem']
+  nonMembers: list['UserListItem']

--- a/tests/test_rpc_system_roles_v2.py
+++ b/tests/test_rpc_system_roles_v2.py
@@ -1,0 +1,53 @@
+import asyncio
+from fastapi import FastAPI, Request
+from rpc.handler import handle_rpc_request
+from rpc.models import RPCRequest
+from server.helpers import roles as role_helper
+
+class DummyDB:
+  def __init__(self):
+    self.roles = {'ROLE_TEST': 2}
+    self.users = {'u1': 2, 'u2': 0}
+
+  async def list_roles(self):
+    return [{'name': n, 'display': n, 'mask': m} for n, m in self.roles.items()]
+
+  async def select_users_with_role(self, mask):
+    return [{'guid': k, 'display_name': k} for k, v in self.users.items() if v & mask]
+
+  async def select_users_without_role(self, mask):
+    return [{'guid': k, 'display_name': k} for k, v in self.users.items() if not (v & mask)]
+
+  async def get_user_roles(self, guid):
+    return self.users.get(guid, 0)
+
+  async def set_user_roles(self, guid, roles):
+    self.users[guid] = roles
+
+class DummyAuth:
+  async def decode_bearer_token(self, token):
+    return {'guid': token}
+
+async def make_app():
+  app = FastAPI()
+  db = DummyDB()
+  app.state.database = db
+  app.state.mssql = db
+  app.state.auth = DummyAuth()
+  app.state.permcap = None
+  app.state.env = None
+  await role_helper.load_roles(db)
+  return app
+
+def test_role_member_flow_v2():
+  app = asyncio.run(make_app())
+  req = Request({'type': 'http', 'app': app, 'headers': []})
+  rpc = RPCRequest(op='urn:system:roles:get_members:2', payload={'role': 'ROLE_TEST'})
+  resp = asyncio.run(handle_rpc_request(rpc, req))
+  assert len(resp.payload.members) == 1
+  rpc = RPCRequest(op='urn:system:roles:add_member:2', payload={'role': 'ROLE_TEST', 'userGuid': 'u2'})
+  resp = asyncio.run(handle_rpc_request(rpc, req))
+  assert any(u.guid == 'u2' for u in resp.payload.members)
+  rpc = RPCRequest(op='urn:system:roles:remove_member:2', payload={'role': 'ROLE_TEST', 'userGuid': 'u1'})
+  resp = asyncio.run(handle_rpc_request(rpc, req))
+  assert all(u.guid != 'u1' for u in resp.payload.members)


### PR DESCRIPTION
## Summary
- add v2 RPC models and services for system role management via MSSQL
- update handler routing for v2 operations
- regenerate RPC metadata and TypeScript clients
- switch frontend components to use v2 role APIs
- test new v2 flow

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_6886ef482b948325808425c011f647d6