### PR TITLE
Update frontend RPC to V1

### DIFF
--- a/frontend/src/AccountRoleMembersPage.tsx
+++ b/frontend/src/AccountRoleMembersPage.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import { Box, Stack, List, ListItemButton, ListItemText, IconButton, Typography } from '@mui/material';
 import { PageTitle } from './shared/PageTitle';
 import { ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
-import type { RoleItem, AccountRoleMembers2, UserListItem, AccountRolesList2 } from './shared/RpcModels';
-import { fetchList2 as fetchList, fetchMembers2 as fetchMembers, fetchAddMember2 as fetchAddMember, fetchRemoveMember2 as fetchRemoveMember } from './rpc/account/roles';
+import type { RoleItem, AccountRoleMembers1, UserListItem, AccountRolesList1 } from './shared/RpcModels';
+import { fetchList, fetchMembers, fetchAddMember, fetchRemoveMember } from './rpc/account/roles';
 
 const AccountRoleMembersPage = (): JSX.Element => {
     const [roles, setRoles] = useState<RoleItem[]>([]);
@@ -15,7 +15,7 @@ const AccountRoleMembersPage = (): JSX.Element => {
     useEffect(() => {
         void (async () => {
             try {
-                const res: AccountRolesList2 = await fetchList();
+                const res: AccountRolesList1 = await fetchList();
                 setRoles(res.roles.sort((a, b) => a.bit - b.bit));
             } catch {
                 setRoles([]);
@@ -28,7 +28,7 @@ const AccountRoleMembersPage = (): JSX.Element => {
             if (members[r.name]) return;
             void (async () => {
                 try {
-                    const res: AccountRoleMembers2 = await fetchMembers({ role: r.name });
+                    const res: AccountRoleMembers1 = await fetchMembers({ role: r.name });
                     setMembers(m => ({ ...m, [r.name]: res.members }));
                     setNonMembers(n => ({ ...n, [r.name]: res.nonMembers }));
                 } catch {
@@ -43,7 +43,7 @@ const AccountRoleMembersPage = (): JSX.Element => {
         const id = selectedLeft[role];
         if (!id) return;
         await fetchAddMember({ role, userGuid: id });
-        const res: AccountRoleMembers2 = await fetchMembers({ role });
+        const res: AccountRoleMembers1 = await fetchMembers({ role });
         setMembers(m => ({ ...m, [role]: res.members }));
         setNonMembers(n => ({ ...n, [role]: res.nonMembers }));
         setSelectedLeft(s => ({ ...s, [role]: '' }));
@@ -53,7 +53,7 @@ const AccountRoleMembersPage = (): JSX.Element => {
         const id = selectedRight[role];
         if (!id) return;
         await fetchRemoveMember({ role, userGuid: id });
-        const res: AccountRoleMembers2 = await fetchMembers({ role });
+        const res: AccountRoleMembers1 = await fetchMembers({ role });
         setMembers(m => ({ ...m, [role]: res.members }));
         setNonMembers(n => ({ ...n, [role]: res.nonMembers }));
         setSelectedRight(s => ({ ...s, [role]: '' }));

--- a/frontend/src/AccountUserPanel.tsx
+++ b/frontend/src/AccountUserPanel.tsx
@@ -3,17 +3,17 @@ import { useParams } from 'react-router-dom';
 import { Box, Stack, Button, List, ListItemButton, ListItemText, IconButton, Typography, Avatar } from '@mui/material';
 import { PageTitle } from './shared/PageTitle';
 import { ArrowForwardIos, ArrowBackIos, CheckCircle, Cancel } from '@mui/icons-material';
-import type { AccountUserRoles2, AccountUserProfile2, RoleItem } from './shared/RpcModels';
-import { fetchRoles2 as fetchRoles, fetchSetRoles2 as fetchSetRoles, fetchProfile2 as fetchProfile, fetchSetCredits2 as fetchSetCredits, fetchEnableStorage2 as fetchEnableStorage, fetchSetDisplayName2 as fetchSetDisplayName } from './rpc/account/users';
+import type { AccountUserRoles1, AccountUserProfile1, RoleItem } from './shared/RpcModels';
+import { fetchRoles, fetchSetRoles, fetchProfile, fetchSetCredits, fetchEnableStorage, fetchSetDisplayName } from './rpc/account/users';
 import EditBox from './shared/EditBox';
 import Notification from './shared/Notification';
-import { fetchList2 as fetchRoleList } from './rpc/account/roles';
+import { fetchList as fetchRoleList } from './rpc/account/roles';
 
 const AccountUserPanel = (): JSX.Element => {
     const { guid } = useParams();
     const [assigned, setAssigned] = useState<string[]>([]);
     const [available, setAvailable] = useState<string[]>([]);
-    const [profile, setProfile] = useState<AccountUserProfile2 | null>(null);
+    const [profile, setProfile] = useState<AccountUserProfile1 | null>(null);
     const [notification, setNotification] = useState(false);
     const [username, setUsername] = useState<string>('');
     const [roles, setRoles] = useState<RoleItem[]>([]);
@@ -27,9 +27,9 @@ const AccountUserPanel = (): JSX.Element => {
         void (async () => {
             if (!guid) return;
             try {
-            const userRoles: AccountUserRoles2 = await fetchRoles({ userGuid: guid });
+            const userRoles: AccountUserRoles1 = await fetchRoles({ userGuid: guid });
                 const roleList = await fetchRoleList();
-                const prof: AccountUserProfile2 = await fetchProfile({ userGuid: guid });
+                const prof: AccountUserProfile1 = await fetchProfile({ userGuid: guid });
                 setRoles(roleList.roles);
                 setAssigned(userRoles.roles);
                 setAvailable(roleList.roles.map(r => r.name).filter(r => !userRoles.roles.includes(r)));

--- a/frontend/src/AccountUsersPage.tsx
+++ b/frontend/src/AccountUsersPage.tsx
@@ -3,8 +3,8 @@ import { Box, Table, TableHead, TableRow, TableCell, TableBody, Button } from '@
 import ColumnHeader from './shared/ColumnHeader';
 import { PageTitle } from './shared/PageTitle';
 import { Link as RouterLink } from 'react-router-dom';
-import type { UserListItem, SystemUsersList2 } from './shared/RpcModels';
-import { fetchList2 as fetchList } from './rpc/system/users';
+import type { UserListItem, SystemUsersList1 } from './shared/RpcModels';
+import { fetchList } from './rpc/system/users';
 
 const AccountUsersPage = (): JSX.Element => {
     const [users, setUsers] = useState<UserListItem[]>([]);
@@ -12,7 +12,7 @@ const AccountUsersPage = (): JSX.Element => {
     useEffect(() => {
         void (async () => {
             try {
-                const res: SystemUsersList2 = await fetchList();
+                const res: SystemUsersList1 = await fetchList();
                 setUsers(res.users);
             } catch {
                 setUsers([]);

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -3,12 +3,12 @@ import { useEffect, useState } from 'react';
 import type { LinkItem } from './shared/RpcModels';
 import Logo from './assets/elideus_group_green.png';
 import {
-        fetchHostname2 as fetchHostname,
-        fetchVersion2 as fetchVersion,
-        fetchRepo2 as fetchRepo,
+        fetchHostname,
+        fetchVersion,
+        fetchRepo,
         fetchFfmpegVersion,
 } from './rpc/frontend/vars';
-import { fetchHome2 as fetchHome } from './rpc/frontend/links';
+import { fetchHome } from './rpc/frontend/links';
 
 const Home = (): JSX.Element => {
 	const [hostname, setHostname] = useState('');

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -47,14 +47,10 @@ const LoginPage = (): JSX.Element => {
                                 storageUsed: 0,
                                 storageEnabled: false,
                                 displayEmail: false,
-                                rotationToken: data.rotationToken ?? null,
-                                rotationExpires: data.rotationExpires ?? null,
                                 roles: []
                         });
                         localStorage.setItem('authTokens', JSON.stringify({
                                 bearerToken: data.bearerToken,
-                                rotationToken: data.rotationToken,
-                                rotationExpires: data.rotationExpires
                         }));
 
 			setNotification({ open: true, severity: 'success', message: 'Login successful!' });

--- a/frontend/src/NavBar.tsx
+++ b/frontend/src/NavBar.tsx
@@ -11,8 +11,8 @@ import {
 	ListItemText,
 } from '@mui/material';
 import { Menu as MenuIcon } from '@mui/icons-material';
-import type { RouteItem, FrontendLinksRoutes2 } from './shared/RpcModels';
-import { fetchRoutes2 as fetchRoutes } from './rpc/frontend/links';
+import type { RouteItem, FrontendLinksRoutes1 } from './shared/RpcModels';
+import { fetchRoutes } from './rpc/frontend/links';
 import { iconMap, defaultIcon } from './icons';
 import Login from './shared/Login';
 import UserContext from './shared/UserContext';
@@ -28,7 +28,7 @@ const NavBar = (): JSX.Element => {
         useEffect(() => {
                 void (async () => {
                         try {
-                                const res: FrontendLinksRoutes2 = await fetchRoutes();
+                                const res: FrontendLinksRoutes1 = await fetchRoutes();
                                 setRoutes(res.routes);
                         } catch {
                                 setRoutes([]);

--- a/frontend/src/SystemConfigPage.tsx
+++ b/frontend/src/SystemConfigPage.tsx
@@ -3,8 +3,8 @@ import { Box, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Text
 import ColumnHeader from './shared/ColumnHeader';
 import { PageTitle } from './shared/PageTitle';
 import { Delete, Add } from '@mui/icons-material';
-import type { ConfigItem, SystemConfigList2 } from './shared/RpcModels';
-import { fetchList2 as fetchList, fetchSet2 as fetchSet, fetchDelete2 as fetchDelete } from './rpc/system/config';
+import type { ConfigItem, SystemConfigList1 } from './shared/RpcModels';
+import { fetchList, fetchSet, fetchDelete } from './rpc/system/config';
 import EditBox from './shared/EditBox';
 import Notification from './shared/Notification';
 
@@ -16,7 +16,7 @@ const SystemConfigPage = (): JSX.Element => {
 
     const load = async (): Promise<void> => {
         try {
-            const res: SystemConfigList2 = await fetchList();
+            const res: SystemConfigList1 = await fetchList();
             setItems(res.items);
         } catch {
             setItems([]);

--- a/frontend/src/SystemRolesPage.tsx
+++ b/frontend/src/SystemRolesPage.tsx
@@ -3,8 +3,8 @@ import { Box, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Text
 import ColumnHeader from './shared/ColumnHeader';
 import { PageTitle } from './shared/PageTitle';
 import { Delete, Add } from '@mui/icons-material';
-import type { RoleItem, SystemRolesList2 } from './shared/RpcModels';
-import { fetchList2 as fetchList, fetchSet2 as fetchSet, fetchDelete2 as fetchDelete } from './rpc/system/roles';
+import type { RoleItem, SystemRolesList1 } from './shared/RpcModels';
+import { fetchList, fetchSet, fetchDelete } from './rpc/system/roles';
 import EditBox from './shared/EditBox';
 import Notification from './shared/Notification';
 
@@ -16,7 +16,7 @@ const SystemRolesPage = (): JSX.Element => {
 
     const load = async (): Promise<void> => {
         try {
-            const res: SystemRolesList2 = await fetchList();
+            const res: SystemRolesList1 = await fetchList();
             setRoles(res.roles.sort((a, b) => a.bit - b.bit));
         } catch {
             setRoles([]);

--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -3,11 +3,11 @@ import { Box, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Stac
 import ColumnHeader from './shared/ColumnHeader';
 import { PageTitle } from './shared/PageTitle';
 import { Delete, Add, ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
-import type { SystemRouteItem, SystemRoutesList2, SystemUserRoles1 } from './shared/RpcModels';
-import { fetchList2 as fetchRoutes, fetchSet2 as fetchSet, fetchDelete2 as fetchDelete } from './rpc/system/routes';
+import type { SystemRouteItem, SystemRoutesList1, SystemUserRoles1 } from './shared/RpcModels';
+import { fetchList as fetchRoutes, fetchSet, fetchDelete } from './rpc/system/routes';
 import EditBox from './shared/EditBox';
 import Notification from './shared/Notification';
-import { fetchListRoles2 as fetchListRoles } from './rpc/system/users';
+import { fetchListRoles } from './rpc/system/users';
 
 const MAX_HEIGHT = 120;
 
@@ -24,7 +24,7 @@ const SystemRoutesPage = (): JSX.Element => {
 
     const load = async (): Promise<void> => {
         try {
-            const res: SystemRoutesList2 = await fetchRoutes();
+            const res: SystemRoutesList1 = await fetchRoutes();
             setRoutes(res.routes.sort((a, b) => a.sequence - b.sequence));
         } catch {
             setRoutes([]);

--- a/frontend/src/UserPage.tsx
+++ b/frontend/src/UserPage.tsx
@@ -5,8 +5,8 @@ import UserContext from './shared/UserContext';
 import { fetchSetDisplayName } from './rpc/frontend/user';
 import EditBox, { EditBoxHandle } from './shared/EditBox';
 import Notification from './shared/Notification';
-import { fetchList2 as fetchRoleList } from './rpc/system/roles';
-import type { SystemRolesList2 } from './shared/RpcModels';
+import { fetchList as fetchRoleList } from './rpc/system/roles';
+import type { SystemRolesList1 } from './shared/RpcModels';
 
 const UserPage = (): JSX.Element => {
     const { userData, setUserData } = useContext(UserContext);
@@ -25,7 +25,7 @@ const UserPage = (): JSX.Element => {
     useEffect(() => {
         void (async () => {
             try {
-                const res: SystemRolesList2 = await fetchRoleList();
+                const res: SystemRolesList1 = await fetchRoleList();
                 const map: Record<string, string> = {};
                 res.roles.forEach(r => { map[r.name] = r.display; });
                 setRoleMap(map);

--- a/frontend/src/shared/Login.tsx
+++ b/frontend/src/shared/Login.tsx
@@ -32,13 +32,11 @@ const Login = ({ open }: LoginProps): JSX.Element => {
 		try {
 			await pca.initialize();
 			await pca.logoutPopup();
-			if (userData?.rotationToken) {
-				try {
-						await fetchInvalidate({ rotationToken: userData.rotationToken });
-				} catch (err) {
-						console.error('Failed to invalidate session', err);
-				}
-			}
+                        try {
+                                await fetchInvalidate();
+                        } catch (err) {
+                                console.error('Failed to invalidate session', err);
+                        }
 			clearUserData();
 			setNotification({ open: true, severity: 'info', message: 'Logged out successfully.' });
 		} catch (error: any) {

--- a/frontend/src/shared/UserContextProvider.tsx
+++ b/frontend/src/shared/UserContextProvider.tsx
@@ -28,8 +28,6 @@ const UserContextProvider = ({ children }: UserContextProviderProps): JSX.Elemen
                                storageUsed: 0,
                                 storageEnabled: false,
                                displayEmail: false,
-                                rotationToken: stored.rotationToken ?? null,
-                                rotationExpires: stored.rotationExpires ?? null,
                                 roles: [],
                         };
                         setUserData(prev => prev ? { ...prev, ...base } : base);

--- a/frontend/tests/rpcClient.test.ts
+++ b/frontend/tests/rpcClient.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import axios from 'axios';
-import { fetchVersion2 as fetchVersion, fetchHostname2 as fetchHostname, fetchRepo2 as fetchRepo, fetchFfmpegVersion } from '../src/rpc/frontend/vars';
-import { fetchHome2 as fetchHome, fetchRoutes2 as fetchRoutes } from '../src/rpc/frontend/links';
+import { fetchVersion, fetchHostname, fetchRepo, fetchFfmpegVersion } from '../src/rpc/frontend/vars';
+import { fetchHome, fetchRoutes } from '../src/rpc/frontend/links';
 import { fetchList as fetchFileList, fetchDelete as fetchFileDelete, fetchUpload as fetchFileUpload } from '../src/rpc/storage/files';
 import { fetchList as fetchUsers, fetchProfile } from '../src/rpc/system/users';
 import { fetchList as fetchConfigList, fetchSet as fetchConfigSet, fetchDelete as fetchConfigDelete } from '../src/rpc/system/config';
@@ -13,21 +13,21 @@ describe('rpcClient', () => {
     it('fetchVersion posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { version: 'v9.9.9' } } });
         const res = await fetchVersion();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:vars:get_version:2' }), expect.anything());
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:vars:get_version:1' }), expect.anything());
         expect(res.version).toBe('v9.9.9');
     });
 
     it('fetchHostname posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { hostname: 'unit-host' } } });
         const res = await fetchHostname();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:vars:get_hostname:2' }), expect.anything());
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:vars:get_hostname:1' }), expect.anything());
         expect(res.hostname).toBe('unit-host');
     });
 
     it('fetchRepo posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { repo: 'https://repo' } } });
         const res = await fetchRepo();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:vars:get_repo:2' }), expect.anything());
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:vars:get_repo:1' }), expect.anything());
         expect(res.repo).toBe('https://repo');
     });
 
@@ -41,14 +41,14 @@ describe('rpcClient', () => {
     it('fetchHome posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { links: [] } } });
         const res = await fetchHome();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:links:get_home:2' }), expect.anything());
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:links:get_home:1' }), expect.anything());
         expect(Array.isArray(res.links)).toBe(true);
     });
 
     it('fetchRoutes posts correct request', async () => {
         mockedPost.mockResolvedValueOnce({ data: { payload: { routes: [] } } });
         const res = await fetchRoutes();
-        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:links:get_routes:2' }), expect.anything());
+        expect(mockedPost).toHaveBeenCalledWith('/rpc', expect.objectContaining({ op: 'urn:frontend:links:get_routes:1' }), expect.anything());
         expect(Array.isArray(res.routes)).toBe(true);
     });
 


### PR DESCRIPTION
## Summary
- update all components to use V1 RPC models
- remove rotation token handling from login flow
- adjust rpcClient tests for V1 endpoints

## Testing
- ❌ `pip install -r requirements.txt` (failed to access internet)
- ❌ `npm ci` (failed to access internet)


------
https://chatgpt.com/codex/tasks/task_e_688bc0fab6c883259d475019a273af30