### PR TITLE
Rename account RPCs to admin

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -10,24 +10,24 @@ Every RPC uses a URN in the form `urn:{domain}:{subsystem}:{function}:{version}`
 
 Each RPC domain has an aligned security role. Other than Auth and Public, all other domains require a bearer token and a security lookup before the function is executed on behalf of the user.
 
-## Account Domain
+## Admin Domain
 
 ### `roles`
 
 | Operation                           | Description                       |
 | ----------------------------------- | --------------------------------- |
-| `urn:account:roles:add_member:1`    | Add members to a given role.      |
-| `urn:account:roles:get_members:1`   | Get members of a given role.      |
-| `urn:account:roles:remove_member:1` | Remove members from a given role. |
+| `urn:admin:roles:add_member:1`      | Add members to a given role.      |
+| `urn:admin:roles:get_members:1`     | Get members of a given role.      |
+| `urn:admin:roles:remove_member:1`   | Remove members from a given role. |
 
 ### `users`
 
 | Operation                            | Description                                      |
 | ------------------------------------ | ------------------------------------------------ |
-| `urn:account:users:get_profile:1`    | Get a user's profile details.                    |
-| `urn:account:users:set_credits:1`    | Moderator can set user credit amount.            |
-| `urn:account:users:enable_storage:1` | Moderator can enable user storage.               |
-| `urn:account:users:reset_display:1`  | Moderator reset of user display name to default. |
+| `urn:admin:users:get_profile:1`      | Get a user's profile details.                    |
+| `urn:admin:users:set_credits:1`      | Moderator can set user credit amount.            |
+| `urn:admin:users:enable_storage:1`   | Moderator can enable user storage.               |
+| `urn:admin:users:reset_display:1`    | Moderator reset of user display name to default. |
 
 ## Users Domain
 

--- a/rpc/admin/roles/__init__.py
+++ b/rpc/admin/roles/__init__.py
@@ -1,15 +1,15 @@
 from .services import (
-  account_roles_get_members_v1,
-  account_roles_add_member_v1,
-  account_roles_remove_member_v1
+  admin_roles_get_members_v1,
+  admin_roles_add_member_v1,
+  admin_roles_remove_member_v1
 )
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   # This module is used by moderators to manage user role membership.
-  # This namespace is restricted to those with the ACCOUNT role.
-  ("get_members", "1"): account_roles_get_members_v1,
-  ("add_member", "1"): account_roles_add_member_v1,
-  ("remove_member", "1"): account_roles_remove_member_v1
+  # This namespace is restricted to those with the ADMIN role.
+  ("get_members", "1"): admin_roles_get_members_v1,
+  ("add_member", "1"): admin_roles_add_member_v1,
+  ("remove_member", "1"): admin_roles_remove_member_v1
 }
 

--- a/rpc/admin/roles/services.py
+++ b/rpc/admin/roles/services.py
@@ -1,11 +1,11 @@
 from fastapi import Request
 
-async def account_roles_get_members_v1(request: Request):
-  raise NotImplementedError("urn:account:roles:get_members:1")
+async def admin_roles_get_members_v1(request: Request):
+  raise NotImplementedError("urn:admin:roles:get_members:1")
 
-async def account_roles_add_member_v1(request: Request):
-  raise NotImplementedError("urn:account:roles:add_member:1")
+async def admin_roles_add_member_v1(request: Request):
+  raise NotImplementedError("urn:admin:roles:add_member:1")
 
-async def account_roles_remove_member_v1(request: Request):
-  raise NotImplementedError("urn:account:roles:remove_member:1")
+async def admin_roles_remove_member_v1(request: Request):
+  raise NotImplementedError("urn:admin:roles:remove_member:1")
 

