### PR TITLE
Use explicit ROLE_MODERATION_SUPPORT constant in moderation modules

### DIFF
--- a/rpc/moderation/content/__init__.py
+++ b/rpc/moderation/content/__init__.py
@@ -1,6 +1,6 @@
 """Content moderation RPC namespace.
 
-Requires ROLE_MODERATOR.
+Requires ROLE_MODERATION_SUPPORT.
 """
 
 from .services import (

--- a/rpc/moderation/content/handler.py
+++ b/rpc/moderation/content/handler.py
@@ -1,6 +1,6 @@
 """Moderation content RPC handler.
 
-Dispatches content review operations requiring ROLE_MODERATOR.
+Dispatches content review operations requiring ROLE_MODERATION_SUPPORT.
 """
 
 from fastapi import HTTPException, Request


### PR DESCRIPTION
## Summary
- replace outdated ROLE_MODERATOR reference with ROLE_MODERATION_SUPPORT in moderation RPC modules

## Testing
- `python scripts/run_tests.py --test` *(fails: "useEffect" is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_689640d9043483259fa4513437ba09cc