### PR TITLE
Fix BaseModule async lifecycle signatures

### DIFF
--- a/server/modules/__init__.py
+++ b/server/modules/__init__.py
@@ -12,11 +12,11 @@ class BaseModule(ABC):
     self._ready_event = asyncio.Event()
 
   @abstractmethod
-  async def startup():
+  async def startup(self):
     pass
 
   @abstractmethod
-  async def shutdown():
+  async def shutdown(self):
     pass
 
   def mark_ready(self):


### PR DESCRIPTION
## Summary
- fix BaseModule to define async lifecycle methods with `self`

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_689e9f41d9e0832585a1b0b467599fbd