### PR TITLE
refactor: move AuthContext to dedicated models module

### DIFF
--- a/rpc/helpers.py
+++ b/rpc/helpers.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from fastapi import HTTPException, Request
 
 from rpc.models import RPCRequest
-from server import AuthContext
+from server.models import AuthContext
 
 if TYPE_CHECKING:
   from server.modules.auth_module import AuthModule

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,23 +1,11 @@
-from typing import Any, Optional
-
-from pydantic import BaseModel, Field
-
 from . import lifespan
 from .routers import rpc_router, web_router
 from .helpers.logging import configure_root_logging
 
-
-class AuthContext(BaseModel):
-  user_guid: Optional[str] = None
-  role_mask: int = 0
-  roles: list[str] = Field(default_factory=list)
-  provider: Optional[str] = None
-  claims: dict[str, Any] = Field(default_factory=dict)
 
 __all__ = [
   "rpc_router",
   "web_router",
   "lifespan",
   "configure_root_logging",
-  "AuthContext",
 ]

--- a/server/models.py
+++ b/server/models.py
@@ -1,0 +1,11 @@
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AuthContext(BaseModel):
+  user_guid: Optional[str] = None
+  role_mask: int = 0
+  roles: list[str] = Field(default_factory=list)
+  provider: Optional[str] = None
+  claims: dict[str, Any] = Field(default_factory=dict)

--- a/tests/test_public_links_service.py
+++ b/tests/test_public_links_service.py
@@ -11,6 +11,7 @@ sys.modules.setdefault('rpc', pkg)
 server_pkg = types.ModuleType('server')
 modules_pkg = types.ModuleType('server.modules')
 db_module_pkg = types.ModuleType('server.modules.db_module')
+models_pkg = types.ModuleType('server.models')
 
 class DbModule:  # minimal placeholder for import
   pass
@@ -22,11 +23,13 @@ class AuthContext:
   def __init__(self, **data):
     self.role_mask = 0
     self.__dict__.update(data)
-server_pkg.AuthContext = AuthContext
+models_pkg.AuthContext = AuthContext
+server_pkg.models = models_pkg
 
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.modules', modules_pkg)
 sys.modules.setdefault('server.modules.db_module', db_module_pkg)
+sys.modules.setdefault('server.models', models_pkg)
 
 from rpc.public.links.services import public_links_get_home_links_v1
 

--- a/tests/test_public_vars_service.py
+++ b/tests/test_public_vars_service.py
@@ -11,6 +11,7 @@ sys.modules.setdefault('rpc', pkg)
 server_pkg = types.ModuleType('server')
 modules_pkg = types.ModuleType('server.modules')
 db_module_pkg = types.ModuleType('server.modules.db_module')
+models_pkg = types.ModuleType('server.models')
 
 class DbModule:  # minimal placeholder for import
   pass
@@ -22,11 +23,13 @@ class AuthContext:
   def __init__(self, **data):
     self.role_mask = 0
     self.__dict__.update(data)
-server_pkg.AuthContext = AuthContext
+models_pkg.AuthContext = AuthContext
+server_pkg.models = models_pkg
 
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.modules', modules_pkg)
 sys.modules.setdefault('server.modules.db_module', db_module_pkg)
+sys.modules.setdefault('server.models', models_pkg)
 
 from rpc.public.vars.services import public_vars_get_hostname_v1, public_vars_get_version_v1
 


### PR DESCRIPTION
## Summary
- move `AuthContext` into new `server/models.py`
- update imports to use `server.models` and adjust tests

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_689d42cae0d88325811286fdfab1a080