### PR TITLE
Implement home links RPC service via database layer

### DIFF
--- a/rpc/public/links/services.py
+++ b/rpc/public/links/services.py
@@ -1,7 +1,20 @@
 from fastapi import Request
 
+from rpc.models import RPCResponse
+from server.modules.db_module import DbModule
+from .models import HomeLinks, LinkItem
+
+
 async def public_links_get_home_links_v1(request: Request):
-  raise NotImplementedError("urn:public:links:get_home_links:1")
+  db: DbModule = request.app.state.db
+  res = await db.run("db:public:links:get_home_links:1", {})
+  links = [LinkItem(**row) for row in res.rows]
+  payload = HomeLinks(links=links)
+  return RPCResponse(
+    op="urn:public:links:get_home_links:1",
+    payload=payload.model_dump(),
+    version=1,
+  )
 
 async def public_links_get_navbar_routes_v1(request: Request):
   raise NotImplementedError("urn:public:links:get_navbar_routes:1")

--- a/server/modules/providers/mssql_provider/registry.py
+++ b/server/modules/providers/mssql_provider/registry.py
@@ -165,6 +165,18 @@ def _users_session_get_rotkey(args: Dict[str, Any]):
     """
     return ("json_one", sql, (guid,))
 
+@register("db:public:links:get_home_links:1")
+def _public_links_get_home_links(args: Dict[str, Any]):
+    sql = """
+      SELECT
+        element_title AS title,
+        element_url AS url
+      FROM frontend_links
+      ORDER BY element_sequence
+      FOR JSON PATH;
+    """
+    return ("json_many", sql, ())
+
 @register("db:public:links:get_navbar_routes:1")
 def _public_links_get_navbar_routes(args: Dict[str, Any]):
     mask = int(args.get("role_mask", 0))

--- a/tests/test_public_links_service.py
+++ b/tests/test_public_links_service.py
@@ -1,0 +1,56 @@
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+import pathlib, sys, types
+
+# Stub rpc package to avoid side effects from rpc.__init__
+pkg = types.ModuleType('rpc')
+pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc')]
+sys.modules.setdefault('rpc', pkg)
+
+# Stub server modules to prevent importing full server app
+server_pkg = types.ModuleType('server')
+modules_pkg = types.ModuleType('server.modules')
+db_module_pkg = types.ModuleType('server.modules.db_module')
+
+class DbModule:  # minimal placeholder for import
+  pass
+
+db_module_pkg.DbModule = DbModule
+modules_pkg.db_module = db_module_pkg
+server_pkg.modules = modules_pkg
+
+sys.modules.setdefault('server', server_pkg)
+sys.modules.setdefault('server.modules', modules_pkg)
+sys.modules.setdefault('server.modules.db_module', db_module_pkg)
+
+from rpc.public.links.services import public_links_get_home_links_v1
+
+
+class DummyDb:
+  async def run(self, op: str, args: dict):
+    assert op == "db:public:links:get_home_links:1"
+    assert args == {}
+    return types.SimpleNamespace(rows=[{"title": "GitHub", "url": "https://github.com"}], rowcount=1)
+
+
+app = FastAPI()
+app.state.db = DummyDb()
+
+
+@app.post("/rpc")
+async def rpc_endpoint(request: Request):
+  return await public_links_get_home_links_v1(request)
+
+
+client = TestClient(app)
+
+
+def test_get_home_links_service():
+  resp = client.post("/rpc", json={})
+  assert resp.status_code == 200
+  data = resp.json()
+  assert data["op"] == "urn:public:links:get_home_links:1"
+  assert data["payload"] == {
+    "links": [{"title": "GitHub", "url": "https://github.com"}]
+  }
+


### PR DESCRIPTION
## Summary
- Implement `public_links_get_home_links_v1` to fetch links through database module
- Add MSSQL provider registry entry for `db:public:links:get_home_links:1`
- Add unit test for home links service

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `python scripts/generate_rpc_metadata.py`
- `npm run lint`
- `npm run type-check`
- `npx vitest run`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ca16aaa58832597b236e982904e09