### PR TITLE
docs: clarify auth and public namespaces

### DIFF
--- a/rpc/auth/handler.py
+++ b/rpc/auth/handler.py
@@ -1,3 +1,9 @@
+"""Handlers for the authentication namespace.
+
+These operations manage login and session flow and are exempt from
+security role checks.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse

--- a/rpc/public/handler.py
+++ b/rpc/public/handler.py
@@ -1,3 +1,9 @@
+"""Handlers for the public namespace accessed by the frontend.
+
+These operations serve unauthenticated data and are exempt from
+security role checks.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse


### PR DESCRIPTION
## Summary
- document auth namespace handlers as exempt from security role checks
- document public namespace handlers as exempt from security role checks

## Testing
- `python scripts/generate_rpc_metadata.py`
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `npm run lint` *(fails: 'useEffect' is defined but never used)*
- `npm run type-check` *(fails: Expected 4 arguments, but got 2)*
- `npm test` *(fails: Cannot find module '../src/shared/ColumnHeader')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68956d43a0b48325bcc92b306139f46a