### PR TITLE
Keep user context internal to RPCRequest

### DIFF
--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -18,6 +18,19 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
+export interface AuthTokens {
+  bearerToken: string;
+  session: SessionToken;
+}
+export interface SessionToken {
+  sub: string;
+  roles: string[];
+  iat: number;
+  exp: number;
+  jti: string;
+  session: string;
+  provider: string;
+}
 export interface HomeLinks {
   links: LinkItem[];
 }
@@ -46,19 +59,6 @@ export interface RepoInfo {
 }
 export interface VersionInfo {
   version: string;
-}
-export interface AuthTokens {
-  bearerToken: string;
-  session: SessionToken;
-}
-export interface SessionToken {
-  sub: string;
-  roles: string[];
-  iat: number;
-  exp: number;
-  jti: string;
-  session: string;
-  provider: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 
 class RPCRequest(BaseModel):
@@ -13,6 +13,25 @@ class RPCRequest(BaseModel):
     default_factory=lambda: datetime.now(timezone.utc),
     description="Client-supplied or default UTC timestamp"
   )
+
+  _user_guid: Optional[str] = PrivateAttr(None)
+  _user_role: int = PrivateAttr(0)
+
+  @property
+  def user_guid(self) -> Optional[str]:
+    return self._user_guid
+
+  @user_guid.setter
+  def user_guid(self, value: Optional[str]) -> None:
+    self._user_guid = value
+
+  @property
+  def user_role(self) -> int:
+    return self._user_role
+
+  @user_role.setter
+  def user_role(self, value: int) -> None:
+    self._user_role = value
 
 class RPCResponse(BaseModel):
   op: str


### PR DESCRIPTION
## Summary
- treat `user_guid` and `user_role` as private RPCRequest attributes so they aren't exposed in client payloads
- drop user context from RPC client generation and regenerate TypeScript models accordingly
- remove obsolete test checking user fields

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68994c929f848325aed2cfa86093c8d2