### PR TITLE
feat(user): add profile page and rpc support

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -20,12 +20,15 @@ Operations supporting user accounts and onboarding.
 | --- | --- |
 | `urn:users:providers:get_by_provider_identifier:1` | Fetch a user record using an external provider and identifier. |
 | `urn:users:providers:create_from_provider:1` | Insert a new user based on provider data, returning the created record. |
+| `urn:users:providers:set_provider:1` | Update the default authentication provider for a user. |
 
 ### `profile`
 
 | Operation | Description |
 | --- | --- |
 | `urn:users:profile:get_profile:1` | Retrieve profile details including email, credits, providers and profile image. |
+| `urn:users:profile:set_display:1` | Update the display name for a user. |
+| `urn:users:profile:set_optin:1` | Update whether a user's email is displayed. |
 | `urn:users:profile:get_roles:1` | Read the stored role bitmask for a user. |
 | `urn:users:profile:set_roles:1` | Update or insert the role bitmask for a user. |
 | `urn:users:profile:set_profile_image:1` | Upsert a profile image for the user. |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import Home from './Home'
 import NavBar from './NavBar'
 import Gallery from './Gallery'
 import LoginPage from './LoginPage'
+import UserPage from './UserPage'
 
 function App(): JSX.Element {
 	return (
@@ -18,9 +19,10 @@ function App(): JSX.Element {
 					<Container maxWidth='lg' disableGutters sx={{ bgcolor: 'background.paper', color: 'text.primary', minHeight: '100vh', py: 2 }}>
 												<Routes>
 														<Route path='/' element={<Home />} />
-														<Route path='/gallery' element={<Gallery />} />
-														<Route path='/loginpage' element={<LoginPage />} />
-												</Routes>
+                                                                                                                <Route path='/gallery' element={<Gallery />} />
+                                                                                                                <Route path='/loginpage' element={<LoginPage />} />
+                                                                                                                <Route path='/userpage' element={<UserPage />} />
+                                                                                                </Routes>
 					</Container>
 				</Router>
 			</UserContextProvider>

--- a/frontend/src/UserPage.tsx
+++ b/frontend/src/UserPage.tsx
@@ -1,0 +1,120 @@
+import { useContext, useEffect, useState, ChangeEvent } from 'react';
+import { Box, Typography, FormControlLabel, Switch, Avatar, TextField, Button, Stack, RadioGroup, Radio } from '@mui/material';
+import UserContext from './shared/UserContext';
+import type { UsersProfileProfile1 } from './shared/RpcModels';
+import { fetchProfile, fetchSetDisplay, fetchSetOptin } from './rpc/users/profile';
+import { fetchSetProvider } from './rpc/users/providers';
+
+const UserPage = (): JSX.Element => {
+        const { userData, setUserData } = useContext(UserContext);
+        const [profile, setProfile] = useState<UsersProfileProfile1 | null>(null);
+        const [displayEmail, setDisplayEmail] = useState(false);
+        const [displayName, setDisplayName] = useState('');
+        const [provider, setProvider] = useState('microsoft');
+        const [dirty, setDirty] = useState(false);
+
+        useEffect(() => {
+                if (!userData) return;
+                void (async () => {
+                        try {
+                                const res: UsersProfileProfile1 = await fetchProfile();
+                                setProfile(res);
+                                setDisplayName(res.display_name);
+                                setDisplayEmail(res.display_email);
+                                setProvider(res.default_provider);
+                        } catch {
+                                setProfile(null);
+                        }
+                })();
+        }, [userData]);
+
+        const handleToggle = (): void => {
+                setDisplayEmail(!displayEmail);
+                setDirty(true);
+        };
+
+        const handleNameChange = (e: ChangeEvent<HTMLInputElement>): void => {
+                setDisplayName(e.target.value);
+                setDirty(true);
+        };
+
+        const handleProviderChange = (e: ChangeEvent<HTMLInputElement>): void => {
+                setProvider(e.target.value);
+                setDirty(true);
+        };
+
+        const handleCancel = (): void => {
+                if (profile) {
+                        setDisplayName(profile.display_name);
+                        setDisplayEmail(profile.display_email);
+                        setProvider(profile.default_provider);
+                }
+                setDirty(false);
+        };
+
+        const handleApply = async (): Promise<void> => {
+                try {
+                        await fetchSetDisplay({ display_name: displayName });
+                        await fetchSetOptin({ display_email: displayEmail });
+                        await fetchSetProvider({ provider });
+                        if (userData) setUserData({ ...userData, display_name: displayName });
+                        if (profile) setProfile({ ...profile, display_name: displayName, display_email: displayEmail, default_provider: provider });
+                        setDirty(false);
+                } catch (err) {
+                        console.error('Failed to update profile', err);
+                }
+        };
+
+        return (
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                        <Box sx={{ maxWidth: 400, width: '100%' }}>
+                                <Stack spacing={2} sx={{ mt: 2, display: 'flex', alignItems: 'flex-end', textAlign: 'right' }}>
+                                        <Typography variant='h5' gutterBottom>User Profile</Typography>
+
+                                        {profile && (
+                                                <Stack spacing={2} sx={{ mt: 2, alignItems: 'flex-end', width: '100%' }}>
+                                                        <Avatar src={profile.profile_image ? `data:image/png;base64,${profile.profile_image}` : undefined} sx={{ width: 80, height: 80 }} />
+
+                                                        <TextField
+                                                                label='Display Name'
+                                                                value={displayName}
+                                                                onChange={handleNameChange}
+                                                                fullWidth
+                                                                slotProps={{
+                                                                        input: {
+                                                                                style: { textAlign: 'right' }
+                                                                        }
+                                                                }}
+                                                        />
+
+                                                        <Typography>Credits: {profile.credits ?? 0}</Typography>
+                                                        <Typography>Email: {profile.email}</Typography>
+
+                                                        <RadioGroup value={provider} onChange={handleProviderChange} sx={{ alignItems: 'flex-end' }}>
+                                                                <FormControlLabel value='microsoft' control={<Radio />} label='Microsoft' />
+                                                                <FormControlLabel value='google' control={<Radio />} label='Google' disabled />
+                                                                <FormControlLabel value='discord' control={<Radio />} label='Discord' disabled />
+                                                                <FormControlLabel value='apple' control={<Radio />} label='Apple' disabled />
+                                                        </RadioGroup>
+
+                                                        <FormControlLabel
+                                                                control={<Switch checked={displayEmail} onChange={handleToggle} />}
+                                                                label='Display email publicly'
+                                                                labelPlacement='start'
+                                                                sx={{ alignSelf: 'flex-end' }}
+                                                        />
+
+                                                        <Stack direction='row' spacing={2} sx={{ justifyContent: 'flex-end', width: '100%' }}>
+                                                                <Button variant='contained' onClick={handleApply} disabled={!dirty}>Apply</Button>
+                                                                <Button variant='outlined' onClick={handleCancel} disabled={!dirty}>Cancel</Button>
+                                                                <Button variant='contained' color='error'>Delete</Button>
+                                                        </Stack>
+                                                </Stack>
+                                        )}
+                                </Stack>
+                        </Box>
+                </Box>
+        );
+};
+
+export default UserPage;

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -18,12 +18,6 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
-export interface AuthMicrosoftOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
-  credits: number;
-  profile_image: string | null;
-}
 export interface UsersProfileAuthProvider1 {
   name: string;
   display: string;
@@ -35,7 +29,32 @@ export interface UsersProfileProfile1 {
   display_email: boolean;
   credits: number;
   profile_image: string | null;
+  default_provider: string;
   auth_providers: UsersProfileAuthProvider1[];
+}
+export interface UsersProfileSetDisplay1 {
+  display_name: string;
+}
+export interface UsersProfileSetOptin1 {
+  display_email: boolean;
+}
+export interface UsersProvidersSetProvider1 {
+  provider: string;
+}
+export interface PublicVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface PublicVarsHostname1 {
+  hostname: string;
+}
+export interface PublicVarsOdbcVersion1 {
+  odbc_version: string;
+}
+export interface PublicVarsRepo1 {
+  repo: string;
+}
+export interface PublicVarsVersion1 {
+  version: string;
 }
 export interface PublicLinksHomeLinks1 {
   links: PublicLinksLinkItem1[];
@@ -52,20 +71,11 @@ export interface PublicLinksNavBarRoute1 {
 export interface PublicLinksNavBarRoutes1 {
   routes: PublicLinksNavBarRoute1[];
 }
-export interface PublicVarsFfmpegVersion1 {
-  ffmpeg_version: string;
-}
-export interface PublicVarsHostname1 {
-  hostname: string;
-}
-export interface PublicVarsOdbcVersion1 {
-  odbc_version: string;
-}
-export interface PublicVarsRepo1 {
-  repo: string;
-}
-export interface PublicVarsVersion1 {
-  version: string;
+export interface AuthMicrosoftOauthLogin1 {
+  sessionToken: string;
+  display_name: string;
+  credits: number;
+  profile_image: string | null;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/users/profile/models.py
+++ b/rpc/users/profile/models.py
@@ -15,5 +15,14 @@ class UsersProfileProfile1(BaseModel):
   display_email: bool
   credits: int
   profile_image: Optional[str] = None
+  default_provider: str
   auth_providers: List[UsersProfileAuthProvider1] = []
+
+
+class UsersProfileSetDisplay1(BaseModel):
+  display_name: str
+
+
+class UsersProfileSetOptin1(BaseModel):
+  display_email: bool
 

--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -3,7 +3,11 @@ from fastapi import HTTPException, Request
 from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
 from server.modules.db_module import DbModule
-from .models import UsersProfileProfile1
+from .models import (
+  UsersProfileProfile1,
+  UsersProfileSetDisplay1,
+  UsersProfileSetOptin1,
+)
 
 
 async def users_profile_get_profile_v1(request: Request):
@@ -24,10 +28,38 @@ async def users_profile_get_profile_v1(request: Request):
   )
 
 async def users_profile_set_display_v1(request: Request):
-  raise NotImplementedError("urn:users:profile:set_display:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  if not auth_ctx.user_guid:
+    raise HTTPException(status_code=401, detail="Unauthorized")
+
+  payload = UsersProfileSetDisplay1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.run(rpc_request.op, {
+    "guid": auth_ctx.user_guid,
+    "display_name": payload.display_name,
+  })
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
 
 async def users_profile_set_optin_v1(request: Request):
-  raise NotImplementedError("urn:users:profile:set_optin:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  if not auth_ctx.user_guid:
+    raise HTTPException(status_code=401, detail="Unauthorized")
+
+  payload = UsersProfileSetOptin1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.run(rpc_request.op, {
+    "guid": auth_ctx.user_guid,
+    "display_email": payload.display_email,
+  })
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
 
 async def users_profile_get_roles_v1(request: Request):
   raise NotImplementedError("urn:users:profile:get_roles:1")

--- a/rpc/users/providers/models.py
+++ b/rpc/users/providers/models.py
@@ -1,4 +1,5 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
+
+class UsersProvidersSetProvider1(BaseModel):
+  provider: str


### PR DESCRIPTION
## Summary
- add user profile page with display name, email opt-in, and provider controls
- extend profile RPC models and services with set_display, set_optin, and set_provider
- back MSSQL provider implementations for profile and provider updates

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a21f58bfbc8325a43cb60312f9b644