--- a/rpc/admin/users/__init__.py
+++ b/rpc/admin/users/__init__.py
@@ -1,17 +1,17 @@
 from .services import (
-  account_users_get_profile_v1,
-  account_users_reset_display_v1,
-  account_users_set_credits_v1, 
-  account_users_enable_storage_v1
+  admin_users_get_profile_v1,
+  admin_users_reset_display_v1,
+  admin_users_set_credits_v1,
+  admin_users_enable_storage_v1
 )
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   # This module is used by moderators to manage user accounts.
-  # This namespace is restricted to those with the ACCOUNT role.
-  ("get_profile", "1"): account_users_get_profile_v1,
-  ("set_credits", "1"): account_users_set_credits_v1,
-  ("reset_display", "1"): account_users_reset_display_v1,
-  ("enable_storage", "1"): account_users_enable_storage_v1
+  # This namespace is restricted to those with the ADMIN role.
+  ("get_profile", "1"): admin_users_get_profile_v1,
+  ("set_credits", "1"): admin_users_set_credits_v1,
+  ("reset_display", "1"): admin_users_reset_display_v1,
+  ("enable_storage", "1"): admin_users_enable_storage_v1
 }
 

--- a/rpc/admin/users/services.py
+++ b/rpc/admin/users/services.py
@@ -1,14 +1,14 @@
 from fastapi import Request
 
-async def account_users_get_profile_v1(request: Request):
-  raise NotImplementedError("urn:account:users:get_profile:1")
+async def admin_users_get_profile_v1(request: Request):
+  raise NotImplementedError("urn:admin:users:get_profile:1")
 
-async def account_users_set_credits_v1(request: Request):
-  raise NotImplementedError("urn:account:users:set_credits:1")
+async def admin_users_set_credits_v1(request: Request):
+  raise NotImplementedError("urn:admin:users:set_credits:1")
 
-async def account_users_reset_display_v1(request: Request):
-  raise NotImplementedError("urn:account:users:reset_display:1")
+async def admin_users_reset_display_v1(request: Request):
+  raise NotImplementedError("urn:admin:users:reset_display:1")
 
-async def account_users_enable_storage_v1(request: Request):
-  raise NotImplementedError("urn:account:users:enable_storage:1")
+async def admin_users_enable_storage_v1(request: Request):
+  raise NotImplementedError("urn:admin:users:enable_storage:1")
 

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -1,31 +1,31 @@
 {
   "rpc": [
     {
-      "op": "urn:account:roles:add_member:1",
+      "op": "urn:admin:roles:add_member:1",
       "capabilities": 0
     },
     {
-      "op": "urn:account:roles:get_members:1",
+      "op": "urn:admin:roles:get_members:1",
       "capabilities": 0
     },
     {
-      "op": "urn:account:roles:remove_member:1",
+      "op": "urn:admin:roles:remove_member:1",
       "capabilities": 0
     },
     {
-      "op": "urn:account:users:enable_storage:1",
+      "op": "urn:admin:users:enable_storage:1",
       "capabilities": 0
     },
     {
-      "op": "urn:account:users:get_profile:1",
+      "op": "urn:admin:users:get_profile:1",
       "capabilities": 0
     },
     {
-      "op": "urn:account:users:reset_display:1",
+      "op": "urn:admin:users:reset_display:1",
       "capabilities": 0
     },
     {
-      "op": "urn:account:users:set_credits:1",
+      "op": "urn:admin:users:set_credits:1",
       "capabilities": 0
     },
     {
@@ -58,6 +58,10 @@
     },
     {
       "op": "urn:public:vars:get_hostname:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:public:vars:get_odbc_version:1",
       "capabilities": 0
     },
     {
@@ -145,15 +149,15 @@
       "capabilities": 0
     },
     {
-      "op": "urn:users:user:get_profile:1",
+      "op": "urn:users:profile:get_profile:1",
       "capabilities": 0
     },
     {
-      "op": "urn:users:user:set_display:1",
+      "op": "urn:users:profile:set_display:1",
       "capabilities": 0
     },
     {
-      "op": "urn:users:user:set_optin:1",
+      "op": "urn:users:profile:set_optin:1",
       "capabilities": 0
     }
   ]


### PR DESCRIPTION
## Summary
- rename account RPC functions to admin equivalents
- update metadata and docs for admin URNs

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars in UserContextProvider.tsx)*
- `npm run type-check` *(fails: numerous TS2554 errors)*
- `npx vitest run` *(fails: module not found errors in tests)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68954bc83b9c83259ea92e53444b0790