### PR TITLE
Add list roles v2

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -30,6 +30,7 @@ These calls expose system administration functionality.
 | `urn:system:users:get_roles:1` | Get the roles assigned to a user. |
 | `urn:system:users:set_roles:1` | Replace the roles assigned to a user. |
 | `urn:system:users:list_roles:1` | List available role names. |
+| `urn:system:users:list_roles:2` | List available role names. |
 | `urn:system:users:get_profile:1` | Retrieve profile information for a user. |
 | `urn:system:users:set_credits:1` | Update a user's credit balance. |
 

--- a/frontend/src/rpc/account/users/index.ts
+++ b/frontend/src/rpc/account/users/index.ts
@@ -10,6 +10,7 @@ export const fetchList = (payload: any = null): Promise<AccountUsersList1> => rp
 export const fetchRoles = (payload: any = null): Promise<AccountUserRoles1> => rpcCall('urn:account:users:get_roles:1', payload);
 export const fetchSetRoles = (payload: any = null): Promise<AccountUserRoles1> => rpcCall('urn:account:users:set_roles:1', payload);
 export const fetchListRoles = (payload: any = null): Promise<AccountUserRoles1> => rpcCall('urn:account:users:list_roles:1', payload);
+export const fetchListRoles2 = (payload: any = null): Promise<AccountUserRoles1> => rpcCall('urn:account:users:list_roles:2', payload);
 export const fetchProfile = (payload: any = null): Promise<AccountUserProfile1> => rpcCall('urn:account:users:get_profile:1', payload);
 export const fetchSetCredits = (payload: any = null): Promise<AccountUserProfile1> => rpcCall('urn:account:users:set_credits:1', payload);
 export const fetchSetDisplayName = (payload: any = null): Promise<AccountUserProfile1> => rpcCall('urn:account:users:set_display_name:1', payload);

--- a/frontend/src/rpc/system/users/index.ts
+++ b/frontend/src/rpc/system/users/index.ts
@@ -10,6 +10,7 @@ export const fetchList = (payload: any = null): Promise<SystemUsersList1> => rpc
 export const fetchRoles = (payload: any = null): Promise<SystemUserRoles1> => rpcCall('urn:system:users:get_roles:1', payload);
 export const fetchSetRoles = (payload: any = null): Promise<SystemUserRoles1> => rpcCall('urn:system:users:set_roles:1', payload);
 export const fetchListRoles = (payload: any = null): Promise<SystemUserRoles1> => rpcCall('urn:system:users:list_roles:1', payload);
