### PR TITLE
feat: add postgres provider interface

### DIFF
--- a/server/modules/database_module.py
+++ b/server/modules/database_module.py
@@ -14,6 +14,10 @@ async def init(provider: str = "mssql", **cfg):
         from .providers.mssql_provider import init as _init, dispatch as _dispatch
         await _init(**cfg)
         _exec = _dispatch
+    elif provider == "postgres":
+        from .providers.postgres_provider import init as _init, dispatch as _dispatch
+        await _init(**cfg)
+        _exec = _dispatch
     else:
         raise ValueError(f"Unsupported provider: {provider}")
 

--- a/server/modules/providers/postgres_provider/__init__.py
+++ b/server/modules/providers/postgres_provider/__init__.py
@@ -1,35 +1,25 @@
-from __future__ import annotations
+# providers/postgres_provider/__init__.py
+from typing import Any, Dict
+from .logic import init_pool, close_pool, fetch_one, fetch_many, execute
+from .registry import get_handler
 
-from . import logic
+async def init(**cfg):
+  await init_pool(**cfg)
 
+async def dispatch(op: str, args: Dict[str, Any]):
+  handler = get_handler(op)
+  spec = handler(args)
+  if hasattr(spec, '__await__'):
+    return await spec
+  mode, sql, params = spec
+  if mode == 'one':
+    row = await fetch_one(sql, params)
+    return {"rows": [row] if row else [], "rowcount": 1 if row else 0}
+  if mode == 'many':
+    rows = await fetch_many(sql, params)
+    return {"rows": rows, "rowcount": len(rows)}
+  if mode == 'exec':
+    rc = await execute(sql, params)
+    return {"rows": [], "rowcount": rc}
+  raise ValueError(f"Unknown mode: {mode}")
 
-class PostgreSQLProvider:
-  """PostgreSQL database provider."""
-
-  async def startup(self) -> None:
-    """Initialize PostgreSQL connections if needed."""
-    # Provider-specific startup logic goes here
-    pass
-
-  async def shutdown(self) -> None:
-    """Cleanup PostgreSQL resources."""
-    # Provider-specific shutdown logic goes here
-    pass
-
-  async def execute(self, query: str, *args, **kwargs):
-    """Execute a write query against PostgreSQL.
-    Provider-specific execution logic should be implemented in ``logic.execute``.
-    """
-    return await logic.execute(query, *args, **kwargs)
-
-  async def fetch_one(self, query: str, *args, **kwargs):
-    """Fetch a single record from PostgreSQL.
-    Provider-specific fetch logic should be implemented in ``logic.fetch_one``.
-    """
-    return await logic.fetch_one(query, *args, **kwargs)
-
-  async def fetch_many(self, query: str, *args, **kwargs):
-    """Fetch multiple records from PostgreSQL.
-    Provider-specific fetch logic should be implemented in ``logic.fetch_many``.
-    """
-    return await logic.fetch_many(query, *args, **kwargs)

--- a/server/modules/providers/postgres_provider/logic.py
+++ b/server/modules/providers/postgres_provider/logic.py
@@ -1,19 +1,65 @@
-from __future__ import annotations
+# providers/postgres_provider/logic.py
+import asyncpg, logging
+from contextlib import asynccontextmanager
+from typing import Any, Iterable
 
+_pool: asyncpg.Pool | None = None
 
-async def execute(query: str, *args, **kwargs):
-  """Placeholder for PostgreSQL-specific execute logic."""
-  # Implement PostgreSQL execution logic here
-  pass
+async def init_pool(*, dsn: str | None = None, **cfg):
+  global _pool
+  if not dsn:
+    raise RuntimeError("PostgreSQL DSN is required")
+  _pool = await asyncpg.create_pool(dsn=dsn, **cfg)
+  logging.info("PostgreSQL Connection Pool Created")
 
+async def close_pool():
+  global _pool
+  if _pool:
+    await _pool.close()
+    _pool = None
+    logging.info("PostgreSQL Connection Pool Closed")
 
-async def fetch_one(query: str, *args, **kwargs):
-  """Placeholder for PostgreSQL-specific single record fetch logic."""
-  # Implement PostgreSQL single record retrieval here
-  return None
+@asynccontextmanager
+async def transaction():
+  assert _pool, "PostgreSQL pool not initialized"
+  async with _pool.acquire() as conn:
+    async with conn.transaction():
+      try:
+        yield conn
+      except Exception as e:
+        logging.debug(f"[TRANSACTION ERROR] Rolled back due to: {e}")
+        raise
 
