### PR TITLE
Implement Microsoft OAuth login workflow

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -4,7 +4,7 @@ This document describes each internal database operation and groups them by doma
 
 ## Naming Scheme
 
-Every database operation uses a URN in the form `db:{domain}:{subsystem}:{function}:{version}`. Providers register handlers for these operations and the database module dispatches calls through the selected provider.
+Database operations use URNs in the form `{namespace}:{domain}:{subsystem}:{function}:{version}`. Operations exposed to the frontend share the `urn:` namespace, while internal-only calls retain the `db:` prefix. Providers register handlers for these operations and the database module dispatches calls through the selected provider.
 
 ## Providers
 
@@ -18,17 +18,17 @@ Operations supporting user accounts and onboarding.
 
 | Operation | Description |
 | --- | --- |
-| `db:users:providers:get_by_provider_identifier:1` | Fetch a user record using an external provider and identifier. |
-| `db:users:providers:create_from_provider:1` | Insert a new user based on provider data, returning the created record. |
+| `urn:users:providers:get_by_provider_identifier:1` | Fetch a user record using an external provider and identifier. |
+| `urn:users:providers:create_from_provider:1` | Insert a new user based on provider data, returning the created record. |
 
 ### `profile`
 
 | Operation | Description |
 | --- | --- |
-| `db:users:profile:get_profile:1` | Retrieve profile details including email, credits, providers and profile image. |
-| `db:users:profile:get_roles:1` | Read the stored role bitmask for a user. |
-| `db:users:profile:set_roles:1` | Update or insert the role bitmask for a user. |
-| `db:users:profile:set_profile_image:1` | Upsert a profile image for the user. |
+| `urn:users:profile:get_profile:1` | Retrieve profile details including email, credits, providers and profile image. |
+| `urn:users:profile:get_roles:1` | Read the stored role bitmask for a user. |
+| `urn:users:profile:set_roles:1` | Update or insert the role bitmask for a user. |
+| `urn:users:profile:set_profile_image:1` | Upsert a profile image for the user. |
 
 ### `session`
 

--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -6,7 +6,7 @@ import { msalConfig, loginRequest } from './config/msal';
 import UserContext from './shared/UserContext';
 import Notification from './Notification';
 import { fetchOauthLogin } from './rpc/auth/microsoft';
-import type { AuthTokens } from './shared/RpcModels';
+import type { AuthSessionAuthTokens } from './shared/RpcModels';
 
 const pca = new PublicClientApplication(msalConfig);
 
