### PR TITLE
Refactor security roles RPC namespace and add audit log stub

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -105,17 +105,6 @@ Calls for user storage management
 
 These calls expose system administration functionality.
 
-### `roles`
-
-| Operation                               | Description                                  |
-| --------------------------------------- | -------------------------------------------- |
-| `urn:system:roles:get_roles:1`          | List all role names and their bit positions. |
-| `urn:system:roles:get_role_members:1`   | Get members and non-members for a role.      |
-| `urn:system:roles:add_role_member:1`    | Add members to a role.                       |
-| `urn:system:roles:remove_role_member:1` | Remove members from a role.                  |
-| `urn:system:roles:upsert_role:1`        | Create or update a role definition.          |
-| `urn:system:roles:delete_role:1`        | Delete a role.                               |
-
 ### `config`
 
 | Operation                           | Description                             |
@@ -145,6 +134,17 @@ All Service domain calls require `ROLE_SERVICE_ADMIN`.
 ## Security Domain
 
 All Security domain calls require `ROLE_SECURITY_ADMIN`.
+
+### `roles`
+
+| Operation                               | Description                                  |
+| --------------------------------------- | -------------------------------------------- |
+| `urn:security:roles:get_roles:1`        | List all role names and their bit positions. |
+| `urn:security:roles:get_role_members:1` | Get members and non-members for a role.      |
+| `urn:security:roles:add_role_member:1`  | Add members to a role.                       |
+| `urn:security:roles:remove_role_member:1` | Remove members from a role.                |
+| `urn:security:roles:upsert_role:1`      | Create or update a role definition.          |
+| `urn:security:roles:delete_role:1`      | Delete a role.                               |
 
 ### `audit`
 

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -77,6 +77,10 @@
       "capabilities": 0
     },
     {
+      "op": "urn:security:audit_log:1",
+      "capabilities": 0
+    },
+    {
       "op": "urn:security:roles:add_role_member:1",
       "capabilities": 0
     },

--- a/rpc/security/__init__.py
+++ b/rpc/security/__init__.py
@@ -1,0 +1,11 @@
+from .roles.handler import handle_roles_request
+from .services import security_audit_log_v1
+
+HANDLERS: dict[str, callable] = {
+  "roles": handle_roles_request
+}
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("audit_log", "1"): security_audit_log_v1
+}
+

--- a/rpc/security/handler.py
+++ b/rpc/security/handler.py
@@ -1,0 +1,24 @@
+"""Security RPC namespace.
+
+Handles security operations requiring ROLE_SECURITY_ADMIN.
+Auth and public domains are exempt from role checks.
+"""
+
+from fastapi import HTTPException, Request
+
+from rpc.models import RPCResponse
+
+from . import HANDLERS, DISPATCHERS
+
+
+async def handle_security_request(parts: list[str], request: Request) -> RPCResponse:
+  subdomain = parts[0]
+  handler = HANDLERS.get(subdomain)
+  if handler:
+    return await handler(parts[1:], request)
+  key = tuple(parts[:2])
+  dispatcher = DISPATCHERS.get(key)
+  if not dispatcher:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await dispatcher(request)
+

--- a/rpc/security/roles/__init__.py
+++ b/rpc/security/roles/__init__.py
@@ -1,10 +1,10 @@
 from .services import (
-  system_roles_get_roles_v1,
-  system_roles_upsert_role_v1,
-  system_roles_delete_role_v1,
-  system_roles_get_role_members_v1,
-  system_roles_add_role_member_v1,
-  system_roles_remove_member_v1
+  security_roles_get_roles_v1,
+  security_roles_upsert_role_v1,
+  security_roles_delete_role_v1,
+  security_roles_get_role_members_v1,
+  security_roles_add_role_member_v1,
+  security_roles_remove_role_member_v1
 )
 
 
@@ -13,12 +13,12 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   # managing role membership. The roles are stored in the database. 
   # Each role has a bitmask flag. Users have a combined bitmask value 
   # stored for all roles assigned.
-  # This namespace is restricted to users with the SYSTEM role.
-  ("get_roles", "1"): system_roles_get_roles_v1,
-  ("upsert_role", "1"): system_roles_upsert_role_v1,
-  ("delete_role", "1"): system_roles_delete_role_v1,
-  ("get_role_members", "1"): system_roles_get_role_members_v1,
-  ("add_role_member", "1"): system_roles_add_role_member_v1,
-  ("remove_role_member", "1"): system_roles_remove_member_v1
+  # This namespace is restricted to users with the SECURITY role.
+  ("get_roles", "1"): security_roles_get_roles_v1,
+  ("upsert_role", "1"): security_roles_upsert_role_v1,
+  ("delete_role", "1"): security_roles_delete_role_v1,
+  ("get_role_members", "1"): security_roles_get_role_members_v1,
+  ("add_role_member", "1"): security_roles_add_role_member_v1,
+  ("remove_role_member", "1"): security_roles_remove_role_member_v1
 }
 

--- a/rpc/security/roles/services.py
+++ b/rpc/security/roles/services.py
@@ -1,20 +1,20 @@
 from fastapi import Request
 
-async def system_roles_get_roles_v1(request: Request):
-  raise NotImplementedError("urn:system:roles:get_roles:1")
+async def security_roles_get_roles_v1(request: Request):
+  raise NotImplementedError("urn:security:roles:get_roles:1")
 
-async def system_roles_upsert_role_v1(request: Request):
-  raise NotImplementedError("urn:system:roles:upsert_role:1")
+async def security_roles_upsert_role_v1(request: Request):
+  raise NotImplementedError("urn:security:roles:upsert_role:1")
 
-async def system_roles_delete_role_v1(request: Request):
-  raise NotImplementedError("urn:system:roles:delete_role:1")
+async def security_roles_delete_role_v1(request: Request):
+  raise NotImplementedError("urn:security:roles:delete_role:1")
 
-async def system_roles_get_role_members_v1(request: Request):
-  raise NotImplementedError("urn:system:roles:get_role_members:1")
+async def security_roles_get_role_members_v1(request: Request):
+  raise NotImplementedError("urn:security:roles:get_role_members:1")
 
-async def system_roles_add_role_member_v1(request: Request):
-  raise NotImplementedError("urn:system:roles:add_role_member:1")
+async def security_roles_add_role_member_v1(request: Request):
+  raise NotImplementedError("urn:security:roles:add_role_member:1")
 
-async def system_roles_remove_member_v1(request: Request):
-  raise NotImplementedError("urn:system:roles:remove_role_member:1")
+async def security_roles_remove_role_member_v1(request: Request):
+  raise NotImplementedError("urn:security:roles:remove_role_member:1")
 

--- a/rpc/security/services.py
+++ b/rpc/security/services.py
@@ -1,0 +1,5 @@
+from fastapi import Request
+
+async def security_audit_log_v1(request: Request):
+  raise NotImplementedError("urn:security:audit_log:1")
+


### PR DESCRIPTION
## Summary
- rename system roles services to security roles and adjust URNs
- add security audit log RPC stub and dispatcher
- route security domain requests to subdomains or root operations

## Testing
- `python scripts/generate_rpc_metadata.py`
- `npm run lint` *(fails: 'useEffect' is defined but never used)*
- `npm run type-check` *(fails: TS2554 expected 4 arguments, but got 2)*
- `npx vitest run` *(fails: Cannot find module '../src/shared/ColumnHeader')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68956506541c83259be30801652a19f9