### PR TITLE
Implement hostname RPC

### DIFF
--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -18,19 +18,6 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
-export interface AuthTokens {
-  bearerToken: string;
-  session: SessionToken;
-}
-export interface SessionToken {
-  sub: string;
-  roles: string[];
-  iat: number;
-  exp: number;
-  jti: string;
-  session: string;
-  provider: string;
-}
 export interface HomeLinks {
   links: LinkItem[];
 }
@@ -48,17 +35,30 @@ export interface NavbarRoutes {
 export interface FfmpegVersion {
   ffmpeg_version: string;
 }
-export interface HostnameInfo {
-  hostname: string;
-}
 export interface OdbcVersion {
   odbc_version: string;
+}
+export interface PublicVarsHostname1 {
+  hostname: string;
 }
 export interface RepoInfo {
   repo: string;
 }
 export interface VersionInfo {
   version: string;
+}
+export interface AuthTokens {
+  bearerToken: string;
+  session: SessionToken;
+}
+export interface SessionToken {
+  sub: string;
+  roles: string[];
+  iat: number;
+  exp: number;
+  jti: string;
+  session: string;
+  provider: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/public/vars/models.py
+++ b/rpc/public/vars/models.py
@@ -5,7 +5,7 @@ class VersionInfo(BaseModel):
   version: str
 
 
-class HostnameInfo(BaseModel):
+class PublicVarsHostname1(BaseModel):
   hostname: str
 
 

--- a/rpc/public/vars/services.py
+++ b/rpc/public/vars/services.py
@@ -1,10 +1,25 @@
 from fastapi import Request
 
+from rpc.helpers import get_rpcrequest_from_request
+from rpc.models import RPCResponse
+from server.modules.db_module import DbModule
+from .models import PublicVarsHostname1
+
+
 async def public_vars_get_version_v1(request: Request):
   raise NotImplementedError("urn:public:vars:get_version:1")
 
 async def public_vars_get_hostname_v1(request: Request):
-  raise NotImplementedError("urn:public:vars:get_hostname:1")
+  rpc_request, _ = await get_rpcrequest_from_request(request)
+  db: DbModule = request.app.state.db
+  res = await db.run(rpc_request.op, rpc_request.payload or {})
+  hostname = res.rows[0].get("hostname") if res.rows else ""
+  payload = PublicVarsHostname1(hostname=hostname)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
 
 async def public_vars_get_repo_v1(request: Request):
   raise NotImplementedError("urn:public:vars:get_repo:1")

--- a/server/modules/providers/mssql_provider/registry.py
+++ b/server/modules/providers/mssql_provider/registry.py
@@ -194,6 +194,16 @@ def _public_links_get_navbar_routes(args: Dict[str, Any]):
     """
     return ("json_many", sql, (mask,))
 
+@register("urn:public:vars:get_hostname:1")
+def _public_vars_get_hostname(args: Dict[str, Any]):
+  sql = """
+    SELECT element_value AS hostname
+    FROM system_config
+    WHERE element_key = 'hostname'
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return ("json_one", sql, ())
+
 @register("db:users:profile:set_profile_image:1")
 async def _users_set_img(args: Dict[str, Any]):
     guid, image_b64 = args["guid"], args["image_b64"]

--- a/tests/test_public_vars_service.py
+++ b/tests/test_public_vars_service.py
@@ -1,0 +1,54 @@
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+import pathlib, sys, types
+
+# Stub rpc package to avoid side effects from rpc.__init__
+pkg = types.ModuleType('rpc')
+pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc')]
+sys.modules.setdefault('rpc', pkg)
+
+# Stub server modules to prevent importing full server app
+server_pkg = types.ModuleType('server')
+modules_pkg = types.ModuleType('server.modules')
+db_module_pkg = types.ModuleType('server.modules.db_module')
+
+class DbModule:  # minimal placeholder for import
+  pass
+
+db_module_pkg.DbModule = DbModule
+modules_pkg.db_module = db_module_pkg
+server_pkg.modules = modules_pkg
+
+sys.modules.setdefault('server', server_pkg)
+sys.modules.setdefault('server.modules', modules_pkg)
+sys.modules.setdefault('server.modules.db_module', db_module_pkg)
+
+from rpc.public.vars.services import public_vars_get_hostname_v1
+
+
+class DummyDb:
+  async def run(self, op: str, args: dict):
+    assert op == "urn:public:vars:get_hostname:1"
+    assert args == {}
+    return types.SimpleNamespace(rows=[{"hostname": "example.com"}], rowcount=1)
+
+
+app = FastAPI()
+app.state.db = DummyDb()
+
+
+@app.post("/rpc")
+async def rpc_endpoint(request: Request):
+  return await public_vars_get_hostname_v1(request)
+
+
+client = TestClient(app)
+
+
+def test_get_hostname_service():
+  resp = client.post("/rpc", json={"op": "urn:public:vars:get_hostname:1"})
+  assert resp.status_code == 200
+  data = resp.json()
+  assert data["op"] == "urn:public:vars:get_hostname:1"
+  assert data["payload"] == {"hostname": "example.com"}
+


### PR DESCRIPTION
## Summary
- add `PublicVarsHostname1` model and use it for hostname responses
- implement `public_vars_get_hostname_v1` to read hostname from config
- register MSSQL query for `urn:public:vars:get_hostname:1`
- generate updated TypeScript models and add service test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cbcc420408325b09fe0ea1ca332f5