### PR TITLE
chore: pin dependency versions for py312

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,14 @@ openai==1.30.1
 lumaai==1.17.0
 azure-storage-blob==12.19.0
 aiofiles==23.2.1
-aiohttp==3.8.6
+# Use versions with prebuilt wheels compatible with Python 3.12
+# Older pins failed to build on some systems
+aiohttp==3.9.5
 aioodbc==0.4.1
 python-dotenv==1.0.1
-asyncpg==0.29.0
+# 0.28 series maintains stable 3.12 wheels
+asyncpg==0.28.0
 python-jose==3.3.0
-tiktoken==0.7.0
+# Earlier tiktoken release avoids build errors without Rust
+tiktoken==0.5.2
 atproto==0.0.61


### PR DESCRIPTION
## Summary
- pin aiohttp to 3.9.5 for Python 3.12 wheel availability
- pin asyncpg to 0.28.0 for stable prebuilt wheels
- pin tiktoken to 0.5.2 to avoid rust build requirement

## Testing
- `python scripts/generate_rpc_client.py` *(fails: No module named 'pydantic')*
- `python scripts/generate_rpc_library.py` *(fails: No module named 'pydantic')*
- `python scripts/generate_rpc_metadata.py` *(fails: No module named 'pydantic')*
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689e9628fee083258bfca35da37545ff