### PR TITLE
docs: clarify roles for RPC initializers

### DIFF
--- a/rpc/storage/files/__init__.py
+++ b/rpc/storage/files/__init__.py
@@ -1,3 +1,8 @@
+"""File storage RPC namespace.
+
+Requires ROLE_STORAGE_ENABLED.
+"""
+
 from .services import (
   storage_files_get_files_v1,
   storage_files_upload_files_v1,

--- a/rpc/system/routes/__init__.py
+++ b/rpc/system/routes/__init__.py
@@ -1,3 +1,8 @@
+"""System routes RPC namespace.
+
+Requires ROLE_SYSTEM_ADMIN.
+"""
+
 from .services import (
   system_routes_delete_route_v1,
   system_routes_get_routes_v1,

--- a/rpc/users/auth/__init__.py
+++ b/rpc/users/auth/__init__.py
@@ -1,3 +1,8 @@
+"""Users auth RPC namespace.
+
+Unauthenticated; no role required.
+"""
+
 from .services import (users_auth_set_provider_v1,
                        users_auth_link_provider_v1,
                        users_auth_unlink_provider_v1)

--- a/rpc/users/profile/__init__.py
+++ b/rpc/users/profile/__init__.py
@@ -1,3 +1,8 @@
+"""Users profile RPC namespace.
+
+Requires ROLE_USERS_ENABLED.
+"""
+
 from .services import (
   users_profile_get_profile_v1,
   users_profile_set_display_v1,


### PR DESCRIPTION
## Summary
- document required roles for users/profile, storage/files, and system/routes RPC namespaces
- mark users/auth namespace as unauthenticated

## Testing
- `python scripts/run_tests.py --test` *(fails: Command '['npm', 'run', 'lint']' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68955c8b1378832599969c5163b5abaf