### PR TITLE
feat: enable runtime debug logging

### DIFF
--- a/server/helpers/logging.py
+++ b/server/helpers/logging.py
@@ -57,6 +57,13 @@ def configure_discord_logging(discord_module):
   handler.setFormatter(logging.Formatter('[%(levelname)s] %(message)s'))
   logging.getLogger().addHandler(handler)
 
+def update_logging_level(debug: bool = False):
+  """Update global logging level including Azure SDK logger."""
+  logger = logging.getLogger()
+  logger.setLevel(logging.DEBUG if debug else logging.INFO)
+  azure_logger = logging.getLogger('azure.core.pipeline.policies.http_logging_policy')
+  azure_logger.setLevel(logging.DEBUG if debug else logging.WARNING)
+
 def configure_root_logging(debug: bool = False):
   logger = logging.getLogger()
   if logger.handlers:
@@ -64,10 +71,7 @@ def configure_root_logging(debug: bool = False):
   handler = logging.StreamHandler(sys.stdout)
   handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
   logger.addHandler(handler)
-  logger.setLevel(logging.DEBUG if debug else logging.INFO)
-
-  azure_logger = logging.getLogger('azure.core.pipeline.policies.http_logging_policy')
-  azure_logger.setLevel(logging.DEBUG if debug else logging.WARNING)
+  update_logging_level(debug)
 
 def remove_discord_logging(discord_module):
   logger = logging.getLogger()

--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -6,7 +6,7 @@ from . import BaseModule
 from .env_module import EnvModule
 from .db_module import DbModule
 
-from server.helpers.logging import configure_discord_logging, remove_discord_logging
+from server.helpers.logging import configure_discord_logging, remove_discord_logging, update_logging_level
 
 class DiscordModule(BaseModule):
   def __init__(self, app: FastAPI):
@@ -27,6 +27,7 @@ class DiscordModule(BaseModule):
     self.bot = self._init_discord_bot('!')
     self.bot.app = self.app
     self._init_bot_routes()
+    update_logging_level(self.db.debug_logging)
     configure_discord_logging(self)
     res = await self.db.run("db:system:config:get_config:1", {"key": "DiscordSyschan"})
     if not res.rows:


### PR DESCRIPTION
## Summary
- add helper to update log level dynamically
- read DebugLogging from system_config during DB startup
- apply debug flag to console and Discord logging

## Testing
- `python scripts/run_tests.py --test`
- `npm run lint`
- `npm run type-check`
- `npx vitest run --coverage`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a27366d5c883259cacf03d429d3b63