### PR TITLE
Await RPC request retrieval in handler

### DIFF
--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -9,7 +9,7 @@ from rpc.suffix import apply_suffixes, split_suffix
 
 
 async def handle_rpc_request(request: Request) -> RPCResponse:
-  rpc_request, parts = get_rpcrequest_from_request(request)
+  rpc_request, parts = await get_rpcrequest_from_request(request)
 
   if parts[:1] != ["urn"]:
     raise HTTPException(400, "Invalid URN prefix")


### PR DESCRIPTION
## Summary
- await async request parsing in `handle_rpc_request`

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_689918efd068832594ee258ed7f43e4f