### PR TITLE
feat: structure RPC metadata by namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Several helper scripts in the `scripts` directory manage the project database an
     - `POSTGRE_SQL_CONNCTION_STRING` environment variable for postgres database.
 - `generate_rpc_client.py` generates function accessors for the RPC namespace, parsing dispatcher mappings and payload models via the Python AST.
 - `generate_rpc_library.py` generates a data entity library for use in the front end.
-- `generate_rpc_metadata.py` generates a metadata.json that catalogs all of the RPC endpoints. This is to be used in the future for security planning and later transition to security management in the application layers.
+- `generate_rpc_metadata.py` generates a hierarchical metadata.json that catalogs all RPC endpoints grouped by domain and subdomain with capability aggregates. This is used for security planning and later transition to security management in the application layers.
 - `genlib.py` handles common RPC namespace generation functions.
 - `dblib.py` handles most of the postgres querying operations.
 - `msdblib.py` handles most of the mssql querying operations.

--- a/RPC.md
+++ b/RPC.md
@@ -1,6 +1,6 @@
 # RPC Namespace Overview
 
-This document describes each RPC operation in the project and groups them by domain. The list mirrors `rpc/metadata.json`.
+This document describes each RPC operation in the project and groups them by domain. The list mirrors `rpc/metadata.json`, which organizes endpoints hierarchically by domain and subdomain with capability aggregates.
 
 ## Naming Scheme
 

