### PR TITLE
Add session lookup RPC

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -68,6 +68,7 @@ Authentication and session management calls.
 | `urn:auth:session:get_token:1`        | Get a bearer token for a new device session.           |
 | `urn:auth:session:refresh_token:1`    | Get a new bearer token for an existing device session. |
 | `urn:auth:session:invalidate_token:1` | Invalidate an existing device session token.           |
+| `urn:auth:session:get_session:1`      | Map a bearer token to its session and device details.  |
 
 ## Public (React/Frontend) Domain
 

--- a/frontend/src/rpc/auth/session/index.ts
+++ b/frontend/src/rpc/auth/session/index.ts
@@ -9,3 +9,4 @@ import { rpcCall } from '../../../shared/RpcModels';
 export const fetchToken = (payload: any = null): Promise<any> => rpcCall('urn:auth:session:get_token:1', payload);
 export const fetchRefreshToken = (payload: any = null): Promise<any> => rpcCall('urn:auth:session:refresh_token:1', payload);
 export const fetchInvalidateToken = (payload: any = null): Promise<any> => rpcCall('urn:auth:session:invalidate_token:1', payload);
+export const fetchSession = (payload: any = null): Promise<any> => rpcCall('urn:auth:session:get_session:1', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -18,35 +18,6 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
-export interface AuthMicrosoftOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
-  credits: number;
-  profile_image: string | null;
-}
-export interface UsersProfileAuthProvider1 {
-  name: string;
-  display: string;
-}
-export interface UsersProfileProfile1 {
-  guid: string;
-  display_name: string;
-  email: string;
-  display_email: boolean;
-  credits: number;
-  profile_image: string | null;
-  default_provider: string;
-  auth_providers: UsersProfileAuthProvider1[];
-}
-export interface UsersProfileSetDisplay1 {
-  display_name: string;
-}
-export interface UsersProfileSetOptin1 {
-  display_email: boolean;
-}
-export interface UsersProvidersSetProvider1 {
-  provider: string;
-}
 export interface PublicLinksHomeLinks1 {
   links: PublicLinksLinkItem1[];
 }
@@ -76,6 +47,35 @@ export interface PublicVarsRepo1 {
 }
 export interface PublicVarsVersion1 {
   version: string;
+}
+export interface UsersProvidersSetProvider1 {
+  provider: string;
+}
+export interface UsersProfileAuthProvider1 {
+  name: string;
+  display: string;
+}
+export interface UsersProfileProfile1 {
+  guid: string;
+  display_name: string;
+  email: string;
+  display_email: boolean;
+  credits: number;
+  profile_image: string | null;
+  default_provider: string;
+  auth_providers: UsersProfileAuthProvider1[];
+}
+export interface UsersProfileSetDisplay1 {
+  display_name: string;
+}
+export interface UsersProfileSetOptin1 {
+  display_email: boolean;
+}
+export interface AuthMicrosoftOauthLogin1 {
+  sessionToken: string;
+  display_name: string;
+  credits: number;
+  profile_image: string | null;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/frontend/src/shared/UserContextProvider.tsx
+++ b/frontend/src/shared/UserContextProvider.tsx
@@ -1,45 +1,72 @@
-import { useState, ReactNode } from 'react';
+import { useState, ReactNode, useEffect } from 'react';
+import { PublicClientApplication } from '@azure/msal-browser';
 import UserContext from './UserContext';
+import { msalConfig, loginRequest } from '../config/msal';
+import { fetchOauthLogin } from '../rpc/auth/microsoft';
 import type { AuthMicrosoftOauthLogin1 } from './RpcModels';
 
 interface UserContextProviderProps {
-  	children: ReactNode;
+	children: ReactNode;
 }
 
 const UserContextProvider = ({ children }: UserContextProviderProps): JSX.Element => {
-        const [userData, setUserDataState] = useState<AuthMicrosoftOauthLogin1 | null>(() => {
-                if (typeof localStorage !== 'undefined') {
-                        try {
-                                const raw = localStorage.getItem('authTokens');
-                                if (raw) {
-                                        return JSON.parse(raw) as AuthMicrosoftOauthLogin1;
-                                }
-                        } catch {
-                                /* ignore */
-                        }
-                }
-                return null;
-        });
+		const [userData, setUserDataState] = useState<AuthMicrosoftOauthLogin1 | null>(() => {
+				if (typeof localStorage !== 'undefined') {
+						try {
+								const raw = localStorage.getItem('authTokens');
+								if (raw) {
+										return JSON.parse(raw) as AuthMicrosoftOauthLogin1;
+								}
+						} catch {
+								/* ignore */
+						}
+				}
+				return null;
+		});
 
-        const setUserData = (data: AuthMicrosoftOauthLogin1) => {
-                setUserDataState(data);
-                if (typeof localStorage !== 'undefined') {
-                        localStorage.setItem('authTokens', JSON.stringify(data));
-                }
-        };
+		const setUserData = (data: AuthMicrosoftOauthLogin1) => {
+				setUserDataState(data);
+				if (typeof localStorage !== 'undefined') {
+						localStorage.setItem('authTokens', JSON.stringify(data));
+				}
+		};
 
-        const clearUserData = () => {
-                setUserDataState(null);
-                if (typeof localStorage !== 'undefined') {
-                        localStorage.removeItem('authTokens');
-                }
-        };
+		const clearUserData = () => {
+				setUserDataState(null);
+				if (typeof localStorage !== 'undefined') {
+						localStorage.removeItem('authTokens');
+				}
+		};
 
-        return (
-        <UserContext.Provider value={{ userData, setUserData, clearUserData }}>
-                {children}
-        </UserContext.Provider>
-        );
+		useEffect(() => {
+				const msal = new PublicClientApplication(msalConfig);
+				const init = async () => {
+						try {
+								await msal.initialize();
+								const account = msal.getActiveAccount() || msal.getAllAccounts()[0];
+								if (!account) return;
+								const result = await msal.acquireTokenSilent({
+										...loginRequest,
+										account
+								});
+								const data = await fetchOauthLogin({
+										idToken: result.idToken,
+										accessToken: result.accessToken,
+										provider: 'microsoft'
+								}) as AuthMicrosoftOauthLogin1;
+								setUserData(data);
+						} catch {
+								/* silent token acquisition failed */
+						}
+				};
+				void init();
+		}, []);
+
+		return (
+		<UserContext.Provider value={{ userData, setUserData, clearUserData }}>
+				{children}
+		</UserContext.Provider>
+		);
 };
 
 export default UserContextProvider;

--- a/rpc/auth/session/__init__.py
+++ b/rpc/auth/session/__init__.py
@@ -1,7 +1,8 @@
 from .services import (
   auth_session_get_token_v1,
   auth_session_refresh_token_v1,
-  auth_session_invalidate_token_v1
+  auth_session_invalidate_token_v1,
+  auth_session_get_session_v1
 )
 
 
@@ -9,5 +10,6 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("get_token", "1"): auth_session_get_token_v1,
   ("refresh_token", "1"): auth_session_refresh_token_v1,
   ("invalidate_token", "1"): auth_session_invalidate_token_v1,
+  ("get_session", "1"): auth_session_get_session_v1,
 }
 

