### PR TITLE
Use row-based MSSQL lookup to avoid JSON parsing errors

### DIFF
--- a/server/modules/providers/mssql_provider/__init__.py
+++ b/server/modules/providers/mssql_provider/__init__.py
@@ -1,6 +1,6 @@
 # providers/mssql_provider/__init__.py
 from typing import Any, Dict
-from .logic import init_pool, close_pool, fetch_json_one, fetch_json_many, exec_
+from .logic import init_pool, close_pool, fetch_json_one, fetch_json_many, fetch_row_one, exec_
 from .registry import get_handler
 
 async def init(**cfg):
@@ -17,6 +17,9 @@ async def dispatch(op: str, args: Dict[str, Any]):
     mode, sql, params = spec
     if mode == "json_one":
         row = await fetch_json_one(sql, params)
+        return {"rows": [row] if row else [], "rowcount": 1 if row else 0}
+    if mode == "row_one":
+        row = await fetch_row_one(sql, params)
         return {"rows": [row] if row else [], "rowcount": 1 if row else 0}
     if mode == "json_many":
         rows = await fetch_json_many(sql, params)

--- a/tests/test_user_creation_profile_img.py
+++ b/tests/test_user_creation_profile_img.py
@@ -24,6 +24,7 @@ def test_create_from_provider_inserts_profile_image(monkeypatch):
 
   monkeypatch.setattr(registry, "transaction", dummy_transaction)
   monkeypatch.setattr(registry, "fetch_json_one", fake_fetch_json_one)
+  monkeypatch.setattr(registry, "fetch_row_one", fake_fetch_json_one)
 
   handler = registry.get_handler("urn:users:providers:create_from_provider:1")
   args = {


### PR DESCRIPTION
## Summary
- add `fetch_row_one` utility for MSSQL provider
- swap provider lookup to use direct row fetch instead of JSON
- update test stubs for new fetch helper

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68a279cb719c8325b230da2672ab5aea