### PR TITLE
Refactor rpc handlers

### DIFF
--- a/rpc/account/__init__.py
+++ b/rpc/account/__init__.py
@@ -1,1 +1,7 @@
+from .users.handler import handle_users_request
+from .roles.handler import handle_roles_request
 
+HANDLERS: dict[str, callable] = {
+  "users": handle_users_request,
+  "roles": handle_roles_request,
+}

--- a/rpc/account/handler.py
+++ b/rpc/account/handler.py
@@ -1,13 +1,10 @@
 from fastapi import Request, HTTPException
-from rpc.account.users.handler import handle_users_request
-from rpc.account.roles.handler import handle_roles_request
-from rpc.models import RPCRequest, RPCResponse
+from rpc.models import RPCResponse
+from . import HANDLERS
 
-async def handle_account_request(parts: list[str], rpc_request: RPCRequest, request: Request) -> RPCResponse:
-  match parts:
-    case ["users", *rest]:
-      return await handle_users_request(rest, rpc_request, request)
-    case ["roles", *rest]:
-      return await handle_roles_request(rest, rpc_request, request)
-    case _:
-      raise HTTPException(status_code=404, detail='Unknown RPC subdomain')
+async def handle_account_request(parts: list[str], request: Request) -> RPCResponse:
+  subdomain = parts[0]
+  handler = HANDLERS.get(subdomain)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC subdomain')
+  return await handler(parts[1:], request)

--- a/rpc/account/roles/__init__.py
+++ b/rpc/account/roles/__init__.py
@@ -1,0 +1,25 @@
+from fastapi import Request
+from rpc.helpers import get_rpcrequest_from_request
+from . import services
+
+
+def _wrap(func):
+  async def wrapped(request: Request):
+    rpc_request, _ = await get_rpcrequest_from_request(request)
+    return await func(rpc_request, request)
+  return wrapped
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list", "1"): services.list_roles_v1,
+  ("set", "1"): _wrap(services.set_role_v1),
+  ("delete", "1"): _wrap(services.delete_role_v1),
+  ("get_members", "1"): _wrap(services.get_role_members_v1),
+  ("add_member", "1"): _wrap(services.add_role_member_v1),
+  ("remove_member", "1"): _wrap(services.remove_role_member_v1),
+  ("list", "2"): services.list_roles_v2,
+  ("set", "2"): _wrap(services.set_role_v2),
+  ("delete", "2"): _wrap(services.delete_role_v2),
+  ("get_members", "2"): _wrap(services.get_role_members_v2),
+  ("add_member", "2"): _wrap(services.add_role_member_v2),
+  ("remove_member", "2"): _wrap(services.remove_role_member_v2),
+}

--- a/rpc/account/roles/handler.py
+++ b/rpc/account/roles/handler.py
@@ -1,52 +1,10 @@
 from fastapi import Request, HTTPException
-from rpc.account.roles import services
-from rpc.models import RPCRequest, RPCResponse
+from rpc.models import RPCResponse
+from . import DISPATCHERS
 
