### PR TITLE
Handle home_account_id during user lookup

### DIFF
--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -41,12 +41,27 @@ async def auth_session_get_token_v1(request: Request):
     except Exception:
       pass
 
-  user = None
-  for pid in identifiers:
+  def _norm(pid: str) -> str | None:
     try:
-      uid = str(uuid.UUID(pid))
+      return str(uuid.UUID(pid))
     except ValueError:
+      try:
+        import base64
+        pad = pid + "=" * (-len(pid) % 4)
+        raw = base64.urlsafe_b64decode(pad)
+        if len(raw) >= 16:
+          return str(uuid.UUID(bytes=raw[-16:]))
+      except Exception:
+        return None
+    return None
+
+  user = None
+  checked = set()
+  for pid in identifiers:
+    uid = _norm(pid)
+    if not uid or uid in checked:
       continue
+    checked.add(uid)
     res = await db.run(
       "urn:users:providers:get_by_provider_identifier:1",
       {"provider": provider, "provider_identifier": uid},

--- a/tests/test_auth_microsoft_home_account_lookup.py
+++ b/tests/test_auth_microsoft_home_account_lookup.py
@@ -1,0 +1,106 @@
+import sys, types, importlib.util, asyncio, base64, uuid
+from types import SimpleNamespace
+from datetime import datetime, timezone, timedelta
+
+class DummyAuth:
+  async def handle_auth_login(self, provider, id_token, access_token):
+    base_uuid = "00000000-0000-0000-0000-000000000001"
+    home_account_id = base64.urlsafe_b64encode(b"\x00" * 16 + uuid.UUID(base_uuid).bytes).decode("utf-8").rstrip("=")
+    profile = {"email": "user@example.com", "username": "User"}
+    return home_account_id, profile, {}
+  def make_rotation_token(self, user_guid):
+    return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, roles, provider):
+    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+
+class DummyAuthz:
+  def mask_to_names(self, mask):
+    return []
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+class DummyDb:
+  def __init__(self):
+    self.calls = []
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    if op == "urn:users:providers:get_by_provider_identifier:1":
+      return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
+    return DBRes()
+
+class DummyState:
+  def __init__(self):
+    self.auth = DummyAuth()
+    self.db = DummyDb()
+    self.authz = DummyAuthz()
+
+class DummyApp:
+  def __init__(self):
+    self.state = DummyState()
+
+class DummyRequest:
+  def __init__(self):
+    self.app = DummyApp()
+    self.headers = {"user-agent": "tester"}
+    self.client = SimpleNamespace(host="127.0.0.1")
+
+def test_lookup_with_home_account_id(monkeypatch):
+  spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
+  models = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(models)
+  sys.modules["rpc.models"] = models
+  RPCRequest = models.RPCRequest
+  RPCResponse = models.RPCResponse
+
+  helpers = types.ModuleType("rpc.helpers")
+  async def fake_get_rpcrequest_from_request(request):
+    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
+    return rpc, None, None
+  helpers.get_rpcrequest_from_request = fake_get_rpcrequest_from_request
+  sys.modules["rpc.helpers"] = helpers
+
+  sys.modules.setdefault("rpc", types.ModuleType("rpc"))
+  sys.modules.setdefault("rpc.auth", types.ModuleType("rpc.auth"))
+  rpc_auth_ms = types.ModuleType("rpc.auth.microsoft")
+  rpc_auth_ms.__path__ = []
+  sys.modules.setdefault("rpc.auth.microsoft", rpc_auth_ms)
+  from pydantic import BaseModel
+  models_mod = types.ModuleType("rpc.auth.microsoft.models")
+  class AuthMicrosoftOauthLogin1(BaseModel):
+    sessionToken: str
+    display_name: str
+    credits: int
+    profile_image: str | None = None
+  models_mod.AuthMicrosoftOauthLogin1 = AuthMicrosoftOauthLogin1
+  sys.modules["rpc.auth.microsoft.models"] = models_mod
+
+  sys.modules["server"] = types.ModuleType("server")
+  sys.modules["server.models"] = types.ModuleType("server.models")
+  sys.modules["server.modules"] = types.ModuleType("server.modules")
+  auth_mod = types.ModuleType("server.modules.auth_module")
+  class AuthModule: ...
+  auth_mod.AuthModule = AuthModule
+  sys.modules["server.modules.auth_module"] = auth_mod
+  authz_mod = types.ModuleType("server.modules.authz_module")
+  class AuthzModule: ...
+  authz_mod.AuthzModule = AuthzModule
+  sys.modules["server.modules.authz_module"] = authz_mod
+  db_mod = types.ModuleType("server.modules.db_module")
+  class DbModule: ...
+  db_mod.DbModule = DbModule
+  sys.modules["server.modules.db_module"] = db_mod
+
+  svc_spec = importlib.util.spec_from_file_location(
+    "rpc.auth.microsoft.services", "rpc/auth/microsoft/services.py"
+  )
+  svc_mod = importlib.util.module_from_spec(svc_spec)
+  svc_spec.loader.exec_module(svc_mod)
+  auth_microsoft_oauth_login_v1 = svc_mod.auth_microsoft_oauth_login_v1
+
+  req = DummyRequest()
+  resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
+  assert isinstance(resp, RPCResponse)
+  assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)


### PR DESCRIPTION
## Summary
- Normalize provider identifiers to decode Microsoft home_account_id strings
- Deduplicate identifiers during lookup to avoid extra queries
- Add regression test for home_account_id user lookup

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68a26460c68c8325b3c45edc8334b6d6