### PR TITLE
Add service, security, and moderation RPC namespaces

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -131,3 +131,33 @@ These calls expose system administration functionality.
 | `urn:system:routes:get_routes:1`   | List application routes.             |
 | `urn:system:routes:upsert_route:1` | Create or update a route definition. |
 | `urn:system:routes:delete_route:1` | Delete a route definition.           |
+
+## Service Domain
+
+All Service domain calls require `ROLE_SERVICE_ADMIN`.
+
+### `general`
+
+| Operation                         | Description                         |
+| --------------------------------- | ----------------------------------- |
+| `urn:service:health_check:1`     | Placeholder service health check.  |
+
+## Security Domain
+
+All Security domain calls require `ROLE_SECURITY_ADMIN`.
+
+### `audit`
+
+| Operation                         | Description                         |
+| --------------------------------- | ----------------------------------- |
+| `urn:security:audit_log:1`       | Placeholder audit log retrieval.    |
+
+## Moderation Domain
+
+All Moderation domain calls require `ROLE_MODERATOR`.
+
+### `content`
+
+| Operation                            | Description                          |
+| ------------------------------------ | ------------------------------------ |
+| `urn:moderation:review_content:1`   | Placeholder content review task.    |

--- a/rpc/__init__.py
+++ b/rpc/__init__.py
@@ -6,7 +6,10 @@ The auth and public domains are exempt from role checks.
 
 from .admin.handler import handle_admin_request
 from .auth.handler import handle_auth_request
+from .moderation.handler import handle_moderation_request
 from .public.handler import handle_public_request
+from .security.handler import handle_security_request
+from .service.handler import handle_service_request
 from .storage.handler import handle_storage_request
 from .system.handler import handle_system_request
 from .users.handler import handle_users_request
@@ -15,7 +18,10 @@ from .users.handler import handle_users_request
 HANDLERS: dict[str, callable] = {
   "admin": handle_admin_request,
   "auth": handle_auth_request,
+  "moderation": handle_moderation_request,
   "public": handle_public_request,
+  "security": handle_security_request,
+  "service": handle_service_request,
   "storage": handle_storage_request,
   "system": handle_system_request,
   "users": handle_users_request

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -45,6 +45,10 @@
       "capabilities": 0
     },
     {
+      "op": "urn:moderation:review_content:1",
+      "capabilities": 0
+    },
+    {
       "op": "urn:public:links:get_home_links:1",
       "capabilities": 0
     },
@@ -70,6 +74,14 @@
     },
     {
       "op": "urn:public:vars:get_version:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:security:audit_log:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:service:health_check:1",
       "capabilities": 0
     },
     {

--- a/rpc/moderation/__init__.py
+++ b/rpc/moderation/__init__.py
@@ -1,0 +1,6 @@
+from .services import moderation_review_content_v1
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  # Requires ROLE_MODERATOR.
+  ("review_content", "1"): moderation_review_content_v1
+}

--- a/rpc/moderation/handler.py
+++ b/rpc/moderation/handler.py
@@ -1,0 +1,18 @@
+"""Moderation RPC namespace.
+
+Handles content moderation operations requiring ROLE_MODERATOR.
+"""
+
+from fastapi import HTTPException, Request
+
+from rpc.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_moderation_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail="Unknown RPC operation")
+  return await handler(request)

--- a/rpc/moderation/models.py
+++ b/rpc/moderation/models.py
@@ -1,0 +1,1 @@
+from pydantic import BaseModel

--- a/rpc/moderation/services.py
+++ b/rpc/moderation/services.py
@@ -1,0 +1,5 @@
+from fastapi import Request
+
+
+async def moderation_review_content_v1(request: Request):
+  raise NotImplementedError("urn:moderation:review_content:1")

--- a/rpc/security/__init__.py
+++ b/rpc/security/__init__.py
@@ -1,0 +1,6 @@
+from .services import security_audit_log_v1
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  # Requires ROLE_SECURITY_ADMIN.
+  ("audit_log", "1"): security_audit_log_v1
+}

--- a/rpc/security/handler.py
+++ b/rpc/security/handler.py
@@ -1,0 +1,18 @@
+"""Security RPC namespace.
+
+Handles security operations requiring ROLE_SECURITY_ADMIN.
+"""
+
+from fastapi import HTTPException, Request
+
+from rpc.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_security_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail="Unknown RPC operation")
+  return await handler(request)

--- a/rpc/security/models.py
+++ b/rpc/security/models.py
@@ -1,0 +1,1 @@
+from pydantic import BaseModel

--- a/rpc/security/services.py
+++ b/rpc/security/services.py
@@ -1,0 +1,5 @@
+from fastapi import Request
+
+
+async def security_audit_log_v1(request: Request):
+  raise NotImplementedError("urn:security:audit_log:1")

--- a/rpc/service/__init__.py
+++ b/rpc/service/__init__.py
@@ -1,0 +1,6 @@
+from .services import service_health_check_v1
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  # Requires ROLE_SERVICE_ADMIN.
+  ("health_check", "1"): service_health_check_v1
+}

--- a/rpc/service/handler.py
+++ b/rpc/service/handler.py
@@ -1,0 +1,18 @@
+"""Service RPC namespace.
+
+Handles service operations requiring ROLE_SERVICE_ADMIN.
+"""
+
+from fastapi import HTTPException, Request
+
+from rpc.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_service_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail="Unknown RPC operation")
+  return await handler(request)

--- a/rpc/service/models.py
+++ b/rpc/service/models.py
@@ -1,0 +1,1 @@
+from pydantic import BaseModel

--- a/rpc/service/services.py
+++ b/rpc/service/services.py
@@ -1,0 +1,5 @@
+from fastapi import Request
+
+
+async def service_health_check_v1(request: Request):
+  raise NotImplementedError("urn:service:health_check:1")


### PR DESCRIPTION
## Summary
- scaffold service, security, and moderation RPC namespaces with role notes
- register new namespaces and document placeholder operations

## Testing
- `npm --prefix frontend run lint` *(fails: useEffect is defined but never used)*
- `npm --prefix frontend run type-check` *(fails: Expected 4 arguments, but got 2)*
- `npm --prefix frontend test` *(fails: module not found errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689559d695f48325aeb8ee5a2f8bd5fd