### PR TITLE
Fix missing provider in profile image insert

### DIFF
--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -27,7 +27,11 @@ async def user_login_v1(rpc_request: RPCRequest, request: Request) -> RPCRespons
   if not user:
     user = await db.insert_user(provider, guid, profile["email"], profile["username"])
   if profile_picture:
-    await db.set_user_profile_image(_utos(user["guid"]), profile_picture)
+    await db.set_user_profile_image(
+      _utos(user["guid"]),
+      profile_picture,
+      user.get("provider_name", provider),
+    )
   else:
     profile_picture = user.get("profile_image")
   logging.debug("user_login_v1 user=%s", user)

--- a/tests/test_mssql_module.py
+++ b/tests/test_mssql_module.py
@@ -102,5 +102,5 @@ def test_mssql_profile_image_ops(mssql_app):
   dbm.pool = Pool(conn)
   img = asyncio.run(dbm.get_user_profile_image('uid'))
   assert img == 'img'
-  asyncio.run(dbm.set_user_profile_image('uid', 'new'))
+  asyncio.run(dbm.set_user_profile_image('uid', 'new', 'microsoft'))
   assert any(e[0].startswith('SELECT 1 FROM users_profileimg') for e in conn.cur.executed)

--- a/tests/test_rpc_microsoft_service.py
+++ b/tests/test_rpc_microsoft_service.py
@@ -27,8 +27,8 @@ class DummyDB:
   async def insert_user(self, provider, mid, email, username):
     return await self.select_user(provider, mid)
 
-  async def set_user_profile_image(self, guid, image):
-    self.image = (guid, image)
+  async def set_user_profile_image(self, guid, image, provider):
+    self.image = (guid, image, provider)
 
   async def set_user_rotation_token(self, guid, token, exp):
     self.rtoken = (guid, token, exp)
@@ -75,7 +75,7 @@ def test_user_login_profile_update():
   req = Request({'type': 'http', 'app': app, 'headers': []})
   rpc_req = RPCRequest(op='op', payload={'idToken': 'id', 'accessToken': 'ac', 'provider': 'microsoft'})
   asyncio.run(services.user_login_v1(rpc_req, req))
-  assert db.image == ('uid', 'img')
+  assert db.image == ('uid', 'img', 'microsoft')
 
 
 def test_user_login_reports_discord():


### PR DESCRIPTION
## Summary
- include provider when saving a profile image
- propagate provider value from Microsoft login
- adjust tests for new parameter

## Testing
- `python scripts/run_tests.py --test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ed4440ec8325912980385541a88a