### PR TITLE
Fix missing session token model

### DIFF
--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -91,6 +91,9 @@ export interface AuthMicrosoftLoginData1 {
   profilePicture: string | null;
   credits: number | null;
 }
+export interface AuthSessionTokens1 {
+  bearerToken: string;
+}
 export interface AccessToken1 {
   accessToken: string;
   accessSubject: string;

--- a/frontend/src/shared/UserContextProvider.tsx
+++ b/frontend/src/shared/UserContextProvider.tsx
@@ -1,6 +1,6 @@
 import { useState, ReactNode, useEffect } from 'react';
 import UserContext from './UserContext';
-import type { FrontendUserProfileData1, BrowserSessionData1 } from './RpcModels';
+import type { FrontendUserProfileData1 } from './RpcModels';
 import { fetchProfileData } from '../rpc/frontend/user';
 
 interface UserContextProviderProps {
@@ -14,7 +14,8 @@ const UserContextProvider = ({ children }: UserContextProviderProps): JSX.Elemen
                 const raw = localStorage.getItem('authTokens');
                 if (!raw) return;
                 try {
-                        const stored: BrowserSessionData1 = JSON.parse(raw);
+                        interface StoredSession { bearerToken: string; }
+                        const stored: StoredSession = JSON.parse(raw);
                         if (!stored.bearerToken) return;
 
                         const base: FrontendUserProfileData1 = {

--- a/rpc/auth/session/models.py
+++ b/rpc/auth/session/models.py
@@ -2,6 +2,11 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
+
+class AuthSessionTokens1(BaseModel):
+  bearerToken: str
+
+
 class AccessToken1(BaseModel):
   accessToken: str
   accessSubject: str


### PR DESCRIPTION
## Summary
- restore `AuthSessionTokens1` model removed in previous revision
- adjust user context provider to use a local `StoredSession` type
- add matching TS interface in `RpcModels`

## Testing
- `python scripts/generate_rpc_library.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `python scripts/generate_rpc_client.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `python scripts/generate_rpc_metadata.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `python scripts/run_tests.py --test` *(fails: ModuleNotFoundError: No module named 'aioodbc')*

------
https://chatgpt.com/codex/tasks/task_e_688bfda3eb3c8325961798071c791a82