### PR TITLE
feat: report odbc version

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -7,15 +7,17 @@ import {
         fetchVersion,
         fetchRepo,
         fetchFfmpegVersion,
+        fetchOdbcVersion,
 } from './rpc/public/vars';
 import { fetchHomeLinks } from './rpc/public/links';
 
 const Home = (): JSX.Element => {
-	const [hostname, setHostname] = useState('');
-	const [version, setVersion] = useState('');
-	const [repo, setRepo] = useState('');
-	const [ffmpegVersion, setFfmpegVersion] = useState<string | null>(null);
-	const [links, setLinks] = useState<LinkItem[]>([]);
+        const [hostname, setHostname] = useState('');
+        const [version, setVersion] = useState('');
+        const [repo, setRepo] = useState('');
+        const [ffmpegVersion, setFfmpegVersion] = useState<string | null>(null);
+        const [odbcVersion, setOdbcVersion] = useState<string | null>(null);
+        const [links, setLinks] = useState<LinkItem[]>([]);
 
 	useEffect(() => {
 		void (async () => {
@@ -43,20 +45,28 @@ const Home = (): JSX.Element => {
 				setVersion('v0.0.0');
 			}
 
-			try {
-				const ffmpegInfo = await fetchFfmpegVersion();
-				const cleanFfmpeg = ffmpegInfo.ffmpeg_version.replace(/^"|"$/g, '');
-				setFfmpegVersion(cleanFfmpeg);
-			} catch {
-				setFfmpegVersion('unknown');
-			}
+                        try {
+                                const ffmpegInfo = await fetchFfmpegVersion();
+                                const cleanFfmpeg = ffmpegInfo.ffmpeg_version.replace(/^"|"$/g, '');
+                                setFfmpegVersion(cleanFfmpeg);
+                        } catch {
+                                setFfmpegVersion('ffmpeg library not found (Windows)');
+                        }
 
-			try {
+                        try {
+                                const odbcInfo = await fetchOdbcVersion();
+                                const cleanOdbc = odbcInfo.odbc_version.replace(/^"|"$/g, '');
+                                setOdbcVersion(cleanOdbc);
+                        } catch {
+                                setOdbcVersion('odbc library not found (Windows)');
+                        }
+
+                        try {
                                 const homeLinks = await fetchHomeLinks();
                                 setLinks(homeLinks.links);
-			} catch {
-				setLinks([]);
-			}
+                        } catch {
+                                setLinks([]);
+                        }
 		})();
 	}, []);
 
@@ -90,14 +100,17 @@ const Home = (): JSX.Element => {
 			<Typography variant="body1" sx={{ marginTop: '20px' }}>
 				{version} running on {hostname}
 			</Typography>
-			<Typography variant="body1" sx={{ marginTop: '4px' }}>
-				{ffmpegVersion ? ffmpegVersion : 'Loading version...'}
-			</Typography>
-			<Typography variant="body1" sx={{ marginTop: '4px' }}>
-				GitHub:{' '}
-				<Link
-					href={repo}
-					target="_blank"
+                        <Typography variant="body1" sx={{ marginTop: '4px' }}>
+                                {ffmpegVersion ? ffmpegVersion : 'Loading version...'}
+                        </Typography>
+                        <Typography variant="body1" sx={{ marginTop: '4px' }}>
+                                {odbcVersion ? odbcVersion : 'Loading version...'}
+                        </Typography>
+                        <Typography variant="body1" sx={{ marginTop: '4px' }}>
+                                GitHub:{' '}
+                                <Link
+                                        href={repo}
+                                        target="_blank"
 					rel="noopener noreferrer"
 					underline="none"
 					sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}

--- a/rpc/public/vars/services.py
+++ b/rpc/public/vars/services.py
@@ -1,4 +1,5 @@
 import asyncio
+import platform
 from fastapi import HTTPException, Request
 
 from rpc.helpers import get_rpcrequest_from_request
@@ -9,6 +10,7 @@ from .models import (
   PublicVarsHostname1,
   PublicVarsRepo1,
   PublicVarsVersion1,
+  PublicVarsOdbcVersion1,
 )
 
 
@@ -72,5 +74,41 @@ async def public_vars_get_ffmpeg_version_v1(request: Request):
     raise HTTPException(status_code=500, detail=f"Error checking ffmpeg: {e}")
 
 async def public_vars_get_odbc_version_v1(request: Request):
-  raise NotImplementedError("urn:public:vars:get_odbc_version:1")
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  try:
+    system = platform.system().lower()
+    if system == "windows":
+      process = await asyncio.create_subprocess_exec(
+        "powershell",
+        "-Command",
+        "(Get-ItemProperty 'HKLM:\\SOFTWARE\\ODBC\\ODBCINST.INI\\ODBC Driver 18 for SQL Server').Version",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+      )
+      stdout, stderr = await process.communicate()
+      version_line = stdout.decode().strip() or stderr.decode().strip() or "odbc library not found"
+    else:
+      pkgs = ["msodbcsql18", "unixodbc", "libodbc2"]
+      parts = []
+      for pkg in pkgs:
+        proc = await asyncio.create_subprocess_exec(
+          "dpkg-query",
+          "-W",
+          "-f=${Version}",
+          pkg,
+          stdout=asyncio.subprocess.PIPE,
+          stderr=asyncio.subprocess.PIPE,
+        )
+        out, _ = await proc.communicate()
+        if proc.returncode == 0 and out:
+          parts.append(f"{pkg} {out.decode().strip()}")
+      version_line = ", ".join(parts) if parts else "odbc libraries not found"
+    payload = PublicVarsOdbcVersion1(odbc_version=version_line)
+    return RPCResponse(
+      op=rpc_request.op,
+      payload=payload.model_dump(),
+      version=rpc_request.version,
+    )
+  except Exception as e:
+    raise HTTPException(status_code=500, detail=f"Error checking ODBC libraries: {e}")
 


### PR DESCRIPTION
## Summary
- add RPC service to report ODBC driver versions
- surface ODBC version in homepage and clarify ffmpeg missing on Windows

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d49974e988325aab372626eccbb3d