### PR TITLE
Fix Login component to show user profile

### DIFF
--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -1,12 +1,14 @@
-import { useState, useContext } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import { useNavigate, Link as RouterLink } from 'react-router-dom';
 import { Login as LoginIcon } from '@mui/icons-material';
 import { Typography, Box, Tooltip, IconButton, ListItemText } from '@mui/material';
 import { PublicClientApplication } from '@azure/msal-browser';
 import { msalConfig } from './config/msal';
 import { fetchInvalidateToken } from './rpc/auth/session';
+import { fetchProfile } from './rpc/users/profile';
 import Notification from './Notification';
 import UserContext from './shared/UserContext';
+import type { UsersProfileProfile1 } from './shared/RpcModels';
 
 const pca = new PublicClientApplication(msalConfig);
 
@@ -16,6 +18,7 @@ interface LoginProps {
 
 const Login = ({ open }: LoginProps): JSX.Element => {
 	const { userData, clearUserData } = useContext(UserContext);
+	const [profile, setProfile] = useState<UsersProfileProfile1 | null>(null);
 	const [notification, setNotification] = useState({
 		open: false,
 		severity: 'info' as 'info' | 'success' | 'warning' | 'error',
@@ -28,6 +31,17 @@ const Login = ({ open }: LoginProps): JSX.Element => {
 	const handleLoginNavigation = (): void => {
 		navigate('/loginpage');
 	};
+	useEffect(() => {
+		let active = true;
+		if (userData) {
+			fetchProfile()
+				.then(data => { if (active) setProfile(data as UsersProfileProfile1); })
+				.catch(err => console.error('Failed to fetch profile', err));
+		} else {
+			setProfile(null);
+		}
+		return () => { active = false; };
+	}, [userData]);
 	const handleLogout = async (): Promise<void> => {
 		try {
 			await pca.initialize();
@@ -40,6 +54,7 @@ const Login = ({ open }: LoginProps): JSX.Element => {
 				}
 			}
 			clearUserData();
+			setProfile(null);
 			setNotification({ open: true, severity: 'info', message: 'Logged out successfully.' });
 		} catch (error: any) {
 			setNotification({ open: true, severity: 'error', message: `Logout failed: ${error.message}` });
@@ -51,7 +66,7 @@ const Login = ({ open }: LoginProps): JSX.Element => {
 			{userData ? (
 				<Tooltip title='Logout'>
 					<IconButton onClick={handleLogout}>
-						<img src='' alt='user avatar' style={{ width: '28px', height: '28px', borderRadius: '50%', border: '1px solid #000' }} />
+						<img src={profile?.profile_image ? `data:image/png;base64,${profile.profile_image}` : ''} alt='user avatar' style={{ width: '28px', height: '28px', borderRadius: '50%', border: '1px solid #000' }} />
 					</IconButton>
 				</Tooltip>
 			) : (
@@ -66,17 +81,17 @@ const Login = ({ open }: LoginProps): JSX.Element => {
 				<ListItemText
 					primary={ userData ? (
 						<Box>
-							<Typography component={RouterLink} to='/userpage' variant='body1' sx={{ fontWeight: 'bold', color: 'gray', textDecoration: 'none' }}>
-								{userData.session?.sub ?? ''}
+							<Typography component={RouterLink} to='/userpage' variant='body1' sx={{fontWeight: 'bold', color: 'gray', textDecoration: 'none' }}>
+								{profile?.display_name ?? ''}
 							</Typography>
 							<Typography component='span' variant='body2' sx={{ display: 'block', fontSize: '0.9em', color: 'gray' }}>
-								{new Intl.NumberFormat(navigator.language).format(Number(0))}
+								{profile ? new Intl.NumberFormat(navigator.language).format(profile.credits) : ''}
 							</Typography>
 						</Box>
 					) : (
 						'Login'
 					)}
-					sx={{ marginLeft: '8px' }}
+					 sx={{ marginLeft: '8px' }}
 				/>
 			)}
 

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -18,19 +18,6 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
-export interface AuthSessionAuthTokens {
-  bearerToken: string;
-  session: AuthSessionSessionToken;
-}
-export interface AuthSessionSessionToken {
-  sub: string;
-  roles: string[];
-  iat: number;
-  exp: number;
-  jti: string;
-  session: string;
-  provider: string;
-}
 export interface PublicLinksHomeLinks1 {
   links: PublicLinksLinkItem1[];
 }
@@ -60,6 +47,32 @@ export interface PublicVarsRepo1 {
 }
 export interface PublicVarsVersion1 {
   version: string;
+}
+export interface AuthSessionAuthTokens {
+  bearerToken: string;
+  session: AuthSessionSessionToken;
+}
+export interface AuthSessionSessionToken {
+  sub: string;
+  roles: string[];
+  iat: number;
+  exp: number;
+  jti: string;
+  session: string;
+  provider: string;
+}
+export interface UsersProfileAuthProvider1 {
+  name: string;
+  display: string;
+}
+export interface UsersProfileProfile1 {
+  guid: string;
+  display_name: string;
+  email: string;
+  display_email: boolean;
+  credits: number;
+  profile_image: string | null;
+  auth_providers: UsersProfileAuthProvider1[];
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/users/profile/models.py
+++ b/rpc/users/profile/models.py
@@ -1,4 +1,19 @@
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel
+
+
+class UsersProfileAuthProvider1(BaseModel):
+  name: str
+  display: str
+
+
+class UsersProfileProfile1(BaseModel):
+  guid: str
+  display_name: str
+  email: str
+  display_email: bool
+  credits: int
+  profile_image: Optional[str] = None
+  auth_providers: List[UsersProfileAuthProvider1] = []
 

--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -1,7 +1,27 @@
-from fastapi import Request
+from fastapi import HTTPException, Request
+
+from rpc.helpers import get_rpcrequest_from_request
+from rpc.models import RPCResponse
+from server.modules.db_module import DbModule
+from .models import UsersProfileProfile1
+
 
 async def users_profile_get_profile_v1(request: Request):
-  raise NotImplementedError("urn:users:profile:get_profile:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  if not auth_ctx.user_guid:
+    raise HTTPException(status_code=401, detail="Unauthorized")
+
+  db: DbModule = request.app.state.db
+  res = await db.run(rpc_request.op, {"guid": auth_ctx.user_guid})
+  if not res.rows:
+    raise HTTPException(status_code=404, detail="Profile not found")
+
+  profile = UsersProfileProfile1(**res.rows[0])
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=profile.model_dump(),
+    version=rpc_request.version,
+  )
 
 async def users_profile_set_display_v1(request: Request):
   raise NotImplementedError("urn:users:profile:set_display:1")


### PR DESCRIPTION
## Summary
- implement service to fetch user profile data
- display profile image, display name and credits in Login
- generate RPC models and types

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_689fa02aff9c8325b4ddd1fcc60bbb35