### PR TITLE
Call mark_ready after JWKS load in auth module

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -52,6 +52,7 @@ class AuthModule(BaseModule):
       jwks_uri = await fetch_ms_jwks_uri()
       self.ms_jwks = await fetch_ms_jwks(jwks_uri)
       logging.info("Auth module loaded")
+      self.mark_ready()
     except Exception as e:
       logging.error(f"[AuthModule] Failed to load Microsoft JWKS: {e}")
 


### PR DESCRIPTION
## Summary
- ensure AuthModule signals readiness once Microsoft JWKS are successfully fetched

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_689d6a5a31e08325a757df9713724467