### PR TITLE
Introduce AuthContext and authz module for role handling

### DIFF
--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -8,7 +8,7 @@ from rpc.models import RPCResponse
 
 
 async def handle_rpc_request(request: Request) -> RPCResponse:
-  rpc_request, parts = await get_rpcrequest_from_request(request)
+  rpc_request, _auth_ctx, parts = await get_rpcrequest_from_request(request)
 
   if parts[:1] != ["urn"]:
     raise HTTPException(400, "Invalid URN prefix")

--- a/rpc/models.py
+++ b/rpc/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic import BaseModel, Field
 
 
 class RPCRequest(BaseModel):
@@ -14,24 +14,6 @@ class RPCRequest(BaseModel):
     description="Client-supplied or default UTC timestamp",
   )
 
-  _user_guid: Optional[str] = PrivateAttr(None)
-  _user_role: int = PrivateAttr(0)
-
-  @property
-  def user_guid(self) -> Optional[str]:
-    return self._user_guid
-
-  @user_guid.setter
-  def user_guid(self, value: Optional[str]) -> None:
-    self._user_guid = value
-
-  @property
-  def user_role(self) -> int:
-    return self._user_role
-
-  @user_role.setter
-  def user_role(self, value: int) -> None:
-    self._user_role = value
 
 class RPCResponse(BaseModel):
   op: str

--- a/rpc/public/links/services.py
+++ b/rpc/public/links/services.py
@@ -7,7 +7,7 @@ from .models import HomeLinks, LinkItem
 
 
 async def public_links_get_home_links_v1(request: Request):
-  rpc_request, _ = await get_rpcrequest_from_request(request)
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
   db: DbModule = request.app.state.db
   res = await db.run(rpc_request.op, rpc_request.payload or {})
   links = [LinkItem(**row) for row in res.rows]

--- a/rpc/public/vars/services.py
+++ b/rpc/public/vars/services.py
@@ -7,7 +7,7 @@ from .models import PublicVarsHostname1, PublicVarsVersion1
 
 
 async def public_vars_get_version_v1(request: Request):
-  rpc_request, _ = await get_rpcrequest_from_request(request)
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
   db: DbModule = request.app.state.db
   res = await db.run(rpc_request.op, rpc_request.payload or {})
   version = res.rows[0].get("version") if res.rows else ""
@@ -19,7 +19,7 @@ async def public_vars_get_version_v1(request: Request):
   )
 
 async def public_vars_get_hostname_v1(request: Request):
-  rpc_request, _ = await get_rpcrequest_from_request(request)
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
   db: DbModule = request.app.state.db
   res = await db.run(rpc_request.op, rpc_request.payload or {})
   hostname = res.rows[0].get("hostname") if res.rows else ""

--- a/server/auth_context.py
+++ b/server/auth_context.py
@@ -1,0 +1,10 @@
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+class AuthContext(BaseModel):
+  user_guid: Optional[str] = None
+  role_mask: int = 0
+  roles: list[str] = Field(default_factory=list)
+  provider: Optional[str] = None
+  claims: dict[str, Any] = Field(default_factory=dict)

--- a/server/modules/authz_module.py
+++ b/server/modules/authz_module.py
@@ -1,0 +1,55 @@
+import logging
+from typing import Dict
+import pyodbc
+
+from fastapi import FastAPI
+
+from . import BaseModule
+from .db_module import DbModule
+
+ROLES: Dict[str, int] = {}
+ROLE_NAMES: list[str] = []
+ROLE_REGISTERED: int = 1
+
+class AuthzModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    await self.load_roles()
+    logging.info("AuthzModule loaded %d roles", len(ROLES))
+    self.mark_ready()
+
+  async def shutdown(self):
+    logging.info("AuthzModule shutdown")
+
+  async def load_roles(self):
+    if not self.db:
+      return
+    list_roles = getattr(self.db, 'list_roles', None)
+    if not list_roles:
+      return
+    try:
+      rows = await list_roles()
+    except pyodbc.Error:
+      return
+    if not rows:
+      return
+    ROLES.clear()
+    for r in rows:
+      ROLES[r['name']] = int(r['mask'])
+    global ROLE_NAMES, ROLE_REGISTERED
+    ROLE_NAMES = [n for n in ROLES.keys() if n != 'ROLE_REGISTERED']
+    ROLE_REGISTERED = ROLES.get('ROLE_REGISTERED', 0)
+
+  def mask_to_names(self, mask: int) -> list[str]:
+    return [name for name, bit in ROLES.items() if mask & bit]
+
+  def names_to_mask(self, names: list[str]) -> int:
+    mask = 0
+    for name in names:
+      mask |= ROLES.get(name, 0)
+    return mask

