### PR TITLE
Remove debug file listings from Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,10 +77,6 @@ RUN rm /app/docker_cleanup.sh
 
 RUN chmod +x /app/startup.sh
 
-# Informative log output of RPC namespace
-RUN ls -al /app
-RUN ls -Ral /app/rpc
-
 # Setup dockerfile entry point
 EXPOSE 8000
 CMD ["/bin/sh", "/app/startup.sh"]


### PR DESCRIPTION
## Summary
- remove extraneous `ls` commands from Dockerfile to streamline final image

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run type-check`
- `npm --prefix frontend test -- --run`
- `pytest`
- `docker build -t elideus .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e0408e46c8325a6c0d93106345232