### PR TITLE
doc: add security docstrings to rpc handlers

### DIFF
--- a/rpc/admin/roles/handler.py
+++ b/rpc/admin/roles/handler.py
@@ -1,3 +1,8 @@
+"""Admin roles RPC handler.
+
+Dispatches role membership operations requiring ROLE_ADMIN_SUPPORT.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse

--- a/rpc/admin/users/handler.py
+++ b/rpc/admin/users/handler.py
@@ -1,3 +1,8 @@
+"""Admin users RPC handler.
+
+Dispatches user management operations requiring ROLE_ADMIN_SUPPORT.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse

--- a/rpc/moderation/content/handler.py
+++ b/rpc/moderation/content/handler.py
@@ -1,3 +1,8 @@
+"""Moderation content RPC handler.
+
+Dispatches content review operations requiring ROLE_MODERATOR.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse

--- a/rpc/security/roles/handler.py
+++ b/rpc/security/roles/handler.py
@@ -1,3 +1,8 @@
+"""Security roles RPC handler.
+
+Dispatches role management operations requiring ROLE_SECURITY_ADMIN.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse

--- a/rpc/storage/files/handler.py
+++ b/rpc/storage/files/handler.py
@@ -1,3 +1,8 @@
+"""Storage files RPC handler.
+
+Dispatches file operations requiring ROLE_STORAGE_ENABLED.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse

--- a/rpc/system/config/handler.py
+++ b/rpc/system/config/handler.py
@@ -1,3 +1,8 @@
+"""System config RPC handler.
+
+Dispatches configuration operations requiring ROLE_SYSTEM_ADMIN.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse

--- a/rpc/system/routes/handler.py
+++ b/rpc/system/routes/handler.py
@@ -1,3 +1,8 @@
+"""System routes RPC handler.
+
+Dispatches route management operations requiring ROLE_SYSTEM_ADMIN.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse

--- a/rpc/users/auth/handler.py
+++ b/rpc/users/auth/handler.py
@@ -1,3 +1,8 @@
+"""Users auth RPC handler.
+
+Dispatches provider management operations. Unauthenticated; no role required.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse

--- a/rpc/users/profile/handler.py
+++ b/rpc/users/profile/handler.py
@@ -1,3 +1,8 @@
+"""Users profile RPC handler.
+
+Dispatches profile operations requiring ROLE_USERS_ENABLED.
+"""
+
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCResponse


### PR DESCRIPTION
## Summary
- document admin role and user RPC dispatchers with ROLE_ADMIN_SUPPORT
- add user profile/auth handler docstrings noting security roles
- note required roles for security, moderation, storage, and system handlers

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `python scripts/generate_rpc_metadata.py`
- `npm run lint` *(fails: 'useEffect' is defined but never used)*
- `npm run type-check` *(fails: TS2554 and TS2307 errors)*
- `npx vitest run --coverage` *(fails: modules not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68956f0e30308325afe87bbf7dbd284f