### PR TITLE
Use unified Discord suffix view model

### DIFF
--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -18,19 +18,21 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
-export interface HomeLinks {
-  links: LinkItem[];
+export interface ViewSuffixDiscord1 {
+  content: string;
 }
-export interface LinkItem {
-  title: string;
-  url: string;
+export interface AuthTokens {
+  bearerToken: string;
+  session: SessionToken;
 }
-export interface NavbarRoute {
-  path: string;
-  label: string;
-}
-export interface NavbarRoutes {
-  routes: NavbarRoute[];
+export interface SessionToken {
+  sub: string;
+  roles: string[];
+  iat: number;
+  exp: number;
+  jti: string;
+  session: string;
+  provider: string;
 }
 export interface FfmpegVersion {
   ffmpeg_version: string;
@@ -47,18 +49,19 @@ export interface RepoInfo {
 export interface VersionInfo {
   version: string;
 }
-export interface AuthTokens {
-  bearerToken: string;
-  session: SessionToken;
+export interface HomeLinks {
+  links: LinkItem[];
 }
-export interface SessionToken {
-  sub: string;
-  roles: string[];
-  iat: number;
-  exp: number;
-  jti: string;
-  session: string;
-  provider: string;
+export interface LinkItem {
+  title: string;
+  url: string;
+}
+export interface NavbarRoute {
+  path: string;
+  label: string;
+}
+export interface NavbarRoutes {
+  routes: NavbarRoute[];
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -42,3 +42,7 @@ class RPCResponse(BaseModel):
     default_factory=lambda: datetime.now(timezone.utc),
     description="Server UTC timestamp of response generation"
   )
+
+
+class ViewSuffixDiscord1(BaseModel):
+  content: str

--- a/rpc/suffix.py
+++ b/rpc/suffix.py
@@ -86,31 +86,31 @@ def apply_suffixes(response: RPCResponse, suffixes: List[Tuple[str, List[str]]],
 
 @register_suffix("view", 2)
 def _view_handler(resp: RPCResponse, args: List[str]) -> RPCResponse:
-  from rpc.public.vars.models import ViewDiscord1, ViewDiscord2
+  from rpc.models import ViewSuffixDiscord1
   context, version = args
   if resp.op == "urn:frontend:vars:hostname:1" and context == "discord" and version == "1":
     from rpc.public.vars.models import FrontendVarsHostname1
     assert isinstance(resp.payload, FrontendVarsHostname1)
-    resp.payload = ViewDiscord1(content=f"Hostname: {resp.payload.hostname}")
+    resp.payload = ViewSuffixDiscord1(content=f"Hostname: {resp.payload.hostname}")
   if resp.op == "urn:frontend:vars:version:1" and context == "discord" and version == "1":
     from rpc.public.vars.models import FrontendVarsVersion1
     assert isinstance(resp.payload, FrontendVarsVersion1)
-    resp.payload = ViewDiscord1(content=f"Version: {resp.payload.version}")
+    resp.payload = ViewSuffixDiscord1(content=f"Version: {resp.payload.version}")
   if resp.op == "urn:frontend:vars:repo:1" and context == "discord" and version == "1":
     from rpc.public.vars.models import FrontendVarsRepo1
     assert isinstance(resp.payload, FrontendVarsRepo1)
-    resp.payload = ViewDiscord1(content=f"GitHub: {resp.payload.repo}")
+    resp.payload = ViewSuffixDiscord1(content=f"GitHub: {resp.payload.repo}")
   if resp.op == "urn:frontend:vars:hostname:2" and context == "discord" and version == "2":
     from rpc.public.vars.models import FrontendVarsHostname2
     assert isinstance(resp.payload, FrontendVarsHostname2)
-    resp.payload = ViewDiscord2(content=f"Hostname: {resp.payload.hostname}")
+    resp.payload = ViewSuffixDiscord1(content=f"Hostname: {resp.payload.hostname}")
   if resp.op == "urn:frontend:vars:version:2" and context == "discord" and version == "2":
     from rpc.public.vars.models import FrontendVarsVersion2
     assert isinstance(resp.payload, FrontendVarsVersion2)
-    resp.payload = ViewDiscord2(content=f"Version: {resp.payload.version}")
+    resp.payload = ViewSuffixDiscord1(content=f"Version: {resp.payload.version}")
   if resp.op == "urn:frontend:vars:repo:2" and context == "discord" and version == "2":
     from rpc.public.vars.models import FrontendVarsRepo2
     assert isinstance(resp.payload, FrontendVarsRepo2)
-    resp.payload = ViewDiscord2(content=f"GitHub: {resp.payload.repo}")
+    resp.payload = ViewSuffixDiscord1(content=f"GitHub: {resp.payload.repo}")
   return resp
 


### PR DESCRIPTION
## Summary
- unify Discord view models into `ViewSuffixDiscord1`
- update suffix handler to use unified model
- regenerate RPC TypeScript models

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `python scripts/generate_rpc_metadata.py`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run type-check`
- `npm --prefix frontend test -- --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cca0e00a883258b76127791936a5c