### PR TITLE
Refactor users core URNs into profile and providers namespaces

### DIFF
--- a/rpc/helpers.py
+++ b/rpc/helpers.py
@@ -35,7 +35,7 @@ async def _process_rpcrequest(request: Request) -> RPCRequest:
 
   rpc_request.user_guid = data.get('guid')
   result: DBResult = await db.run(
-    "urn:users:core:get_roles:v1", {"guid": rpc_request.user_guid}
+    "urn:users:profile:get_roles:1", {"guid": rpc_request.user_guid}
   )
   rows = getattr(result, "rows", [])
   rpc_request.user_role = int(rows[0].get("element_roles", 0)) if rows else 0

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -149,11 +149,31 @@
       "capabilities": 0
     },
     {
+      "op": "urn:users:profile:get_roles:1",
+      "capabilities": 0
+    },
+    {
       "op": "urn:users:profile:set_display:1",
       "capabilities": 0
     },
     {
       "op": "urn:users:profile:set_optin:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:users:profile:set_profile_image:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:users:profile:set_roles:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:users:providers:create_from_provider:1",
+      "capabilities": 0
+    },
+    {
+      "op": "urn:users:providers:get_by_provider_identifier:1",
       "capabilities": 0
     },
     {

--- a/rpc/users/profile/__init__.py
+++ b/rpc/users/profile/__init__.py
@@ -6,13 +6,19 @@ Requires ROLE_USERS_ENABLED.
 from .services import (
   users_profile_get_profile_v1,
   users_profile_set_display_v1,
-  users_profile_set_optin_v1
+  users_profile_set_optin_v1,
+  users_profile_get_roles_v1,
+  users_profile_set_roles_v1,
+  users_profile_set_profile_image_v1
 )
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("get_profile", "1"): users_profile_get_profile_v1,
   ("set_display", "1"): users_profile_set_display_v1,
-  ("set_optin", "1"): users_profile_set_optin_v1
+  ("set_optin", "1"): users_profile_set_optin_v1,
+  ("get_roles", "1"): users_profile_get_roles_v1,
+  ("set_roles", "1"): users_profile_set_roles_v1,
+  ("set_profile_image", "1"): users_profile_set_profile_image_v1
 }
 

--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -9,3 +9,12 @@ async def users_profile_set_display_v1(request: Request):
 async def users_profile_set_optin_v1(request: Request):
   raise NotImplementedError("urn:users:profile:set_optin:1")
 
+async def users_profile_get_roles_v1(request: Request):
+  raise NotImplementedError("urn:users:profile:get_roles:1")
+
+async def users_profile_set_roles_v1(request: Request):
+  raise NotImplementedError("urn:users:profile:set_roles:1")
+
+async def users_profile_set_profile_image_v1(request: Request):
+  raise NotImplementedError("urn:users:profile:set_profile_image:1")
+

--- a/rpc/users/providers/__init__.py
+++ b/rpc/users/providers/__init__.py
@@ -8,6 +8,8 @@ from .services import (
   users_providers_set_provider_v1,
   users_providers_link_provider_v1,
   users_providers_unlink_provider_v1,
+  users_providers_get_by_provider_identifier_v1,
+  users_providers_create_from_provider_v1,
 )
 
 
@@ -15,5 +17,7 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("set_provider", "1"): users_providers_set_provider_v1,
   ("link_provider", "1"): users_providers_link_provider_v1,
   ("unlink_provider", "1"): users_providers_unlink_provider_v1,
+  ("get_by_provider_identifier", "1"): users_providers_get_by_provider_identifier_v1,
+  ("create_from_provider", "1"): users_providers_create_from_provider_v1,
 }
 

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -9,3 +9,9 @@ async def users_providers_link_provider_v1(request: Request):
 async def users_providers_unlink_provider_v1(request: Request):
   raise NotImplementedError("urn:users:providers:unlink_provider:1")
 
+async def users_providers_get_by_provider_identifier_v1(request: Request):
+  raise NotImplementedError("urn:users:providers:get_by_provider_identifier:1")
+
+async def users_providers_create_from_provider_v1(request: Request):
+  raise NotImplementedError("urn:users:providers:create_from_provider:1")
+

--- a/server/modules/providers/mssql_provider/registry.py
+++ b/server/modules/providers/mssql_provider/registry.py
@@ -22,7 +22,7 @@ def get_handler(op: str):
 
 # -------------------- MAPPINGS (representative set) --------------------
 