@@ -33,7 +33,7 @@ const LoginPage = (): JSX.Element => {
 				idToken,
 				accessToken,
 				provider: 'microsoft',
-			}) as AuthTokens;
+                        }) as AuthSessionAuthTokens;
 
 			setUserData(data);
 			setNotification({ open: true, severity: 'success', message: 'Login successful!' });

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -18,11 +18,11 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
-export interface AuthTokens {
+export interface AuthSessionAuthTokens {
   bearerToken: string;
-  session: SessionToken;
+  session: AuthSessionSessionToken;
 }
-export interface SessionToken {
+export interface AuthSessionSessionToken {
   sub: string;
   roles: string[];
   iat: number;

--- a/frontend/src/shared/UserContext.tsx
+++ b/frontend/src/shared/UserContext.tsx
@@ -1,9 +1,9 @@
 import { createContext } from 'react';
-import type { AuthTokens } from './RpcModels';
+import type { AuthSessionAuthTokens } from './RpcModels';
 
 export interface UserContext {
-        userData: AuthTokens | null;
-        setUserData: (data: AuthTokens) => void;
+        userData: AuthSessionAuthTokens | null;
+        setUserData: (data: AuthSessionAuthTokens) => void;
         clearUserData: () => void;
 }
 

--- a/frontend/src/shared/UserContextProvider.tsx
+++ b/frontend/src/shared/UserContextProvider.tsx
@@ -1,18 +1,18 @@
 import { useState, ReactNode } from 'react';
 import UserContext from './UserContext';
-import type { AuthTokens } from './RpcModels';
+import type { AuthSessionAuthTokens } from './RpcModels';
 
 interface UserContextProviderProps {
   	children: ReactNode;
 }
 
 const UserContextProvider = ({ children }: UserContextProviderProps): JSX.Element => {
-        const [userData, setUserDataState] = useState<AuthTokens | null>(() => {
+        const [userData, setUserDataState] = useState<AuthSessionAuthTokens | null>(() => {
                 if (typeof localStorage !== 'undefined') {
                         try {
                                 const raw = localStorage.getItem('authTokens');
                                 if (raw) {
-                                        return JSON.parse(raw) as AuthTokens;
+                                        return JSON.parse(raw) as AuthSessionAuthTokens;
                                 }
                         } catch {
                                 /* ignore */
@@ -21,7 +21,7 @@ const UserContextProvider = ({ children }: UserContextProviderProps): JSX.Elemen
                 return null;
         });
 
-        const setUserData = (data: AuthTokens) => {
+        const setUserData = (data: AuthSessionAuthTokens) => {
                 setUserDataState(data);
                 if (typeof localStorage !== 'undefined') {
                         localStorage.setItem('authTokens', JSON.stringify(data));

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -1,5 +1,65 @@
-from fastapi import Request
+from datetime import datetime, timezone
+
+from fastapi import HTTPException, Request
+
+from rpc.auth.session.models import AuthSessionAuthTokens, AuthSessionSessionToken
+from rpc.helpers import get_rpcrequest_from_request
+from rpc.models import RPCResponse
+from server.modules.auth_module import AuthModule
+from server.modules.authz_module import AuthzModule
+from server.modules.db_module import DbModule
+
 
 async def auth_microsoft_oauth_login_v1(request: Request):
-  raise NotImplementedError("urn:auth:microsoft:oauth_login:1")
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  req_payload = rpc_request.payload or {}
+
+  provider = req_payload.get("provider", "microsoft")
+  id_token = req_payload.get("idToken") or req_payload.get("id_token")
+  access_token = req_payload.get("accessToken") or req_payload.get("access_token")
+  if not id_token or not access_token:
+    raise HTTPException(status_code=400, detail="Missing credentials")
+
+  auth: AuthModule = request.app.state.auth
+  db: DbModule = request.app.state.db
+
+  provider_uid, profile = await auth.handle_auth_login(provider, id_token, access_token)
+
+  res = await db.run(
+    "urn:users:providers:get_by_provider_identifier:1",
+    {"provider": provider, "provider_identifier": provider_uid},
+  )
+  user = res.rows[0] if res.rows else None
+  if not user:
+    res = await db.run(
+      "urn:users:providers:create_from_provider:1",
+      {
+        "provider": provider,
+        "provider_identifier": provider_uid,
+        "provider_email": profile["email"],
+        "provider_displayname": profile["username"],
+      },
+    )
+    user = res.rows[0] if res.rows else None
+  if not user:
+    raise HTTPException(status_code=500, detail="Unable to create user")
+
+  user_guid = user["guid"]
+  rotation_token, rot_exp = auth.make_rotation_token(user_guid)
+  now = datetime.now(timezone.utc)
+  await db.run(
+    "db:users:session:set_rotkey:1",
+    {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
+  )
+
+  roles_res = await db.run("urn:users:profile:get_roles:1", {"guid": user_guid})
+  role_mask = int(roles_res.rows[0].get("element_roles", 0)) if roles_res.rows else 0
+  authz: AuthzModule = request.app.state.authz
+  roles = authz.mask_to_names(role_mask)
+
+  bearer = auth.make_session_token(user_guid, rotation_token, roles, provider)
+  session_claims = await auth.decode_session_token(bearer)
+
+  payload = AuthSessionAuthTokens(bearerToken=bearer, session=AuthSessionSessionToken(**session_claims))
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
 

--- a/rpc/auth/session/models.py
+++ b/rpc/auth/session/models.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 
 
-class SessionToken(BaseModel):
+class AuthSessionSessionToken(BaseModel):
   sub: str
   roles: list[str]
   iat: int
@@ -11,6 +11,6 @@ class SessionToken(BaseModel):
   provider: str
 
 
-class AuthTokens(BaseModel):
+class AuthSessionAuthTokens(BaseModel):
   bearerToken: str
-  session: SessionToken
+  session: AuthSessionSessionToken

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -21,13 +21,13 @@ async def auth_session_get_token_v1(request: Request):
   provider_uid, profile = await auth.handle_auth_login(provider, id_token, access_token)
 
   res = await db.run(
-    "db:users:providers:get_by_provider_identifier:1",
+    "urn:users:providers:get_by_provider_identifier:1",
     {"provider": provider, "provider_identifier": provider_uid},
   )
   user = res.rows[0] if res.rows else None
   if not user:
     res = await db.run(
-      "db:users:providers:create_from_provider:1",
+      "urn:users:providers:create_from_provider:1",
       {
         "provider": provider,
         "provider_identifier": provider_uid,
@@ -47,7 +47,7 @@ async def auth_session_get_token_v1(request: Request):
     {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
   )
 
-  roles_res = await db.run("db:users:profile:get_roles:1", {"guid": user_guid})
+  roles_res = await db.run("urn:users:profile:get_roles:1", {"guid": user_guid})
   role_mask = int(roles_res.rows[0].get("element_roles", 0)) if roles_res.rows else 0
   authz = request.app.state.authz
   roles = authz.mask_to_names(role_mask)
@@ -81,7 +81,7 @@ async def auth_session_refresh_token_v1(request: Request):
   if not stored.rows or stored.rows[0].get("rotkey") != rotation_token:
     raise HTTPException(status_code=401, detail="Invalid rotation token")
 
-  roles_res = await db.run("db:users:profile:get_roles:1", {"guid": user_guid})
+  roles_res = await db.run("urn:users:profile:get_roles:1", {"guid": user_guid})
   role_mask = int(roles_res.rows[0].get("element_roles", 0)) if roles_res.rows else 0
   authz = request.app.state.authz
   roles = authz.mask_to_names(role_mask)

--- a/server/modules/providers/mssql_provider/registry.py
+++ b/server/modules/providers/mssql_provider/registry.py
@@ -22,7 +22,7 @@ def get_handler(op: str):
 
 # -------------------- MAPPINGS (representative set) --------------------
 
-@register("db:users:providers:get_by_provider_identifier:1")
+@register("urn:users:providers:get_by_provider_identifier:1")
 def _users_select(provider_args: Dict[str, Any]):
     provider = provider_args["provider"]
     identifier = provider_args["provider_identifier"]
@@ -45,7 +45,7 @@ def _users_select(provider_args: Dict[str, Any]):
     """
     return ("json_one", sql, (provider, identifier))
 
-@register("db:users:providers:create_from_provider:1")
+@register("urn:users:providers:create_from_provider:1")
 async def _users_insert(args: Dict[str, Any]):
     # mirrors your insert_user() logic, including provider recid lookup + 3 inserts
     from uuid import uuid4
@@ -89,7 +89,7 @@ async def _users_insert(args: Dict[str, Any]):
                                (_users_select({"provider": provider, "provider_identifier": identifier})[2]))
     return {"rows": [out] if out else [], "rowcount": 1 if out else 0}
 
-@register("db:users:profile:get_profile:1")
+@register("urn:users:profile:get_profile:1")
 def _users_profile(args: Dict[str, Any]):
     guid = args["guid"]
     sql = """
@@ -117,7 +117,7 @@ def _users_profile(args: Dict[str, Any]):
     """
     return ("json_one", sql, (guid,))
 
-@register("db:users:profile:get_roles:1")
+@register("urn:users:profile:get_roles:1")
 def _users_get_roles(args: Dict[str, Any]):
     guid = args["guid"]
     sql = """
@@ -127,7 +127,7 @@ def _users_get_roles(args: Dict[str, Any]):
     """
     return ("json_one", sql, (guid,))
 
-@register("db:users:profile:set_roles:1")
+@register("urn:users:profile:set_roles:1")
 async def _users_set_roles(args: Dict[str, Any]):
     guid, roles = args["guid"], int(args["roles"])
     if roles == 0:
@@ -222,7 +222,7 @@ def _public_vars_get_repo(args: Dict[str, Any]):
   """
   return ("json_one", sql, ())
 
-@register("db:users:profile:set_profile_image:1")
+@register("urn:users:profile:set_profile_image:1")
 async def _users_set_img(args: Dict[str, Any]):
     guid, image_b64 = args["guid"], args["image_b64"]
     rc = await exec_("UPDATE users_profileimg SET element_base64 = ? WHERE users_guid = ?;", (image_b64, guid))

--- a/server/modules/providers/postgres_provider/registry.py
+++ b/server/modules/providers/postgres_provider/registry.py
@@ -18,7 +18,7 @@ def get_handler(op: str):
   except KeyError:
     raise KeyError(f"No PostgreSQL handler for '{op}'")
 
-@register("db:users:providers:get_by_provider_identifier:1")
+@register("urn:users:providers:get_by_provider_identifier:1")
 def _users_select(args: Dict[str, Any]):
   provider = args["provider"]
   identifier = args["provider_identifier"]
@@ -40,7 +40,7 @@ def _users_select(args: Dict[str, Any]):
   """
   return ("one", sql, (provider, identifier))
 
-@register("db:users:profile:get_roles:1")
+@register("urn:users:profile:get_roles:1")
 def _users_get_roles(args: Dict[str, Any]):
   guid = args["guid"]
   sql = """
@@ -49,7 +49,7 @@ def _users_get_roles(args: Dict[str, Any]):
   """
   return ("many", sql, (guid,))
 
-@register("db:users:profile:set_roles:1")
+@register("urn:users:profile:set_roles:1")
 async def _users_set_roles(args: Dict[str, Any]):
   guid, roles = args["guid"], int(args["roles"])
   rc = await execute(


### PR DESCRIPTION
## Summary
- align database lookups with frontend URN namespaces
- rename AuthTokens and SessionToken to AuthSessionAuthTokens and AuthSessionSessionToken
- update frontend context and login usage for new token models
- map user profile and provider queries to frontend URNs in MSSQL/Postgres providers

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_689f74c717708325aa5cfded0df5b539