### PR TITLE
fix: normalize profile guid on user page

### DIFF
--- a/frontend/src/UserPage.tsx
+++ b/frontend/src/UserPage.tsx
@@ -13,20 +13,36 @@ const UserPage = (): JSX.Element => {
         const [provider, setProvider] = useState('microsoft');
         const [dirty, setDirty] = useState(false);
 
-        useEffect(() => {
-                if (!userData) return;
-                void (async () => {
-                        try {
-                                const res: UsersProfileProfile1 = await fetchProfile();
-                                setProfile(res);
-                                setDisplayName(res.display_name);
-                                setDisplayEmail(res.display_email);
-                                setProvider(res.default_provider);
-                        } catch {
-                                setProfile(null);
-                        }
-                })();
-        }, [userData]);
+	const normalizeGuid = (guid: unknown): string => {
+		if (typeof guid === 'string') return guid;
+		if (guid && typeof guid === 'object') {
+			const val = (guid as { toString?: () => string }).toString;
+			if (val) {
+				try {
+					return val.call(guid);
+				} catch {
+					/* ignore */
+				}
+			}
+		}
+		return '';
+	};
+
+	useEffect(() => {
+		if (!userData) return;
+		void (async () => {
+			try {
+				const res: any = await fetchProfile();
+				const profileData: UsersProfileProfile1 = { ...res, guid: normalizeGuid(res.guid) };
+				setProfile(profileData);
+				setDisplayName(profileData.display_name);
+				setDisplayEmail(profileData.display_email);
+				setProvider(profileData.default_provider);
+			} catch {
+				setProfile(null);
+			}
+		})();
+	}, [userData]);
 
         const handleToggle = (): void => {
                 setDisplayEmail(!displayEmail);

--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -19,8 +19,13 @@ async def users_profile_get_profile_v1(request: Request):
   res = await db.run(rpc_request.op, {"guid": auth_ctx.user_guid})
   if not res.rows:
     raise HTTPException(status_code=404, detail="Profile not found")
-
-  profile = UsersProfileProfile1(**res.rows[0])
+  row = res.rows[0]
+  row["guid"] = str(row.get("guid", ""))
+  auth_providers = row.get("auth_providers")
+  if isinstance(auth_providers, str):
+    import json
+    row["auth_providers"] = json.loads(auth_providers) if auth_providers else []
+  profile = UsersProfileProfile1(**row)
   return RPCResponse(
     op=rpc_request.op,
     payload=profile.model_dump(),

--- a/server/modules/providers/mssql_provider/registry.py
+++ b/server/modules/providers/mssql_provider/registry.py
@@ -98,7 +98,7 @@ async def _users_insert(args: Dict[str, Any]):
 
 @register("urn:users:profile:get_profile:1")
 def _users_profile(args: Dict[str, Any]):
-    guid = args["guid"]
+    guid = str(args["guid"])
     sql = """
       SELECT TOP 1
         v.user_guid AS guid,
@@ -118,10 +118,9 @@ def _users_profile(args: Dict[str, Any]):
           FOR JSON PATH
         ) AS auth_providers
       FROM vw_account_user_profile v
-      WHERE v.user_guid = ?
-      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+      WHERE v.user_guid = ?;
     """
-    return ("json_one", sql, (guid,))
+    return ("row_one", sql, (guid,))
 
 
 @register("urn:users:profile:set_display:1")


### PR DESCRIPTION
## Summary
- normalize profile guid before using user profile data
- fetch user profile via row query and decode auth providers

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `python scripts/generate_rpc_metadata.py`
- `npm run lint`
- `npm run type-check`
- `npx vitest run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a29149dd008325acb3c01e3a65b468