### PR TITLE
Handle Microsoft login identifier fallback and profile images

### DIFF
--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -18,13 +18,26 @@ async def auth_session_get_token_v1(request: Request):
   auth: AuthModule = request.app.state.auth
   db: DbModule = request.app.state.db
 
-  provider_uid, profile = await auth.handle_auth_login(provider, id_token, access_token)
+  provider_uid, profile, payload = await auth.handle_auth_login(provider, id_token, access_token)
 
-  res = await db.run(
-    "urn:users:providers:get_by_provider_identifier:1",
-    {"provider": provider, "provider_identifier": provider_uid},
-  )
-  user = res.rows[0] if res.rows else None
+  identifiers = []
+  oid = payload.get("oid")
+  sub = payload.get("sub")
+  if oid:
+    identifiers.append(oid)
+  if sub and sub not in identifiers:
+    identifiers.append(sub)
+
+  user = None
+  for pid in identifiers:
+    res = await db.run(
+      "urn:users:providers:get_by_provider_identifier:1",
+      {"provider": provider, "provider_identifier": pid},
+    )
+    if res.rows:
+      user = res.rows[0]
+      break
+
   if not user:
     res = await db.run(
       "urn:users:providers:create_from_provider:1",
@@ -40,6 +53,12 @@ async def auth_session_get_token_v1(request: Request):
     raise HTTPException(status_code=500, detail="Unable to create user")
 
   user_guid = user["guid"]
+
+  if profile.get("profilePicture"):
+    await db.run(
+      "urn:users:profile:set_profile_image:1",
+      {"guid": user_guid, "image_b64": profile["profilePicture"], "provider": provider},
+    )
   rotation_token, rot_exp = auth.make_rotation_token(user_guid)
   now = datetime.now(timezone.utc)
   await db.run(

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -128,7 +128,7 @@ class AuthModule(BaseModule):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload.")
       profile = await self.fetch_ms_user_profile(access_token)
       logging.info(f"Processing login for: {profile['username']}, {profile['email']}")
-      return guid, profile
+      return guid, profile, payload
     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported auth provider")
 
   def make_session_token(self, guid: str, rotation_token: str, roles: list[str], provider: str) -> str:

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -48,9 +48,11 @@ def test_handle_auth_login_prefers_oid(monkeypatch):
   monkeypatch.setattr(module, "verify_ms_id_token", fake_verify_ms_id_token)
   monkeypatch.setattr(module, "fetch_ms_user_profile", fake_fetch_ms_user_profile)
 
-  guid, profile = asyncio.run(module.handle_auth_login("microsoft", "id", "access"))
+  guid, profile, payload = asyncio.run(module.handle_auth_login("microsoft", "id", "access"))
   assert guid == "oid123"
   assert profile["email"] == "user@example.com"
+  assert payload["oid"] == "oid123"
+  assert payload["sub"] == "sub456"
 
 
 def test_handle_auth_login_falls_back_to_sub(monkeypatch):
@@ -66,5 +68,6 @@ def test_handle_auth_login_falls_back_to_sub(monkeypatch):
   monkeypatch.setattr(module, "verify_ms_id_token", fake_verify_ms_id_token)
   monkeypatch.setattr(module, "fetch_ms_user_profile", fake_fetch_ms_user_profile)
 
-  guid, _ = asyncio.run(module.handle_auth_login("microsoft", "id", "access"))
+  guid, _, payload = asyncio.run(module.handle_auth_login("microsoft", "id", "access"))
   assert guid == "sub456"
+  assert payload["sub"] == "sub456"


### PR DESCRIPTION
## Summary
- allow auth module to surface verified token payload for provider logins
- search for users by both Microsoft OID and sub and store profile image data
- upsert profile images with provider reference

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_689fa69562c48325ab0d46b01321ce99