### PR TITLE
feat: add database provider interface

### DIFF
--- a/rpc/account/roles/services.py
+++ b/rpc/account/roles/services.py
@@ -9,7 +9,7 @@ from rpc.account.roles.models import (
 )
 from rpc.account.users.models import UserListItem
 from rpc.models import RPCRequest, RPCResponse
-from server.modules.mssql_module import MSSQLModule, _utos
+from server.modules.database_provider import DatabaseProvider, _utos
 from server.helpers import roles as role_helper
 
 
@@ -25,7 +25,7 @@ def bit_to_mask(bit: int) -> int:
 
 
 async def list_roles_v2(request: Request) -> RPCResponse:
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   rows = await db.list_roles()
   roles = [
     RoleItem(name=r['name'], display=r['display'], bit=mask_to_bit(int(r['mask'])))
@@ -37,7 +37,7 @@ async def list_roles_v2(request: Request) -> RPCResponse:
 
 async def set_role_v2(rpc_request, request: Request) -> RPCResponse:
   data = AccountRoleUpdate2(**(rpc_request.payload or {}))
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   mask = bit_to_mask(data.bit)
   await db.set_role(data.name, mask, data.display)
   await role_helper.load_roles(db)
@@ -45,7 +45,7 @@ async def set_role_v2(rpc_request, request: Request) -> RPCResponse:
 
 async def delete_role_v2(rpc_request, request: Request) -> RPCResponse:
   data = AccountRoleDelete2(**(rpc_request.payload or {}))
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   await db.delete_role(data.name)
   await role_helper.load_roles(db)
   return await list_roles_v2(request)
@@ -55,7 +55,7 @@ async def get_role_members_v2(rpc_request, request: Request) -> RPCResponse:
   role = payload.get('role')
   if not role:
     raise HTTPException(status_code=400, detail='Missing role')
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   rows = await db.list_roles()
   role_map = {r['name']: int(r['mask']) for r in rows}
   mask = role_map.get(role)
@@ -74,7 +74,7 @@ async def get_role_members_v2(rpc_request, request: Request) -> RPCResponse:
 
 async def add_role_member_v2(rpc_request, request: Request) -> RPCResponse:
   data = AccountRoleMemberUpdate2(**(rpc_request.payload or {}))
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   rows = await db.list_roles()
   role_map = {r['name']: int(r['mask']) for r in rows}
   mask = role_map.get(data.role)
@@ -87,7 +87,7 @@ async def add_role_member_v2(rpc_request, request: Request) -> RPCResponse:
 
 async def remove_role_member_v2(rpc_request, request: Request) -> RPCResponse:
   data = AccountRoleMemberUpdate2(**(rpc_request.payload or {}))
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   rows = await db.list_roles()
   role_map = {r['name']: int(r['mask']) for r in rows}
   mask = role_map.get(data.role)

--- a/rpc/account/users/services.py
+++ b/rpc/account/users/services.py
@@ -9,7 +9,7 @@ from rpc.account.users.models import (
   AccountUserDisplayNameUpdate2,
   AccountUserProfile2,
 )
-from server.modules.mssql_module import MSSQLModule, _utos
+from server.modules.database_provider import DatabaseProvider, _utos
 from server.modules.storage_module import StorageModule
 from server.helpers.roles import (
   mask_to_names,
@@ -18,7 +18,7 @@ from server.helpers.roles import (
 )
 
 async def get_users_v2(request: Request) -> RPCResponse:
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   rows = await db.select_users()
   users = [UserListItem(guid=_utos(r['guid']), displayName=r['display_name']) for r in rows]
   payload = AccountUsersList2(users=users)
@@ -29,7 +29,7 @@ async def get_user_roles_v2(rpc_request: RPCRequest, request: Request) -> RPCRes
   guid = payload.get('userGuid')
   if not guid:
     raise HTTPException(status_code=400, detail='Missing userGuid')
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   mask = await db.get_user_roles(guid)
   roles = mask_to_names(mask)
   payload = AccountUserRoles2(roles=roles)
@@ -38,14 +38,14 @@ async def get_user_roles_v2(rpc_request: RPCRequest, request: Request) -> RPCRes
 async def set_user_roles_v2(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   payload = rpc_request.payload or {}
   data = AccountUserRolesUpdate2(**payload)
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   mask = names_to_mask(data.roles) | ROLE_REGISTERED
   await db.set_user_roles(data.userGuid, mask)
   payload = AccountUserRoles2(roles=mask_to_names(mask))
   return RPCResponse(op='urn:account:users:set_roles:2', payload=payload, version=2)
 
 async def list_available_roles_v2(request: Request) -> RPCResponse:
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   rows = await db.list_roles()
   names = [r['name'] for r in rows]
   payload = AccountUserRoles2(roles=names)
@@ -56,7 +56,7 @@ async def get_user_profile_v2(rpc_request: RPCRequest, request: Request) -> RPCR
   guid = payload.get('userGuid')
   if not guid:
     raise HTTPException(status_code=400, detail='Missing userGuid')
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   storage: StorageModule = request.app.state.storage
   user = await db.get_user_profile(guid)
   if not user:
@@ -80,7 +80,7 @@ async def get_user_profile_v2(rpc_request: RPCRequest, request: Request) -> RPCR
 async def set_user_credits_v2(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   payload = rpc_request.payload or {}
   data = AccountUserCreditsUpdate2(**payload)
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   storage: StorageModule = request.app.state.storage
   await db.set_user_credits(data.userGuid, data.credits)
   user = await db.get_user_profile(data.userGuid)
@@ -105,7 +105,7 @@ async def set_user_credits_v2(rpc_request: RPCRequest, request: Request) -> RPCR
 async def set_user_display_name_v2(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   payload = rpc_request.payload or {}
   data = AccountUserDisplayNameUpdate2(**payload)
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   storage: StorageModule = request.app.state.storage
   await db.update_display_name(data.userGuid, data.displayName)
   user = await db.get_user_profile(data.userGuid)
@@ -133,7 +133,7 @@ async def enable_user_storage_v2(rpc_request: RPCRequest, request: Request) -> R
   if not guid:
     raise HTTPException(status_code=400, detail='Missing userGuid')
   storage: StorageModule = request.app.state.storage
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   await storage.ensure_user_folder(guid)
   user = await db.get_user_profile(guid)
   if not user:

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -3,13 +3,13 @@ import logging
 from rpc.models import RPCResponse, RPCRequest
 from rpc.auth.microsoft.models import AuthMicrosoftLoginData1
 from server.modules.auth_module import AuthModule
-from server.modules.mssql_module import MSSQLModule, _utos
+from server.modules.database_provider import DatabaseProvider, _utos
 from server.helpers.roles import mask_to_names
 
 async def user_login_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   req_payload = rpc_request.payload or {}
   auth: AuthModule = request.app.state.auth
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   logging.debug(
     "user_login_v1 payload=%s",
     req_payload,

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -2,7 +2,7 @@ from fastapi import Request, HTTPException
 from rpc.models import RPCRequest, RPCResponse
 from rpc.auth.session.models import AuthSessionTokens1
 from server.modules.auth_module import AuthModule
-from server.modules.mssql_module import MSSQLModule
+from server.modules.database_provider import DatabaseProvider
 
 async def refresh_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   payload = rpc_request.payload or {}
@@ -10,7 +10,7 @@ async def refresh_v1(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   if not rotation:
     raise HTTPException(status_code=400, detail='Missing rotationToken')
   auth: AuthModule = request.app.state.auth
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   data = await auth.decode_rotation_token(rotation)
   session = await db.get_session_by_rotation(rotation)
   if not session:
@@ -27,7 +27,7 @@ async def invalidate_v1(rpc_request: RPCRequest, request: Request) -> RPCRespons
   rotation = payload.get('rotationToken')
   if not rotation:
     raise HTTPException(status_code=400, detail='Missing rotationToken')
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   session = await db.get_session_by_rotation(rotation)
   if session:
     await db.delete_session(session['session_id'])

--- a/rpc/frontend/links/services.py
+++ b/rpc/frontend/links/services.py
@@ -9,12 +9,12 @@ from rpc.frontend.links.models import (
   FrontendLinksHome2,
   FrontendLinksRoutes2,
 )
-from server.modules.mssql_module import MSSQLModule
+from server.modules.database_provider import DatabaseProvider
 from server.modules.permcap_module import PermCapModule
 
 
 async def get_home_v2(request: Request) -> RPCResponse:
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   permcap: PermCapModule = request.app.state.permcap
   role_mask = getattr(request.state, 'role_mask', 0)
   data = await db.select_links(role_mask)
@@ -27,7 +27,7 @@ async def get_home_v2(request: Request) -> RPCResponse:
   return RPCResponse(op="urn:frontend:links:home:2", payload=payload, version=2)
 
 async def get_routes_v2(request: Request) -> RPCResponse:
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   permcap: PermCapModule = request.app.state.permcap
   role_mask = getattr(request.state, 'role_mask', 0)
   data = await db.select_routes(role_mask)

--- a/rpc/frontend/user/services.py
+++ b/rpc/frontend/user/services.py
@@ -2,7 +2,7 @@ from fastapi import Request, HTTPException
 from rpc.models import RPCRequest, RPCResponse
 from rpc.frontend.user.models import FrontendUserProfileData1, FrontendUserSetDisplayName1
 from server.modules.auth_module import AuthModule
-from server.modules.mssql_module import MSSQLModule, _utos
+from server.modules.database_provider import DatabaseProvider, _utos
 from server.helpers.roles import mask_to_names
 from server.modules.storage_module import StorageModule
 
@@ -12,7 +12,7 @@ async def get_profile_data_v1(rpc_request: RPCRequest, request: Request) -> RPCR
   if not token:
     raise HTTPException(status_code=401, detail='Missing bearer token')
   auth: AuthModule = request.app.state.auth
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   storage: StorageModule = request.app.state.storage
   token_data = await auth.decode_bearer_token(token)
   guid = token_data['guid']
@@ -45,7 +45,7 @@ async def set_display_name_v1(rpc_request: RPCRequest, request: Request) -> RPCR
   if not token or display_name is None:
     raise HTTPException(status_code=400, detail='Missing parameters')
   auth: AuthModule = request.app.state.auth
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   storage: StorageModule = request.app.state.storage
   token_data = await auth.decode_bearer_token(token)
   guid = token_data['guid']

--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -8,7 +8,7 @@ from rpc.storage.handler import handle_storage_request
 from rpc.models import RPCRequest, RPCResponse
 from rpc.suffix import split_suffix, apply_suffixes
 from server.modules.auth_module import AuthModule
-from server.modules.mssql_module import MSSQLModule
+from server.modules.database_provider import DatabaseProvider
 from server.helpers.roles import ROLE_REGISTERED
 
 
@@ -19,7 +19,7 @@ async def _populate_request_roles(request: Request) -> None:
     return
   token = header.split(' ', 1)[1].strip()
   auth: AuthModule | None = getattr(request.app.state, 'auth', None)
-  db: MSSQLModule | None = getattr(request.app.state, 'mssql', None)
+  db: DatabaseProvider | None = getattr(request.app.state, 'mssql', None)
   if not auth or not db:
     return
   try:

--- a/rpc/system/config/services.py
+++ b/rpc/system/config/services.py
@@ -6,10 +6,10 @@ from rpc.system.config.models import (
   SystemConfigUpdate2,
   SystemConfigDelete2,
 )
-from server.modules.mssql_module import MSSQLModule
+from server.modules.database_provider import DatabaseProvider
 
 async def list_config_v2(request: Request) -> RPCResponse:
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   rows = await db.list_config()
   items = [ConfigItem(key=r['element_key'], value=str(r['element_value'])) for r in rows]
   payload = SystemConfigList2(items=items)
@@ -17,12 +17,12 @@ async def list_config_v2(request: Request) -> RPCResponse:
 
 async def set_config_v2(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   data = SystemConfigUpdate2(**(rpc_request.payload or {}))
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   await db.set_config_value(data.key, str(data.value))
   return await list_config_v2(request)
 
 async def delete_config_v2(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   data = SystemConfigDelete2(**(rpc_request.payload or {}))
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   await db.delete_config_value(data.key)
   return await list_config_v2(request)

--- a/rpc/system/routes/services.py
+++ b/rpc/system/routes/services.py
@@ -6,12 +6,12 @@ from rpc.system.routes.models import (
   SystemRouteUpdate2,
   SystemRouteDelete2,
 )
-from server.modules.mssql_module import MSSQLModule
+from server.modules.database_provider import DatabaseProvider
 from server.helpers.roles import mask_to_names, names_to_mask
 
 
 async def list_routes_v2(request: Request) -> RPCResponse:
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   rows = await db.list_routes()
   routes = [
     SystemRouteItem(
@@ -29,7 +29,7 @@ async def list_routes_v2(request: Request) -> RPCResponse:
 
 async def set_route_v2(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   data = SystemRouteUpdate2(**(rpc_request.payload or {}))
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   mask = names_to_mask(data.requiredRoles)
   await db.set_route(data.path, data.name, data.icon, mask, data.sequence)
   return await list_routes_v2(request)
@@ -37,6 +37,6 @@ async def set_route_v2(rpc_request: RPCRequest, request: Request) -> RPCResponse
 
 async def delete_route_v2(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   data = SystemRouteDelete2(**(rpc_request.payload or {}))
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   await db.delete_route(data.path)
   return await list_routes_v2(request)

--- a/rpc/system/users/services.py
+++ b/rpc/system/users/services.py
@@ -8,7 +8,7 @@ from rpc.system.users.models import (
   SystemUserCreditsUpdate2,
   SystemUserProfile2,
 )
-from server.modules.mssql_module import MSSQLModule, _utos
+from server.modules.database_provider import DatabaseProvider, _utos
 from server.modules.storage_module import StorageModule
 from server.helpers.roles import (
   mask_to_names,
@@ -17,7 +17,7 @@ from server.helpers.roles import (
 )
 
 async def get_users_v2(request: Request) -> RPCResponse:
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   rows = await db.select_users()
   users = [UserListItem(guid=_utos(r['guid']), displayName=r['display_name']) for r in rows]
   payload = SystemUsersList2(users=users)
@@ -28,7 +28,7 @@ async def get_user_roles_v2(rpc_request: RPCRequest, request: Request) -> RPCRes
   guid = payload.get('userGuid')
   if not guid:
     raise HTTPException(status_code=400, detail='Missing userGuid')
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   mask = await db.get_user_roles(guid)
   roles = mask_to_names(mask)
   payload = SystemUserRoles2(roles=roles)
@@ -37,14 +37,14 @@ async def get_user_roles_v2(rpc_request: RPCRequest, request: Request) -> RPCRes
 async def set_user_roles_v2(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   payload = rpc_request.payload or {}
   data = SystemUserRolesUpdate2(**payload)
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   mask = names_to_mask(data.roles) | ROLE_REGISTERED
   await db.set_user_roles(data.userGuid, mask)
   payload = SystemUserRoles2(roles=mask_to_names(mask))
   return RPCResponse(op='urn:system:users:set_roles:2', payload=payload, version=2)
 
 async def list_available_roles_v2(request: Request) -> RPCResponse:
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   rows = await db.list_roles()
   names = [r['name'] for r in rows]
   payload = SystemUserRoles2(roles=names)
@@ -55,7 +55,7 @@ async def get_user_profile_v2(rpc_request: RPCRequest, request: Request) -> RPCR
   guid = payload.get('userGuid')
   if not guid:
     raise HTTPException(status_code=400, detail='Missing userGuid')
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   storage: StorageModule = request.app.state.storage
   user = await db.get_user_profile(guid)
   if not user:
@@ -79,7 +79,7 @@ async def get_user_profile_v2(rpc_request: RPCRequest, request: Request) -> RPCR
 async def set_user_credits_v2(rpc_request: RPCRequest, request: Request) -> RPCResponse:
   payload = rpc_request.payload or {}
   data = SystemUserCreditsUpdate2(**payload)
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   storage: StorageModule = request.app.state.storage
   await db.set_user_credits(data.userGuid, data.credits)
   user = await db.get_user_profile(data.userGuid)
@@ -107,7 +107,7 @@ async def enable_user_storage_v2(rpc_request: RPCRequest, request: Request) -> R
   if not guid:
     raise HTTPException(status_code=400, detail='Missing userGuid')
   storage: StorageModule = request.app.state.storage
-  db: MSSQLModule = request.app.state.mssql
+  db: DatabaseProvider = request.app.state.mssql
   await storage.ensure_user_folder(guid)
   user = await db.get_user_profile(guid)
   if not user:

--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -9,14 +9,14 @@ from server.modules.storage_module import StorageModule
 from server.modules.discord_module import DiscordModule
 from server.modules.auth_module import AuthModule
 from server.modules.permcap_module import PermCapModule
-from server.modules.mssql_module import MSSQLModule
+from server.modules.mssql_provider import MSSQLProvider
 
 from server.helpers import roles as role_helper
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
   mssql_dsn = os.getenv("AZURE_SQL_CONNECTION_STRING")
-  app.state.mssql = MSSQLModule(app, dsn=mssql_dsn)
+  app.state.mssql = MSSQLProvider(app, dsn=mssql_dsn)
   await app.state.mssql.startup()
 
   await role_helper.load_roles(app.state.mssql)

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 from . import BaseModule
 from .env_module import EnvironmentModule
 from .discord_module import DiscordModule
-from .mssql_module import MSSQLModule
+from .database_provider import DatabaseProvider
 
 async def fetch_ms_jwks_uri() -> str:
   async with aiohttp.ClientSession() as session:
@@ -31,7 +31,7 @@ class AuthModule(BaseModule):
     try:
       self.env: EnvironmentModule = app.state.env
       self.discord: DiscordModule = app.state.discord
-      self.db: MSSQLModule = app.state.mssql
+      self.db: DatabaseProvider = app.state.mssql
     except AttributeError:
       raise Exception("Env, Database and Discord modules must be loaded first")
     self.ms_api_id: Optional[str] = None

--- a/server/modules/database_provider.py
+++ b/server/modules/database_provider.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from datetime import datetime
+from uuid import UUID
+
+
+def _stou(value: str) -> UUID:
+  return UUID(value)
+
+
+def _utos(value: UUID) -> str:
+  return str(value)
+
+
+class DatabaseProvider(ABC):
+  @abstractmethod
+  async def select_user(self, provider: str, provider_user_id: str):
+    pass
+
+  @abstractmethod
+  async def insert_user(self, provider: str, provider_user_id: str, email: str, username: str):
+    pass
+
+  @abstractmethod
+  async def get_user_profile(self, guid: str):
+    pass
+
+  @abstractmethod
+  async def get_user_roles(self, guid: str) -> int:
+    pass
+
+  @abstractmethod
+  async def list_roles(self) -> list[dict]:
+    pass
+
+  @abstractmethod
+  async def set_role(self, name: str, mask: int, display: str):
+    pass
+
+  @abstractmethod
+  async def delete_role(self, name: str):
+    pass
+
+  @abstractmethod
+  async def get_user_enablements(self, guid: str) -> int:
+    pass
+
+  @abstractmethod
+  async def select_routes(self, role_mask: int = 0):
+    pass
+
+  @abstractmethod
+  async def list_routes(self) -> list[dict]:
+    pass
+
+  @abstractmethod
+  async def set_route(self, path: str, name: str, icon: str, required_roles: int, sequence: int):
+    pass
+
+  @abstractmethod
+  async def delete_route(self, path: str):
+    pass
+
+  @abstractmethod
+  async def select_links(self, role_mask: int = 0):
+    pass
+
+  @abstractmethod
+  async def get_config_value(self, key: str) -> str | None:
+    pass
+
+  @abstractmethod
+  async def set_config_value(self, key: str, value: str):
+    pass
+
+  @abstractmethod
+  async def list_config(self) -> list[dict]:
+    pass
+
+  @abstractmethod
+  async def delete_config_value(self, key: str):
+    pass
+
+  @abstractmethod
+  async def update_display_name(self, guid: str, display_name: str):
+    pass
+
+  @abstractmethod
+  async def select_users(self):
+    pass
+
+  @abstractmethod
+  async def select_users_with_role(self, mask: int):
+    pass
+
+  @abstractmethod
+  async def select_users_without_role(self, mask: int):
+    pass
+
+  @abstractmethod
+  async def set_user_roles(self, guid: str, roles: int):
+    pass
+
+  @abstractmethod
+  async def set_user_credits(self, guid: str, credits: int):
+    pass
+
+  @abstractmethod
+  async def set_user_rotation_token(self, guid: str, token: str, expires: datetime):
+    pass
+
+  @abstractmethod
+  async def create_user_session(self, user_guid: str, bearer: str, rotation: str, expires: datetime) -> str:
+    pass
+
+  @abstractmethod
+  async def get_session_by_rotation(self, rotation_token: str):
+    pass
+
+  @abstractmethod
+  async def update_session_tokens(self, session_id: str, bearer: str, rotation: str, expires: datetime):
+    pass
+
+  @abstractmethod
+  async def delete_session(self, session_id: str):
+    pass
+
+  @abstractmethod
+  async def get_user_profile_image(self, guid: str) -> str | None:
+    pass
+
+  @abstractmethod
+  async def set_user_profile_image(self, guid: str, image_b64: str, provider: str | None = None):
+    pass

--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -1,6 +1,6 @@
 import logging, discord, asyncio, json
 from .env_module import EnvironmentModule
-from server.modules.mssql_module import MSSQLModule
+from server.modules.database_provider import DatabaseProvider
 from fastapi import FastAPI, Request
 from discord.ext import commands
 from server.helpers.logging import configure_discord_logging #, remove_discord_logging
@@ -10,7 +10,7 @@ class DiscordModule():
     self.app: FastAPI = app
     try:
       self.env: EnvironmentModule = app.state.env
-      self.db: MSSQLModule = app.state.mssql
+      self.db: DatabaseProvider = app.state.mssql
     except AttributeError:
       raise Exception("Env and Database modules must be loaded first")
     self.secret = self.env.get("DISCORD_SECRET")

--- a/server/modules/mssql_provider.py
+++ b/server/modules/mssql_provider.py
@@ -1,9 +1,10 @@
 import json, aioodbc, logging
-from uuid import UUID, uuid4
+from uuid import uuid4
 from datetime import datetime
 from fastapi import FastAPI
 from . import BaseModule
 from .env_module import EnvironmentModule
+from .database_provider import DatabaseProvider, _utos
 
 def _maybe_loads_json(data):
   if isinstance(data, str):
@@ -17,13 +18,7 @@ def _maybe_loads_json(data):
     return [_maybe_loads_json(v) for v in data]
   return data
 
-def _stou(value: str) -> UUID:
-  return UUID(value)
-
-def _utos(value: UUID) -> str:
-  return str(value)
-
-class MSSQLModule(BaseModule):
+class MSSQLProvider(BaseModule, DatabaseProvider):
   def __init__(self, app: FastAPI, dsn: str | None = None):
     super().__init__(app)
     self.pool: aioodbc.pool.Pool | None = None

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -3,7 +3,7 @@ from azure.core.exceptions import ResourceExistsError
 from fastapi import FastAPI
 from . import BaseModule
 from .env_module import EnvironmentModule
-from .mssql_module import MSSQLModule
+from .database_provider import DatabaseProvider
 import io, logging
 
 class StorageModule(BaseModule):
@@ -11,7 +11,7 @@ class StorageModule(BaseModule):
     super().__init__(app)
     try:
       self.env: EnvironmentModule = app.state.env
-      self.db: MSSQLModule = app.state.mssql
+      self.db: DatabaseProvider = app.state.mssql
     except AttributeError:
       raise Exception("Env and Database modules must be loaded first")
     self.client = None

--- a/tests/test_services_mock_provider.py
+++ b/tests/test_services_mock_provider.py
@@ -1,0 +1,89 @@
+import asyncio
+from fastapi import FastAPI, Request
+from rpc.account.users.services import get_users_v2
+from rpc.system.routes.services import list_routes_v2
+from server.modules.database_provider import DatabaseProvider
+
+class MockProvider(DatabaseProvider):
+  async def select_user(self, *args, **kwargs):
+    raise NotImplementedError
+  async def insert_user(self, *args, **kwargs):
+    raise NotImplementedError
+  async def get_user_profile(self, *args, **kwargs):
+    raise NotImplementedError
+  async def get_user_roles(self, *args, **kwargs):
+    raise NotImplementedError
+  async def list_roles(self, *args, **kwargs):
+    raise NotImplementedError
+  async def set_role(self, *args, **kwargs):
+    raise NotImplementedError
+  async def delete_role(self, *args, **kwargs):
+    raise NotImplementedError
+  async def get_user_enablements(self, *args, **kwargs):
+    raise NotImplementedError
+  async def select_routes(self, *args, **kwargs):
+    raise NotImplementedError
+  async def list_routes(self):
+    return [{
+      'element_path': '/p',
+      'element_name': 'P',
+      'element_icon': 'i',
+      'element_roles': 0,
+      'element_sequence': 1,
+    }]
+  async def set_route(self, *args, **kwargs):
+    raise NotImplementedError
+  async def delete_route(self, *args, **kwargs):
+    raise NotImplementedError
+  async def select_links(self, *args, **kwargs):
+    raise NotImplementedError
+  async def get_config_value(self, *args, **kwargs):
+    raise NotImplementedError
+  async def set_config_value(self, *args, **kwargs):
+    raise NotImplementedError
+  async def list_config(self, *args, **kwargs):
+    raise NotImplementedError
+  async def delete_config_value(self, *args, **kwargs):
+    raise NotImplementedError
+  async def update_display_name(self, *args, **kwargs):
+    raise NotImplementedError
+  async def select_users(self):
+    return [{'guid': 'u', 'display_name': 'User'}]
+  async def select_users_with_role(self, *args, **kwargs):
+    raise NotImplementedError
+  async def select_users_without_role(self, *args, **kwargs):
+    raise NotImplementedError
+  async def set_user_roles(self, *args, **kwargs):
+    raise NotImplementedError
+  async def set_user_credits(self, *args, **kwargs):
+    raise NotImplementedError
+  async def set_user_rotation_token(self, *args, **kwargs):
+    raise NotImplementedError
+  async def create_user_session(self, *args, **kwargs):
+    raise NotImplementedError
+  async def get_session_by_rotation(self, *args, **kwargs):
+    raise NotImplementedError
+  async def update_session_tokens(self, *args, **kwargs):
+    raise NotImplementedError
+  async def delete_session(self, *args, **kwargs):
+    raise NotImplementedError
+  async def get_user_profile_image(self, *args, **kwargs):
+    raise NotImplementedError
+  async def set_user_profile_image(self, *args, **kwargs):
+    raise NotImplementedError
+
+
+def test_get_users_with_mock_provider():
+  app = FastAPI()
+  app.state.mssql = MockProvider()
+  req = Request({'type': 'http', 'app': app, 'headers': []})
+  resp = asyncio.run(get_users_v2(req))
+  assert resp.payload.users[0].displayName == 'User'
+
+
+def test_list_routes_with_mock_provider():
+  app = FastAPI()
+  app.state.mssql = MockProvider()
+  req = Request({'type': 'http', 'app': app, 'headers': []})
+  resp = asyncio.run(list_routes_v2(req))
+  assert resp.payload.routes[0].path == '/p'


### PR DESCRIPTION
## Summary
- add `DatabaseProvider` abstract class for data access
- rename MSSQL module to `MSSQLProvider` implementing new interface
- update services to depend on the provider interface
- add tests using a mock provider

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_6896485662b08325b93bcc94b9857b4b