### PR TITLE
Rename user profile RPC service functions

### DIFF
--- a/rpc/users/profile/__init__.py
+++ b/rpc/users/profile/__init__.py
@@ -1,13 +1,13 @@
 from .services import (
-  users_user_get_profile_v1,
-  users_user_set_display_v1,
-  users_user_set_optin_v1
+  users_profile_get_profile_v1,
+  users_profile_set_display_v1,
+  users_profile_set_optin_v1
 )
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
-  ("get_profile", "1"): users_user_get_profile_v1,
-  ("set_display", "1"): users_user_set_display_v1,
-  ("set_optin", "1"): users_user_set_optin_v1
+  ("get_profile", "1"): users_profile_get_profile_v1,
+  ("set_display", "1"): users_profile_set_display_v1,
+  ("set_optin", "1"): users_profile_set_optin_v1
 }
 

--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -1,11 +1,11 @@
 from fastapi import Request
 
-async def users_user_get_profile_v1(request: Request):
-  raise NotImplementedError("urn:users:user:get_profile:1")
+async def users_profile_get_profile_v1(request: Request):
+  raise NotImplementedError("urn:users:profile:get_profile:1")
 
-async def users_user_set_display_v1(request: Request):
-  raise NotImplementedError("urn:users:user:set_display:1")
+async def users_profile_set_display_v1(request: Request):
+  raise NotImplementedError("urn:users:profile:set_display:1")
 
-async def users_user_set_optin_v1(request: Request):
-  raise NotImplementedError("urn:users:user:set_optin:1")
+async def users_profile_set_optin_v1(request: Request):
+  raise NotImplementedError("urn:users:profile:set_optin:1")
 


### PR DESCRIPTION
## Summary
- rename user profile service functions to `users_profile_*`
- update dispatcher imports for renamed profile services

## Testing
- `python scripts/run_tests.py --test` *(fails: Command '['npm', 'run', 'lint']' returned non-zero exit status 1)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689554b41eac8325a5a3cf7d1775fb58