-async def handle_roles_request(parts: list[str], rpc_request: RPCRequest | None, request: Request) -> RPCResponse:
-  match parts:
-    case ["list", "1"]:
-      return await services.list_roles_v1(request)
-    case ["set", "1"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.set_role_v1(rpc_request, request)
-    case ["delete", "1"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.delete_role_v1(rpc_request, request)
-    case ["list", "2"]:
-      return await services.list_roles_v2(request)
-    case ["set", "2"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.set_role_v2(rpc_request, request)
-    case ["delete", "2"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.delete_role_v2(rpc_request, request)
-    case ["get_members", "1"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.get_role_members_v1(rpc_request, request)
-    case ["add_member", "1"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.add_role_member_v1(rpc_request, request)
-    case ["remove_member", "1"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.remove_role_member_v1(rpc_request, request)
-    case ["get_members", "2"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.get_role_members_v2(rpc_request, request)
-    case ["add_member", "2"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.add_role_member_v2(rpc_request, request)
-    case ["remove_member", "2"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.remove_role_member_v2(rpc_request, request)
-    case _:
-      raise HTTPException(status_code=404, detail='Unknown RPC operation')
+async def handle_roles_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/account/users/__init__.py
+++ b/rpc/account/users/__init__.py
@@ -1,0 +1,29 @@
+from fastapi import Request
+from rpc.helpers import get_rpcrequest_from_request
+from . import services
+
+
+def _wrap(func):
+  async def wrapped(request: Request):
+    rpc_request, _ = await get_rpcrequest_from_request(request)
+    return await func(rpc_request, request)
+  return wrapped
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list", "1"): services.get_users_v1,
+  ("get_roles", "1"): _wrap(services.get_user_roles_v1),
+  ("set_roles", "1"): _wrap(services.set_user_roles_v1),
+  ("list_roles", "1"): services.list_available_roles_v1,
+  ("get_profile", "1"): _wrap(services.get_user_profile_v1),
+  ("set_credits", "1"): _wrap(services.set_user_credits_v1),
+  ("set_display_name", "1"): _wrap(services.set_user_display_name_v1),
+  ("enable_storage", "1"): _wrap(services.enable_user_storage_v1),
+  ("list", "2"): services.get_users_v2,
+  ("get_roles", "2"): _wrap(services.get_user_roles_v2),
+  ("set_roles", "2"): _wrap(services.set_user_roles_v2),
+  ("list_roles", "2"): services.list_available_roles_v2,
+  ("get_profile", "2"): _wrap(services.get_user_profile_v2),
+  ("set_credits", "2"): _wrap(services.set_user_credits_v2),
+  ("set_display_name", "2"): _wrap(services.set_user_display_name_v2),
+  ("enable_storage", "2"): _wrap(services.enable_user_storage_v2),
+}

--- a/rpc/account/users/handler.py
+++ b/rpc/account/users/handler.py
@@ -1,40 +1,10 @@
 from fastapi import Request, HTTPException
-from rpc.models import RPCRequest, RPCResponse
-from rpc.account.users import services
+from rpc.models import RPCResponse
+from . import DISPATCHERS
 
-async def handle_users_request(parts: list[str], rpc_request: RPCRequest | None, request: Request) -> RPCResponse:
-  match parts:
-    case ["list", "1"]:
-      return await services.get_users_v1(request)
-    case ["list", "2"]:
-      return await services.get_users_v2(request)
-    case ["get_roles", "1"]:
-      return await services.get_user_roles_v1(rpc_request, request)
-    case ["get_roles", "2"]:
-      return await services.get_user_roles_v2(rpc_request, request)
-    case ["set_roles", "1"]:
-      return await services.set_user_roles_v1(rpc_request, request)
-    case ["set_roles", "2"]:
-      return await services.set_user_roles_v2(rpc_request, request)
-    case ["list_roles", "1"]:
-      return await services.list_available_roles_v1(request)
-    case ["list_roles", "2"]:
-      return await services.list_available_roles_v2(request)
-    case ["get_profile", "1"]:
-      return await services.get_user_profile_v1(rpc_request, request)
-    case ["get_profile", "2"]:
-      return await services.get_user_profile_v2(rpc_request, request)
-    case ["set_credits", "1"]:
-      return await services.set_user_credits_v1(rpc_request, request)
-    case ["set_credits", "2"]:
-      return await services.set_user_credits_v2(rpc_request, request)
-    case ["set_display_name", "1"]:
-      return await services.set_user_display_name_v1(rpc_request, request)
-    case ["set_display_name", "2"]:
-      return await services.set_user_display_name_v2(rpc_request, request)
-    case ["enable_storage", "1"]:
-      return await services.enable_user_storage_v1(rpc_request, request)
-    case ["enable_storage", "2"]:
-      return await services.enable_user_storage_v2(rpc_request, request)
-    case _:
-      raise HTTPException(status_code=404, detail='Unknown RPC operation')
+async def handle_users_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/auth/__init__.py
+++ b/rpc/auth/__init__.py
@@ -1,1 +1,7 @@
+from .microsoft.handler import handle_ms_request
+from .session.handler import handle_session_request
 
+HANDLERS: dict[str, callable] = {
+  "microsoft": handle_ms_request,
+  "session": handle_session_request,
+}

--- a/rpc/auth/handler.py
+++ b/rpc/auth/handler.py
@@ -1,14 +1,10 @@
 from fastapi import Request, HTTPException
-import logging
-from rpc.auth.microsoft.handler import handle_ms_request
-from rpc.auth.session.handler import handle_session_request
-from rpc.models import RPCRequest, RPCResponse
+from rpc.models import RPCResponse
+from . import HANDLERS
 
-async def handle_auth_request(parts: list[str], rpc_request: RPCRequest, request: Request) -> RPCResponse:
-  match parts:
-    case ["microsoft", *rest]:
-      return await handle_ms_request(rest, rpc_request, request)
-    case ["session", *rest]:
-      return await handle_session_request(rest, rpc_request, request)
-    case _:
-      raise HTTPException(status_code=404, detail="Unknown RPC subdomain")
+async def handle_auth_request(parts: list[str], request: Request) -> RPCResponse:
+  subdomain = parts[0]
+  handler = HANDLERS.get(subdomain)
+  if not handler:
+    raise HTTPException(status_code=404, detail="Unknown RPC subdomain")
+  return await handler(parts[1:], request)

--- a/rpc/auth/microsoft/__init__.py
+++ b/rpc/auth/microsoft/__init__.py
@@ -1,0 +1,11 @@
+from fastapi import Request
+from rpc.helpers import get_rpcrequest_from_request
+from . import services
+
+async def user_login_v1(request: Request):
+  rpc_request, _ = await get_rpcrequest_from_request(request)
+  return await services.user_login_v1(rpc_request, request)
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("user_login", "1"): user_login_v1,
+}

--- a/rpc/auth/session/__init__.py
+++ b/rpc/auth/session/__init__.py
@@ -1,0 +1,16 @@
+from fastapi import Request
+from rpc.helpers import get_rpcrequest_from_request
+from . import services
+
+async def refresh_v1(request: Request):
+  rpc_request, _ = await get_rpcrequest_from_request(request)
+  return await services.refresh_v1(rpc_request, request)
+
+async def invalidate_v1(request: Request):
+  rpc_request, _ = await get_rpcrequest_from_request(request)
+  return await services.invalidate_v1(rpc_request, request)
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("refresh", "1"): refresh_v1,
+  ("invalidate", "1"): invalidate_v1,
+}

--- a/rpc/auth/session/handler.py
+++ b/rpc/auth/session/handler.py
@@ -1,14 +1,12 @@
 from fastapi import Request, HTTPException
 import logging
-from rpc.auth.session import services
-from rpc.models import RPCRequest, RPCResponse
+from rpc.models import RPCResponse
+from . import DISPATCHERS
 
-async def handle_session_request(parts: list[str], rpc_request: RPCRequest, request: Request) -> RPCResponse:
+async def handle_session_request(parts: list[str], request: Request) -> RPCResponse:
   logging.debug("handle_session_request parts=%s", parts)
-  match parts:
-    case ["refresh", "1"]:
-      return await services.refresh_v1(rpc_request, request)
-    case ["invalidate", "1"]:
-      return await services.invalidate_v1(rpc_request, request)
-    case _:
-      raise HTTPException(status_code=404, detail="Unknown RPC operation")
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail="Unknown RPC operation")
+  return await handler(request)

--- a/rpc/frontend/__init__.py
+++ b/rpc/frontend/__init__.py
@@ -1,1 +1,9 @@
+from .user.handler import handle_user_request
+from .links.handler import handle_links_request
+from .vars.handler import handle_vars_request
 
+HANDLERS: dict[str, callable] = {
+  "user": handle_user_request,
+  "links": handle_links_request,
+  "vars": handle_vars_request,
+}

--- a/rpc/frontend/handler.py
+++ b/rpc/frontend/handler.py
@@ -1,16 +1,10 @@
 from fastapi import Request, HTTPException
-from rpc.models import RPCRequest, RPCResponse
-from rpc.frontend.user.handler import handle_user_request
-from rpc.frontend.links.handler import handle_links_request
-from rpc.frontend.vars.handler import handle_vars_request
+from rpc.models import RPCResponse
+from . import HANDLERS
 
-async def handle_frontend_request(parts: list[str], rpc_request: RPCRequest, request: Request) -> RPCResponse:
-  match parts:
-    case ['user', *rest]:
-      return await handle_user_request(rest, rpc_request, request)
-    case ['links', *rest]:
-      return await handle_links_request(rest, request)
-    case ['vars', *rest]:
-      return await handle_vars_request(rest, request)
-    case _:
-      raise HTTPException(status_code=404, detail='Unknown RPC subdomain')
+async def handle_frontend_request(parts: list[str], request: Request) -> RPCResponse:
+  subdomain = parts[0]
+  handler = HANDLERS.get(subdomain)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC subdomain')
+  return await handler(parts[1:], request)

--- a/rpc/frontend/links/__init__.py
+++ b/rpc/frontend/links/__init__.py
@@ -1,1 +1,8 @@
+from . import services
 
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("get_home", "1"): services.get_home_v1,
+  ("get_routes", "1"): services.get_routes_v1,
+  ("get_home", "2"): services.get_home_v2,
+  ("get_routes", "2"): services.get_routes_v2,
+}

--- a/rpc/frontend/links/handler.py
+++ b/rpc/frontend/links/handler.py
@@ -1,17 +1,10 @@
 from fastapi import Request, HTTPException
-from rpc.frontend.links import services
 from rpc.models import RPCResponse
+from . import DISPATCHERS
 
 async def handle_links_request(parts: list[str], request: Request) -> RPCResponse:
-  match parts:
-    case ["get_home", "1"]:
-      return await services.get_home_v1(request)
-    case ["get_routes", "1"]:
-      return await services.get_routes_v1(request)
-    case ["get_home", "2"]:
-      return await services.get_home_v2(request)
-    case ["get_routes", "2"]:
-      return await services.get_routes_v2(request)
-    case _:
-      raise HTTPException(status_code=404, detail="Unknown RPC operation")
-
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail="Unknown RPC operation")
+  return await handler(request)

--- a/rpc/frontend/user/__init__.py
+++ b/rpc/frontend/user/__init__.py
@@ -1,1 +1,15 @@
+from fastapi import Request
+from rpc.helpers import get_rpcrequest_from_request
+from . import services
 
+
+def _wrap(func):
+  async def wrapped(request: Request):
+    rpc_request, _ = await get_rpcrequest_from_request(request)
+    return await func(rpc_request, request)
+  return wrapped
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("get_profile_data", "1"): _wrap(services.get_profile_data_v1),
+  ("set_display_name", "1"): _wrap(services.set_display_name_v1),
+}

--- a/rpc/frontend/user/handler.py
+++ b/rpc/frontend/user/handler.py
@@ -1,12 +1,10 @@
 from fastapi import Request, HTTPException
-from rpc.models import RPCRequest, RPCResponse
-from rpc.frontend.user import services
+from rpc.models import RPCResponse
+from . import DISPATCHERS
 
-async def handle_user_request(parts: list[str], rpc_request: RPCRequest, request: Request) -> RPCResponse:
-  match parts:
-    case ["get_profile_data", "1"]:
-      return await services.get_profile_data_v1(rpc_request, request)
-    case ["set_display_name", "1"]:
-      return await services.set_display_name_v1(rpc_request, request)
-    case _:
-      raise HTTPException(status_code=404, detail='Unknown RPC operation')
+async def handle_user_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/frontend/vars/__init__.py
+++ b/rpc/frontend/vars/__init__.py
@@ -1,0 +1,11 @@
+from . import services
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("get_version", "1"): services.get_version_v1,
+  ("get_hostname", "1"): services.get_hostname_v1,
+  ("get_repo", "1"): services.get_repo_v1,
+  ("get_version", "2"): services.get_version_v2,
+  ("get_hostname", "2"): services.get_hostname_v2,
+  ("get_repo", "2"): services.get_repo_v2,
+  ("get_ffmpeg_version", "1"): services.get_ffmpeg_version_v1,
+}

--- a/rpc/frontend/vars/handler.py
+++ b/rpc/frontend/vars/handler.py
@@ -1,23 +1,10 @@
 from fastapi import Request, HTTPException
-from rpc.frontend.vars import services
 from rpc.models import RPCResponse
+from . import DISPATCHERS
 
 async def handle_vars_request(parts: list[str], request: Request) -> RPCResponse:
-  match parts:
-    case ["get_version", "1"]:
-      return await services.get_version_v1(request)
-    case ["get_hostname", "1"]:
-      return await services.get_hostname_v1(request)
-    case ["get_repo", "1"]:
-      return await services.get_repo_v1(request)
-    case ["get_version", "2"]:
-      return await services.get_version_v2(request)
-    case ["get_hostname", "2"]:
-      return await services.get_hostname_v2(request)
-    case ["get_repo", "2"]:
-      return await services.get_repo_v2(request)
-    case ["get_ffmpeg_version", "1"]:
-      return await services.get_ffmpeg_version_v1(request)
-    case _:
-      raise HTTPException(status_code=404, detail="Unknown RPC operation")
-
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail="Unknown RPC operation")
+  return await handler(request)

--- a/rpc/storage/__init__.py
+++ b/rpc/storage/__init__.py
@@ -1,1 +1,5 @@
+from .files.handler import handle_files_request
 
+HANDLERS: dict[str, callable] = {
+  "files": handle_files_request,
+}

--- a/rpc/storage/files/__init__.py
+++ b/rpc/storage/files/__init__.py
@@ -1,0 +1,16 @@
+from fastapi import Request
+from rpc.helpers import get_rpcrequest_from_request
+from . import services
+
+
+def _wrap(func):
+  async def wrapped(request: Request):
+    rpc_request, _ = await get_rpcrequest_from_request(request)
+    return await func(rpc_request, request)
+  return wrapped
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list", "1"): _wrap(services.list_files_v1),
+  ("delete", "1"): _wrap(services.delete_file_v1),
+  ("upload", "1"): _wrap(services.upload_file_v1),
+}

