### PR TITLE
Document role requirements for RPC namespaces

### DIFF
--- a/rpc/__init__.py
+++ b/rpc/__init__.py
@@ -1,3 +1,9 @@
+"""RPC namespace root.
+
+Exports handlers for each RPC domain with role-based access.
+The auth and public domains are exempt from role checks.
+"""
+
 from .admin.handler import handle_admin_request
 from .auth.handler import handle_auth_request
 from .public.handler import handle_public_request

--- a/rpc/admin/handler.py
+++ b/rpc/admin/handler.py
@@ -1,3 +1,9 @@
+"""Admin RPC namespace.
+
+Handles administrative operations requiring ROLE_ADMIN_SUPPORT.
+Auth and public domains are exempt from role checks.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse

--- a/rpc/storage/handler.py
+++ b/rpc/storage/handler.py
@@ -1,3 +1,9 @@
+"""Storage RPC namespace.
+
+Provides storage operations requiring ROLE_STORAGE_ENABLED.
+Auth and public domains are exempt from role checks.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse

--- a/rpc/system/handler.py
+++ b/rpc/system/handler.py
@@ -1,3 +1,9 @@
+"""System RPC namespace.
+
+Contains system-level operations requiring ROLE_SYSTEM_ADMIN.
+Auth and public domains are exempt from role checks.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse

--- a/rpc/users/handler.py
+++ b/rpc/users/handler.py
@@ -1,3 +1,9 @@
+"""Users RPC namespace.
+
+Manages user operations requiring ROLE_USERS_ENABLED.
+Auth and public domains are exempt from role checks.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse


### PR DESCRIPTION
## Summary
- describe RPC package purpose and note auth/public exemptions from role checks
- document required roles for admin, storage, system, and users RPC handlers

## Testing
- `python scripts/run_tests.py --test` *(fails: 'npm run lint' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_689557cea79c8325b014d41b1124edf7