### PR TITLE
feat: left-align NavBar menu icon

### DIFF
--- a/frontend/src/NavBar.tsx
+++ b/frontend/src/NavBar.tsx
@@ -55,7 +55,7 @@ const NavBar = (): JSX.Element => {
 				},
 			}}
 		>
-			<Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', pl: 1, py: 1 }}>
+			<Box sx={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center', pl: 1, py: 1 }}>
 				<Tooltip title="Toggle Menu">
 					<IconButton onClick={() => setOpen(!open)}>
 						<MenuIcon />


### PR DESCRIPTION
## Summary
- adjust NavBar drawer toggle so menu icon is left aligned even when expanded

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68a21b28b9e48325bb0725cb8cd51ffb