--- a/rpc/storage/files/handler.py
+++ b/rpc/storage/files/handler.py
@@ -1,14 +1,10 @@
 from fastapi import Request, HTTPException
-from rpc.models import RPCRequest, RPCResponse
-from rpc.storage.files import services
+from rpc.models import RPCResponse
+from . import DISPATCHERS
 
-async def handle_files_request(parts: list[str], rpc_request: RPCRequest, request: Request) -> RPCResponse:
-  match parts:
-    case ["list", "1"]:
-      return await services.list_files_v1(rpc_request, request)
-    case ["delete", "1"]:
-      return await services.delete_file_v1(rpc_request, request)
-    case ["upload", "1"]:
-      return await services.upload_file_v1(rpc_request, request)
-    case _:
-      raise HTTPException(status_code=404, detail='Unknown RPC operation')
+async def handle_files_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/storage/handler.py
+++ b/rpc/storage/handler.py
@@ -1,10 +1,10 @@
 from fastapi import Request, HTTPException
-from rpc.models import RPCRequest, RPCResponse
-from rpc.storage.files.handler import handle_files_request
+from rpc.models import RPCResponse
+from . import HANDLERS
 
-async def handle_storage_request(parts: list[str], rpc_request: RPCRequest, request: Request) -> RPCResponse:
-  match parts:
-    case ['files', *rest]:
-      return await handle_files_request(rest, rpc_request, request)
-    case _:
-      raise HTTPException(status_code=404, detail='Unknown RPC subdomain')
+async def handle_storage_request(parts: list[str], request: Request) -> RPCResponse:
+  subdomain = parts[0]
+  handler = HANDLERS.get(subdomain)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC subdomain')
+  return await handler(parts[1:], request)

