### PR TITLE
Fix OAuth provider lookup to include session joins

### DIFF
--- a/server/modules/providers/mssql_provider/registry.py
+++ b/server/modules/providers/mssql_provider/registry.py
@@ -27,7 +27,7 @@ def _users_select(provider_args: Dict[str, Any]):
     provider = provider_args["provider"]
     identifier = provider_args["provider_identifier"]
     sql = """
-      SELECT
+      SELECT TOP 1
         u.element_guid AS guid,
         u.element_display AS display_name,
         u.element_email AS email,
@@ -37,6 +37,8 @@ def _users_select(provider_args: Dict[str, Any]):
         upi.element_base64 AS profile_image
       FROM account_users u
       JOIN users_auth ua ON ua.users_guid = u.element_guid
+      LEFT JOIN users_sessions us ON us.users_guid = u.element_guid
+      LEFT JOIN sessions_devices sd ON sd.sessions_guid = us.element_guid
       JOIN auth_providers ap ON ap.recid = ua.providers_recid
       LEFT JOIN users_credits uc ON uc.users_guid = u.element_guid
       LEFT JOIN users_profileimg upi ON upi.users_guid = u.element_guid

--- a/server/modules/providers/postgres_provider/registry.py
+++ b/server/modules/providers/postgres_provider/registry.py
@@ -33,10 +33,13 @@ def _users_select(args: Dict[str, Any]):
       upi.element_base64 AS profile_image
     FROM account_users u
     JOIN users_auth ua ON ua.users_guid = u.element_guid
+    LEFT JOIN users_sessions us ON us.users_guid = u.element_guid
+    LEFT JOIN sessions_devices sd ON sd.sessions_guid = us.element_guid
     JOIN auth_providers ap ON ap.recid = ua.providers_recid
     LEFT JOIN users_credits uc ON uc.users_guid = u.element_guid
     LEFT JOIN users_profileimg upi ON upi.users_guid = u.element_guid
-    WHERE ap.element_name = $1 AND ua.element_identifier = $2;
+    WHERE ap.element_name = $1 AND ua.element_identifier = $2
+    LIMIT 1;
   """
   return ("one", sql, (provider, identifier))
 

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -1,0 +1,18 @@
+from server.modules.providers.mssql_provider.registry import get_handler as get_mssql_handler
+from server.modules.providers.postgres_provider.registry import get_handler as get_pg_handler
+
+
+def test_mssql_get_by_provider_identifier_joins_sessions_tables():
+  handler = get_mssql_handler("urn:users:providers:get_by_provider_identifier:1")
+  _, sql, _ = handler({"provider": "microsoft", "provider_identifier": "pid"})
+  sql_lower = sql.lower()
+  assert "users_sessions" in sql_lower
+  assert "sessions_devices" in sql_lower
+
+
+def test_pg_get_by_provider_identifier_joins_sessions_tables():
+  handler = get_pg_handler("urn:users:providers:get_by_provider_identifier:1")
+  _, sql, _ = handler({"provider": "microsoft", "provider_identifier": "pid"})
+  sql_lower = sql.lower()
+  assert "users_sessions" in sql_lower
+  assert "sessions_devices" in sql_lower


### PR DESCRIPTION
## Summary
- ensure provider user lookup joins users_sessions and sessions_devices tables
- add regression test confirming lookup SQL covers session tables

## Testing
- `python scripts/generate_rpc_metadata.py`
- `python scripts/generate_rpc_client.py`
- `python scripts/generate_rpc_library.py`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a221ae2fc083258db6f4291d9a0c89