### PR TITLE
Organize RPC imports

### DIFF
--- a/rpc/account/__init__.py
+++ b/rpc/account/__init__.py
@@ -1,5 +1,5 @@
-from .users.handler import handle_users_request
 from .roles.handler import handle_roles_request
+from .users.handler import handle_users_request
 
 HANDLERS: dict[str, callable] = {
   "users": handle_users_request,

--- a/rpc/account/handler.py
+++ b/rpc/account/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import HANDLERS
+
 
 async def handle_account_request(parts: list[str], request: Request) -> RPCResponse:
   subdomain = parts[0]

--- a/rpc/account/roles/__init__.py
+++ b/rpc/account/roles/__init__.py
@@ -1,11 +1,5 @@
-from .services import (
-  list_roles_v1,
-  set_role_v1,
-  delete_role_v1,
-  get_role_members_v1,
-  add_role_member_v1,
-  remove_role_member_v1
-)
+from .services import (add_role_member_v1, delete_role_v1, get_role_members_v1,
+                       list_roles_v1, remove_role_member_v1, set_role_v1)
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("list", "1"): list_roles_v1,

--- a/rpc/account/roles/handler.py
+++ b/rpc/account/roles/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import DISPATCHERS
+
 
 async def handle_roles_request(parts: list[str], request: Request) -> RPCResponse:
   key = tuple(parts[:2])

--- a/rpc/account/roles/models.py
+++ b/rpc/account/roles/models.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel
+
 from rpc.account.users.models import UserListItem
+
 
 class RoleItem(BaseModel):
   name: str

--- a/rpc/account/roles/services.py
+++ b/rpc/account/roles/services.py
@@ -1,17 +1,14 @@
-from fastapi import Request, HTTPException
-from rpc.account.roles.models import (
-  RoleItem,
-  AccountRolesList1,
-  AccountRoleUpdate1,
-  AccountRoleDelete1,
-  AccountRoleMembers1,
-  AccountRoleMemberUpdate1
-)
+from fastapi import HTTPException, Request
+
+from rpc.account.roles.models import (AccountRoleDelete1, AccountRoleMembers1,
+                                      AccountRoleMemberUpdate1,
+                                      AccountRolesList1, AccountRoleUpdate1,
+                                      RoleItem)
 from rpc.account.users.models import UserListItem
-from rpc.models import RPCRequest, RPCResponse
-from server.modules.mssql_module import MSSQLModule, _utos
-from server.helpers import roles as role_helper
 from rpc.helpers import get_rpcrequest_from_request
+from rpc.models import RPCRequest, RPCResponse
+from server.helpers import roles as role_helper
+from server.modules.mssql_module import MSSQLModule, _utos
 
 
 def mask_to_bit(mask: int) -> int:

--- a/rpc/account/users/__init__.py
+++ b/rpc/account/users/__init__.py
@@ -1,13 +1,7 @@
-from .services import (
-  get_users_v1,
-  get_user_roles_v1,
-  set_user_roles_v1,
-  list_available_roles_v1,
-  get_user_profile_v1,
-  set_user_credits_v1,
-  set_user_display_name_v1,
-  enable_user_storage_v1
-)
+from .services import (enable_user_storage_v1, get_user_profile_v1,
+                       get_user_roles_v1, get_users_v1,
+                       list_available_roles_v1, set_user_credits_v1,
+                       set_user_display_name_v1, set_user_roles_v1)
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("list", "1"): get_users_v1,

--- a/rpc/account/users/handler.py
+++ b/rpc/account/users/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import DISPATCHERS
+
 
 async def handle_users_request(parts: list[str], request: Request) -> RPCResponse:
   key = tuple(parts[:2])

--- a/rpc/account/users/models.py
+++ b/rpc/account/users/models.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel
 from datetime import datetime
+
+from pydantic import BaseModel
+
 
 class UserListItem(BaseModel):
   guid: str

--- a/rpc/account/users/services.py
+++ b/rpc/account/users/services.py
@@ -1,22 +1,16 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
+from rpc.account.users.models import (AccountUserCreditsUpdate1,
+                                      AccountUserDisplayNameUpdate1,
+                                      AccountUserProfile1, AccountUserRoles1,
+                                      AccountUserRolesUpdate1,
+                                      AccountUsersList1, UserListItem)
+from rpc.helpers import (ROLE_REGISTERED, get_rpcrequest_from_request,
+                         mask_to_names, names_to_mask)
 from rpc.models import RPCRequest, RPCResponse
-from rpc.account.users.models import (
-  AccountUsersList1,
-  UserListItem,
-  AccountUserRoles1,
-  AccountUserRolesUpdate1,
-  AccountUserCreditsUpdate1,
-  AccountUserDisplayNameUpdate1,
-  AccountUserProfile1
-)
 from server.modules.mssql_module import MSSQLModule, _utos
 from server.modules.storage_module import StorageModule
-from rpc.helpers import (
-  mask_to_names,
-  names_to_mask,
-  ROLE_REGISTERED,
-)
-from rpc.helpers import get_rpcrequest_from_request
+
 
 async def get_users_v1(request: Request) -> RPCResponse:
   db: MSSQLModule = request.app.state.mssql

--- a/rpc/auth/handler.py
+++ b/rpc/auth/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import HANDLERS
+
 
 async def handle_auth_request(parts: list[str], request: Request) -> RPCResponse:
   subdomain = parts[0]

--- a/rpc/auth/microsoft/__init__.py
+++ b/rpc/auth/microsoft/__init__.py
@@ -1,6 +1,4 @@
-from .services import (
-  user_login_v1
-)
+from .services import user_login_v1
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("user_login", "1"): user_login_v1

--- a/rpc/auth/microsoft/handler.py
+++ b/rpc/auth/microsoft/handler.py
@@ -1,7 +1,11 @@
-from fastapi import Request, HTTPException
 import logging
+
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import DISPATCHERS
+
 
 async def handle_ms_request(parts: list[str], request: Request) -> RPCResponse:
   logging.debug("handle_ms_request parts=%s", parts)

--- a/rpc/auth/microsoft/models.py
+++ b/rpc/auth/microsoft/models.py
@@ -1,6 +1,8 @@
-from pydantic import BaseModel
-from typing import Optional
 from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
 
 class AuthMicrosoftLoginData1(BaseModel):
   bearerToken: str

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -1,11 +1,13 @@
-from fastapi import Request
 import logging
-from rpc.models import RPCResponse, RPCRequest
+
+from fastapi import Request
+
 from rpc.auth.microsoft.models import AuthMicrosoftLoginData1
+from rpc.helpers import get_rpcrequest_from_request, mask_to_names
+from rpc.models import RPCRequest, RPCResponse
 from server.modules.auth_module import AuthModule
 from server.modules.mssql_module import MSSQLModule, _utos
-from rpc.helpers import mask_to_names
-from rpc.helpers import get_rpcrequest_from_request
+
 
 async def user_login_v1(request: Request) -> RPCResponse:
   rpc_request: RPCRequest = get_rpcrequest_from_request(request)

--- a/rpc/auth/session/__init__.py
+++ b/rpc/auth/session/__init__.py
@@ -1,7 +1,4 @@
-from .services import (
-    refresh_v1,
-    invalidate_v1
-)
+from .services import invalidate_v1, refresh_v1
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("refresh", "1"): refresh_v1,

--- a/rpc/auth/session/handler.py
+++ b/rpc/auth/session/handler.py
@@ -1,7 +1,11 @@
-from fastapi import Request, HTTPException
 import logging
+
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import DISPATCHERS
+
 
 async def handle_session_request(parts: list[str], request: Request) -> RPCResponse:
   logging.debug("handle_session_request parts=%s", parts)

--- a/rpc/auth/session/models.py
+++ b/rpc/auth/session/models.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel
 from datetime import datetime
+
+from pydantic import BaseModel
+
 
 class AuthSessionTokens1(BaseModel):
   bearerToken: str

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -1,9 +1,11 @@
-from fastapi import Request, HTTPException
-from rpc.models import RPCResponse
-from rpc.helpers import get_rpcrequest_from_request
+from fastapi import HTTPException, Request
+
 from rpc.auth.session.models import AuthSessionTokens1
+from rpc.helpers import get_rpcrequest_from_request
+from rpc.models import RPCResponse
 from server.modules.auth_module import AuthModule
 from server.modules.mssql_module import MSSQLModule
+
 
 async def refresh_v1(request: Request) -> RPCResponse:
   rpc_request = get_rpcrequest_from_request(request)

--- a/rpc/frontend/__init__.py
+++ b/rpc/frontend/__init__.py
@@ -1,5 +1,5 @@
-from .user.handler import handle_user_request
 from .links.handler import handle_links_request
+from .user.handler import handle_user_request
 from .vars.handler import handle_vars_request
 
 HANDLERS: dict[str, callable] = {

--- a/rpc/frontend/handler.py
+++ b/rpc/frontend/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import HANDLERS
+
 
 async def handle_frontend_request(parts: list[str], request: Request) -> RPCResponse:
   subdomain = parts[0]

--- a/rpc/frontend/links/__init__.py
+++ b/rpc/frontend/links/__init__.py
@@ -1,7 +1,4 @@
-from .services import (
-    get_home_v1,
-    get_routes_v1
-)
+from .services import get_home_v1, get_routes_v1
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("get_home", "1"): get_home_v1,

--- a/rpc/frontend/links/handler.py
+++ b/rpc/frontend/links/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import DISPATCHERS
+
 
 async def handle_links_request(parts: list[str], request: Request) -> RPCResponse:
   key = tuple(parts[:2])

--- a/rpc/frontend/links/models.py
+++ b/rpc/frontend/links/models.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+
 class LinkItem(BaseModel):
   title: str
   url: str

--- a/rpc/frontend/links/services.py
+++ b/rpc/frontend/links/services.py
@@ -1,14 +1,13 @@
 
 from fastapi import Request
+
+from rpc.frontend.links.models import (FrontendLinksHome1,
+                                       FrontendLinksRoutes1, LinkItem,
+                                       RouteItem)
 from rpc.models import RPCResponse
-from rpc.frontend.links.models import (
-  FrontendLinksHome1,
-  LinkItem,
-  FrontendLinksRoutes1,
-  RouteItem
-)
 from server.modules.mssql_module import MSSQLModule
 from server.modules.permcap_module import PermCapModule
+
 
 async def get_home_v1(request: Request) -> RPCResponse:
   db: MSSQLModule = request.app.state.mssql

--- a/rpc/frontend/user/__init__.py
+++ b/rpc/frontend/user/__init__.py
@@ -1,7 +1,4 @@
-from .services import (
-    get_profile_data_v1,
-    set_display_name_v1
-)
+from .services import get_profile_data_v1, set_display_name_v1
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("get_profile_data", "1"): get_profile_data_v1,

--- a/rpc/frontend/user/handler.py
+++ b/rpc/frontend/user/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import DISPATCHERS
+
 
 async def handle_user_request(parts: list[str], request: Request) -> RPCResponse:
   key = tuple(parts[:2])

--- a/rpc/frontend/user/models.py
+++ b/rpc/frontend/user/models.py
@@ -1,6 +1,8 @@
-from pydantic import BaseModel
-from typing import Optional
 from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
 
 class FrontendUserProfileData1(BaseModel):
   bearerToken: str

--- a/rpc/frontend/user/services.py
+++ b/rpc/frontend/user/services.py
@@ -1,11 +1,12 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
+from rpc.frontend.user.models import (FrontendUserProfileData1,
+                                      FrontendUserSetDisplayName1)
+from rpc.helpers import get_rpcrequest_from_request, mask_to_names
 from rpc.models import RPCRequest, RPCResponse
-from rpc.frontend.user.models import FrontendUserProfileData1, FrontendUserSetDisplayName1
 from server.modules.auth_module import AuthModule
 from server.modules.mssql_module import MSSQLModule, _utos
-from rpc.helpers import mask_to_names
 from server.modules.storage_module import StorageModule
-from rpc.helpers import get_rpcrequest_from_request
 
 
 async def get_profile_data_v1(request: Request) -> RPCResponse:

--- a/rpc/frontend/vars/__init__.py
+++ b/rpc/frontend/vars/__init__.py
@@ -1,9 +1,5 @@
-from .services import (
-    get_version_v1,
-    get_hostname_v1,
-    get_repo_v1,
-    get_ffmpeg_version_v1
-)
+from .services import (get_ffmpeg_version_v1, get_hostname_v1, get_repo_v1,
+                       get_version_v1)
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("get_version", "1"): get_version_v1,

--- a/rpc/frontend/vars/handler.py
+++ b/rpc/frontend/vars/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import DISPATCHERS
+
 
 async def handle_vars_request(parts: list[str], request: Request) -> RPCResponse:
   key = tuple(parts[:2])

--- a/rpc/frontend/vars/models.py
+++ b/rpc/frontend/vars/models.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+
 class FrontendVarsVersion1(BaseModel):
   version: str
 

--- a/rpc/frontend/vars/services.py
+++ b/rpc/frontend/vars/services.py
@@ -1,12 +1,12 @@
 import asyncio
-from fastapi import Request, HTTPException
-from rpc.frontend.vars.models import (
-  FrontendVarsVersion1,
-  FrontendVarsHostname1,
-  FrontendVarsRepo1,
-  FrontendVarsFfmpegVersion1
-)
+
+from fastapi import HTTPException, Request
+
+from rpc.frontend.vars.models import (FrontendVarsFfmpegVersion1,
+                                      FrontendVarsHostname1, FrontendVarsRepo1,
+                                      FrontendVarsVersion1)
 from rpc.models import RPCResponse
+
 
 async def get_version_v1(request: Request):
   db = request.app.state.mssql

--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -1,9 +1,12 @@
 import logging
-from fastapi import Request, HTTPException
-from rpc.models import RPCResponse
-from rpc.helpers import get_rpcrequest_from_request
-from rpc.suffix import apply_suffixes, split_suffix
+
+from fastapi import HTTPException, Request
+
 from rpc import HANDLERS
+from rpc.helpers import get_rpcrequest_from_request
+from rpc.models import RPCResponse
+from rpc.suffix import apply_suffixes, split_suffix
+
 
 async def handle_rpc_request(request: Request) -> RPCResponse:
   rpc_request, parts = get_rpcrequest_from_request(request)

--- a/rpc/helpers.py
+++ b/rpc/helpers.py
@@ -1,8 +1,11 @@
 import logging
+
 from fastapi import Request
+
+from rpc.models import RPCRequest
 from server.modules.auth_module import AuthModule
 from server.modules.mssql_module import MSSQLModule
-from rpc.models import RPCRequest
+
 
 def _get_token_from_request(request: Request) -> str:
   header = request.headers.get('authorization')
@@ -42,6 +45,7 @@ ROLE_NAMES: list[str] = []
 ROLE_REGISTERED: int = 1
 
 import pyodbc
+
 
 async def load_roles(db) -> None:
   try:

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -1,6 +1,8 @@
-from pydantic import BaseModel, Field
-from typing import Any, Optional
 from datetime import datetime, timezone
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
 
 class RPCRequest(BaseModel):
   op: str

--- a/rpc/storage/files/__init__.py
+++ b/rpc/storage/files/__init__.py
@@ -1,9 +1,4 @@
-from .services import (
-    list_files_v1,
-    delete_file_v1,
-    upload_file_v1
-)
-
+from .services import delete_file_v1, list_files_v1, upload_file_v1
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("list", "1"): list_files_v1,

--- a/rpc/storage/files/handler.py
+++ b/rpc/storage/files/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import DISPATCHERS
+
 
 async def handle_files_request(parts: list[str], request: Request) -> RPCResponse:
   key = tuple(parts[:2])

--- a/rpc/storage/files/models.py
+++ b/rpc/storage/files/models.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel
 from typing import Optional
+
+from pydantic import BaseModel
+
 
 class FileItem(BaseModel):
   name: str

--- a/rpc/storage/files/services.py
+++ b/rpc/storage/files/services.py
@@ -1,11 +1,16 @@
-from fastapi import Request, HTTPException
+import base64
+import re
+
+from fastapi import HTTPException, Request
+
+from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCRequest, RPCResponse
-from rpc.storage.files.models import StorageFilesList1, FileItem, StorageFileDelete1, StorageFileUpload1
+from rpc.storage.files.models import (FileItem, StorageFileDelete1,
+                                      StorageFilesList1, StorageFileUpload1)
 from server.helpers.buffers import AsyncBufferWriter
-import base64, re
 from server.modules.auth_module import AuthModule
 from server.modules.storage_module import StorageModule
-from rpc.helpers import get_rpcrequest_from_request
+
 
 async def list_files_v1(request: Request) -> RPCResponse:
   rpc_request: RPCRequest = get_rpcrequest_from_request(request)

--- a/rpc/storage/handler.py
+++ b/rpc/storage/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import HANDLERS
+
 
 async def handle_storage_request(parts: list[str], request: Request) -> RPCResponse:
   subdomain = parts[0]

--- a/rpc/suffix.py
+++ b/rpc/suffix.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
+
 from typing import Callable, Dict, List, Tuple
+
 from fastapi import HTTPException
+
 from rpc.models import RPCResponse
 
 SuffixHandler = Callable[[RPCResponse, List[str]], RPCResponse]

--- a/rpc/system/__init__.py
+++ b/rpc/system/__init__.py
@@ -1,7 +1,7 @@
-from .users.handler import handle_users_request
+from .config.handler import handle_config_request
 from .roles.handler import handle_roles_request
 from .routes.handler import handle_routes_request
-from .config.handler import handle_config_request
+from .users.handler import handle_users_request
 
 HANDLERS: dict[str, callable] = {
     "users": handle_users_request,

--- a/rpc/system/config/__init__.py
+++ b/rpc/system/config/__init__.py
@@ -1,8 +1,4 @@
-from .services import (
-    list_config_v1,
-    set_config_v1,
-    delete_config_v1
-)
+from .services import delete_config_v1, list_config_v1, set_config_v1
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("list", "1"): list_config_v1,

--- a/rpc/system/config/handler.py
+++ b/rpc/system/config/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import DISPATCHERS
+
 
 async def handle_config_request(parts: list[str], request: Request) -> RPCResponse:
   key = tuple(parts[:2])

--- a/rpc/system/config/models.py
+++ b/rpc/system/config/models.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+
 class ConfigItem(BaseModel):
   key: str
   value: str

--- a/rpc/system/config/services.py
+++ b/rpc/system/config/services.py
@@ -1,13 +1,11 @@
 from fastapi import Request
-from rpc.models import RPCRequest, RPCResponse
-from rpc.system.config.models import (
-  SystemConfigList1,
-  ConfigItem,
-  SystemConfigUpdate1,
-  SystemConfigDelete1
-)
-from server.modules.mssql_module import MSSQLModule
+
 from rpc.helpers import get_rpcrequest_from_request
+from rpc.models import RPCRequest, RPCResponse
+from rpc.system.config.models import (ConfigItem, SystemConfigDelete1,
+                                      SystemConfigList1, SystemConfigUpdate1)
+from server.modules.mssql_module import MSSQLModule
+
 
 async def list_config_v1(request: Request) -> RPCResponse:
   db: MSSQLModule = request.app.state.mssql

--- a/rpc/system/handler.py
+++ b/rpc/system/handler.py
@@ -1,10 +1,13 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import HANDLERS
+
 
 async def handle_system_request(parts: list[str], request: Request) -> RPCResponse:
   subdomain = parts[0]
   handler = HANDLERS.get(subdomain)
   if not handler:
-    raise HTTPException(status_code=404, details="Unknown RPC subdomain")
+    raise HTTPException(status_code=404, detail="Unknown RPC subdomain")
   return await handler(parts[1:], request)

--- a/rpc/system/roles/__init__.py
+++ b/rpc/system/roles/__init__.py
@@ -1,11 +1,5 @@
-from .services import (
-    list_roles_v1,
-    set_role_v1,
-    delete_role_v1,
-    get_role_members_v1,
-    add_role_member_v1,
-    remove_role_member_v1
-)
+from .services import (add_role_member_v1, delete_role_v1, get_role_members_v1,
+                       list_roles_v1, remove_role_member_v1, set_role_v1)
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("list", "1"): list_roles_v1,

--- a/rpc/system/roles/handler.py
+++ b/rpc/system/roles/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import DISPATCHERS
+
 
 async def handle_roles_request(parts: list[str], request: Request) -> RPCResponse:
   key = tuple(parts[:2])

--- a/rpc/system/roles/models.py
+++ b/rpc/system/roles/models.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel
+
 from rpc.system.users.models import UserListItem
+
 
 class RoleItem(BaseModel):
   name: str

--- a/rpc/system/roles/services.py
+++ b/rpc/system/roles/services.py
@@ -1,17 +1,14 @@
-from fastapi import Request, HTTPException
-from rpc.system.roles.models import (
-  RoleItem,
-  SystemRolesList1,
-  SystemRoleUpdate1,
-  SystemRoleDelete1,
-  SystemRoleMembers1,
-  SystemRoleMemberUpdate1
-)
-from rpc.system.users.models import UserListItem
+from fastapi import HTTPException, Request
+
+from rpc.helpers import (ROLE_REGISTERED, get_rpcrequest_from_request,
+                         load_roles)
 from rpc.models import RPCRequest, RPCResponse
+from rpc.system.roles.models import (RoleItem, SystemRoleDelete1,
+                                     SystemRoleMembers1,
+                                     SystemRoleMemberUpdate1, SystemRolesList1,
+                                     SystemRoleUpdate1)
+from rpc.system.users.models import UserListItem
 from server.modules.mssql_module import MSSQLModule, _utos
-from rpc.helpers import get_rpcrequest_from_request
-from rpc.helpers import ROLE_REGISTERED, load_roles
 
 
 def mask_to_bit(mask: int) -> int:

--- a/rpc/system/routes/__init__.py
+++ b/rpc/system/routes/__init__.py
@@ -1,8 +1,4 @@
-from .services import (
-    list_routes_v1,
-    set_route_v1,
-    delete_route_v1
-)
+from .services import delete_route_v1, list_routes_v1, set_route_v1
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("list", "1"): list_routes_v1,

--- a/rpc/system/routes/handler.py
+++ b/rpc/system/routes/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import DISPATCHERS
+
 
 async def handle_routes_request(parts: list[str], request: Request) -> RPCResponse:
   key = tuple(parts[:2])

--- a/rpc/system/routes/models.py
+++ b/rpc/system/routes/models.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+
 class SystemRouteItem(BaseModel):
   path: str
   name: str

--- a/rpc/system/routes/services.py
+++ b/rpc/system/routes/services.py
@@ -1,15 +1,12 @@
 from fastapi import Request
-from rpc.models import RPCRequest, RPCResponse
-from rpc.helpers import get_rpcrequest_from_request
-from rpc.system.routes.models import (
-  SystemRouteItem,
-  SystemRoutesList1,
-  SystemRouteUpdate1,
-  SystemRouteDelete1
-)
 
+from rpc.helpers import (get_rpcrequest_from_request, mask_to_names,
+                         names_to_mask)
+from rpc.models import RPCRequest, RPCResponse
+from rpc.system.routes.models import (SystemRouteDelete1, SystemRouteItem,
+                                      SystemRoutesList1, SystemRouteUpdate1)
 from server.modules.mssql_module import MSSQLModule
-from rpc.helpers import mask_to_names, names_to_mask
+
 
 async def list_routes_v1(request: Request) -> RPCResponse:
   db: MSSQLModule = request.app.state.mssql

--- a/rpc/system/users/__init__.py
+++ b/rpc/system/users/__init__.py
@@ -1,12 +1,12 @@
-from services import (
-  get_users_v1,
-  get_user_roles_v1,
-  set_user_roles_v1,
-  list_available_roles_v1,
+from .services import (
+  enable_user_storage_v1,
   get_user_profile_v1,
+  get_user_roles_v1,
+  get_users_v1,
+  list_available_roles_v1,
   set_user_credits_v1,
-  enable_user_storage_v1
-) 
+  set_user_roles_v1,
+)
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("list", "1"): get_users_v1,

--- a/rpc/system/users/handler.py
+++ b/rpc/system/users/handler.py
@@ -1,6 +1,9 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
 from rpc.models import RPCResponse
+
 from . import DISPATCHERS
+
 
 async def handle_users_request(parts: list[str], request: Request) -> RPCResponse:
   key = tuple(parts[:2])

--- a/rpc/system/users/models.py
+++ b/rpc/system/users/models.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel
 from datetime import datetime
+
+from pydantic import BaseModel
+
 
 class UserListItem(BaseModel):
   guid: str

--- a/rpc/system/users/services.py
+++ b/rpc/system/users/services.py
@@ -1,21 +1,15 @@
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
+
+from rpc.helpers import (ROLE_REGISTERED, get_rpcrequest_from_request,
+                         mask_to_names, names_to_mask)
 from rpc.models import RPCRequest, RPCResponse
-from rpc.helpers import get_rpcrequest_from_request
-from rpc.system.users.models import (
-  SystemUsersList1,
-  UserListItem,
-  SystemUserRoles1,
-  SystemUserRolesUpdate1,
-  SystemUserCreditsUpdate1,
-  SystemUserProfile1
-)
+from rpc.system.users.models import (SystemUserCreditsUpdate1,
+                                     SystemUserProfile1, SystemUserRoles1,
+                                     SystemUserRolesUpdate1, SystemUsersList1,
+                                     UserListItem)
 from server.modules.mssql_module import MSSQLModule, _utos
 from server.modules.storage_module import StorageModule
-from rpc.helpers import (
-  mask_to_names,
-  names_to_mask,
-  ROLE_REGISTERED,
-)
+
 
 async def get_users_v1(request: Request) -> RPCResponse:
   db: MSSQLModule = request.app.state.mssql


### PR DESCRIPTION
## Summary
- run isort on rpc namespace and fix a few formatting inconsistencies
- fix typo in system handler HTTPException
- normalize dispatch table import in `rpc/system/users`

## Testing
- `python scripts/generate_rpc_library.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check` *(fails: cannot find module 'react')*
- `npm test -- --run` *(fails: vitest not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aee3e66d08325b806f531116221a7