### PR TITLE
Handle missing roles table

### DIFF
--- a/frontend/src/rpc/account/roles/index.ts
+++ b/frontend/src/rpc/account/roles/index.ts
@@ -4,11 +4,17 @@
 // overwritten the next time the generator runs.
 // ================================================
 
-import { rpcCall, AccountRolesList1 } from '../../../shared/RpcModels';
+import { rpcCall, AccountRolesList1, AccountRolesList2 } from '../../../shared/RpcModels';
 
 export const fetchList = (payload: any = null): Promise<AccountRolesList1> => rpcCall('urn:account:roles:list:1', payload);
 export const fetchSet = (payload: any = null): Promise<any> => rpcCall('urn:account:roles:set:1', payload);
 export const fetchDelete = (payload: any = null): Promise<any> => rpcCall('urn:account:roles:delete:1', payload);
+export const fetchList2 = (payload: any = null): Promise<AccountRolesList2> => rpcCall('urn:account:roles:list:2', payload);
+export const fetchSet2 = (payload: any = null): Promise<any> => rpcCall('urn:account:roles:set:2', payload);
+export const fetchDelete2 = (payload: any = null): Promise<any> => rpcCall('urn:account:roles:delete:2', payload);
 export const fetchMembers = (payload: any = null): Promise<any> => rpcCall('urn:account:roles:get_members:1', payload);
 export const fetchAddMember = (payload: any = null): Promise<any> => rpcCall('urn:account:roles:add_member:1', payload);
 export const fetchRemoveMember = (payload: any = null): Promise<any> => rpcCall('urn:account:roles:remove_member:1', payload);
