### PR TITLE
Implement home links service via DB provider

### DIFF
--- a/rpc/public/links/services.py
+++ b/rpc/public/links/services.py
@@ -1,7 +1,19 @@
 from fastapi import Request
 
+from rpc.models import RPCResponse
+from server.modules.db_module import DbModule
+
+
 async def public_links_get_home_links_v1(request: Request):
-  raise NotImplementedError("urn:public:links:get_home_links:1")
+  db: DbModule = request.app.state.db
+  res = await db.run("db:public:links:get_home_links:1", {})
+  payload = {"links": res.rows}
+  return RPCResponse(
+    op="urn:public:links:get_home_links:1",
+    payload=payload,
+    version=1,
+  )
+
 
 async def public_links_get_navbar_routes_v1(request: Request):
   raise NotImplementedError("urn:public:links:get_navbar_routes:1")

--- a/server/modules/providers/mssql_provider/registry.py
+++ b/server/modules/providers/mssql_provider/registry.py
@@ -165,6 +165,18 @@ def _users_session_get_rotkey(args: Dict[str, Any]):
     """
     return ("json_one", sql, (guid,))
 
+@register("db:public:links:get_home_links:1")
+def _public_links_get_home_links(args: Dict[str, Any]):
+  sql = """
+    SELECT
+      element_title AS title,
+      element_url AS url
+    FROM frontend_links
+    ORDER BY element_sequence
+    FOR JSON PATH;
+  """
+  return ("json_many", sql, ())
+
 @register("db:public:links:get_navbar_routes:1")
 def _public_links_get_navbar_routes(args: Dict[str, Any]):
     mask = int(args.get("role_mask", 0))


### PR DESCRIPTION
## Summary
- Add service to fetch home links and return RPC response
- Register MSSQL provider operation to read home link records

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_689ca16aaa58832597b236e982904e09