### PR TITLE
Use AST for RPC dispatcher parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Several helper scripts in the `scripts` directory manage the project database an
 - `mssql_cli.py` provides similar features for Azure SQL using the `AZURE_SQL_CONNECTION_STRING` environment variable.
 - `run_tests.py` executes various test, generate, and update operations for build automation. It increments the build version directly in the Azure SQL database.
     - Requires `AZURE_SQL_CONNECTION_STRING` environment variable to function properly.
-- `generate_rpc_client.py` generates function accessors for the RPC namespace defining required interface types.
+- `generate_rpc_client.py` generates function accessors for the RPC namespace, parsing dispatcher mappings and payload models via the Python AST.
 - `generate_rpc_library.py` generates a data entity library for use in the front end.
 - `genlib.py` handles common RPC namespace generation functions.
 - `dblib.py` handles most of the database querying operations.

--- a/scripts/generate_rpc_client.py
+++ b/scripts/generate_rpc_client.py
@@ -1,114 +1,149 @@
 from __future__ import annotations
-import os, re
+import ast, os
+
+"""Generate TypeScript RPC client functions by parsing Python sources.
+
+This version uses the Python AST to read DISPATCHERS mappings and payload
+models rather than brittle regular expressions.
+"""
 
 from genlib import REPO_ROOT, HEADER_COMMENT, camel_case
 
 RPC_ROOT = os.path.join(REPO_ROOT, 'rpc')
 FRONTEND_RPC = os.path.join(REPO_ROOT, 'frontend', 'src', 'rpc')
 
-DISPATCHER_RE = re.compile(r'\(\s*"([^"]+)",\s*"([^"]+)"\s*\):\s*([A-Za-z0-9_]+)')
-PAYLOAD_RE = re.compile(r'payload\s*=\s*([A-Za-z0-9_]+)\(')
-
 
 def urn_to_func(op: str, version: str) -> str:
-    if op.startswith('get_'):
-        op = op[4:]
-    name = 'fetch' + camel_case(op)
-    if version != '1':
-        name += version
-    return name
+  if op.startswith('get_'):
+    op = op[4:]
+  name = 'fetch' + camel_case(op)
+  if version != '1':
+    name += version
+  return name
 
 
 def parse_dispatchers(path: str) -> tuple[list[str], list[dict[str, str]]]:
-    with open(path, 'r') as f:
-        content = f.read()
+  with open(path, 'r') as f:
+    tree = ast.parse(f.read(), filename=path)
 
-    matches = DISPATCHER_RE.findall(content)
-    operations = [{'op': op, 'version': ver, 'func': func} for op, ver, func in matches]
-
-    rel_dir = os.path.relpath(os.path.dirname(path), RPC_ROOT)
-    parts = rel_dir.split(os.sep)
-    return parts, operations
+  operations: list[dict[str, str]] = []
+  for node in tree.body:
+    if isinstance(node, ast.Assign):
+      targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+      value = node.value
+    elif isinstance(node, ast.AnnAssign):
+      targets = [node.target.id] if isinstance(node.target, ast.Name) else []
+      value = node.value
+    else:
+      continue
+    if 'DISPATCHERS' in targets and isinstance(value, ast.Dict):
+      for key, val in zip(value.keys, value.values):
+        if not (isinstance(key, ast.Tuple) and len(key.elts) == 2):
+          continue
+        k0, k1 = key.elts
+        if not (isinstance(k0, ast.Constant) and isinstance(k1, ast.Constant)):
+          continue
+        op, ver = k0.value, k1.value
+        if isinstance(val, ast.Name):
+          func = val.id
+          operations.append({'op': op, 'version': ver, 'func': func})
+  rel_dir = os.path.relpath(os.path.dirname(path), RPC_ROOT)
+  parts = [] if rel_dir == '.' else rel_dir.split(os.sep)
+  return parts, operations
 
 
 def parse_service_models(path: str) -> dict[str, str]:
-    models: dict[str, str] = {}
-    if not os.path.exists(path):
-        return models
-    with open(path, 'r') as f:
-        lines = f.readlines()
-    current = None
-    for line in lines:
-        func = re.match(r'async def (\w+)\(', line)
-        if func:
-            current = func.group(1)
-            continue
-        m = PAYLOAD_RE.search(line)
-        if m and current:
-            models[current] = m.group(1)
-            current = None
+  models: dict[str, str] = {}
+  if not os.path.exists(path):
     return models
+  with open(path, 'r') as f:
+    tree = ast.parse(f.read(), filename=path)
+  for node in tree.body:
+    if isinstance(node, ast.AsyncFunctionDef):
+      defaults = [None] * (len(node.args.args) - len(node.args.defaults)) + node.args.defaults
+      for arg, _default in zip(node.args.args, defaults):
+        if arg.arg != 'payload':
+          continue
+        if arg.annotation is None:
+          continue
+        model = _annotation_to_str(arg.annotation)
+        models[node.name] = model
+  return models
+
+
+def _annotation_to_str(node: ast.AST) -> str:
+  if isinstance(node, ast.Name):
+    return node.id
+  if isinstance(node, ast.Attribute):
+    return node.attr
+  if isinstance(node, ast.Subscript):
+    return _annotation_to_str(node.slice)
+  if isinstance(node, ast.Index):  # type: ignore[attr-defined]
+    return _annotation_to_str(node.value)
+  if isinstance(node, ast.Constant):
+    return str(node.value)
+  return 'any'
 
 
 def generate_ts(base: list[str], ops: list[dict[str, str]], service_models: dict[str, str]) -> str:
-    models = {service_models.get(o['func'], 'any') for o in ops}
-    model_imports = ', '.join(sorted(m for m in models if m != 'any'))
+  models = {service_models.get(o['func'], 'any') for o in ops}
+  model_imports = ', '.join(sorted(m for m in models if m != 'any'))
 
-    lines = HEADER_COMMENT.copy()
+  lines = HEADER_COMMENT.copy()
 
-    if model_imports:
-        lines.append(f"import {{ rpcCall, {model_imports} }} from '../../../shared/RpcModels';")
-    else:
-        lines.append("import { rpcCall } from '../../../shared/RpcModels';")
+  if model_imports:
+    lines.append(f"import {{ rpcCall, {model_imports} }} from '../../../shared/RpcModels';")
+  else:
+    lines.append("import { rpcCall } from '../../../shared/RpcModels';")
 
-    lines.append('')
+  lines.append('')
 
-    base_urn = ':'.join(['urn'] + base)
-    for o in ops:
-        func_name = urn_to_func(o['op'], o['version'])
-        model = service_models.get(o['func'], 'any')
-        urn = f"{base_urn}:{o['op']}:{o['version']}"
-        lines.append(f"export const {func_name} = (payload: any = null): Promise<{model}> => rpcCall('{urn}', payload);")
+  base_urn = ':'.join(['urn'] + base)
+  for o in ops:
+    func_name = urn_to_func(o['op'], o['version'])
+    model = service_models.get(o['func'], 'any')
+    urn = f"{base_urn}:{o['op']}:{o['version']}"
+    lines.append(f"export const {func_name} = (payload: any = null): Promise<{model}> => rpcCall('{urn}', payload);")
 
-    lines.append('')
-    return "\n".join(lines)
+  lines.append('')
+  return "\n".join(lines)
 
 
 def main(output_dir: str = FRONTEND_RPC) -> None:
-    print("✨ Starting DISPATCHER-based RPC function generation...")
-    for root, dirs, files in os.walk(RPC_ROOT):
-        if '__init__.py' not in files:
-            continue
+  print("✨ Starting DISPATCHER-based RPC function generation...")
+  for root, dirs, files in os.walk(RPC_ROOT):
+    if '__init__.py' not in files:
+      continue
 
