### PR TITLE
Align database RPC namespace

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -42,7 +42,7 @@ class AuthModule(BaseModule):
     self.db: DatabaseModule = self.app.state.db
     await self.db.on_ready()
 
-    res = await self.db.run("urn:system:config:get:v1", {"key": "MsApiId"})
+    res = await self.db.run("db:system:config:get_config:1", {"key": "MsApiId"})
     if not res.rows:
       raise ValueError("Missing config value for key: MsApiId")
     self.ms_api_id = res.rows[0]["value"]
@@ -158,7 +158,7 @@ class AuthModule(BaseModule):
     if not guid:
       raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Subject not found", headers={"WWW-Authenticate": "Bearer"})
 
-    res = await self.db.run("urn:users:rotkey:get:1", {"guid": guid})
+    res = await self.db.run("db:users:session:get_rotkey:1", {"guid": guid})
     rotkey = res.rows[0].get("rotkey") if res.rows else None
     if not rotkey:
       raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid rotation token", headers={"WWW-Authenticate": "Bearer"})

--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -28,7 +28,7 @@ class DiscordModule(BaseModule):
     self.bot.app = self.app
     self._init_bot_routes()
     configure_discord_logging(self)
-    res = await self.db.run("urn:system:config:get:v1", {"key": "DiscordSyschan"})
+    res = await self.db.run("db:system:config:get_config:1", {"key": "DiscordSyschan"})
     if not res.rows:
       raise ValueError("Missing config value for key: DiscordSyschan")
     self.syschan = int(res.rows[0]["value"] or 0)
@@ -66,7 +66,7 @@ class DiscordModule(BaseModule):
     async def on_ready():
       channel = self.bot.get_channel(self.syschan)
       if channel:
-        res = await self.db.run("urn:system:config:get:v1", {"key": "Version"})
+        res = await self.db.run("db:system:config:get_config:1", {"key": "Version"})
         version = res.rows[0]["value"] if res.rows else None
         logging.info(f"TheOracleGPT-Dev Online. Version: {version or 'unknown'}")
       else:

--- a/server/modules/providers/postgres_provider/registry.py
+++ b/server/modules/providers/postgres_provider/registry.py
@@ -18,7 +18,7 @@ def get_handler(op: str):
   except KeyError:
     raise KeyError(f"No PostgreSQL handler for '{op}'")
 
-@register("urn:users:providers:get_by_provider_identifier:1")
+@register("db:users:providers:get_by_provider_identifier:1")
 def _users_select(args: Dict[str, Any]):
   provider = args["provider"]
   identifier = args["provider_identifier"]
@@ -40,7 +40,7 @@ def _users_select(args: Dict[str, Any]):
   """
   return ("one", sql, (provider, identifier))
 
-@register("urn:users:profile:get_roles:1")
+@register("db:users:profile:get_roles:1")
 def _users_get_roles(args: Dict[str, Any]):
   guid = args["guid"]
   sql = """
@@ -49,7 +49,7 @@ def _users_get_roles(args: Dict[str, Any]):
   """
   return ("many", sql, (guid,))
 
-@register("urn:users:profile:set_roles:1")
+@register("db:users:profile:set_roles:1")
 async def _users_set_roles(args: Dict[str, Any]):
   guid, roles = args["guid"], int(args["roles"])
   rc = await execute(
@@ -63,8 +63,8 @@ async def _users_set_roles(args: Dict[str, Any]):
     )
   return {"rows": [], "rowcount": rc}
 
-@register("urn:users:rotkey:set:1")
-def _users_rotkey_set(args: Dict[str, Any]):
+@register("db:users:session:set_rotkey:1")
+def _users_session_set_rotkey(args: Dict[str, Any]):
   guid = args["guid"]
   rotkey = args["rotkey"]
   iat = args["iat"]
@@ -76,8 +76,8 @@ def _users_rotkey_set(args: Dict[str, Any]):
   """
   return ("exec", sql, (rotkey, iat, exp, guid))
 
-@register("urn:users:rotkey:get:1")
-def _users_rotkey_get(args: Dict[str, Any]):
+@register("db:users:session:get_rotkey:1")
+def _users_session_get_rotkey(args: Dict[str, Any]):
   guid = args["guid"]
   sql = "SELECT element_rotkey AS rotkey FROM account_users WHERE element_guid = $1;"
   return ("one", sql, (guid,))

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -19,7 +19,7 @@ class StorageModule(BaseModule):
     await self.db.on_ready()
 
     dsn = self.env.get("AZURE_BLOB_CONNECTION_STRING")
-    res = await self.db.run("urn:system:config:get:v1", {"key": "AzureBlobContainerName"})
+    res = await self.db.run("db:system:config:get_config:1", {"key": "AzureBlobContainerName"})
     if not res.rows:
       raise ValueError("Missing config value for key: AzureBlobContainerName")
     self.container = res.rows[0]["value"]


### PR DESCRIPTION
## Summary
- Align database provider operation names with RPC conventions, using `db:` prefix and structured domain/subdomain/method/version.
- Update server modules to call new `db:` operations for rotkey management, session handling, and system config lookups.

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `python scripts/generate_rpc_metadata.py`
- `npm run lint` *(fails: 'useEffect' is defined but never used)*
- `npm run type-check` *(fails: Expected 4 arguments, but got 2)*
- `npx vitest run` *(fails: Cannot find module '../src/shared/ColumnHeader')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896c44ee5288325bd2fa4c54511ff77