### PR TITLE
Implement Microsoft OAuth login workflow

### DIFF
--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -6,7 +6,7 @@ import { msalConfig, loginRequest } from './config/msal';
 import UserContext from './shared/UserContext';
 import Notification from './Notification';
 import { fetchOauthLogin } from './rpc/auth/microsoft';
-import type { AuthTokens } from './shared/RpcModels';
+import type { AuthSessionAuthTokens } from './shared/RpcModels';
 
 const pca = new PublicClientApplication(msalConfig);
 
@@ -33,7 +33,7 @@ const LoginPage = (): JSX.Element => {
 				idToken,
 				accessToken,
 				provider: 'microsoft',
-			}) as AuthTokens;
+                        }) as AuthSessionAuthTokens;
 
 			setUserData(data);
 			setNotification({ open: true, severity: 'success', message: 'Login successful!' });

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -18,11 +18,11 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
-export interface AuthTokens {
+export interface AuthSessionAuthTokens {
   bearerToken: string;
-  session: SessionToken;
+  session: AuthSessionSessionToken;
 }
-export interface SessionToken {
+export interface AuthSessionSessionToken {
   sub: string;
   roles: string[];
   iat: number;

--- a/frontend/src/shared/UserContext.tsx
+++ b/frontend/src/shared/UserContext.tsx
@@ -1,9 +1,9 @@
 import { createContext } from 'react';
-import type { AuthTokens } from './RpcModels';
+import type { AuthSessionAuthTokens } from './RpcModels';
 
 export interface UserContext {
-        userData: AuthTokens | null;
-        setUserData: (data: AuthTokens) => void;
+        userData: AuthSessionAuthTokens | null;
+        setUserData: (data: AuthSessionAuthTokens) => void;
         clearUserData: () => void;
 }
 

--- a/frontend/src/shared/UserContextProvider.tsx
+++ b/frontend/src/shared/UserContextProvider.tsx
@@ -1,18 +1,18 @@
 import { useState, ReactNode } from 'react';
 import UserContext from './UserContext';
-import type { AuthTokens } from './RpcModels';
+import type { AuthSessionAuthTokens } from './RpcModels';
 
 interface UserContextProviderProps {
   	children: ReactNode;
 }
 
 const UserContextProvider = ({ children }: UserContextProviderProps): JSX.Element => {
-        const [userData, setUserDataState] = useState<AuthTokens | null>(() => {
+        const [userData, setUserDataState] = useState<AuthSessionAuthTokens | null>(() => {
                 if (typeof localStorage !== 'undefined') {
                         try {
                                 const raw = localStorage.getItem('authTokens');
                                 if (raw) {
-                                        return JSON.parse(raw) as AuthTokens;
+                                        return JSON.parse(raw) as AuthSessionAuthTokens;
                                 }
                         } catch {
                                 /* ignore */
@@ -21,7 +21,7 @@ const UserContextProvider = ({ children }: UserContextProviderProps): JSX.Elemen
                 return null;
         });
 
-        const setUserData = (data: AuthTokens) => {
+        const setUserData = (data: AuthSessionAuthTokens) => {
                 setUserDataState(data);
                 if (typeof localStorage !== 'undefined') {
                         localStorage.setItem('authTokens', JSON.stringify(data));

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -1,5 +1,65 @@
-from fastapi import Request
+from datetime import datetime, timezone
+
+from fastapi import HTTPException, Request
+
+from rpc.auth.session.models import AuthSessionAuthTokens, AuthSessionSessionToken
+from rpc.helpers import get_rpcrequest_from_request
+from rpc.models import RPCResponse
+from server.modules.auth_module import AuthModule
+from server.modules.authz_module import AuthzModule
+from server.modules.db_module import DbModule
+
 
 async def auth_microsoft_oauth_login_v1(request: Request):
-  raise NotImplementedError("urn:auth:microsoft:oauth_login:1")
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  req_payload = rpc_request.payload or {}
+
+  provider = req_payload.get("provider", "microsoft")
+  id_token = req_payload.get("idToken") or req_payload.get("id_token")
+  access_token = req_payload.get("accessToken") or req_payload.get("access_token")
+  if not id_token or not access_token:
+    raise HTTPException(status_code=400, detail="Missing credentials")
+
+  auth: AuthModule = request.app.state.auth
+  db: DbModule = request.app.state.db
+
+  provider_uid, profile = await auth.handle_auth_login(provider, id_token, access_token)
+
+  res = await db.run(
+    "urn:users:providers:get_by_provider_identifier:1",
+    {"provider": provider, "provider_identifier": provider_uid},
+  )
+  user = res.rows[0] if res.rows else None
+  if not user:
+    res = await db.run(
+      "urn:users:providers:create_from_provider:1",
+      {
+        "provider": provider,
+        "provider_identifier": provider_uid,
+        "provider_email": profile["email"],
+        "provider_displayname": profile["username"],
+      },
+    )
+    user = res.rows[0] if res.rows else None
+  if not user:
+    raise HTTPException(status_code=500, detail="Unable to create user")
+
+  user_guid = user["guid"]
+  rotation_token, rot_exp = auth.make_rotation_token(user_guid)
+  now = datetime.now(timezone.utc)
+  await db.run(
+    "db:users:session:set_rotkey:1",
+    {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
+  )
+
+  roles_res = await db.run("urn:users:profile:get_roles:1", {"guid": user_guid})
+  role_mask = int(roles_res.rows[0].get("element_roles", 0)) if roles_res.rows else 0
+  authz: AuthzModule = request.app.state.authz
+  roles = authz.mask_to_names(role_mask)
+
+  bearer = auth.make_session_token(user_guid, rotation_token, roles, provider)
+  session_claims = await auth.decode_session_token(bearer)
+
+  payload = AuthSessionAuthTokens(bearerToken=bearer, session=AuthSessionSessionToken(**session_claims))
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
 

--- a/rpc/auth/session/models.py
+++ b/rpc/auth/session/models.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 
 
-class SessionToken(BaseModel):
+class AuthSessionSessionToken(BaseModel):
   sub: str
   roles: list[str]
   iat: int
@@ -11,6 +11,6 @@ class SessionToken(BaseModel):
   provider: str
 
 
-class AuthTokens(BaseModel):
+class AuthSessionAuthTokens(BaseModel):
   bearerToken: str
-  session: SessionToken
+  session: AuthSessionSessionToken

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -21,13 +21,13 @@ async def auth_session_get_token_v1(request: Request):
   provider_uid, profile = await auth.handle_auth_login(provider, id_token, access_token)
 
   res = await db.run(
-    "db:users:providers:get_by_provider_identifier:1",
+    "urn:users:providers:get_by_provider_identifier:1",
     {"provider": provider, "provider_identifier": provider_uid},
   )
   user = res.rows[0] if res.rows else None
   if not user:
     res = await db.run(
-      "db:users:providers:create_from_provider:1",
+      "urn:users:providers:create_from_provider:1",
       {
         "provider": provider,
         "provider_identifier": provider_uid,
@@ -47,7 +47,7 @@ async def auth_session_get_token_v1(request: Request):
     {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
   )
 
-  roles_res = await db.run("db:users:profile:get_roles:1", {"guid": user_guid})
+  roles_res = await db.run("urn:users:profile:get_roles:1", {"guid": user_guid})
   role_mask = int(roles_res.rows[0].get("element_roles", 0)) if roles_res.rows else 0
   authz = request.app.state.authz
   roles = authz.mask_to_names(role_mask)
@@ -81,7 +81,7 @@ async def auth_session_refresh_token_v1(request: Request):
   if not stored.rows or stored.rows[0].get("rotkey") != rotation_token:
     raise HTTPException(status_code=401, detail="Invalid rotation token")
 
-  roles_res = await db.run("db:users:profile:get_roles:1", {"guid": user_guid})
+  roles_res = await db.run("urn:users:profile:get_roles:1", {"guid": user_guid})
   role_mask = int(roles_res.rows[0].get("element_roles", 0)) if roles_res.rows else 0
   authz = request.app.state.authz
   roles = authz.mask_to_names(role_mask)


### PR DESCRIPTION
## Summary
- align database lookups with frontend URN namespaces
- rename AuthTokens and SessionToken to AuthSessionAuthTokens and AuthSessionSessionToken
- update frontend context and login usage for new token models

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f74c717708325aa5cfded0df5b539