### PR TITLE
Persist provider profile data on user creation

### DIFF
--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -79,6 +79,7 @@ async def auth_microsoft_oauth_login_v1(request: Request):
         "provider_identifier": provider_uid,
         "provider_email": profile["email"],
         "provider_displayname": profile["username"],
+        "provider_profile_image": profile.get("profilePicture"),
       },
     )
     user = res.rows[0] if res.rows else None
@@ -87,13 +88,6 @@ async def auth_microsoft_oauth_login_v1(request: Request):
     raise HTTPException(status_code=500, detail="Unable to create user")
 
   user_guid = user["guid"]
-
-  if profile.get("profilePicture"):
-    await db.run(
-      "urn:users:profile:set_profile_image:1",
-      {"guid": user_guid, "image_b64": profile["profilePicture"], "provider": provider},
-    )
-    user["profile_image"] = profile["profilePicture"]
   rotation_token, rot_exp = auth.make_rotation_token(user_guid)
   logging.debug(f"[auth_microsoft_oauth_login_v1] rotation_token={rotation_token[:40]}")
   now = datetime.now(timezone.utc)

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -67,6 +67,7 @@ async def auth_session_get_token_v1(request: Request):
         "provider_identifier": provider_uid,
         "provider_email": profile["email"],
         "provider_displayname": profile["username"],
+        "provider_profile_image": profile.get("profilePicture"),
       },
     )
     user = res.rows[0] if res.rows else None
@@ -74,12 +75,6 @@ async def auth_session_get_token_v1(request: Request):
     raise HTTPException(status_code=500, detail="Unable to create user")
 
   user_guid = user["guid"]
-
-  if profile.get("profilePicture"):
-    await db.run(
-      "urn:users:profile:set_profile_image:1",
-      {"guid": user_guid, "image_b64": profile["profilePicture"], "provider": provider},
-    )
   rotation_token, rot_exp = auth.make_rotation_token(user_guid)
   now = datetime.now(timezone.utc)
   await db.run(

--- a/tests/test_user_creation_profile_img.py
+++ b/tests/test_user_creation_profile_img.py
@@ -1,0 +1,42 @@
+import asyncio
+from contextlib import asynccontextmanager
+from uuid import uuid4
+
+from server.modules.providers.mssql_provider import registry
+
+
+def test_create_from_provider_inserts_profile_image(monkeypatch):
+  executed = []
+
+  class DummyCursor:
+    async def execute(self, sql, params):
+      executed.append(sql.lower())
+
+  @asynccontextmanager
+  async def dummy_transaction():
+    yield DummyCursor()
+
+  async def fake_fetch_json_one(query, params):
+    q = query.strip().lower()
+    if q.startswith("select recid from auth_providers"):
+      return {"recid": 1}
+    return {"guid": "gid", "profile_image": args["provider_profile_image"]}
+
+  monkeypatch.setattr(registry, "transaction", dummy_transaction)
+  monkeypatch.setattr(registry, "fetch_json_one", fake_fetch_json_one)
+
+  handler = registry.get_handler("urn:users:providers:create_from_provider:1")
+  args = {
+    "provider": "microsoft",
+    "provider_identifier": str(uuid4()),
+    "provider_email": "user@example.com",
+    "provider_displayname": "User",
+    "provider_profile_image": "img",
+  }
+  res = asyncio.run(handler(args))
+
+  assert any("insert into users_profileimg" in sql for sql in executed)
+  assert any("insert into users_roles" in sql for sql in executed)
+  assert res["rows"]
+  assert res["rows"][0]["profile_image"] == "img"
+


### PR DESCRIPTION
## Summary
- capture provider profile image and default role when creating a user
- pass provider profile image through Microsoft OAuth and session login flows
- extend regression test to verify profile image and role insertion

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68a25967f6b483258f811f471af1b286