### PR TITLE
Add navbar routes RPC and component

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -56,7 +56,7 @@ Frontend-facing operations.
 
 | Operation | Description |
 | --- | --- |
-| `db:public:links:get_navbar_routes:1` | Return navigation routes filtered by role mask. |
+| `urn:public:links:get_navbar_routes:1` | Return navigation routes filtered by role mask. |
 
 ## System Domain
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import { CssBaseline, Container } from '@mui/material'
 import ElideusTheme from './shared/ElideusTheme'
 import UserContextProvider from './shared/UserContextProvider'
 import Home from './Home'
+import NavBar from './NavBar'
+import Gallery from './Gallery'
 
 function App(): JSX.Element {
 	return (
@@ -11,9 +13,11 @@ function App(): JSX.Element {
 			<CssBaseline />
 			<UserContextProvider>
 				<Router>
-                    <Container maxWidth='lg' disableGutters sx={{ bgcolor: 'background.paper', color: 'text.primary', minHeight: '100vh', py: 2 }}>
+					<NavBar />
+					<Container maxWidth='lg' disableGutters sx={{ bgcolor: 'background.paper', color: 'text.primary', minHeight: '100vh', py: 2 }}>
 						<Routes>
 							<Route path='/' element={<Home />} />
+							<Route path='/gallery' element={<Gallery />} />
 						</Routes>
 					</Container>
 				</Router>

--- a/frontend/src/Gallery.tsx
+++ b/frontend/src/Gallery.tsx
@@ -1,0 +1,6 @@
+import type { JSX } from 'react';
+
+// TODO: Implement gallery component
+export default function Gallery(): JSX.Element {
+	return <div>Gallery placeholder</div>;
+}

--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography, Link, CardMedia } from '@mui/material';
 import { useEffect, useState } from 'react';
-import type { LinkItem } from './shared/RpcModels';
+import type { PublicLinksLinkItem1 } from './shared/RpcModels';
 import Logo from './assets/elideus_group_green.png';
 import {
         fetchHostname,
@@ -17,7 +17,7 @@ const Home = (): JSX.Element => {
         const [repo, setRepo] = useState('');
         const [ffmpegVersion, setFfmpegVersion] = useState<string | null>(null);
         const [odbcVersion, setOdbcVersion] = useState<string | null>(null);
-        const [links, setLinks] = useState<LinkItem[]>([]);
+        const [links, setLinks] = useState<PublicLinksLinkItem1[]>([]);
 
 	useEffect(() => {
 		void (async () => {

--- a/frontend/src/NavBar.tsx
+++ b/frontend/src/NavBar.tsx
@@ -1,0 +1,79 @@
+import { useState, useEffect, useContext } from 'react';
+import { Link } from 'react-router-dom';
+import {
+	Drawer,
+	Box,
+	IconButton,
+	Tooltip,
+	List,
+	ListItemButton,
+	ListItemIcon,
+	ListItemText,
+} from '@mui/material';
+import { Menu as MenuIcon } from '@mui/icons-material';
+import type { PublicLinksNavBarRoute1, PublicLinksNavBarRoutes1 } from './shared/RpcModels';
+import { fetchNavbarRoutes } from './rpc/public/links';
+import { iconMap, defaultIcon } from './icons';
+import UserContext from './shared/UserContext';
+
+const DRAWER_OPEN = 240;
+const DRAWER_CLOSED = 60;
+
+const NavBar = (): JSX.Element => {
+	const [open, setOpen] = useState(false);
+        const [routes, setRoutes] = useState<PublicLinksNavBarRoute1[]>([]);
+	const { userData } = useContext(UserContext);
+
+	useEffect(() => {
+		void (async () => {
+			try {
+                                const res: PublicLinksNavBarRoutes1 = await fetchNavbarRoutes();
+				setRoutes(res.routes);
+			} catch {
+				setRoutes([]);
+			}
+		})();
+	}, [userData]);
+
+	return (
+		<Drawer
+			variant="permanent"
+			open={open}
+			sx={{
+				width: open ? DRAWER_OPEN : DRAWER_CLOSED,
+				position: 'fixed',
+				height: '100%',
+				zIndex: 1300,
+				left: (theme) => theme.spacing(3),
+				'& .MuiDrawer-paper': {
+					width: open ? DRAWER_OPEN : DRAWER_CLOSED,
+					overflowX: 'hidden',
+					position: 'fixed',
+				},
+			}}
+		>
+			<Box sx={{ display: 'flex', justifyContent: 'flex-start', pl: 1, py: 1 }}>
+				<Tooltip title="Toggle Menu">
+					<IconButton onClick={() => setOpen(!open)}>
+						<MenuIcon />
+					</IconButton>
+				</Tooltip>
+			</Box>
+			<List sx={{ flexGrow: 1 }}>
+				{routes.map((route) => {
+					const IconComp = iconMap[route.icon ?? ''] || defaultIcon;
+					return (
+						<ListItemButton component={Link} to={route.path} key={route.path}>
+							<ListItemIcon>
+								<IconComp />
+							</ListItemIcon>
+							{open && <ListItemText primary={route.name} />}
+						</ListItemButton>
+					);
+				})}
+			</List>
+		</Drawer>
+	);
+};
+
+export default NavBar;

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -31,6 +31,21 @@ export interface SessionToken {
   session: string;
   provider: string;
 }
+export interface PublicLinksHomeLinks1 {
+  links: PublicLinksLinkItem1[];
+}
+export interface PublicLinksLinkItem1 {
+  title: string;
+  url: string;
+}
+export interface PublicLinksNavBarRoute1 {
+  path: string;
+  name: string;
+  icon: string | null;
+}
+export interface PublicLinksNavBarRoutes1 {
+  routes: PublicLinksNavBarRoute1[];
+}
 export interface PublicVarsFfmpegVersion1 {
   ffmpeg_version: string;
 }
@@ -45,20 +60,6 @@ export interface PublicVarsRepo1 {
 }
 export interface PublicVarsVersion1 {
   version: string;
-}
-export interface HomeLinks {
-  links: LinkItem[];
-}
-export interface LinkItem {
-  title: string;
-  url: string;
-}
-export interface NavbarRoute {
-  path: string;
-  label: string;
-}
-export interface NavbarRoutes {
-  routes: NavbarRoute[];
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/public/links/models.py
+++ b/rpc/public/links/models.py
@@ -1,20 +1,23 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 
-class LinkItem(BaseModel):
+class PublicLinksLinkItem1(BaseModel):
   title: str
   url: str
 
 
-class HomeLinks(BaseModel):
-  links: list[LinkItem]
+class PublicLinksHomeLinks1(BaseModel):
+  links: list[PublicLinksLinkItem1]
 
 
-class NavbarRoute(BaseModel):
+class PublicLinksNavBarRoute1(BaseModel):
   path: str
-  label: str
+  name: str
+  icon: Optional[str] = None
 
 
-class NavbarRoutes(BaseModel):
-  routes: list[NavbarRoute]
+class PublicLinksNavBarRoutes1(BaseModel):
+  routes: list[PublicLinksNavBarRoute1]
 

--- a/rpc/public/links/services.py
+++ b/rpc/public/links/services.py
@@ -3,15 +3,20 @@ from fastapi import Request
 from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
 from server.modules.db_module import DbModule
-from .models import HomeLinks, LinkItem
+from .models import (
+  PublicLinksHomeLinks1,
+  PublicLinksLinkItem1,
+  PublicLinksNavBarRoute1,
+  PublicLinksNavBarRoutes1,
+)
 
 
 async def public_links_get_home_links_v1(request: Request):
   rpc_request, _, _ = await get_rpcrequest_from_request(request)
   db: DbModule = request.app.state.db
   res = await db.run(rpc_request.op, rpc_request.payload or {})
-  links = [LinkItem(**row) for row in res.rows]
-  payload = HomeLinks(links=links)
+  links = [PublicLinksLinkItem1(**row) for row in res.rows]
+  payload = PublicLinksHomeLinks1(links=links)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -19,5 +24,14 @@ async def public_links_get_home_links_v1(request: Request):
   )
 
 async def public_links_get_navbar_routes_v1(request: Request):
-  raise NotImplementedError("urn:public:links:get_navbar_routes:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  db: DbModule = request.app.state.db
+  res = await db.run("urn:public:links:get_navbar_routes:1", {"role_mask": auth_ctx.role_mask})
+  routes = [PublicLinksNavBarRoute1(**row) for row in res.rows]
+  payload = PublicLinksNavBarRoutes1(routes=routes)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
 

--- a/server/modules/providers/mssql_provider/registry.py
+++ b/server/modules/providers/mssql_provider/registry.py
@@ -177,16 +177,14 @@ def _public_links_get_home_links(args: Dict[str, Any]):
     """
     return ("json_many", sql, ())
 
-@register("db:public:links:get_navbar_routes:1")
+@register("urn:public:links:get_navbar_routes:1")
 def _public_links_get_navbar_routes(args: Dict[str, Any]):
     mask = int(args.get("role_mask", 0))
     sql = """
       SELECT
-        element_path,
-        element_name,
-        element_icon,
-        element_roles,
-        element_sequence
+        element_path AS path,
+        element_name AS name,
+        element_icon AS icon
       FROM frontend_routes
       WHERE element_roles = 0 OR (element_roles & ?) = element_roles
       ORDER BY element_sequence

--- a/tests/test_public_links_service.py
+++ b/tests/test_public_links_service.py
@@ -31,14 +31,22 @@ sys.modules.setdefault('server.modules', modules_pkg)
 sys.modules.setdefault('server.modules.db_module', db_module_pkg)
 sys.modules.setdefault('server.models', models_pkg)
 
-from rpc.public.links.services import public_links_get_home_links_v1
+from rpc.public.links.services import public_links_get_home_links_v1, public_links_get_navbar_routes_v1
 
 
 class DummyDb:
   async def run(self, op: str, args: dict):
-    assert op == "urn:public:links:get_home_links:1"
-    assert args == {}
-    return types.SimpleNamespace(rows=[{"title": "GitHub", "url": "https://github.com"}], rowcount=1)
+    if op == "urn:public:links:get_home_links:1":
+      assert args == {}
+      return types.SimpleNamespace(rows=[{"title": "GitHub", "url": "https://github.com"}], rowcount=1)
+    if op == "urn:public:links:get_navbar_routes:1":
+      assert args == {"role_mask": 0}
+      rows = [
+        {"path": "/", "name": "Home", "icon": "home"},
+        {"path": "/gallery", "name": "Gallery", "icon": "gallery"},
+      ]
+      return types.SimpleNamespace(rows=rows, rowcount=2)
+    raise AssertionError(f"unexpected op {op}")
 
 
 app = FastAPI()
@@ -47,7 +55,12 @@ app.state.db = DummyDb()
 
 @app.post("/rpc")
 async def rpc_endpoint(request: Request):
-  return await public_links_get_home_links_v1(request)
+  body = await request.json()
+  if body["op"] == "urn:public:links:get_home_links:1":
+    return await public_links_get_home_links_v1(request)
+  if body["op"] == "urn:public:links:get_navbar_routes:1":
+    return await public_links_get_navbar_routes_v1(request)
+  raise AssertionError("unexpected op")
 
 
 client = TestClient(app)
@@ -60,5 +73,18 @@ def test_get_home_links_service():
   assert data["op"] == "urn:public:links:get_home_links:1"
   assert data["payload"] == {
     "links": [{"title": "GitHub", "url": "https://github.com"}]
+  }
+
+
+def test_get_navbar_routes_service():
+  resp = client.post("/rpc", json={"op": "urn:public:links:get_navbar_routes:1"})
+  assert resp.status_code == 200
+  data = resp.json()
+  assert data["op"] == "urn:public:links:get_navbar_routes:1"
+  assert data["payload"] == {
+    "routes": [
+      {"path": "/", "name": "Home", "icon": "home"},
+      {"path": "/gallery", "name": "Gallery", "icon": "gallery"},
+    ]
   }
 


### PR DESCRIPTION
## Summary
- implement public links service to fetch navbar routes based on roles
- expose navbar routes query in MSSQL provider
- add React NavBar component with home and gallery links
- use Optional typing for navbar route icon field to fix RPC generation

## Testing
- `python scripts/generate_rpc_metadata.py`
- `python scripts/generate_rpc_client.py`
- `python scripts/generate_rpc_library.py`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run type-check`
- `npm --prefix frontend test -- --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eb31a0ae0832588202ec7a27f1f5b