--- a/frontend/src/shared/UserContextProvider.tsx
+++ b/frontend/src/shared/UserContextProvider.tsx
@@ -1,4 +1,4 @@
-import { useState, ReactNode, useEffect } from 'react';
+import { useState, ReactNode } from 'react';
 import UserContext from './UserContext';
 
 interface UserContextProviderProps {

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -1,192 +1,333 @@
 {
-  "rpc": [
-    {
-      "op": "urn:admin:roles:add_member:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:admin:roles:get_members:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:admin:roles:remove_member:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:admin:users:enable_storage:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:admin:users:get_profile:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:admin:users:reset_display:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:admin:users:set_credits:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:auth:microsoft:oauth_login:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:auth:session:get_token:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:auth:session:invalidate_token:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:auth:session:refresh_token:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:moderation:content:review_content:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:public:links:get_home_links:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:public:links:get_navbar_routes:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:public:vars:get_ffmpeg_version:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:public:vars:get_hostname:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:public:vars:get_odbc_version:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:public:vars:get_repo:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:public:vars:get_version:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:security:roles:add_role_member:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:security:roles:delete_role:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:security:roles:get_role_members:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:security:roles:get_roles:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:security:roles:remove_role_member:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:security:roles:upsert_role:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:service:health_check:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:storage:files:delete_files:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:storage:files:get_files:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:storage:files:set_gallery:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:storage:files:upload_files:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:system:config:delete_config:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:system:config:get_configs:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:system:config:upsert_config:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:system:routes:delete_route:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:system:routes:get_routes:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:system:routes:upsert_route:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:users:profile:get_profile:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:users:profile:get_roles:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:users:profile:set_display:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:users:profile:set_optin:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:users:profile:set_profile_image:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:users:profile:set_roles:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:users:providers:create_from_provider:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:users:providers:get_by_provider_identifier:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:users:providers:link_provider:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:users:providers:set_provider:1",
-      "capabilities": 0
-    },
-    {
-      "op": "urn:users:providers:unlink_provider:1",
-      "capabilities": 0
-    }
-  ]
+  "rpc": {
+    "capabilities": 0,
+    "domains": [
+      {
+        "domain": "admin",
+        "capabilities": 0,
+        "subdomains": [
+          {
+            "subdomain": "roles",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:admin:roles:add_member:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:admin:roles:get_members:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:admin:roles:remove_member:1",
+                "capabilities": 0
+              }
+            ]
+          },
+          {
+            "subdomain": "users",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:admin:users:enable_storage:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:admin:users:get_profile:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:admin:users:reset_display:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:admin:users:set_credits:1",
+                "capabilities": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "domain": "auth",
+        "capabilities": 0,
+        "subdomains": [
+          {
+            "subdomain": "microsoft",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:auth:microsoft:oauth_login:1",
+                "capabilities": 0
+              }
+            ]
+          },
+          {
+            "subdomain": "session",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:auth:session:get_token:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:auth:session:invalidate_token:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:auth:session:refresh_token:1",
+                "capabilities": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "domain": "moderation",
+        "capabilities": 0,
+        "subdomains": [
+          {
+            "subdomain": "content",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:moderation:content:review_content:1",
+                "capabilities": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "domain": "public",
+        "capabilities": 0,
+        "subdomains": [
+          {
+            "subdomain": "links",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:public:links:get_home_links:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:public:links:get_navbar_routes:1",
+                "capabilities": 0
+              }
+            ]
+          },
+          {
+            "subdomain": "vars",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:public:vars:get_ffmpeg_version:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:public:vars:get_hostname:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:public:vars:get_odbc_version:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:public:vars:get_repo:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:public:vars:get_version:1",
+                "capabilities": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "domain": "security",
+        "capabilities": 0,
+        "subdomains": [
+          {
+            "subdomain": "roles",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:security:roles:add_role_member:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:security:roles:delete_role:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:security:roles:get_role_members:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:security:roles:get_roles:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:security:roles:remove_role_member:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:security:roles:upsert_role:1",
+                "capabilities": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "domain": "service",
+        "capabilities": 0,
+        "subdomains": [
+          {
+            "subdomain": "general",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:service:health_check:1",
+                "capabilities": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "domain": "storage",
+        "capabilities": 0,
+        "subdomains": [
+          {
+            "subdomain": "files",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:storage:files:delete_files:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:storage:files:get_files:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:storage:files:set_gallery:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:storage:files:upload_files:1",
+                "capabilities": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "domain": "system",
+        "capabilities": 0,
+        "subdomains": [
+          {
+            "subdomain": "config",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:system:config:delete_config:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:system:config:get_configs:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:system:config:upsert_config:1",
+                "capabilities": 0
+              }
+            ]
+          },
+          {
+            "subdomain": "routes",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:system:routes:delete_route:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:system:routes:get_routes:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:system:routes:upsert_route:1",
+                "capabilities": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "domain": "users",
+        "capabilities": 0,
+        "subdomains": [
+          {
+            "subdomain": "profile",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:users:profile:get_profile:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:users:profile:get_roles:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:users:profile:set_display:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:users:profile:set_optin:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:users:profile:set_profile_image:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:users:profile:set_roles:1",
+                "capabilities": 0
+              }
+            ]
+          },
+          {
+            "subdomain": "providers",
+            "capabilities": 0,
+            "functions": [
+              {
+                "op": "urn:users:providers:create_from_provider:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:users:providers:get_by_provider_identifier:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:users:providers:link_provider:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:users:providers:set_provider:1",
+                "capabilities": 0
+              },
+              {
+                "op": "urn:users:providers:unlink_provider:1",
+                "capabilities": 0
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/scripts/generate_rpc_metadata.py
+++ b/scripts/generate_rpc_metadata.py
@@ -8,8 +8,8 @@ RPC_ROOT = Path(REPO_ROOT) / 'rpc'
 METADATA_FILE = RPC_ROOT / 'metadata.json'
 
 
-def gather_ops() -> dict[str, int]:
-  metadata: dict[str, int] = {}
+def gather_ops() -> dict:
+  tree: dict[str, dict] = {}
   for root, dirs, files in os.walk(RPC_ROOT):
     if '__init__.py' not in files:
       continue
@@ -18,34 +18,80 @@ def gather_ops() -> dict[str, int]:
     if not ops:
       continue
     print(f"\n📦 Found DISPATCHERS in: {'.'.join(base_parts)}")
+    domain = base_parts[0]
+    subdomain = base_parts[1] if len(base_parts) > 1 else 'general'
+    dom = tree.setdefault(domain, {'subdomains': {}})
+    sub = dom['subdomains'].setdefault(subdomain, {'functions': []})
     for op in ops:
       urn = ':'.join(['urn'] + base_parts + [op['op'], op['version']])
       print(f"  • {urn}")
-      metadata.setdefault(urn, 0)
-  return metadata
+      sub['functions'].append({'op': urn, 'capabilities': 0})
+  return tree
 
 
 def load_existing() -> dict[str, int]:
   if METADATA_FILE.exists():
     with open(METADATA_FILE, 'r') as f:
       data = json.load(f)
-    return {item['op']: item.get('capabilities', 0) for item in data.get('rpc', [])}
+    existing: dict[str, int] = {}
+    rpc_section = data.get('rpc', {})
+    if isinstance(rpc_section, list):
+      for item in rpc_section:
+        existing[item['op']] = item.get('capabilities', 0)
+      return existing
+    for dom in rpc_section.get('domains', []):
+      for sub in dom.get('subdomains', []):
+        for fn in sub.get('functions', []):
+          existing[fn['op']] = fn.get('capabilities', 0)
+    return existing
   return {}
 
 
-def write_metadata(data: dict[str, int]):
-  out = {'rpc': [{'op': k, 'capabilities': v} for k, v in sorted(data.items())]}
+def write_metadata(tree: dict):
+  for dom in tree.values():
+    for sub in dom['subdomains'].values():
+      sub['capabilities'] = sum(f['capabilities'] for f in sub['functions'])
+    dom['capabilities'] = sum(sub['capabilities'] for sub in dom['subdomains'].values())
+  total = sum(dom['capabilities'] for dom in tree.values())
+  out = {
+    'rpc': {
+      'capabilities': total,
+      'domains': [
+        {
+          'domain': d,
+          'capabilities': dom['capabilities'],
+          'subdomains': [
+            {
+              'subdomain': s,
+              'capabilities': sub['capabilities'],
+              'functions': sorted(sub['functions'], key=lambda f: f['op'])
+            }
+            for s, sub in sorted(dom['subdomains'].items())
+          ]
+        }
+        for d, dom in sorted(tree.items())
+      ]
+    }
+  }
   METADATA_FILE.write_text(json.dumps(out, indent=2))
 
 
 def main() -> None:
   print("✨ Scanning RPC namespaces for capability metadata...")
-  ops = gather_ops()
+  tree = gather_ops()
   existing = load_existing()
-  merged = {op: existing.get(op, cap) for op, cap in ops.items()}
-  missing = [op for op, cap in merged.items() if cap == 0]
-  write_metadata(merged)
+  for dom in tree.values():
+    for sub in dom['subdomains'].values():
+      for fn in sub['functions']:
+        fn['capabilities'] = existing.get(fn['op'], fn['capabilities'])
+  write_metadata(tree)
 
+  missing: list[str] = []
+  for dom in tree.values():
+    for sub in dom['subdomains'].values():
+      for fn in sub['functions']:
+        if fn['capabilities'] == 0:
+          missing.append(fn['op'])
   if missing:
     print("\n⚠️ Missing capability metadata for:")
     for op in missing:

--- a/server/modules/security_module.py
+++ b/server/modules/security_module.py
@@ -22,11 +22,13 @@ class SecurityModule(BaseModule):
     try:
       with open(self.metadata_file, 'r') as f:
         data = json.load(f)
-      self.capabilities = {
-        i['op']: i.get('capabilities', 0)
-        for i in data.get('rpc', [])
-        if 'op' in i
-      }
+      self.capabilities = {}
+      for dom in data.get('rpc', {}).get('domains', []):
+        for sub in dom.get('subdomains', []):
+          for fn in sub.get('functions', []):
+            op = fn.get('op')
+            if op:
+              self.capabilities[op] = fn.get('capabilities', 0)
     except FileNotFoundError:
       logging.warning("PermCapModule metadata file not found: %s", self.metadata_file)
       self.capabilities = {}


### PR DESCRIPTION
## Summary
- group RPC metadata by domain and subdomain with aggregated capability counts
- load hierarchical metadata in security module
- fix frontend lint issue in `UserContextProvider`

## Testing
- `python scripts/generate_rpc_client.py`
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_metadata.py`
- `npm run lint` (in `frontend`)
- `npm run type-check` (failed: Module has no exported member, missing modules, TS2554)
- `npm test` (failed: modules not found)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68978ae4db888325b586860c3d48101c