### PR TITLE
retry user fetch after provider creation

### DIFF
--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -83,6 +83,13 @@ async def auth_microsoft_oauth_login_v1(request: Request):
       },
     )
     user = res.rows[0] if res.rows else None
+    if not user:
+      logging.debug("[auth_microsoft_oauth_login_v1] fetching user after creation")
+      res = await db.run(
+        "urn:users:providers:get_by_provider_identifier:1",
+        {"provider": provider, "provider_identifier": provider_uid},
+      )
+      user = res.rows[0] if res.rows else None
   if not user:
     logging.debug("[auth_microsoft_oauth_login_v1] failed to create user")
     raise HTTPException(status_code=500, detail="Unable to create user")

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -71,6 +71,12 @@ async def auth_session_get_token_v1(request: Request):
       },
     )
     user = res.rows[0] if res.rows else None
+    if not user:
+      res = await db.run(
+        "urn:users:providers:get_by_provider_identifier:1",
+        {"provider": provider, "provider_identifier": provider_uid},
+      )
+      user = res.rows[0] if res.rows else None
   if not user:
     raise HTTPException(status_code=500, detail="Unable to create user")
 

--- a/tests/test_auth_microsoft_oauth_login_creation.py
+++ b/tests/test_auth_microsoft_oauth_login_creation.py
@@ -1,0 +1,119 @@
+import sys, types, pytest, importlib.util, importlib.machinery, asyncio
+from types import SimpleNamespace
+from datetime import datetime, timezone, timedelta
+
+class DummyAuth:
+  async def handle_auth_login(self, provider, id_token, access_token):
+    profile = {"email": "user@example.com", "username": "User"}
+    return "00000000-0000-0000-0000-000000000001", profile, {}
+  def make_rotation_token(self, user_guid):
+    return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, roles, provider):
+    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+
+class DummyAuthz:
+  def mask_to_names(self, mask):
+    return []
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+class DummyDb:
+  def __init__(self):
+    self.calls = []
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    if op == "urn:users:providers:get_by_provider_identifier:1":
+      if len([c for c in self.calls if c[0] == op]) == 1:
+        return DBRes([], 0)
+      return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
+    if op == "urn:users:providers:create_from_provider:1":
+      return DBRes([], 1)
+    if op == "db:users:session:set_rotkey:1":
+      return DBRes([], 1)
+    if op == "urn:users:profile:get_roles:1":
+      return DBRes([{ "element_roles": 0 }], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([], 1)
+    return DBRes()
+
+class DummyState:
+  def __init__(self):
+    self.auth = DummyAuth()
+    self.db = DummyDb()
+    self.authz = DummyAuthz()
+
+class DummyApp:
+  def __init__(self):
+    self.state = DummyState()
+
+class DummyRequest:
+  def __init__(self):
+    self.app = DummyApp()
+    self.headers = {"user-agent": "tester"}
+    self.client = SimpleNamespace(host="127.0.0.1")
+
+def test_fetch_user_after_create(monkeypatch):
+  spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
+  models = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(models)
+  sys.modules["rpc.models"] = models
+  RPCRequest = models.RPCRequest
+  RPCResponse = models.RPCResponse
+
+  helpers = types.ModuleType("rpc.helpers")
+  async def fake_get_rpcrequest_from_request(request):
+    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
+    return rpc, None, None
+  helpers.get_rpcrequest_from_request = fake_get_rpcrequest_from_request
+  sys.modules["rpc.helpers"] = helpers
+
+  sys.modules.setdefault("rpc", types.ModuleType("rpc"))
+  sys.modules.setdefault("rpc.auth", types.ModuleType("rpc.auth"))
+  rpc_auth_ms = types.ModuleType("rpc.auth.microsoft")
+  rpc_auth_ms.__path__ = []
+  sys.modules.setdefault("rpc.auth.microsoft", rpc_auth_ms)
+  from pydantic import BaseModel
+  models_mod = types.ModuleType("rpc.auth.microsoft.models")
+  class AuthMicrosoftOauthLogin1(BaseModel):
+    sessionToken: str
+    display_name: str
+    credits: int
+    profile_image: str | None = None
+  models_mod.AuthMicrosoftOauthLogin1 = AuthMicrosoftOauthLogin1
+  sys.modules["rpc.auth.microsoft.models"] = models_mod
+
+  sys.modules["server"] = types.ModuleType("server")
+  sys.modules["server.models"] = types.ModuleType("server.models")
+  sys.modules["server.modules"] = types.ModuleType("server.modules")
+  auth_mod = types.ModuleType("server.modules.auth_module")
+  class AuthModule: ...
+  auth_mod.AuthModule = AuthModule
+  sys.modules["server.modules.auth_module"] = auth_mod
+  authz_mod = types.ModuleType("server.modules.authz_module")
+  class AuthzModule: ...
+  authz_mod.AuthzModule = AuthzModule
+  sys.modules["server.modules.authz_module"] = authz_mod
+  db_mod = types.ModuleType("server.modules.db_module")
+  class DbModule: ...
+  db_mod.DbModule = DbModule
+  sys.modules["server.modules.db_module"] = db_mod
+
+  svc_spec = importlib.util.spec_from_file_location(
+    "rpc.auth.microsoft.services", "rpc/auth/microsoft/services.py"
+  )
+  svc_mod = importlib.util.module_from_spec(svc_spec)
+  svc_spec.loader.exec_module(svc_mod)
+  auth_microsoft_oauth_login_v1 = svc_mod.auth_microsoft_oauth_login_v1
+
+  req = DummyRequest()
+  resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
+  assert isinstance(resp, RPCResponse)
+  calls = [op for op, _ in req.app.state.db.calls if op == "urn:users:providers:get_by_provider_identifier:1"]
+  assert len(calls) == 2
+  assert any(op == "db:auth:session:create_session:1" for op, _ in req.app.state.db.calls)
+
+
+


### PR DESCRIPTION
## Summary
- fetch user record again after provider creation if initial query returns empty
- ensure session login flow tests cover user fetch retry

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68a2606b25488325b74821eb425afb83