### PR TITLE
feat(frontend): add login page and user session handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import UserContextProvider from './shared/UserContextProvider'
 import Home from './Home'
 import NavBar from './NavBar'
 import Gallery from './Gallery'
+import LoginPage from './LoginPage'
 
 function App(): JSX.Element {
 	return (
@@ -15,10 +16,11 @@ function App(): JSX.Element {
 				<Router>
 					<NavBar />
 					<Container maxWidth='lg' disableGutters sx={{ bgcolor: 'background.paper', color: 'text.primary', minHeight: '100vh', py: 2 }}>
-						<Routes>
-							<Route path='/' element={<Home />} />
-							<Route path='/gallery' element={<Gallery />} />
-						</Routes>
+												<Routes>
+														<Route path='/' element={<Home />} />
+														<Route path='/gallery' element={<Gallery />} />
+														<Route path='/loginpage' element={<LoginPage />} />
+												</Routes>
 					</Container>
 				</Router>
 			</UserContextProvider>

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -1,0 +1,93 @@
+import { useState, useContext } from 'react';
+import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import { Login as LoginIcon } from '@mui/icons-material';
+import { Typography, Box, Tooltip, IconButton, ListItemText } from '@mui/material';
+import { PublicClientApplication } from '@azure/msal-browser';
+import { msalConfig } from './config/msal';
+import { fetchInvalidateToken } from './rpc/auth/session';
+import Notification from './Notification';
+import UserContext from './shared/UserContext';
+
+const pca = new PublicClientApplication(msalConfig);
+
+interface LoginProps {
+	open: boolean;
+}
+
+const Login = ({ open }: LoginProps): JSX.Element => {
+	const { userData, clearUserData } = useContext(UserContext);
+	const [notification, setNotification] = useState({
+		open: false,
+		severity: 'info' as 'info' | 'success' | 'warning' | 'error',
+		message: ''
+	});
+	const handleNotificationClose = (): void => {
+		setNotification(prev => ({ ...prev, open: false }));
+	};
+	const navigate = useNavigate();
+	const handleLoginNavigation = (): void => {
+		navigate('/loginpage');
+	};
+	const handleLogout = async (): Promise<void> => {
+		try {
+			await pca.initialize();
+			await pca.logoutPopup();
+			if (userData?.session?.session) {
+				try {
+					await fetchInvalidateToken({ rotationToken: userData.session.session });
+				} catch (err) {
+					console.error('Failed to invalidate session', err);
+				}
+			}
+			clearUserData();
+			setNotification({ open: true, severity: 'info', message: 'Logged out successfully.' });
+		} catch (error: any) {
+			setNotification({ open: true, severity: 'error', message: `Logout failed: ${error.message}` });
+		}
+	};
+
+	return (
+		<Box sx={{ display: 'flex', alignItems: 'center' }}>
+			{userData ? (
+				<Tooltip title='Logout'>
+					<IconButton onClick={handleLogout}>
+						<img src='' alt='user avatar' style={{ width: '28px', height: '28px', borderRadius: '50%', border: '1px solid #000' }} />
+					</IconButton>
+				</Tooltip>
+			) : (
+				<Tooltip title='Login'>
+					<IconButton onClick={handleLoginNavigation}>
+						<LoginIcon />
+					</IconButton>
+				</Tooltip>
+			)}
+
+			{open && (
+				<ListItemText
+					primary={ userData ? (
+						<Box>
+							<Typography component={RouterLink} to='/userpage' variant='body1' sx={{ fontWeight: 'bold', color: 'gray', textDecoration: 'none' }}>
+								{userData.session?.sub ?? ''}
+							</Typography>
+							<Typography component='span' variant='body2' sx={{ display: 'block', fontSize: '0.9em', color: 'gray' }}>
+								{new Intl.NumberFormat(navigator.language).format(Number(0))}
+							</Typography>
+						</Box>
+					) : (
+						'Login'
+					)}
+					sx={{ marginLeft: '8px' }}
+				/>
+			)}
+
+			<Notification
+				open={notification.open}
+				handleClose={handleNotificationClose}
+				severity={notification.severity}
+				message={notification.message}
+			/>
+		</Box>
+	);
+};
+
+export default Login;

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -1,0 +1,84 @@
+import { useContext, useState } from 'react';
+import { Container, Paper, Typography, Button, Stack } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { PublicClientApplication } from '@azure/msal-browser';
+import { msalConfig, loginRequest } from './config/msal';
+import UserContext from './shared/UserContext';
+import Notification from './Notification';
+import { fetchOauthLogin } from './rpc/auth/microsoft';
+import type { AuthTokens } from './shared/RpcModels';
+
+const pca = new PublicClientApplication(msalConfig);
+
+const LoginPage = (): JSX.Element => {
+	const { setUserData } = useContext(UserContext);
+	const [notification, setNotification] = useState({
+		open: false,
+		severity: 'info' as 'info' | 'success' | 'warning' | 'error',
+		message: ''
+	});
+	const navigate = useNavigate();
+
+	const handleNotificationClose = (): void => {
+		setNotification(prev => ({ ...prev, open: false }));
+	};
+
+	const handleMicrosoftLogin = async (): Promise<void> => {
+		try {
+			await pca.initialize();
+			const loginResponse = await pca.loginPopup(loginRequest);
+			const { idToken, accessToken } = loginResponse;
+
+			const data = await fetchOauthLogin({
+				idToken,
+				accessToken,
+				provider: 'microsoft',
+			}) as AuthTokens;
+
+			setUserData(data);
+			setNotification({ open: true, severity: 'success', message: 'Login successful!' });
+			navigate('/');
+		} catch (error: any) {
+			setNotification({ open: true, severity: 'error', message: `Login failed: ${error.message}` });
+		}
+	};
+
+	return (
+		<Container component='main' maxWidth='xs'>
+			<Paper elevation={3} sx={{ marginTop: 8, padding: 4 }}>
+				<Typography component='h1' variant='h5' align='center'>
+					Sign in
+				</Typography>
+				<Typography variant='body2' align='center' sx={{ mt: 2 }}>
+					Only OAuth providers are supported. Please sign in using one of the following services:
+					<br />
+					Microsoft, Discord, Google, or Apple.
+					<br />
+					<strong>Note:</strong> Email-only login is not available.
+				</Typography>
+				<Stack spacing={2} sx={{ mt: 4 }}>
+					<Button variant='contained' fullWidth onClick={handleMicrosoftLogin}>
+						Sign in with Microsoft
+					</Button>
+					<Button variant='outlined' fullWidth disabled>
+						Sign in with Discord (Coming Soon)
+					</Button>
+					<Button variant='outlined' fullWidth disabled>
+						Sign in with Google (Coming Soon)
+					</Button>
+					<Button variant='outlined' fullWidth disabled>
+						Sign in with Apple (Coming Soon)
+					</Button>
+				</Stack>
+			</Paper>
+			<Notification
+				open={notification.open}
+				handleClose={handleNotificationClose}
+				severity={notification.severity}
+				message={notification.message}
+			/>
+		</Container>
+	);
+};
+
+export default LoginPage;

--- a/frontend/src/NavBar.tsx
+++ b/frontend/src/NavBar.tsx
@@ -15,19 +15,20 @@ import type { PublicLinksNavBarRoute1, PublicLinksNavBarRoutes1 } from './shared
 import { fetchNavbarRoutes } from './rpc/public/links';
 import { iconMap, defaultIcon } from './icons';
 import UserContext from './shared/UserContext';
+import Login from './Login';
 
 const DRAWER_OPEN = 240;
 const DRAWER_CLOSED = 60;
 
 const NavBar = (): JSX.Element => {
 	const [open, setOpen] = useState(false);
-        const [routes, setRoutes] = useState<PublicLinksNavBarRoute1[]>([]);
+	const [routes, setRoutes] = useState<PublicLinksNavBarRoute1[]>([]);
 	const { userData } = useContext(UserContext);
 
 	useEffect(() => {
 		void (async () => {
 			try {
-                                const res: PublicLinksNavBarRoutes1 = await fetchNavbarRoutes();
+				const res: PublicLinksNavBarRoutes1 = await fetchNavbarRoutes();
 				setRoutes(res.routes);
 			} catch {
 				setRoutes([]);
@@ -49,10 +50,12 @@ const NavBar = (): JSX.Element => {
 					width: open ? DRAWER_OPEN : DRAWER_CLOSED,
 					overflowX: 'hidden',
 					position: 'fixed',
+					display: 'flex',
+					flexDirection: 'column',
 				},
 			}}
 		>
-			<Box sx={{ display: 'flex', justifyContent: 'flex-start', pl: 1, py: 1 }}>
+			<Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', pl: 1, py: 1 }}>
 				<Tooltip title="Toggle Menu">
 					<IconButton onClick={() => setOpen(!open)}>
 						<MenuIcon />
@@ -72,6 +75,9 @@ const NavBar = (): JSX.Element => {
 					);
 				})}
 			</List>
+			<Box sx={{ p: 1 }}>
+				<Login open={open} />
+			</Box>
 		</Drawer>
 	);
 };

--- a/frontend/src/Notification.tsx
+++ b/frontend/src/Notification.tsx
@@ -1,0 +1,19 @@
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+
+interface NotificationProps {
+	open: boolean;
+	handleClose: () => void;
+	severity: 'success' | 'info' | 'warning' | 'error';
+	message: string;
+}
+
+const Notification = ({ open, handleClose, severity, message }: NotificationProps): JSX.Element => (
+	<Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
+		<Alert onClose={handleClose} severity={severity} sx={{ width: '100%' }}>
+			{message}
+		</Alert>
+	</Snackbar>
+);
+
+export default Notification;


### PR DESCRIPTION
## Summary
- implement MSAL-based login page and user session management
- add login/logout control with notifications
- wire login route and component into nav bar
- place login control at bottom of navigation drawer

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_689ebfba1f408325bfcb06258ddf68cb