### PR TITLE
Implement ffmpeg and repo public vars

### DIFF
--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -31,6 +31,21 @@ export interface SessionToken {
   session: string;
   provider: string;
 }
+export interface PublicVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface PublicVarsHostname1 {
+  hostname: string;
+}
+export interface PublicVarsOdbcVersion1 {
+  odbc_version: string;
+}
+export interface PublicVarsRepo1 {
+  repo: string;
+}
+export interface PublicVarsVersion1 {
+  version: string;
+}
 export interface HomeLinks {
   links: LinkItem[];
 }
@@ -44,21 +59,6 @@ export interface NavbarRoute {
 }
 export interface NavbarRoutes {
   routes: NavbarRoute[];
-}
-export interface FfmpegVersion {
-  ffmpeg_version: string;
-}
-export interface OdbcVersion {
-  odbc_version: string;
-}
-export interface PublicVarsHostname1 {
-  hostname: string;
-}
-export interface PublicVarsVersion1 {
-  version: string;
-}
-export interface RepoInfo {
-  repo: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/public/vars/models.py
+++ b/rpc/public/vars/models.py
@@ -9,13 +9,13 @@ class PublicVarsHostname1(BaseModel):
   hostname: str
 
 
-class RepoInfo(BaseModel):
+class PublicVarsRepo1(BaseModel):
   repo: str
 
 
-class FfmpegVersion(BaseModel):
+class PublicVarsFfmpegVersion1(BaseModel):
   ffmpeg_version: str
 
 
-class OdbcVersion(BaseModel):
+class PublicVarsOdbcVersion1(BaseModel):
   odbc_version: str

--- a/rpc/public/vars/services.py
+++ b/rpc/public/vars/services.py
@@ -1,9 +1,15 @@
-from fastapi import Request
+import asyncio
+from fastapi import HTTPException, Request
 
 from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
 from server.modules.db_module import DbModule
-from .models import PublicVarsHostname1, PublicVarsVersion1
+from .models import (
+  PublicVarsFfmpegVersion1,
+  PublicVarsHostname1,
+  PublicVarsRepo1,
+  PublicVarsVersion1,
+)
 
 
 async def public_vars_get_version_v1(request: Request):
@@ -31,10 +37,39 @@ async def public_vars_get_hostname_v1(request: Request):
   )
 
 async def public_vars_get_repo_v1(request: Request):
-  raise NotImplementedError("urn:public:vars:get_repo:1")
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  db: DbModule = request.app.state.db
+  res = await db.run(rpc_request.op, rpc_request.payload or {})
+  repo = res.rows[0].get("repo") if res.rows else ""
+  payload = PublicVarsRepo1(repo=repo)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
 
 async def public_vars_get_ffmpeg_version_v1(request: Request):
-  raise NotImplementedError("urn:public:vars:get_ffmpeg_version:1")
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  try:
+    process = await asyncio.create_subprocess_exec(
+      "ffmpeg",
+      "-version",
+      stdout=asyncio.subprocess.PIPE,
+      stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    if stdout:
+      version_line = stdout.decode().splitlines()[0]
+    else:
+      version_line = stderr.decode().splitlines()[0]
+    payload = PublicVarsFfmpegVersion1(ffmpeg_version=version_line)
+    return RPCResponse(
+      op=rpc_request.op,
+      payload=payload.model_dump(),
+      version=rpc_request.version,
+    )
+  except Exception as e:
+    raise HTTPException(status_code=500, detail=f"Error checking ffmpeg: {e}")
 
 async def public_vars_get_odbc_version_v1(request: Request):
   raise NotImplementedError("urn:public:vars:get_odbc_version:1")


### PR DESCRIPTION
## Summary
- add models and handlers for public vars repo and ffmpeg version
- regenerate RPC models

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_689d460b61c08325bb972f8d97225c5f