+async def execute(query: str, params: Iterable[Any] = ()):  # returns rowcount
+  assert _pool, "PostgreSQL pool not initialized"
+  try:
+    async with _pool.acquire() as conn:
+      status = await conn.execute(query, *params)
+      try:
+        return int(status.split()[-1])
+      except Exception:
+        return 0
+  except Exception as e:
+    logging.debug(f"Exec failed:\n{query}\nArgs: {params}\nError: {e}")
+    return 0
 
-async def fetch_many(query: str, *args, **kwargs):
-  """Placeholder for PostgreSQL-specific multi-record fetch logic."""
-  # Implement PostgreSQL multiple record retrieval here
-  return []
+async def fetch_one(query: str, params: Iterable[Any] = ()):  # returns dict or None
+  assert _pool, "PostgreSQL pool not initialized"
+  try:
+    async with _pool.acquire() as conn:
+      row = await conn.fetchrow(query, *params)
+      return dict(row) if row else None
+  except Exception as e:
+    logging.debug(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
+    return None
+
+async def fetch_many(query: str, params: Iterable[Any] = ()):  # returns list[dict]
+  assert _pool, "PostgreSQL pool not initialized"
+  try:
+    async with _pool.acquire() as conn:
+      rows = await conn.fetch(query, *params)
+      return [dict(r) for r in rows]
+  except Exception as e:
+    logging.debug(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
+    return []
+

--- a/server/modules/providers/postgres_provider/registry.py
+++ b/server/modules/providers/postgres_provider/registry.py
@@ -1,0 +1,65 @@
+# providers/postgres_provider/registry.py
+from typing import Any, Awaitable, Callable, Dict, Tuple
+from .logic import execute, fetch_one, fetch_many, transaction
+
+_REG: Dict[str, Callable[[Dict[str, Any]], Any]] = {}
+
+def register(op: str):
+  def deco(fn):
+    if op in _REG:
+      raise ValueError(f"Duplicate op: {op}")
+    _REG[op] = fn
+    return fn
+  return deco
+
+def get_handler(op: str):
+  try:
+    return _REG[op]
+  except KeyError:
+    raise KeyError(f"No PostgreSQL handler for '{op}'")
+
+@register("urn:users:core:get_by_provider_identifier:v1")
+def _users_select(args: Dict[str, Any]):
+  provider = args["provider"]
+  identifier = args["provider_identifier"]
+  sql = """
+    SELECT
+      u.element_guid AS guid,
+      u.element_display AS display_name,
+      u.element_email AS email,
+      COALESCE(uc.element_credits, 0) AS credits,
+      ap.element_name AS provider_name,
+      ap.element_display AS provider_display,
+      upi.element_base64 AS profile_image
+    FROM account_users u
+    JOIN users_auth ua ON ua.users_guid = u.element_guid
+    JOIN auth_providers ap ON ap.recid = ua.providers_recid
+    LEFT JOIN users_credits uc ON uc.users_guid = u.element_guid
+    LEFT JOIN users_profileimg upi ON upi.users_guid = u.element_guid
+    WHERE ap.element_name = $1 AND ua.element_identifier = $2;
+  """
+  return ("one", sql, (provider, identifier))
+
+@register("urn:users:core:get_roles:v1")
+def _users_get_roles(args: Dict[str, Any]):
+  guid = args["guid"]
+  sql = """
+    SELECT element_roles FROM users_roles
+    WHERE users_guid = $1;
+  """
+  return ("many", sql, (guid,))
+
+@register("urn:users:core:set_roles:v1")
+async def _users_set_roles(args: Dict[str, Any]):
+  guid, roles = args["guid"], int(args["roles"])
+  rc = await execute(
+    "UPDATE users_roles SET element_roles = $1 WHERE users_guid = $2;",
+    (roles, guid)
+  )
+  if rc == 0:
+    rc = await execute(
+      "INSERT INTO users_roles (users_guid, element_roles) VALUES ($1, $2);",
+      (guid, roles)
+    )
+  return {"rows": [], "rowcount": rc}
+


### PR DESCRIPTION
## Summary
- add init/dispatch functions for postgres provider
- implement asyncpg pooling with execute/fetch helpers
- register basic postgres operations and enable provider selection

## Testing
- `python scripts/generate_rpc_metadata.py`
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `npm --prefix frontend run lint` (fails: useEffect is defined but never used)
- `npm --prefix frontend run type-check` (fails: multiple TS errors)
- `npm --prefix frontend test` (fails: missing modules)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68965cb2acc88325a4441f5418354b2c