--- a/tests/test_public_links_service.py
+++ b/tests/test_public_links_service.py
@@ -11,6 +11,7 @@ sys.modules.setdefault('rpc', pkg)
 server_pkg = types.ModuleType('server')
 modules_pkg = types.ModuleType('server.modules')
 db_module_pkg = types.ModuleType('server.modules.db_module')
+auth_context_pkg = types.ModuleType('server.auth_context')
 
 class DbModule:  # minimal placeholder for import
   pass
@@ -18,10 +19,16 @@ class DbModule:  # minimal placeholder for import
 db_module_pkg.DbModule = DbModule
 modules_pkg.db_module = db_module_pkg
 server_pkg.modules = modules_pkg
+class AuthContext:
+  def __init__(self, **data):
+    self.role_mask = 0
+    self.__dict__.update(data)
+auth_context_pkg.AuthContext = AuthContext
 
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.modules', modules_pkg)
 sys.modules.setdefault('server.modules.db_module', db_module_pkg)
+sys.modules.setdefault('server.auth_context', auth_context_pkg)
 
 from rpc.public.links.services import public_links_get_home_links_v1
 

--- a/tests/test_public_vars_service.py
+++ b/tests/test_public_vars_service.py
@@ -11,6 +11,7 @@ sys.modules.setdefault('rpc', pkg)
 server_pkg = types.ModuleType('server')
 modules_pkg = types.ModuleType('server.modules')
 db_module_pkg = types.ModuleType('server.modules.db_module')
+auth_context_pkg = types.ModuleType('server.auth_context')
 
 class DbModule:  # minimal placeholder for import
   pass
@@ -18,10 +19,16 @@ class DbModule:  # minimal placeholder for import
 db_module_pkg.DbModule = DbModule
 modules_pkg.db_module = db_module_pkg
 server_pkg.modules = modules_pkg
+class AuthContext:
+  def __init__(self, **data):
+    self.role_mask = 0
+    self.__dict__.update(data)
+auth_context_pkg.AuthContext = AuthContext
 
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.modules', modules_pkg)
 sys.modules.setdefault('server.modules.db_module', db_module_pkg)
+sys.modules.setdefault('server.auth_context', auth_context_pkg)
 
 from rpc.public.vars.services import public_vars_get_hostname_v1, public_vars_get_version_v1
 

--- a/tests/test_rpc_helpers.py
+++ b/tests/test_rpc_helpers.py
@@ -21,14 +21,23 @@ models_mod.RPCRequest = RPCRequest
 models_mod.RPCResponse = RPCResponse
 sys.modules['rpc.models'] = models_mod
 
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+  sys.path.insert(0, str(ROOT))
+
+server_pkg = types.ModuleType('server')
+server_pkg.__path__ = [str(ROOT / 'server')]
+sys.modules.pop('server', None)
+sys.modules['server'] = server_pkg
+
 from rpc.helpers import get_rpcrequest_from_request
 
 app = FastAPI()
 
 @app.post('/rpc')
 async def parse_rpc(request: Request):
-  rpc_request, parts = await get_rpcrequest_from_request(request)
-  return {'user_role': rpc_request.user_role, 'parts': parts}
+  rpc_request, auth_ctx, parts = await get_rpcrequest_from_request(request)
+  return {'user_role': auth_ctx.role_mask, 'parts': parts}
 
 client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- add AuthContext model for token claims
- create AuthzModule to load roles and convert role masks
- refactor RPC helpers and services to use AuthContext instead of mutating RPCRequest

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `python scripts/generate_rpc_metadata.py`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d2a9934188325b3ce7e6502819fec