### PR TITLE
Switch metadata root to urn and domain roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Several helper scripts in the `scripts` directory manage the project database an
     - `POSTGRE_SQL_CONNCTION_STRING` environment variable for postgres database.
 - `generate_rpc_client.py` generates function accessors for the RPC namespace, parsing dispatcher mappings and payload models via the Python AST.
 - `generate_rpc_library.py` generates a data entity library for use in the front end.
-- `generate_rpc_metadata.py` generates a hierarchical metadata.json that catalogs all RPC endpoints grouped by domain and subdomain with capability aggregates. This is used for security planning and later transition to security management in the application layers.
+- `generate_rpc_metadata.py` generates a hierarchical metadata.json that catalogs all RPC endpoints grouped by domain and subdomain with role aggregates. This is used for security planning and later transition to security management in the application layers.
 - `genlib.py` handles common RPC namespace generation functions.
 - `dblib.py` handles most of the postgres querying operations.
 - `msdblib.py` handles most of the mssql querying operations.

--- a/RPC.md
+++ b/RPC.md
@@ -1,6 +1,6 @@
 # RPC Namespace Overview
 
-This document describes each RPC operation in the project and groups them by domain. The list mirrors `rpc/metadata.json`, which organizes endpoints hierarchically by domain and subdomain with capability aggregates.
+This document describes each RPC operation in the project and groups them by domain. The list mirrors `rpc/metadata.json`, which organizes endpoints hierarchically by domain and subdomain with role aggregates.
 
 ## Naming Scheme
 

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -1,14 +1,13 @@
 {
-  "rpc": {
-    "capabilities": 0,
+  "urn": {
+    "roles": 0,
     "domains": [
       {
         "domain": "admin",
-        "capabilities": 0,
+        "roles": 0,
         "subdomains": [
           {
             "subdomain": "roles",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:admin:roles:add_member:1",
@@ -26,7 +25,6 @@
           },
           {
             "subdomain": "users",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:admin:users:enable_storage:1",
@@ -50,11 +48,10 @@
       },
       {
         "domain": "auth",
-        "capabilities": 0,
+        "roles": 0,
         "subdomains": [
           {
             "subdomain": "microsoft",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:auth:microsoft:oauth_login:1",
@@ -64,7 +61,6 @@
           },
           {
             "subdomain": "session",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:auth:session:get_token:1",
@@ -84,11 +80,10 @@
       },
       {
         "domain": "moderation",
-        "capabilities": 0,
+        "roles": 0,
         "subdomains": [
           {
             "subdomain": "content",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:moderation:content:review_content:1",
@@ -100,11 +95,10 @@
       },
       {
         "domain": "public",
-        "capabilities": 0,
+        "roles": 0,
         "subdomains": [
           {
             "subdomain": "links",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:public:links:get_home_links:1",
@@ -118,7 +112,6 @@
           },
           {
             "subdomain": "vars",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:public:vars:get_ffmpeg_version:1",
@@ -146,11 +139,10 @@
       },
       {
         "domain": "security",
-        "capabilities": 0,
+        "roles": 0,
         "subdomains": [
           {
             "subdomain": "roles",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:security:roles:add_role_member:1",
@@ -182,11 +174,10 @@
       },
       {
         "domain": "service",
-        "capabilities": 0,
+        "roles": 0,
         "subdomains": [
           {
             "subdomain": "general",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:service:health_check:1",
@@ -198,11 +189,10 @@
       },
       {
         "domain": "storage",
-        "capabilities": 0,
+        "roles": 0,
         "subdomains": [
           {
             "subdomain": "files",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:storage:files:delete_files:1",
@@ -226,11 +216,10 @@
       },
       {
         "domain": "system",
-        "capabilities": 0,
+        "roles": 0,
         "subdomains": [
           {
             "subdomain": "config",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:system:config:delete_config:1",
@@ -248,7 +237,6 @@
           },
           {
             "subdomain": "routes",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:system:routes:delete_route:1",
@@ -268,11 +256,10 @@
       },
       {
         "domain": "users",
-        "capabilities": 0,
+        "roles": 0,
         "subdomains": [
           {
             "subdomain": "profile",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:users:profile:get_profile:1",
@@ -302,7 +289,6 @@
           },
           {
             "subdomain": "providers",
-            "capabilities": 0,
             "functions": [
               {
                 "op": "urn:users:providers:create_from_provider:1",

--- a/server/modules/security_module.py
+++ b/server/modules/security_module.py
@@ -23,7 +23,8 @@ class SecurityModule(BaseModule):
       with open(self.metadata_file, 'r') as f:
         data = json.load(f)
       self.capabilities = {}
-      for dom in data.get('rpc', {}).get('domains', []):
+      section = data.get('urn') or {}
+      for dom in section.get('domains', []):
         for sub in dom.get('subdomains', []):
           for fn in sub.get('functions', []):
             op = fn.get('op')


### PR DESCRIPTION
## Summary
- Change RPC metadata generator to emit `urn` root with domain roles and no subdomain capabilities
- Update security module and documentation for new metadata structure
- Regenerate metadata.json with `urn` root
- Remove legacy `rpc` metadata fallback now that `urn` is primary

## Testing
- `python scripts/generate_rpc_metadata.py` (reports missing capability metadata for many URNs)
- `npm run lint` *(fails: Could not read package.json)*
- `npm run type-check` *(fails: Could not read package.json)*
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979fb4b0cc83259518d30ab3edfc3d