-        init_path = os.path.join(root, '__init__.py')
-        service_path = os.path.join(root, 'services.py')
-        base_parts, ops = parse_dispatchers(init_path)
+    init_path = os.path.join(root, '__init__.py')
+    service_path = os.path.join(root, 'services.py')
+    base_parts, ops = parse_dispatchers(init_path)
 
-        namespace = '.'.join(base_parts)
-        print(f"\n🧩 Found DISPATCHERS in: {namespace}")
+    namespace = '.'.join(base_parts)
+    print(f"\n🧩 Found DISPATCHERS in: {namespace}")
 
-        if ops:
-            for op in ops:
-                print(f"  • RPC op: {op['op']} (v{op['version']}) → {op['func']}")
-        else:
-            print("  ⚠️ No valid dispatchers found, skipping.")
-            continue
+    if ops:
+      for op in ops:
+        print(f"  • RPC op: {op['op']} (v{op['version']}) → {op['func']}")
+    else:
+      print("  ⚠️ No valid dispatchers found, skipping.")
+      continue
 
-        service_models = parse_service_models(service_path)
-        if service_models:
-            print(f"  📦 Extracted models from services.py: {', '.join(service_models.values())}")
-        else:
-            print("  ⚠️ No payload models found in services.py")
+    service_models = parse_service_models(service_path)
+    if service_models:
+      print(f"  📦 Extracted models from services.py: {', '.join(service_models.values())}")
+    else:
+      print("  ⚠️ No payload models found in services.py")
 
-        out_dir = os.path.join(output_dir, *base_parts)
-        os.makedirs(out_dir, exist_ok=True)
-        content = generate_ts(base_parts, ops, service_models)
-        out_file = os.path.join(out_dir, 'index.ts')
-        with open(out_file, 'w') as f:
-            f.write(content)
-        print(f"✅ Wrote {out_file}")
-    print("\n🏁 RPC function generation complete.")
+    out_dir = os.path.join(output_dir, *base_parts)
+    os.makedirs(out_dir, exist_ok=True)
+    content = generate_ts(base_parts, ops, service_models)
+    out_file = os.path.join(out_dir, 'index.ts')
+    with open(out_file, 'w') as f:
+      f.write(content)
+    print(f"✅ Wrote {out_file}")
+  print("\n🏁 RPC function generation complete.")
 
 
 if __name__ == '__main__':
-    main()
+  main()

--- a/tests/test_generate_rpc_client.py
+++ b/tests/test_generate_rpc_client.py
@@ -1,0 +1,22 @@
+import os, sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+from generate_rpc_client import parse_dispatchers, parse_service_models
+
+
+def test_parse_dispatchers():
+  path = 'rpc/auth/microsoft/__init__.py'
+  base, ops = parse_dispatchers(path)
+  assert base == ['auth', 'microsoft']
+  assert ops == [{
+    'op': 'oauth_login',
+    'version': '1',
+    'func': 'auth_microsoft_oauth_login_v1'
+  }]
+
+
+def test_parse_service_models_no_payload():
+  path = 'rpc/auth/microsoft/services.py'
+  models = parse_service_models(path)
+  assert models == {}
+


### PR DESCRIPTION
## Summary
- Refactor `generate_rpc_client.py` to parse dispatcher dictionaries and payload annotations using Python's AST instead of regex
- Document AST-driven RPC client generation in README
- Add unit tests for dispatcher and payload model parsing

## Testing
- `python scripts/generate_rpc_client.py`
- `npm run lint --prefix frontend` *(fails: useEffect is defined but never used)*
- `npm run type-check --prefix frontend` *(fails: Cannot find module './shared/RpcModels')*
- `npm test --prefix frontend` *(fails: Cannot find module '../src/shared/ColumnHeader', etc.)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896647acb488325be761f84bbb6eb3e