-@register("urn:users:core:get_by_provider_identifier:v1")
+@register("urn:users:providers:get_by_provider_identifier:1")
 def _users_select(provider_args: Dict[str, Any]):
     provider = provider_args["provider"]
     identifier = provider_args["provider_identifier"]
@@ -45,7 +45,7 @@ def _users_select(provider_args: Dict[str, Any]):
     """
     return ("json_one", sql, (provider, identifier))
 
-@register("urn:users:core:create_from_provider:v1")
+@register("urn:users:providers:create_from_provider:1")
 async def _users_insert(args: Dict[str, Any]):
     # mirrors your insert_user() logic, including provider recid lookup + 3 inserts
     from uuid import uuid4
@@ -89,7 +89,7 @@ async def _users_insert(args: Dict[str, Any]):
                                (_users_select({"provider": provider, "provider_identifier": identifier})[2]))
     return {"rows": [out] if out else [], "rowcount": 1 if out else 0}
 
-@register("urn:users:core:get_profile:v1")
+@register("urn:users:profile:get_profile:1")
 def _users_profile(args: Dict[str, Any]):
     guid = args["guid"]
     sql = """
@@ -117,7 +117,7 @@ def _users_profile(args: Dict[str, Any]):
     """
     return ("json_one", sql, (guid,))
 
-@register("urn:users:core:get_roles:v1")
+@register("urn:users:profile:get_roles:1")
 def _users_get_roles(args: Dict[str, Any]):
     guid = args["guid"]
     sql = """
@@ -127,7 +127,7 @@ def _users_get_roles(args: Dict[str, Any]):
     """
     return ("json_one", sql, (guid,))
 
-@register("urn:users:core:set_roles:v1")
+@register("urn:users:profile:set_roles:1")
 async def _users_set_roles(args: Dict[str, Any]):
     guid, roles = args["guid"], int(args["roles"])
     if roles == 0:
@@ -158,7 +158,7 @@ def _routes_get(args: Dict[str, Any]):
     """
     return ("json_many", sql, (mask,))
 
-@register("urn:users:core:set_profile_image:v1")
+@register("urn:users:profile:set_profile_image:1")
 async def _users_set_img(args: Dict[str, Any]):
     guid, image_b64 = args["guid"], args["image_b64"]
     rc = await exec_("UPDATE users_profileimg SET element_base64 = ? WHERE users_guid = ?;", (image_b64, guid))

--- a/server/modules/providers/postgres_provider/registry.py
+++ b/server/modules/providers/postgres_provider/registry.py
@@ -18,7 +18,7 @@ def get_handler(op: str):
   except KeyError:
     raise KeyError(f"No PostgreSQL handler for '{op}'")
 
-@register("urn:users:core:get_by_provider_identifier:v1")
+@register("urn:users:providers:get_by_provider_identifier:1")
 def _users_select(args: Dict[str, Any]):
   provider = args["provider"]
   identifier = args["provider_identifier"]
@@ -40,7 +40,7 @@ def _users_select(args: Dict[str, Any]):
   """
   return ("one", sql, (provider, identifier))
 
-@register("urn:users:core:get_roles:v1")
+@register("urn:users:profile:get_roles:1")
 def _users_get_roles(args: Dict[str, Any]):
   guid = args["guid"]
   sql = """
@@ -49,7 +49,7 @@ def _users_get_roles(args: Dict[str, Any]):
   """
   return ("many", sql, (guid,))
 
-@register("urn:users:core:set_roles:v1")
+@register("urn:users:profile:set_roles:1")
 async def _users_set_roles(args: Dict[str, Any]):
   guid, roles = args["guid"], int(args["roles"])
   rc = await execute(


### PR DESCRIPTION
## Summary
- replace fake `urn:users:core` operations with proper `users:profile` and `users:providers` namespaces
- expand RPC services and dispatchers to include role, image, and provider helpers
- align MSSQL/Postgres registries and metadata with new URNs

## Testing
- `python scripts/generate_rpc_metadata.py`
- `python scripts/generate_rpc_client.py`
- `pytest`
- `npm --prefix frontend run lint` *(fails: useEffect defined but never used)*
- `npm --prefix frontend run type-check` *(fails: missing modules)*
- `cd frontend && npm test` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6896b72d09fc8325865376530d3ba1b0