--- a/rpc/system/config/__init__.py
+++ b/rpc/system/config/__init__.py
@@ -1,1 +1,19 @@
+from fastapi import Request
+from rpc.helpers import get_rpcrequest_from_request
+from . import services
 
+
+def _wrap(func):
+  async def wrapped(request: Request):
+    rpc_request, _ = await get_rpcrequest_from_request(request)
+    return await func(rpc_request, request)
+  return wrapped
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list", "1"): services.list_config_v1,
+  ("set", "1"): _wrap(services.set_config_v1),
+  ("delete", "1"): _wrap(services.delete_config_v1),
+  ("list", "2"): services.list_config_v2,
+  ("set", "2"): _wrap(services.set_config_v2),
+  ("delete", "2"): _wrap(services.delete_config_v2),
+}

--- a/rpc/system/config/handler.py
+++ b/rpc/system/config/handler.py
@@ -1,28 +1,10 @@
 from fastapi import Request, HTTPException
-from rpc.models import RPCRequest, RPCResponse
-from rpc.system.config import services
+from rpc.models import RPCResponse
+from . import DISPATCHERS
 
-async def handle_config_request(parts: list[str], rpc_request: RPCRequest | None, request: Request) -> RPCResponse:
-  match parts:
-    case ["list", "1"]:
-      return await services.list_config_v1(request)
-    case ["set", "1"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.set_config_v1(rpc_request, request)
-    case ["delete", "1"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.delete_config_v1(rpc_request, request)
-    case ["list", "2"]:
-      return await services.list_config_v2(request)
-    case ["set", "2"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.set_config_v2(rpc_request, request)
-    case ["delete", "2"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.delete_config_v2(rpc_request, request)
-    case _:
-      raise HTTPException(status_code=404, detail='Unknown RPC operation')
+async def handle_config_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/system/roles/__init__.py
+++ b/rpc/system/roles/__init__.py
@@ -1,0 +1,25 @@
+from fastapi import Request
+from rpc.helpers import get_rpcrequest_from_request
+from . import services
+
+
+def _wrap(func):
+  async def wrapped(request: Request):
+    rpc_request, _ = await get_rpcrequest_from_request(request)
+    return await func(rpc_request, request)
+  return wrapped
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list", "1"): services.list_roles_v1,
+  ("set", "1"): _wrap(services.set_role_v1),
+  ("delete", "1"): _wrap(services.delete_role_v1),
+  ("get_members", "1"): _wrap(services.get_role_members_v1),
+  ("add_member", "1"): _wrap(services.add_role_member_v1),
+  ("remove_member", "1"): _wrap(services.remove_role_member_v1),
+  ("list", "2"): services.list_roles_v2,
+  ("set", "2"): _wrap(services.set_role_v2),
+  ("delete", "2"): _wrap(services.delete_role_v2),
+  ("get_members", "2"): _wrap(services.get_role_members_v2),
+  ("add_member", "2"): _wrap(services.add_role_member_v2),
+  ("remove_member", "2"): _wrap(services.remove_role_member_v2),
+}

--- a/rpc/system/roles/handler.py
+++ b/rpc/system/roles/handler.py
@@ -1,52 +1,10 @@
 from fastapi import Request, HTTPException
-from rpc.system.roles import services
-from rpc.models import RPCRequest, RPCResponse
+from rpc.models import RPCResponse
+from . import DISPATCHERS
 
-async def handle_roles_request(parts: list[str], rpc_request: RPCRequest | None, request: Request) -> RPCResponse:
-  match parts:
-    case ["list", "1"]:
-      return await services.list_roles_v1(request)
-    case ["set", "1"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.set_role_v1(rpc_request, request)
-    case ["delete", "1"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.delete_role_v1(rpc_request, request)
-    case ["get_members", "1"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.get_role_members_v1(rpc_request, request)
-    case ["add_member", "1"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.add_role_member_v1(rpc_request, request)
-    case ["remove_member", "1"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.remove_role_member_v1(rpc_request, request)
-    case ["list", "2"]:
-      return await services.list_roles_v2(request)
-    case ["set", "2"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.set_role_v2(rpc_request, request)
-    case ["delete", "2"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.delete_role_v2(rpc_request, request)
-    case ["get_members", "2"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.get_role_members_v2(rpc_request, request)
-    case ["add_member", "2"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.add_role_member_v2(rpc_request, request)
-    case ["remove_member", "2"]:
-      if rpc_request is None:
-        raise HTTPException(status_code=400, detail='Missing payload')
-      return await services.remove_role_member_v2(rpc_request, request)
-    case _:
-      raise HTTPException(status_code=404, detail='Unknown RPC operation')
+async def handle_roles_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/system/routes/__init__.py
+++ b/rpc/system/routes/__init__.py
@@ -1,0 +1,19 @@
+from fastapi import Request
+from rpc.helpers import get_rpcrequest_from_request
+from . import services
+
+
+def _wrap(func):
+  async def wrapped(request: Request):
+    rpc_request, _ = await get_rpcrequest_from_request(request)
+    return await func(rpc_request, request)
+  return wrapped
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list", "1"): services.list_routes_v1,
+  ("set", "1"): _wrap(services.set_route_v1),
+  ("delete", "1"): _wrap(services.delete_route_v1),
+  ("list", "2"): services.list_routes_v2,
+  ("set", "2"): _wrap(services.set_route_v2),
+  ("delete", "2"): _wrap(services.delete_route_v2),
+}


### PR DESCRIPTION
## Summary
- refactor account, auth, frontend, storage and system namespaces
- add dispatcher dictionaries and wrappers for versioned handlers
- update domain handlers to use new HANDLERS pattern

## Testing
- `python scripts/run_tests.py --test` *(fails: ModuleNotFoundError: No module named 'aioodbc')*

------
https://chatgpt.com/codex/tasks/task_e_688aa679378c8325bee3bf2bbf1a3dcb