### PR TITLE
Use request op for home links service

### DIFF
--- a/rpc/public/links/services.py
+++ b/rpc/public/links/services.py
@@ -1,19 +1,21 @@
 from fastapi import Request
 
+from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
 from server.modules.db_module import DbModule
 from .models import HomeLinks, LinkItem
 
 
 async def public_links_get_home_links_v1(request: Request):
+  rpc_request, _ = await get_rpcrequest_from_request(request)
   db: DbModule = request.app.state.db
-  res = await db.run("db:public:links:get_home_links:1", {})
+  res = await db.run(rpc_request.op, rpc_request.payload or {})
   links = [LinkItem(**row) for row in res.rows]
   payload = HomeLinks(links=links)
   return RPCResponse(
-    op="urn:public:links:get_home_links:1",
+    op=rpc_request.op,
     payload=payload.model_dump(),
-    version=1,
+    version=rpc_request.version,
   )
 
 async def public_links_get_navbar_routes_v1(request: Request):

--- a/server/modules/providers/mssql_provider/registry.py
+++ b/server/modules/providers/mssql_provider/registry.py
@@ -165,7 +165,7 @@ def _users_session_get_rotkey(args: Dict[str, Any]):
     """
     return ("json_one", sql, (guid,))
 
-@register("db:public:links:get_home_links:1")
+@register("urn:public:links:get_home_links:1")
 def _public_links_get_home_links(args: Dict[str, Any]):
     sql = """
       SELECT

--- a/tests/test_public_links_service.py
+++ b/tests/test_public_links_service.py
@@ -28,7 +28,7 @@ from rpc.public.links.services import public_links_get_home_links_v1
 
 class DummyDb:
   async def run(self, op: str, args: dict):
-    assert op == "db:public:links:get_home_links:1"
+    assert op == "urn:public:links:get_home_links:1"
     assert args == {}
     return types.SimpleNamespace(rows=[{"title": "GitHub", "url": "https://github.com"}], rowcount=1)
 
@@ -46,7 +46,7 @@ client = TestClient(app)
 
 
 def test_get_home_links_service():
-  resp = client.post("/rpc", json={})
+  resp = client.post("/rpc", json={"op": "urn:public:links:get_home_links:1"})
   assert resp.status_code == 200
   data = resp.json()
   assert data["op"] == "urn:public:links:get_home_links:1"


### PR DESCRIPTION
## Summary
- derive RPC operation from request in `public_links_get_home_links_v1`
- register MSSQL handler using front-end op string
- adjust service test to send and assert `urn:public:links:get_home_links:1`

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_689ca53beabc8325a1d4257e7be06918