+export const fetchMembers2 = (payload: any = null): Promise<any> => rpcCall('urn:account:roles:get_members:2', payload);
+export const fetchAddMember2 = (payload: any = null): Promise<any> => rpcCall('urn:account:roles:add_member:2', payload);
+export const fetchRemoveMember2 = (payload: any = null): Promise<any> => rpcCall('urn:account:roles:remove_member:2', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,6 +28,107 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
+export interface FileItem {
+  name: string;
+  url: string;
+  contentType: string | null;
+}
+export interface StorageFileDelete1 {
+  bearerToken: string;
+  filename: string;
+}
+export interface StorageFileUpload1 {
+  bearerToken: string;
+  filename: string;
+  dataUrl: string;
+  contentType: string;
+}
+export interface StorageFilesList1 {
+  files: FileItem[];
+}
+export interface AuthSessionTokens1 {
+  bearerToken: string;
+  rotationToken: string;
+  rotationExpires: any;
+}
+export interface AuthMicrosoftLoginData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface FrontendLinksHome1 {
+  links: LinkItem[];
+}
+export interface FrontendLinksHome2 {
+  links: LinkItem[];
+}
+export interface FrontendLinksRoutes1 {
+  routes: RouteItem[];
+}
+export interface FrontendLinksRoutes2 {
+  routes: RouteItem[];
+}
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+export interface RouteItem {
+  path: string;
+  name: string;
+  icon: string;
+}
+export interface FrontendVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface FrontendVarsHostname1 {
+  hostname: string;
+}
+export interface FrontendVarsHostname2 {
+  hostname: string;
+}
+export interface FrontendVarsRepo1 {
+  repo: string;
+}
+export interface FrontendVarsRepo2 {
+  repo: string;
+}
+export interface FrontendVarsVersion1 {
+  version: string;
+}
+export interface FrontendVarsVersion2 {
+  version: string;
+}
+export interface ViewDiscord1 {
+  content: string;
+}
+export interface ViewDiscord2 {
+  content: string;
+}
+export interface FrontendUserProfileData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  storageUsed: number | null;
+  storageEnabled: boolean | null;
+  displayEmail: boolean;
+  roles: string[];
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface FrontendUserSetDisplayName1 {
+  bearerToken: string;
+  displayName: string;
+}
 export interface ConfigItem {
   key: string;
   value: string;
@@ -89,6 +190,34 @@ export interface UserListItem {
   guid: string;
   displayName: string;
 }
+export interface SystemUserCreditsUpdate1 {
+  userGuid: string;
+  credits: number;
+}
+export interface SystemUserProfile1 {
+  guid: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: any;
+  profilePicture: any;
+  credits: any;
+  storageUsed: any;
+  storageEnabled: any;
+  displayEmail: boolean;
+  rotationToken: any;
+  rotationExpires: any;
+}
+export interface SystemUserRoles1 {
+  roles: string[];
+}
+export interface SystemUserRolesUpdate1 {
+  userGuid: string;
+  roles: string[];
+}
+export interface SystemUsersList1 {
+  users: UserListItem[];
+}
 export interface SystemRouteDelete1 {
   path: string;
 }
@@ -122,76 +251,25 @@ export interface SystemRoutesList1 {
 export interface SystemRoutesList2 {
   routes: SystemRouteItem[];
 }
-export interface SystemUserCreditsUpdate1 {
-  userGuid: string;
-  credits: number;
-}
-export interface SystemUserProfile1 {
-  guid: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: any;
-  profilePicture: any;
-  credits: any;
-  storageUsed: any;
-  storageEnabled: any;
-  displayEmail: boolean;
-  rotationToken: any;
-  rotationExpires: any;
-}
-export interface SystemUserRoles1 {
-  roles: string[];
-}
-export interface SystemUserRolesUpdate1 {
-  userGuid: string;
-  roles: string[];
-}
-export interface SystemUsersList1 {
-  users: UserListItem[];
-}
-export interface FileItem {
-  name: string;
-  url: string;
-  contentType: string | null;
-}
-export interface StorageFileDelete1 {
-  bearerToken: string;
-  filename: string;
-}
-export interface StorageFileUpload1 {
-  bearerToken: string;
-  filename: string;
-  dataUrl: string;
-  contentType: string;
-}
-export interface StorageFilesList1 {
-  files: FileItem[];
-}
-export interface AuthSessionTokens1 {
-  bearerToken: string;
-  rotationToken: string;
-  rotationExpires: any;
-}
-export interface AuthMicrosoftLoginData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
 export interface AccountRoleDelete1 {
+  name: string;
+}
+export interface AccountRoleDelete2 {
   name: string;
 }
 export interface AccountRoleMemberUpdate1 {
   role: string;
   userGuid: string;
 }
+export interface AccountRoleMemberUpdate2 {
+  role: string;
+  userGuid: string;
+}
 export interface AccountRoleMembers1 {
+  members: UserListItem[];
+  nonMembers: UserListItem[];
+}
+export interface AccountRoleMembers2 {
   members: UserListItem[];
   nonMembers: UserListItem[];
 }
@@ -200,7 +278,15 @@ export interface AccountRoleUpdate1 {
   display: string;
   bit: number;
 }
+export interface AccountRoleUpdate2 {
+  name: string;
+  display: string;
+  bit: number;
+}
 export interface AccountRolesList1 {
+  roles: RoleItem[];
+}
+export interface AccountRolesList2 {
   roles: RoleItem[];
 }
 export interface AccountUserCreditsUpdate1 {
@@ -234,73 +320,6 @@ export interface AccountUserRolesUpdate1 {
 }
 export interface AccountUsersList1 {
   users: UserListItem[];
-}
-export interface FrontendVarsFfmpegVersion1 {
-  ffmpeg_version: string;
-}
-export interface FrontendVarsHostname1 {
-  hostname: string;
-}
-export interface FrontendVarsHostname2 {
-  hostname: string;
-}
-export interface FrontendVarsRepo1 {
-  repo: string;
-}
-export interface FrontendVarsRepo2 {
-  repo: string;
-}
-export interface FrontendVarsVersion1 {
-  version: string;
-}
-export interface FrontendVarsVersion2 {
-  version: string;
-}
-export interface ViewDiscord1 {
-  content: string;
-}
-export interface ViewDiscord2 {
-  content: string;
-}
-export interface FrontendLinksHome1 {
-  links: LinkItem[];
-}
-export interface FrontendLinksHome2 {
-  links: LinkItem[];
-}
-export interface FrontendLinksRoutes1 {
-  routes: RouteItem[];
-}
-export interface FrontendLinksRoutes2 {
-  routes: RouteItem[];
-}
-export interface LinkItem {
-  title: string;
-  url: string;
-}
-export interface RouteItem {
-  path: string;
-  name: string;
-  icon: string;
-}
-export interface FrontendUserProfileData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  storageUsed: number | null;
-  storageEnabled: boolean | null;
-  displayEmail: boolean;
-  roles: string[];
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
-export interface FrontendUserSetDisplayName1 {
-  bearerToken: string;
-  displayName: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/account/roles/handler.py
+++ b/rpc/account/roles/handler.py
@@ -14,6 +14,16 @@ async def handle_roles_request(parts: list[str], rpc_request: RPCRequest | None,
       if rpc_request is None:
         raise HTTPException(status_code=400, detail='Missing payload')
       return await services.delete_role_v1(rpc_request, request)
+    case ["list", "2"]:
+      return await services.list_roles_v2(request)
+    case ["set", "2"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.set_role_v2(rpc_request, request)
+    case ["delete", "2"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.delete_role_v2(rpc_request, request)
     case ["get_members", "1"]:
       if rpc_request is None:
         raise HTTPException(status_code=400, detail='Missing payload')
@@ -26,5 +36,17 @@ async def handle_roles_request(parts: list[str], rpc_request: RPCRequest | None,
       if rpc_request is None:
         raise HTTPException(status_code=400, detail='Missing payload')
       return await services.remove_role_member_v1(rpc_request, request)
+    case ["get_members", "2"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.get_role_members_v2(rpc_request, request)
+    case ["add_member", "2"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.add_role_member_v2(rpc_request, request)
+    case ["remove_member", "2"]:
+      if rpc_request is None:
+        raise HTTPException(status_code=400, detail='Missing payload')
+      return await services.remove_role_member_v2(rpc_request, request)
     case _:
       raise HTTPException(status_code=404, detail='Unknown RPC operation')

--- a/rpc/account/roles/models.py
+++ b/rpc/account/roles/models.py
@@ -24,3 +24,22 @@ class AccountRoleMemberUpdate1(BaseModel):
 class AccountRoleMembers1(BaseModel):
   members: list[UserListItem]
   nonMembers: list[UserListItem]
+
+class AccountRolesList2(BaseModel):
+  roles: list[RoleItem]
+
+class AccountRoleUpdate2(BaseModel):
+  name: str
+  display: str
+  bit: int
+
+class AccountRoleDelete2(BaseModel):
+  name: str
+
+class AccountRoleMemberUpdate2(BaseModel):
+  role: str
+  userGuid: str
+
+class AccountRoleMembers2(BaseModel):
+  members: list[UserListItem]
+  nonMembers: list[UserListItem]

--- a/rpc/account/roles/services.py
+++ b/rpc/account/roles/services.py
@@ -6,10 +6,16 @@ from rpc.account.roles.models import (
   AccountRoleDelete1,
   AccountRoleMembers1,
   AccountRoleMemberUpdate1,
+  AccountRolesList2,
+  AccountRoleUpdate2,
+  AccountRoleDelete2,
+  AccountRoleMembers2,
+  AccountRoleMemberUpdate2,
 )
 from rpc.account.users.models import UserListItem
 from rpc.models import RPCRequest, RPCResponse
 from server.modules.database_module import DatabaseModule, _utos
+from server.modules.mssql_module import MSSQLModule
 from server.helpers import roles as role_helper
 
 
@@ -96,3 +102,77 @@ async def remove_role_member_v1(rpc_request, request: Request) -> RPCResponse:
   await db.set_user_roles(data.userGuid, current & ~mask | role_helper.ROLE_REGISTERED)
   new_req = RPCRequest(op='', payload={'role': data.role}, version=1)
   return await get_role_members_v1(new_req, request)
+
+async def list_roles_v2(request: Request) -> RPCResponse:
+  db: MSSQLModule = request.app.state.mssql
+  rows = await db.list_roles()
+  roles = [
+    RoleItem(name=r['name'], display=r['display'], bit=mask_to_bit(int(r['mask'])))
+    for r in rows
+  ]
+  roles.sort(key=lambda r: r.bit)
+  payload = AccountRolesList2(roles=roles)
+  return RPCResponse(op='urn:account:roles:list:2', payload=payload, version=2)
+
+async def set_role_v2(rpc_request, request: Request) -> RPCResponse:
+  data = AccountRoleUpdate2(**(rpc_request.payload or {}))
+  db: MSSQLModule = request.app.state.mssql
+  mask = bit_to_mask(data.bit)
+  await db.set_role(data.name, mask, data.display)
+  await role_helper.load_roles(db)
+  return await list_roles_v2(request)
+
+async def delete_role_v2(rpc_request, request: Request) -> RPCResponse:
+  data = AccountRoleDelete2(**(rpc_request.payload or {}))
+  db: MSSQLModule = request.app.state.mssql
+  await db.delete_role(data.name)
+  await role_helper.load_roles(db)
+  return await list_roles_v2(request)
+
+async def get_role_members_v2(rpc_request, request: Request) -> RPCResponse:
+  payload = rpc_request.payload or {}
+  role = payload.get('role')
+  if not role:
+    raise HTTPException(status_code=400, detail='Missing role')
+  db: MSSQLModule = request.app.state.mssql
+  rows = await db.list_roles()
+  role_map = {r['name']: int(r['mask']) for r in rows}
+  mask = role_map.get(role)
+  if mask is None:
+    raise HTTPException(status_code=404, detail='Role not found')
+  members = [
+    UserListItem(guid=_utos(r['guid']), displayName=r['display_name'])
+    for r in await db.select_users_with_role(mask)
+  ]
+  non_members = [
+    UserListItem(guid=_utos(r['guid']), displayName=r['display_name'])
+    for r in await db.select_users_without_role(mask)
+  ]
+  payload = AccountRoleMembers2(members=members, nonMembers=non_members)
+  return RPCResponse(op='urn:account:roles:get_members:2', payload=payload, version=2)
+
+async def add_role_member_v2(rpc_request, request: Request) -> RPCResponse:
+  data = AccountRoleMemberUpdate2(**(rpc_request.payload or {}))
+  db: MSSQLModule = request.app.state.mssql
+  rows = await db.list_roles()
+  role_map = {r['name']: int(r['mask']) for r in rows}
+  mask = role_map.get(data.role)
+  if mask is None:
+    raise HTTPException(status_code=404, detail='Role not found')
+  current = await db.get_user_roles(data.userGuid)
+  await db.set_user_roles(data.userGuid, current | mask | role_helper.ROLE_REGISTERED)
+  new_req = RPCRequest(op='', payload={'role': data.role}, version=2)
+  return await get_role_members_v2(new_req, request)
+
+async def remove_role_member_v2(rpc_request, request: Request) -> RPCResponse:
+  data = AccountRoleMemberUpdate2(**(rpc_request.payload or {}))
+  db: MSSQLModule = request.app.state.mssql
+  rows = await db.list_roles()
+  role_map = {r['name']: int(r['mask']) for r in rows}
+  mask = role_map.get(data.role)
+  if mask is None:
+    raise HTTPException(status_code=404, detail='Role not found')
+  current = await db.get_user_roles(data.userGuid)
+  await db.set_user_roles(data.userGuid, current & ~mask | role_helper.ROLE_REGISTERED)
+  new_req = RPCRequest(op='', payload={'role': data.role}, version=2)
+  return await get_role_members_v2(new_req, request)

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -5,7 +5,15 @@
       "capabilities": 0
     },
     {
+      "op": "urn:account:roles:add_member:2",
+      "capabilities": 0
+    },
+    {
       "op": "urn:account:roles:delete:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:account:roles:delete:2",
       "capabilities": 0
     },
     {
@@ -13,7 +21,15 @@
       "capabilities": 0
     },
     {
+      "op": "urn:account:roles:get_members:2",
+      "capabilities": 0
+    },
+    {
       "op": "urn:account:roles:list:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:account:roles:list:2",
       "capabilities": 0
     },
     {
@@ -21,7 +37,15 @@
       "capabilities": 0
     },
     {
+      "op": "urn:account:roles:remove_member:2",
+      "capabilities": 0
+    },
+    {
       "op": "urn:account:roles:set:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:account:roles:set:2",
       "capabilities": 0
     },
     {

--- a/server/helpers/roles.py
+++ b/server/helpers/roles.py
@@ -9,8 +9,13 @@ ROLE_NAMES: list[str] = []
 # constant before roles are loaded behaves as expected.
 ROLE_REGISTERED: int = 1
 
+import pyodbc
+
 async def load_roles(db) -> None:
-  rows = await db.list_roles()
+  try:
+    rows = await db.list_roles()
+  except pyodbc.Error:
+    return
   if not rows:
     return
   ROLES.clear()

--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -19,15 +19,14 @@ async def lifespan(app: FastAPI):
   dsn = os.getenv("POSTGRES_CONNECTION_STRING")
   app.state.database = DatabaseModule(app, dsn=dsn)
   await app.state.database.startup()
-
-  await role_helper.load_roles(app.state.database)
-
-  debug = await app.state.database.get_config_value("DebugLogging")
-  configure_root_logging(debug=str(debug).lower() in ["1", "true"])
-
   mssql_dsn = os.getenv("AZURE_SQL_CONNECTION_STRING")
   app.state.mssql = MSSQLModule(app, dsn=mssql_dsn)
   await app.state.mssql.startup()
+
+  await role_helper.load_roles(app.state.mssql)
+
+  debug = await app.state.database.get_config_value("DebugLogging")
+  configure_root_logging(debug=str(debug).lower() in ["1", "true"])
 
   app.state.env = EnvironmentModule(app)
 

--- a/tests/test_helper_roles.py
+++ b/tests/test_helper_roles.py
@@ -1,0 +1,22 @@
+import asyncio
+import pyodbc
+from server.helpers import roles as role_helper
+
+class DummyDB:
+  async def list_roles(self):
+    raise pyodbc.Error()
+
+
+def test_load_roles_handles_missing_table():
+  prev = role_helper.ROLES.copy()
+  prev_names = role_helper.ROLE_NAMES[:]
+  prev_reg = role_helper.ROLE_REGISTERED
+  try:
+    asyncio.run(role_helper.load_roles(DummyDB()))
+    assert role_helper.ROLES == prev
+    assert role_helper.ROLE_NAMES == prev_names
+    assert role_helper.ROLE_REGISTERED == prev_reg
+  finally:
+    role_helper.ROLES = prev
+    role_helper.ROLE_NAMES = prev_names
+    role_helper.ROLE_REGISTERED = prev_reg

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -53,7 +53,7 @@ def test_lifespan_initializes_modules(monkeypatch):
 
   async def fake_list_roles(self):
     return []
-  monkeypatch.setattr(db_mod.DatabaseModule, "list_roles", fake_list_roles)
+  monkeypatch.setattr(mssql_mod.MSSQLModule, "list_roles", fake_list_roles)
 
   async def fake_get_config(self, key):
     if key == "DiscordSyschan":

--- a/tests/test_rpc_account_roles_v2.py
+++ b/tests/test_rpc_account_roles_v2.py
@@ -1,0 +1,54 @@
+import asyncio
+from fastapi import FastAPI, Request
+from rpc.handler import handle_rpc_request
+from rpc.models import RPCRequest
+from server.helpers import roles as role_helper
+
+class DummyDB:
+  def __init__(self):
+    self.roles = {'ROLE_TEST': 2}
+    self.users = {'u1': 2, 'u2': 0}
+
+  async def list_roles(self):
+    return [{'name': n, 'display': n, 'mask': m} for n, m in self.roles.items()]
+
+  async def select_users_with_role(self, mask):
+    return [{'guid': k, 'display_name': k} for k, v in self.users.items() if v & mask]
+
+  async def select_users_without_role(self, mask):
+    return [{'guid': k, 'display_name': k} for k, v in self.users.items() if not (v & mask)]
+
+  async def get_user_roles(self, guid):
+    return self.users.get(guid, 0)
+
+  async def set_user_roles(self, guid, roles):
+    self.users[guid] = roles
+
+class DummyAuth:
+  async def decode_bearer_token(self, token):
+    return {'guid': token}
+
+async def make_app():
+  app = FastAPI()
+  db = DummyDB()
+  app.state.database = db
+  app.state.mssql = db
+  app.state.auth = DummyAuth()
+  app.state.permcap = None
+  app.state.env = None
+  await role_helper.load_roles(db)
+  return app
+
+
+def test_role_member_flow_account_v2():
+  app = asyncio.run(make_app())
+  req = Request({'type': 'http', 'app': app, 'headers': []})
+  rpc = RPCRequest(op='urn:account:roles:get_members:2', payload={'role': 'ROLE_TEST'})
+  resp = asyncio.run(handle_rpc_request(rpc, req))
+  assert len(resp.payload.members) == 1
+  rpc = RPCRequest(op='urn:account:roles:add_member:2', payload={'role': 'ROLE_TEST', 'userGuid': 'u2'})
+  resp = asyncio.run(handle_rpc_request(rpc, req))
+  assert any(u.guid == 'u2' for u in resp.payload.members)
+  rpc = RPCRequest(op='urn:account:roles:remove_member:2', payload={'role': 'ROLE_TEST', 'userGuid': 'u1'})
+  resp = asyncio.run(handle_rpc_request(rpc, req))
+  assert all(u.guid != 'u1' for u in resp.payload.members)


### PR DESCRIPTION
## Summary
- load roles from MSSQL during startup
- handle missing table via `pyodbc.Error`
- expose account roles RPC v2 using MSSQL
- generate new frontend RPC wiring
- update tests

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_6886f9fdb2dc8325bb501d6b78c11ee3