### PR TITLE
refactor: centralize provider interfaces

### DIFF
--- a/rpc/helpers.py
+++ b/rpc/helpers.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException, Request
 
 from rpc.models import RPCRequest
 from server.modules.auth_module import AuthModule
-from server.modules import database_module
+from server.modules.provider import DBResult
 
 
 def mask_to_bit(mask: int) -> int:
@@ -34,7 +34,7 @@ async def _process_rpcrequest(request: Request) -> RPCRequest:
   data: dict[str, str] = await _auth.decode_bearer_token(token) #TODO: Include user_role int in bearer token
 
   rpc_request.user_guid = data.get('guid')
-  result: database_module.DBResult = await db.run(
+  result: DBResult = await db.run(
     "urn:users:core:get_roles:v1", {"guid": rpc_request.user_guid}
   )
   rows = getattr(result, "rows", [])

--- a/server/modules/database_module.py
+++ b/server/modules/database_module.py
@@ -2,22 +2,12 @@
 
 import os
 from importlib import import_module
-from typing import Any, Dict, Protocol, cast, Awaitable, Callable
-from pydantic import BaseModel
+from typing import Any, Dict, cast, Awaitable, Callable
 from fastapi import FastAPI
 
 from . import BaseModule
 from .env_module import EnvModule
-
-
-class DBResult(BaseModel):
-  rows: list[dict] = []
-  rowcount: int = 0
-
-
-class Provider(Protocol):
-  async def init(**cfg) -> None: ...
-  async def dispatch(op: str, args: Dict[str, Any]) -> Dict[str, Any] | DBResult: ...
+from .provider import DBResult, Provider
 
 
 _dispatch_executor: Callable[[str, Dict[str, Any]], Awaitable[Dict[str, Any] | DBResult]] | None = None

--- a/server/modules/provider/__init__.py
+++ b/server/modules/provider/__init__.py
@@ -1,0 +1,12 @@
+from typing import Any, Dict, Protocol
+from pydantic import BaseModel
+
+
+class DBResult(BaseModel):
+  rows: list[dict] = []
+  rowcount: int = 0
+
+
+class Provider(Protocol):
+  async def init(**cfg) -> None: ...
+  async def dispatch(op: str, args: Dict[str, Any]) -> Dict[str, Any] | DBResult: ...


### PR DESCRIPTION
## Summary
- move DBResult and Provider protocol into new provider package
- update database module and RPC helper imports

## Testing
- `python scripts/run_tests.py --test` *(fails: UserContextProvider.tsx unused variable)*
- `npm run type-check --prefix frontend` *(fails: multiple TS2554 errors and missing module RpcModels)*
- `npx vitest run --coverage --run --dir frontend` *(fails: 403 Forbidden fetching vitest)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896ae4ac1188325bece0b711eb42faa