+export const fetchListRoles2 = (payload: any = null): Promise<SystemUserRoles1> => rpcCall('urn:system:users:list_roles:2', payload);
 export const fetchProfile = (payload: any = null): Promise<SystemUserProfile1> => rpcCall('urn:system:users:get_profile:1', payload);
 export const fetchSetCredits = (payload: any = null): Promise<SystemUserProfile1> => rpcCall('urn:system:users:set_credits:1', payload);
 export const fetchEnableStorage = (payload: any = null): Promise<SystemUserProfile1> => rpcCall('urn:system:users:enable_storage:1', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -28,121 +28,6 @@ export interface RPCResponse {
 export interface UserData {
   bearerToken: string;
 }
-export interface FileItem {
-  name: string;
-  url: string;
-  contentType: string | null;
-}
-export interface StorageFileDelete1 {
-  bearerToken: string;
-  filename: string;
-}
-export interface StorageFileUpload1 {
-  bearerToken: string;
-  filename: string;
-  dataUrl: string;
-  contentType: string;
-}
-export interface StorageFilesList1 {
-  files: FileItem[];
-}
-export interface AuthSessionTokens1 {
-  bearerToken: string;
-  rotationToken: string;
-  rotationExpires: any;
-}
-export interface AuthMicrosoftLoginData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
-export interface FrontendLinksHome1 {
-  links: LinkItem[];
-}
-export interface FrontendLinksHome2 {
-  links: LinkItem[];
-}
-export interface FrontendLinksRoutes1 {
-  routes: RouteItem[];
-}
-export interface FrontendLinksRoutes2 {
-  routes: RouteItem[];
-}
-export interface LinkItem {
-  title: string;
-  url: string;
-}
-export interface RouteItem {
-  path: string;
-  name: string;
-  icon: string;
-}
-export interface FrontendVarsFfmpegVersion1 {
-  ffmpeg_version: string;
-}
-export interface FrontendVarsHostname1 {
-  hostname: string;
-}
-export interface FrontendVarsHostname2 {
-  hostname: string;
-}
-export interface FrontendVarsRepo1 {
-  repo: string;
-}
-export interface FrontendVarsRepo2 {
-  repo: string;
-}
-export interface FrontendVarsVersion1 {
-  version: string;
-}
-export interface FrontendVarsVersion2 {
-  version: string;
-}
-export interface ViewDiscord1 {
-  content: string;
-}
-export interface ViewDiscord2 {
-  content: string;
-}
-export interface FrontendUserProfileData1 {
-  bearerToken: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: string | null;
-  profilePicture: string | null;
-  credits: number | null;
-  storageUsed: number | null;
-  storageEnabled: boolean | null;
-  displayEmail: boolean;
-  roles: string[];
-  rotationToken: string | null;
-  rotationExpires: any | null;
-}
-export interface FrontendUserSetDisplayName1 {
-  bearerToken: string;
-  displayName: string;
-}
-export interface ConfigItem {
-  key: string;
-  value: string;
-}
-export interface SystemConfigDelete1 {
-  key: string;
-}
-export interface SystemConfigList1 {
-  items: ConfigItem[];
-}
-export interface SystemConfigUpdate1 {
-  key: string;
-  value: string;
-}
 export interface RoleItem {
   name: string;
   display: string;
@@ -190,34 +75,6 @@ export interface UserListItem {
   guid: string;
   displayName: string;
 }
-export interface SystemUserCreditsUpdate1 {
-  userGuid: string;
-  credits: number;
-}
-export interface SystemUserProfile1 {
-  guid: string;
-  defaultProvider: string;
-  username: string;
-  email: string;
-  backupEmail: any;
-  profilePicture: any;
-  credits: any;
-  storageUsed: any;
-  storageEnabled: any;
-  displayEmail: boolean;
-  rotationToken: any;
-  rotationExpires: any;
-}
-export interface SystemUserRoles1 {
-  roles: string[];
-}
-export interface SystemUserRolesUpdate1 {
-  userGuid: string;
-  roles: string[];
-}
-export interface SystemUsersList1 {
-  users: UserListItem[];
-}
 export interface SystemRouteDelete1 {
   path: string;
 }
@@ -250,6 +107,82 @@ export interface SystemRoutesList1 {
 }
 export interface SystemRoutesList2 {
   routes: SystemRouteItem[];
+}
+export interface SystemUserCreditsUpdate1 {
+  userGuid: string;
+  credits: number;
+}
+export interface SystemUserProfile1 {
+  guid: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: any;
+  profilePicture: any;
+  credits: any;
+  storageUsed: any;
+  storageEnabled: any;
+  displayEmail: boolean;
+  rotationToken: any;
+  rotationExpires: any;
+}
+export interface SystemUserRoles1 {
+  roles: string[];
+}
+export interface SystemUserRolesUpdate1 {
+  userGuid: string;
+  roles: string[];
+}
+export interface SystemUsersList1 {
+  users: UserListItem[];
+}
+export interface ConfigItem {
+  key: string;
+  value: string;
+}
+export interface SystemConfigDelete1 {
+  key: string;
+}
+export interface SystemConfigList1 {
+  items: ConfigItem[];
+}
+export interface SystemConfigUpdate1 {
+  key: string;
+  value: string;
+}
+export interface FileItem {
+  name: string;
+  url: string;
+  contentType: string | null;
+}
+export interface StorageFileDelete1 {
+  bearerToken: string;
+  filename: string;
+}
+export interface StorageFileUpload1 {
+  bearerToken: string;
+  filename: string;
+  dataUrl: string;
+  contentType: string;
+}
+export interface StorageFilesList1 {
+  files: FileItem[];
+}
+export interface AuthMicrosoftLoginData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface AuthSessionTokens1 {
+  bearerToken: string;
+  rotationToken: string;
+  rotationExpires: any;
 }
 export interface AccountRoleDelete1 {
   name: string;
@@ -320,6 +253,73 @@ export interface AccountUserRolesUpdate1 {
 }
 export interface AccountUsersList1 {
   users: UserListItem[];
+}
+export interface FrontendVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface FrontendVarsHostname1 {
+  hostname: string;
+}
+export interface FrontendVarsHostname2 {
+  hostname: string;
+}
+export interface FrontendVarsRepo1 {
+  repo: string;
+}
+export interface FrontendVarsRepo2 {
+  repo: string;
+}
+export interface FrontendVarsVersion1 {
+  version: string;
+}
+export interface FrontendVarsVersion2 {
+  version: string;
+}
+export interface ViewDiscord1 {
+  content: string;
+}
+export interface ViewDiscord2 {
+  content: string;
+}
+export interface FrontendUserProfileData1 {
+  bearerToken: string;
+  defaultProvider: string;
+  username: string;
+  email: string;
+  backupEmail: string | null;
+  profilePicture: string | null;
+  credits: number | null;
+  storageUsed: number | null;
+  storageEnabled: boolean | null;
+  displayEmail: boolean;
+  roles: string[];
+  rotationToken: string | null;
+  rotationExpires: any | null;
+}
+export interface FrontendUserSetDisplayName1 {
+  bearerToken: string;
+  displayName: string;
+}
+export interface FrontendLinksHome1 {
+  links: LinkItem[];
+}
+export interface FrontendLinksHome2 {
+  links: LinkItem[];
+}
+export interface FrontendLinksRoutes1 {
+  routes: RouteItem[];
+}
+export interface FrontendLinksRoutes2 {
+  routes: RouteItem[];
+}
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+export interface RouteItem {
+  path: string;
+  name: string;
+  icon: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/account/users/handler.py
+++ b/rpc/account/users/handler.py
@@ -12,6 +12,8 @@ async def handle_users_request(parts: list[str], rpc_request: RPCRequest | None,
       return await services.set_user_roles_v1(rpc_request, request)
     case ["list_roles", "1"]:
       return await services.list_available_roles_v1(request)
+    case ["list_roles", "2"]:
+      return await services.list_available_roles_v2(request)
     case ["get_profile", "1"]:
       return await services.get_user_profile_v1(rpc_request, request)
     case ["set_credits", "1"]:

--- a/rpc/account/users/services.py
+++ b/rpc/account/users/services.py
@@ -10,6 +10,7 @@ from rpc.account.users.models import (
   AccountUserProfile1,
 )
 from server.modules.database_module import DatabaseModule, _utos
+from server.modules.mssql_module import MSSQLModule
 from server.modules.storage_module import StorageModule
 from server.helpers.roles import (
   mask_to_names,
@@ -50,6 +51,13 @@ async def list_available_roles_v1(request: Request) -> RPCResponse:
   names = [r['name'] for r in rows]
   payload = AccountUserRoles1(roles=names)
   return RPCResponse(op='urn:account:users:list_roles:1', payload=payload, version=1)
+
+async def list_available_roles_v2(request: Request) -> RPCResponse:
+  db: MSSQLModule = request.app.state.mssql
+  rows = await db.list_roles()
+  names = [r['name'] for r in rows]
+  payload = AccountUserRoles1(roles=names)
+  return RPCResponse(op='urn:account:users:list_roles:2', payload=payload, version=2)
 
 async def get_user_profile_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   payload = rpc_request.payload or {}

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -69,6 +69,10 @@
       "capabilities": 0
     },
     {
+      "op": "urn:account:users:list_roles:2",
+      "capabilities": 0
+    },
+    {
       "op": "urn:account:users:set_credits:1",
       "capabilities": 0
     },
@@ -258,6 +262,10 @@
     },
     {
       "op": "urn:system:users:list_roles:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:system:users:list_roles:2",
       "capabilities": 0
     },
     {

--- a/rpc/system/users/handler.py
+++ b/rpc/system/users/handler.py
@@ -12,6 +12,8 @@ async def handle_users_request(parts: list[str], rpc_request: RPCRequest | None,
       return await services.set_user_roles_v1(rpc_request, request)
     case ["list_roles", "1"]:
       return await services.list_available_roles_v1(request)
+    case ["list_roles", "2"]:
+      return await services.list_available_roles_v2(request)
     case ["get_profile", "1"]:
       return await services.get_user_profile_v1(rpc_request, request)
     case ["set_credits", "1"]:

--- a/rpc/system/users/services.py
+++ b/rpc/system/users/services.py
@@ -9,6 +9,7 @@ from rpc.system.users.models import (
   SystemUserProfile1,
 )
 from server.modules.database_module import DatabaseModule, _utos
+from server.modules.mssql_module import MSSQLModule
 from server.modules.storage_module import StorageModule
 from server.helpers.roles import (
   mask_to_names,
@@ -49,6 +50,13 @@ async def list_available_roles_v1(request: Request) -> RPCResponse:
   names = [r['name'] for r in rows]
   payload = SystemUserRoles1(roles=names)
   return RPCResponse(op='urn:system:users:list_roles:1', payload=payload, version=1)
+
+async def list_available_roles_v2(request: Request) -> RPCResponse:
+  db: MSSQLModule = request.app.state.mssql
+  rows = await db.list_roles()
+  names = [r['name'] for r in rows]
+  payload = SystemUserRoles1(roles=names)
+  return RPCResponse(op='urn:system:users:list_roles:2', payload=payload, version=2)
 
 async def get_user_profile_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   payload = rpc_request.payload or {}


### PR DESCRIPTION
## Summary
- implement new v2 API for listing available roles for users
- route new v2 handler cases
- regenerate RPC client code
- document v2 user list roles operation

## Testing
- `python3 scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_688701ea78d08325b995619af93726dd