### PR TITLE
docs: rename user profile section

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -31,13 +31,15 @@ Each RPC domain has an aligned security role. Other than Auth and Public, all ot
 
 ## Users Domain
 
-### `user`
+All Users domain calls require `ROLE_USERS_ENABLED`.
 
-| Operation                      | Description                                    |
-| ------------------------------ | ---------------------------------------------- |
-| `urn:users:user:get_profile:1` | Get a user's profile data.                     |
-| `urn:users:user:set_display:1` | A user can set their display name.             |
-| `urn:users:user:set_optin:1`   | A user can select if their email is displayed. |
+### `profile`
+
+| Operation                         | Description                                    |
+| --------------------------------- | ---------------------------------------------- |
+| `urn:users:profile:get_profile:1` | Get a user's profile data.                     |
+| `urn:users:profile:set_display:1` | A user can set their display name.             |
+| `urn:users:profile:set_optin:1`   | A user can select if their email is displayed. |
 
 ### `auth`
 


### PR DESCRIPTION
## Summary
- rename Users domain `user` subsection to `profile`
- document `ROLE_USERS_ENABLED` requirement for Users domain

## Testing
- `python scripts/run_tests.py --test` *(fails: Command '['npm', 'run', 'type-check']' returned non-zero exit status 2)*

------
https://chatgpt.com/codex/tasks/task_e_6895506436288325a9140a5b4482ba1f