### PR TITLE
Rename database module to match app state and update references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,15 @@ This project uses the following technologies currently:
 - FastAPI on Python 3.12::Back end RPC server
 - Docker::WSGI Compliant Container
 
+## Module Initialization
+ - `server/modules/__init__.py` auto-loads classes from files named `*_module.py` and attaches each instance to `app.state` using the file name without the `_module` suffix. `db_module.py` becomes `app.state.db`.
+ - When other modules depend on the database they should retrieve it from `app.state.db` and await `on_ready()` before use.
+- Modules inherit from `BaseModule` and should:
+  - call `super().__init__(app)` in `__init__`
+  - during `startup`, fetch dependencies from `app.state`, await their `on_ready()` methods, perform setup, and call `mark_ready()` when initialization completes
+  - expose any required helpers on `app.state` if other modules need them
+- Consumers should await `on_ready()` for any module they depend on to ensure startup ordering.
+
 ## File Structure:
 ### **PYTHON:**
 - / folder contains solution build and test automation, configuration and main entry point to FastAPI server

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -8,7 +8,7 @@ Every database operation uses a URN in the form `db:{domain}:{subsystem}:{functi
 
 ## Providers
 
-`DatabaseModule` selects a provider at startup and exposes a `run` method that delegates to provider-specific registries. Configuration comes from environment variables such as `DATABASE_PROVIDER` and DSN strings.
+`DbModule` selects a provider at startup and exposes a `run` method that delegates to provider-specific registries. Configuration comes from environment variables such as `DATABASE_PROVIDER` and DSN strings.
 
 ## Users Domain
 

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -6,7 +6,7 @@ from fastapi.responses import JSONResponse
 from rpc.helpers import mask_to_names
 from rpc.models import RPCResponse
 from server.modules.auth_module import AuthModule
-from server.modules.database_module import DatabaseModule
+from server.modules.db_module import DbModule
 
 async def auth_session_get_token_v1(request: Request):
   body = await request.json()
@@ -17,7 +17,7 @@ async def auth_session_get_token_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing credentials")
 
   auth: AuthModule = request.app.state.auth
-  db: DatabaseModule = request.app.state.db
+  db: DbModule = request.app.state.db
 
   provider_uid, profile = await auth.handle_auth_login(provider, id_token, access_token)
 
@@ -73,7 +73,7 @@ async def auth_session_refresh_token_v1(request: Request):
     raise HTTPException(status_code=401, detail="Missing rotation token")
 
   auth: AuthModule = request.app.state.auth
-  db: DatabaseModule = request.app.state.db
+  db: DbModule = request.app.state.db
 
   data = auth.decode_rotation_token(rotation_token)
   user_guid = data["guid"]
@@ -94,7 +94,7 @@ async def auth_session_invalidate_token_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing rotation token")
 
   auth: AuthModule = request.app.state.auth
-  db: DatabaseModule = request.app.state.db
+  db: DbModule = request.app.state.db
 
   data = auth.decode_rotation_token(rotation_token)
   user_guid = data["guid"]

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -6,7 +6,7 @@ from typing import Dict
 
 from server.modules import BaseModule
 from server.modules.env_module import EnvModule
-from server.modules.database_module import DatabaseModule
+from server.modules.db_module import DbModule
 
 DEFAULT_SESSION_TOKEN_EXPIRY = 15 # minutes
 DEFAULT_ROTATION_TOKEN_EXPIRY = 90 # days
@@ -39,7 +39,7 @@ class AuthModule(BaseModule):
   async def startup(self):
     self.env: EnvModule = self.app.state.env
     await self.env.on_ready()
-    self.db: DatabaseModule = self.app.state.db
+    self.db: DbModule = self.app.state.db
     await self.db.on_ready()
 
     res = await self.db.run("db:system:config:get_config:1", {"key": "MsApiId"})

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -37,7 +37,7 @@ async def init(provider: str | None = None, **cfg):
 
 
 async def run(op: str, args: Dict[str, Any]) -> DBResult:
-  assert _dispatch_executor, "database_module not initialized"
+  assert _dispatch_executor, "db_module not initialized"
   out = await _dispatch_executor(op, args)
   # normalize to DBResult
   if isinstance(out, DBResult):
@@ -45,7 +45,7 @@ async def run(op: str, args: Dict[str, Any]) -> DBResult:
   return DBResult(**out)  # expects {"rows":[...], "rowcount":N}
 
 
-class DatabaseModule(BaseModule):
+class DbModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.provider: str = "mssql"
@@ -60,7 +60,6 @@ class DatabaseModule(BaseModule):
     elif self.provider == "postgres":
       cfg["dsn"] = env.get("POSTGRES_CONNECTION_STRING")
     await init(provider=self.provider, **cfg)
-    self.app.state.db = self
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 
 from . import BaseModule
 from .env_module import EnvModule
-from .database_module import DatabaseModule
+from .db_module import DbModule
 
 from server.helpers.logging import configure_discord_logging, remove_discord_logging
 
@@ -15,13 +15,13 @@ class DiscordModule(BaseModule):
     self.syschan: int = 0
     self.task: asyncio.Task | None = None
     self.bot: commands.Bot | None = None
-    self.db: DatabaseModule | None = None
+    self.db: DbModule | None = None
     self.env: EnvModule | None = None
     
   async def startup(self):
     self.env: EnvModule = self.app.state.env
     await self.env.on_ready()
-    self.db: DatabaseModule = self.app.state.db
+    self.db: DbModule = self.app.state.db
     await self.db.on_ready()
     self.secret = self.env.get("DISCORD_SECRET")
     self.bot = self._init_discord_bot('!')

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -3,7 +3,7 @@ from azure.core.exceptions import ResourceExistsError
 from fastapi import FastAPI
 from . import BaseModule
 from .env_module import EnvModule
-from .database_module import DatabaseModule
+from .db_module import DbModule
 import io, logging
 
 class StorageModule(BaseModule):
@@ -15,7 +15,7 @@ class StorageModule(BaseModule):
   async def startup(self):
     self.env: EnvModule = self.app.state.env
     await self.env.on_ready()
-    self.db: DatabaseModule = self.app.state.db
+    self.db: DbModule = self.app.state.db
     await self.db.on_ready()
 
     dsn = self.env.get("AZURE_BLOB_CONNECTION_STRING")


### PR DESCRIPTION
## Summary
- rename `database_module.py` to `db_module.py` so ModuleManager registers the database as `app.state.db`
- update modules, services, and docs to import `DbModule` and drop the old alias logic
- clarify AGENTS instructions about module naming and database access

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `python scripts/generate_rpc_metadata.py`
- `npm run lint`
- `npm run type-check`
- `npm test` *(Vitest watch mode exited)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689908bcdd388325af0169d8d8b2ab7e