--- a/rpc/metadata.json
+++ b/rpc/metadata.json
@@ -63,6 +63,10 @@
             "subdomain": "session",
             "functions": [
               {
+                "op": "urn:auth:session:get_session:1",
+                "capabilities": 0
+              },
+              {
                 "op": "urn:auth:session:get_token:1",
                 "capabilities": 0
               },

--- a/tests/test_auth_session_get_session.py
+++ b/tests/test_auth_session_get_session.py
@@ -1,0 +1,75 @@
+import sys, types, asyncio, importlib.util
+from types import SimpleNamespace
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+class DummyDb:
+  def __init__(self):
+    self.calls = []
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    if op == "db:auth:session:get_by_access_token:1":
+      return DBRes([
+        {
+          "session_guid": "sess-guid",
+          "device_guid": "dev-guid",
+          "user_guid": "user-guid",
+          "issued_at": "2099-01-01T00:00:00Z",
+          "expires_at": "2099-01-01T01:00:00Z",
+          "device_fingerprint": "fp",
+          "user_agent": "ua",
+          "ip_last_seen": "127.0.0.1",
+        }
+      ], 1)
+    return DBRes()
+
+class DummyState:
+  def __init__(self):
+    self.db = DummyDb()
+
+class DummyApp:
+  def __init__(self):
+    self.state = DummyState()
+
+class DummyRequest:
+  def __init__(self):
+    self.app = DummyApp()
+    self.headers = {"authorization": "Bearer tok"}
+
+
+def test_get_session(monkeypatch):
+  spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
+  models = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(models)
+  sys.modules["rpc.models"] = models
+  RPCRequest = models.RPCRequest
+  RPCResponse = models.RPCResponse
+
+  helpers = types.ModuleType("rpc.helpers")
+  async def fake_get_rpcrequest_from_request(request):
+    rpc = RPCRequest(op="urn:auth:session:get_session:1", payload=None, version=1)
+    return rpc, SimpleNamespace(), None
+  helpers.get_rpcrequest_from_request = fake_get_rpcrequest_from_request
+  sys.modules["rpc.helpers"] = helpers
+
+  sys.modules.setdefault("server", types.ModuleType("server"))
+  sys.modules.setdefault("server.modules", types.ModuleType("server.modules"))
+  db_mod = types.ModuleType("server.modules.db_module")
+  class DbModule: ...
+  db_mod.DbModule = DbModule
+  sys.modules["server.modules.db_module"] = db_mod
+
+  svc_spec = importlib.util.spec_from_file_location(
+    "rpc.auth.session.services", "rpc/auth/session/services.py"
+  )
+  svc_mod = importlib.util.module_from_spec(svc_spec)
+  svc_spec.loader.exec_module(svc_mod)
+  auth_session_get_session_v1 = svc_mod.auth_session_get_session_v1
+
+  req = DummyRequest()
+  resp = asyncio.run(auth_session_get_session_v1(req))
+  assert isinstance(resp, RPCResponse)
+  assert any(op == "db:auth:session:get_by_access_token:1" for op, _ in req.app.state.db.calls)


### PR DESCRIPTION
## Summary
- add `get_session` RPC to map bearer tokens to session/device details
- document new auth session operation and expose client helper
- test session lookups via `db:auth:session:get_by_access_token:1`
- silently acquire Microsoft tokens on load and refresh session so RPC requests include Authorization header

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68a285f1420c83258388154c99787d99