### PR TITLE
Fix RPC router to forward request correctly

### DIFF
--- a/server/routers/rpc_router.py
+++ b/server/routers/rpc_router.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter, Request
 from rpc.handler import handle_rpc_request
-from rpc.models import RPCRequest, RPCResponse
+from rpc.models import RPCResponse
 
 router = APIRouter()
 
 @router.post("")
 @router.post("/")
-async def post_root(rpc_request: RPCRequest, request: Request) -> RPCResponse:
-  return await handle_rpc_request(rpc_request, request)
+async def post_root(request: Request) -> RPCResponse:
+  return await handle_rpc_request(request)


### PR DESCRIPTION
## Summary
- fix RPC router to pass only the FastAPI Request to the RPC handler

## Testing
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_689913cc57948325b56991feeedcb057