### PR TITLE
Add RPC service stubs and clean dispatcher imports

### DIFF
--- a/rpc/account/roles/__init__.py
+++ b/rpc/account/roles/__init__.py
@@ -6,10 +6,8 @@ from .services import (
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
-  """
-    This module is used by moderators to manage user role membership.
-    This namespace is restricted to those with the ACCOUNT role.
-  """
+  # This module is used by moderators to manage user role membership.
+  # This namespace is restricted to those with the ACCOUNT role.
   ("get_members", "1"): account_roles_get_members_v1,
   ("add_member", "1"): account_roles_add_member_v1,
   ("remove_member", "1"): account_roles_remove_member_v1

--- a/rpc/account/roles/services.py
+++ b/rpc/account/roles/services.py
@@ -1,0 +1,11 @@
+from fastapi import Request
+
+async def account_roles_get_members_v1(request: Request):
+  raise NotImplementedError("urn:account:roles:get_members:1")
+
+async def account_roles_add_member_v1(request: Request):
+  raise NotImplementedError("urn:account:roles:add_member:1")
+
+async def account_roles_remove_member_v1(request: Request):
+  raise NotImplementedError("urn:account:roles:remove_member:1")
+

--- a/rpc/account/users/__init__.py
+++ b/rpc/account/users/__init__.py
@@ -7,10 +7,8 @@ from .services import (
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
-  """
-    This module is used by moderators to manage user accounts.
-    This namespace is restricted to those with the ACCOUNT role.
-  """
+  # This module is used by moderators to manage user accounts.
+  # This namespace is restricted to those with the ACCOUNT role.
   ("get_profile", "1"): account_users_get_profile_v1,
   ("set_credits", "1"): account_users_set_credits_v1,
   ("reset_display", "1"): account_users_reset_display_v1,

--- a/rpc/account/users/services.py
+++ b/rpc/account/users/services.py
@@ -1,0 +1,14 @@
+from fastapi import Request
+
+async def account_users_get_profile_v1(request: Request):
+  raise NotImplementedError("urn:account:users:get_profile:1")
+
+async def account_users_set_credits_v1(request: Request):
+  raise NotImplementedError("urn:account:users:set_credits:1")
+
+async def account_users_reset_display_v1(request: Request):
+  raise NotImplementedError("urn:account:users:reset_display:1")
+
+async def account_users_enable_storage_v1(request: Request):
+  raise NotImplementedError("urn:account:users:enable_storage:1")
+

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -1,0 +1,5 @@
+from fastapi import Request
+
+async def auth_microsoft_oauth_login_v1(request: Request):
+  raise NotImplementedError("urn:auth:microsoft:oauth_login:1")
+

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -1,0 +1,11 @@
+from fastapi import Request
+
+async def auth_session_get_token_v1(request: Request):
+  raise NotImplementedError("urn:auth:session:get_token:1")
+
+async def auth_session_refresh_token_v1(request: Request):
+  raise NotImplementedError("urn:auth:session:refresh_token:1")
+
+async def auth_session_invalidate_token_v1(request: Request):
+  raise NotImplementedError("urn:auth:session:invalidate_token:1")
+

--- a/rpc/public/links/services.py
+++ b/rpc/public/links/services.py
@@ -1,0 +1,8 @@
+from fastapi import Request
+
+async def public_links_get_home_links_v1(request: Request):
+  raise NotImplementedError("urn:public:links:get_home_links:1")
+
+async def public_links_get_navbar_routes_v1(request: Request):
+  raise NotImplementedError("urn:public:links:get_navbar_routes:1")
+

--- a/rpc/public/vars/services.py
+++ b/rpc/public/vars/services.py
@@ -1,0 +1,17 @@
+from fastapi import Request
+
+async def public_vars_get_version_v1(request: Request):
+  raise NotImplementedError("urn:public:vars:get_version:1")
+
+async def public_vars_get_hostname_v1(request: Request):
+  raise NotImplementedError("urn:public:vars:get_hostname:1")
+
+async def public_vars_get_repo_v1(request: Request):
+  raise NotImplementedError("urn:public:vars:get_repo:1")
+
+async def public_vars_get_ffmpeg_version_v1(request: Request):
+  raise NotImplementedError("urn:public:vars:get_ffmpeg_version:1")
+
+async def public_vars_get_odbc_version_v1(request: Request):
+  raise NotImplementedError("urn:public:vars:get_odbc_version:1")
+

--- a/rpc/storage/files/services.py
+++ b/rpc/storage/files/services.py
@@ -1,0 +1,14 @@
+from fastapi import Request
+
+async def storage_files_get_files_v1(request: Request):
+  raise NotImplementedError("urn:storage:files:get_files:1")
+
+async def storage_files_upload_files_v1(request: Request):
+  raise NotImplementedError("urn:storage:files:upload_files:1")
+
+async def storage_files_delete_files_v1(request: Request):
+  raise NotImplementedError("urn:storage:files:delete_files:1")
+
+async def storage_files_set_gallery_v1(request: Request):
+  raise NotImplementedError("urn:storage:files:set_gallery:1")
+

--- a/rpc/system/config/__init__.py
+++ b/rpc/system/config/__init__.py
@@ -6,11 +6,9 @@ from .services import (
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
-  """
-    These functions are used to make changes to the system configuration.
-    These values are stored in the database.
-    This namespace is restricted to only users with the SYSTEM role.
-  """
+  # These functions are used to make changes to the system configuration.
+  # These values are stored in the database.
+  # This namespace is restricted to only users with the SYSTEM role.
   ("get_configs", "1"): system_config_get_configs_v1,
   ("upsert_config", "1"): system_config_upsert_config_v1,
   ("delete_config", "1"): system_config_delete_config_v1

--- a/rpc/system/config/services.py
+++ b/rpc/system/config/services.py
@@ -1,0 +1,11 @@
+from fastapi import Request
+
+async def system_config_get_configs_v1(request: Request):
+  raise NotImplementedError("urn:system:config:get_configs:1")
+
+async def system_config_upsert_config_v1(request: Request):
+  raise NotImplementedError("urn:system:config:upsert_config:1")
+
+async def system_config_delete_config_v1(request: Request):
+  raise NotImplementedError("urn:system:config:delete_config:1")
+

--- a/rpc/system/roles/__init__.py
+++ b/rpc/system/roles/__init__.py
@@ -9,12 +9,10 @@ from .services import (
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
-  """
-    These functions are used to make changes to user role assignments.
-    The roles are stored in the database. Each role has a bitmask flag.
-    Users have a combined bitmask value stored for all roles assigned.
-    This namespace is restricted to users with the SYSTEM role.
-  """
+  # These functions are used to make changes to user role assignments.
+  # The roles are stored in the database. Each role has a bitmask flag.
+  # Users have a combined bitmask value stored for all roles assigned.
+  # This namespace is restricted to users with the SYSTEM role.
   ("get_roles", "1"): system_roles_get_roles_v1,
   ("upsert_role", "1"): system_roles_upsert_role_v1,
   ("delete_role", "1"): system_roles_delete_role_v1,

--- a/rpc/system/roles/services.py
+++ b/rpc/system/roles/services.py
@@ -1,0 +1,20 @@
+from fastapi import Request
+
+async def system_roles_get_roles_v1(request: Request):
+  raise NotImplementedError("urn:system:roles:get_roles:1")
+
+async def system_roles_upsert_role_v1(request: Request):
+  raise NotImplementedError("urn:system:roles:upsert_role:1")
+
+async def system_roles_delete_role_v1(request: Request):
+  raise NotImplementedError("urn:system:roles:delete_role:1")
+
+async def system_roles_get_role_members_v1(request: Request):
+  raise NotImplementedError("urn:system:roles:get_role_members:1")
+
+async def system_roles_add_role_member_v1(request: Request):
+  raise NotImplementedError("urn:system:roles:add_role_member:1")
+
+async def system_roles_remove_member_v1(request: Request):
+  raise NotImplementedError("urn:system:roles:remove_role_member:1")
+

--- a/rpc/system/routes/services.py
+++ b/rpc/system/routes/services.py
@@ -1,0 +1,11 @@
+from fastapi import Request
+
+async def system_routes_get_routes_v1(request: Request):
+  raise NotImplementedError("urn:system:routes:get_routes:1")
+
+async def system_routes_upsert_route_v1(request: Request):
+  raise NotImplementedError("urn:system:routes:upsert_route:1")
+
+async def system_routes_delete_route_v1(request: Request):
+  raise NotImplementedError("urn:system:routes:delete_route:1")
+

--- a/rpc/users/auth/services.py
+++ b/rpc/users/auth/services.py
@@ -1,0 +1,11 @@
+from fastapi import Request
+
+async def users_auth_set_provider_v1(request: Request):
+  raise NotImplementedError("urn:users:auth:set_provider:1")
+
+async def users_auth_link_provider_v1(request: Request):
+  raise NotImplementedError("urn:users:auth:link_provider:1")
+
+async def users_auth_unlink_provider_v1(request: Request):
+  raise NotImplementedError("urn:users:auth:unlink_provider:1")
+

--- a/rpc/users/user/services.py
+++ b/rpc/users/user/services.py
@@ -1,0 +1,11 @@
+from fastapi import Request
+
+async def users_user_get_profile_v1(request: Request):
+  raise NotImplementedError("urn:users:user:get_profile:1")
+
+async def users_user_set_display_v1(request: Request):
+  raise NotImplementedError("urn:users:user:set_display:1")
+
+async def users_user_set_optin_v1(request: Request):
+  raise NotImplementedError("urn:users:user:set_optin:1")
+


### PR DESCRIPTION
## Summary
- add placeholder async service functions for all RPC endpoints with NotImplementedError URNs
- replace inline dispatcher docstrings with comments so modules import cleanly

## Testing
- `python scripts/run_tests.py --test` *(fails: UserContextProvider.tsx - useEffect defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_689524ed4f708325aa8b4c7427e548bd