### PR TITLE
Add moderation content RPC scaffold

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -160,4 +160,4 @@ All Moderation domain calls require `ROLE_MODERATOR`.
 
 | Operation                            | Description                          |
 | ------------------------------------ | ------------------------------------ |
-| `urn:moderation:review_content:1`   | Placeholder content review task.    |
+| `urn:moderation:content:review_content:1` | Placeholder content review task.    |

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -45,7 +45,7 @@
       "capabilities": 0
     },
     {
-      "op": "urn:moderation:review_content:1",
+      "op": "urn:moderation:content:review_content:1",
       "capabilities": 0
     },
     {
@@ -77,7 +77,27 @@
       "capabilities": 0
     },
     {
-      "op": "urn:security:audit_log:1",
+      "op": "urn:security:roles:add_role_member:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:security:roles:delete_role:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:security:roles:get_role_members:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:security:roles:get_roles:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:security:roles:remove_role_member:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:security:roles:upsert_role:1",
       "capabilities": 0
     },
     {
@@ -110,30 +130,6 @@
     },
     {
       "op": "urn:system:config:upsert_config:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:system:roles:add_role_member:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:system:roles:delete_role:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:system:roles:get_role_members:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:system:roles:get_roles:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:system:roles:remove_role_member:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:system:roles:upsert_role:1",
       "capabilities": 0
     },
     {

--- a/rpc/moderation/__init__.py
+++ b/rpc/moderation/__init__.py
@@ -1,0 +1,5 @@
+from .content.handler import handle_content_request
+
+HANDLERS: dict[str, callable] = {
+  "content": handle_content_request,
+}

--- a/rpc/moderation/content/__init__.py
+++ b/rpc/moderation/content/__init__.py
@@ -1,0 +1,12 @@
+"""Content moderation RPC namespace.
+
+Requires ROLE_MODERATOR.
+"""
+
+from .services import (
+  moderation_content_review_content_v1,
+)
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("review_content", "1"): moderation_content_review_content_v1,
+}

--- a/rpc/moderation/content/handler.py
+++ b/rpc/moderation/content/handler.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, Request
+
+from rpc.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_content_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/moderation/content/models.py
+++ b/rpc/moderation/content/models.py
@@ -1,0 +1,4 @@
+from typing import Optional
+
+from pydantic import BaseModel
+

--- a/rpc/moderation/content/services.py
+++ b/rpc/moderation/content/services.py
@@ -1,0 +1,6 @@
+from fastapi import Request
+
+
+async def moderation_content_review_content_v1(request: Request):
+  raise NotImplementedError("urn:moderation:content:review_content:1")
+

--- a/rpc/moderation/handler.py
+++ b/rpc/moderation/handler.py
@@ -1,0 +1,19 @@
+"""Moderation RPC namespace.
+
+Handles moderation operations requiring ROLE_MODERATOR.
+Auth and public domains are exempt from role checks.
+"""
+
+from fastapi import HTTPException, Request
+
+from rpc.models import RPCResponse
+
+from . import HANDLERS
+
+
+async def handle_moderation_request(parts: list[str], request: Request) -> RPCResponse:
+  subdomain = parts[0]
+  handler = HANDLERS.get(subdomain)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC subdomain')
+  return await handler(parts[1:], request)


### PR DESCRIPTION
## Summary
- add content subdomain to moderation RPC with dispatcher and stub service
- document `urn:moderation:content:review_content:1`

## Testing
- `python scripts/run_tests.py --test` *(fails: useEffect is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_6895634c445c8325a81c2dcb0f970a00