### PR TITLE
feat: add system routes admin page and chunking

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,28 +1,42 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
-import { ThemeProvider } from '@mui/material/styles';
-import { CssBaseline, Container } from '@mui/material'
-import ElideusTheme from './shared/ElideusTheme'
-import UserContextProvider from './shared/UserContextProvider'
-import Home from './Home'
-import NavBar from './NavBar'
-import Gallery from './Gallery'
-import LoginPage from './LoginPage'
-import UserPage from './UserPage'
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { ThemeProvider } from "@mui/material/styles";
+import { CssBaseline, Container } from "@mui/material";
+import ElideusTheme from "./shared/ElideusTheme";
+import UserContextProvider from "./shared/UserContextProvider";
+import Home from "./Home";
+import NavBar from "./NavBar";
+import Gallery from "./Gallery";
+import LoginPage from "./LoginPage";
+import UserPage from "./UserPage";
+import SystemRoutesPage from "./SystemRoutesPage";
 
 function App(): JSX.Element {
 	return (
-		<ThemeProvider theme={ ElideusTheme }>
+		<ThemeProvider theme={ElideusTheme}>
 			<CssBaseline />
 			<UserContextProvider>
 				<Router>
 					<NavBar />
-					<Container maxWidth='lg' disableGutters sx={{ bgcolor: 'background.paper', color: 'text.primary', minHeight: '100vh', py: 2 }}>
-												<Routes>
-														<Route path='/' element={<Home />} />
-                                                                                                                <Route path='/gallery' element={<Gallery />} />
-                                                                                                                <Route path='/loginpage' element={<LoginPage />} />
-                                                                                                                <Route path='/userpage' element={<UserPage />} />
-                                                                                                </Routes>
+					<Container
+						maxWidth="lg"
+						disableGutters
+						sx={{
+							bgcolor: "background.paper",
+							color: "text.primary",
+							minHeight: "100vh",
+							py: 2,
+						}}
+					>
+						<Routes>
+							<Route path="/" element={<Home />} />
+							<Route path="/gallery" element={<Gallery />} />
+							<Route path="/loginpage" element={<LoginPage />} />
+							<Route path="/userpage" element={<UserPage />} />
+							<Route
+								path="/system/routes"
+								element={<SystemRoutesPage />}
+							/>
+						</Routes>
 					</Container>
 				</Router>
 			</UserContextProvider>

--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -1,0 +1,421 @@
+import { useEffect, useState } from "react";
+import {
+	Box,
+	Divider,
+	Table,
+	TableHead,
+	TableRow,
+	TableCell,
+	TableBody,
+	TextField,
+	IconButton,
+	Stack,
+	List,
+	ListItemButton,
+	ListItemText,
+	Typography,
+} from "@mui/material";
+import {
+	Delete,
+	Add,
+	ArrowForwardIos,
+	ArrowBackIos,
+} from "@mui/icons-material";
+import type {
+	SystemRoutesRouteItem1,
+	SystemRoutesList1,
+	SecurityRolesRoles1,
+} from "./shared/RpcModels";
+import {
+	fetchRoutes,
+	fetchUpsertRoute,
+	fetchDeleteRoute,
+} from "./rpc/system/routes";
+import { fetchRoles } from "./rpc/security/roles";
+
+const MAX_HEIGHT = 120;
+
+const SystemRoutesPage = (): JSX.Element => {
+	const [routes, setRoutes] = useState<SystemRoutesRouteItem1[]>([]);
+	const [roleNames, setRoleNames] = useState<string[]>([]);
+	const [selectedLeft, setSelectedLeft] = useState<Record<number, string>>(
+		{},
+	);
+	const [selectedRight, setSelectedRight] = useState<Record<number, string>>(
+		{},
+	);
+	const [newRoute, setNewRoute] = useState<SystemRoutesRouteItem1>({
+		path: "",
+		name: "",
+		icon: "",
+		sequence: 0,
+		required_roles: [],
+	});
+	const [newLeft, setNewLeft] = useState<string | null>(null);
+	const [newRight, setNewRight] = useState<string | null>(null);
+
+	const load = async (): Promise<void> => {
+		try {
+			const res: SystemRoutesList1 = await fetchRoutes();
+			setRoutes(res.routes.sort((a, b) => a.sequence - b.sequence));
+		} catch {
+			setRoutes([]);
+		}
+		try {
+			const roles: SecurityRolesRoles1 = await fetchRoles();
+			setRoleNames(roles.roles);
+		} catch {
+			setRoleNames([]);
+		}
+	};
+
+	useEffect(() => {
+		void load();
+	}, []);
+
+	const updateRoute = async (
+		index: number,
+		field: keyof SystemRoutesRouteItem1,
+		value: any,
+	): Promise<void> => {
+		const updated = [...routes];
+		(updated[index] as any)[field] = value;
+		setRoutes(updated);
+		await fetchUpsertRoute(updated[index]);
+		void load();
+	};
+
+	const moveRight = async (idx: number): Promise<void> => {
+		const role = selectedLeft[idx];
+		if (!role) return;
+		const updatedRoles = [...routes[idx].required_roles, role];
+		setSelectedLeft({ ...selectedLeft, [idx]: "" });
+		await updateRoute(idx, "required_roles", updatedRoles);
+	};
+
+	const moveLeft = async (idx: number): Promise<void> => {
+		const role = selectedRight[idx];
+		if (!role) return;
+		const updatedRoles = routes[idx].required_roles.filter(
+			(r) => r !== role,
+		);
+		setSelectedRight({ ...selectedRight, [idx]: "" });
+		await updateRoute(idx, "required_roles", updatedRoles);
+	};
+
+	const handleDelete = async (path: string): Promise<void> => {
+		await fetchDeleteRoute({ path });
+		void load();
+	};
+
+	const addMoveRight = (role: string | null): void => {
+		if (!role) return;
+		setNewRoute({
+			...newRoute,
+			required_roles: [...newRoute.required_roles, role],
+		});
+		setNewLeft(null);
+	};
+
+	const addMoveLeft = (role: string | null): void => {
+		if (!role) return;
+		setNewRoute({
+			...newRoute,
+			required_roles: newRoute.required_roles.filter((r) => r !== role),
+		});
+		setNewRight(null);
+	};
+
+	const handleAdd = async (): Promise<void> => {
+		if (!newRoute.path) return;
+		await fetchUpsertRoute(newRoute);
+		setNewRoute({
+			path: "",
+			name: "",
+			icon: "",
+			sequence: 0,
+			required_roles: [],
+		});
+		setNewLeft(null);
+		setNewRight(null);
+		void load();
+	};
+
+	return (
+		<Box sx={{ p: 2 }}>
+			<Typography variant="h5">System Routes</Typography>
+			<Divider sx={{ mb: 2 }} />
+			<Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
+				<TableHead>
+					<TableRow>
+						<TableCell>Path</TableCell>
+						<TableCell>Name</TableCell>
+						<TableCell>Icon</TableCell>
+						<TableCell>Sequence</TableCell>
+						<TableCell>Roles</TableCell>
+						<TableCell />
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					{routes.map((r, idx) => {
+						const available = roleNames.filter(
+							(n) => !r.required_roles.includes(n),
+						);
+						return (
+							<TableRow key={r.path}>
+								<TableCell>
+									<TextField
+										value={r.path}
+										onChange={(e) =>
+											updateRoute(
+												idx,
+												"path",
+												e.target.value,
+											)
+										}
+									/>
+								</TableCell>
+								<TableCell>
+									<TextField
+										value={r.name}
+										onChange={(e) =>
+											updateRoute(
+												idx,
+												"name",
+												e.target.value,
+											)
+										}
+									/>
+								</TableCell>
+								<TableCell>
+									<TextField
+										value={r.icon ?? ""}
+										onChange={(e) =>
+											updateRoute(
+												idx,
+												"icon",
+												e.target.value,
+											)
+										}
+									/>
+								</TableCell>
+								<TableCell>
+									<TextField
+										type="number"
+										value={r.sequence}
+										onChange={(e) =>
+											updateRoute(
+												idx,
+												"sequence",
+												Number(e.target.value),
+											)
+										}
+									/>
+								</TableCell>
+								<TableCell>
+									<Stack direction="row" spacing={1}>
+										<List
+											sx={{
+												width: 120,
+												maxHeight: MAX_HEIGHT,
+												overflow: "auto",
+												border: 1,
+											}}
+										>
+											{available.map((role) => (
+												<ListItemButton
+													key={role}
+													selected={
+														selectedLeft[idx] ===
+														role
+													}
+													onClick={() =>
+														setSelectedLeft({
+															...selectedLeft,
+															[idx]: role,
+														})
+													}
+												>
+													<ListItemText
+														primary={role}
+													/>
+												</ListItemButton>
+											))}
+										</List>
+										<Stack
+											spacing={1}
+											justifyContent="center"
+										>
+											<IconButton
+												onClick={() =>
+													void moveRight(idx)
+												}
+											>
+												<ArrowForwardIos />
+											</IconButton>
+											<IconButton
+												onClick={() =>
+													void moveLeft(idx)
+												}
+											>
+												<ArrowBackIos />
+											</IconButton>
+										</Stack>
+										<List
+											sx={{
+												width: 120,
+												maxHeight: MAX_HEIGHT,
+												overflow: "auto",
+												border: 1,
+											}}
+										>
+											{r.required_roles.map((role) => (
+												<ListItemButton
+													key={role}
+													selected={
+														selectedRight[idx] ===
+														role
+													}
+													onClick={() =>
+														setSelectedRight({
+															...selectedRight,
+															[idx]: role,
+														})
+													}
+												>
+													<ListItemText
+														primary={role}
+													/>
+												</ListItemButton>
+											))}
+										</List>
+									</Stack>
+								</TableCell>
+								<TableCell>
+									<IconButton
+										onClick={() => handleDelete(r.path)}
+									>
+										<Delete />
+									</IconButton>
+								</TableCell>
+							</TableRow>
+						);
+					})}
+					<TableRow>
+						<TableCell>
+							<TextField
+								value={newRoute.path}
+								onChange={(e) =>
+									setNewRoute({
+										...newRoute,
+										path: e.target.value,
+									})
+								}
+							/>
+						</TableCell>
+						<TableCell>
+							<TextField
+								value={newRoute.name}
+								onChange={(e) =>
+									setNewRoute({
+										...newRoute,
+										name: e.target.value,
+									})
+								}
+							/>
+						</TableCell>
+						<TableCell>
+							<TextField
+								value={newRoute.icon ?? ""}
+								onChange={(e) =>
+									setNewRoute({
+										...newRoute,
+										icon: e.target.value,
+									})
+								}
+							/>
+						</TableCell>
+						<TableCell>
+							<TextField
+								type="number"
+								value={newRoute.sequence}
+								onChange={(e) =>
+									setNewRoute({
+										...newRoute,
+										sequence: Number(e.target.value),
+									})
+								}
+							/>
+						</TableCell>
+						<TableCell>
+							<Stack direction="row" spacing={1}>
+								<List
+									sx={{
+										width: 120,
+										maxHeight: MAX_HEIGHT,
+										overflow: "auto",
+										border: 1,
+									}}
+								>
+									{roleNames
+										.filter(
+											(r) =>
+												!newRoute.required_roles.includes(
+													r,
+												),
+										)
+										.map((role) => (
+											<ListItemButton
+												key={role}
+												selected={newLeft === role}
+												onClick={() => setNewLeft(role)}
+											>
+												<ListItemText primary={role} />
+											</ListItemButton>
+										))}
+								</List>
+								<Stack spacing={1} justifyContent="center">
+									<IconButton
+										onClick={() => addMoveRight(newLeft)}
+									>
+										<ArrowForwardIos />
+									</IconButton>
+									<IconButton
+										onClick={() => addMoveLeft(newRight)}
+									>
+										<ArrowBackIos />
+									</IconButton>
+								</Stack>
+								<List
+									sx={{
+										width: 120,
+										maxHeight: MAX_HEIGHT,
+										overflow: "auto",
+										border: 1,
+									}}
+								>
+									{newRoute.required_roles.map((role) => (
+										<ListItemButton
+											key={role}
+											selected={newRight === role}
+											onClick={() => setNewRight(role)}
+										>
+											<ListItemText primary={role} />
+										</ListItemButton>
+									))}
+								</List>
+							</Stack>
+						</TableCell>
+						<TableCell>
+							<IconButton onClick={handleAdd}>
+								<Add />
+							</IconButton>
+						</TableCell>
+					</TableRow>
+				</TableBody>
+			</Table>
+		</Box>
+	);
+};
+
+export default SystemRoutesPage;

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -18,6 +18,12 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
+export interface AuthMicrosoftOauthLogin1 {
+  sessionToken: string;
+  display_name: string;
+  credits: number;
+  profile_image: string | null;
+}
 export interface PublicLinksHomeLinks1 {
   links: PublicLinksLinkItem1[];
 }
@@ -48,6 +54,19 @@ export interface PublicVarsRepo1 {
 export interface PublicVarsVersion1 {
   version: string;
 }
+export interface SystemRoutesDeleteRoute1 {
+  path: string;
+}
+export interface SystemRoutesList1 {
+  routes: SystemRoutesRouteItem1[];
+}
+export interface SystemRoutesRouteItem1 {
+  path: string;
+  name: string;
+  icon: string | null;
+  sequence: number;
+  required_roles: string[];
+}
 export interface UsersProvidersSetProvider1 {
   provider: string;
 }
@@ -71,11 +90,8 @@ export interface UsersProfileSetDisplay1 {
 export interface UsersProfileSetOptin1 {
   display_email: boolean;
 }
-export interface AuthMicrosoftOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
-  credits: number;
-  profile_image: string | null;
+export interface SecurityRolesRoles1 {
+  roles: string[];
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,15 +1,27 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig(({ mode }) => {
-	const isProduction = mode === 'production'
-	
+	const isProduction = mode === "production";
+
 	return {
-    	plugins: [react()],
-   		base: isProduction ? '/static/' : '/',
-    	build: {
-      		outDir: '../static',
-      		assetsDir: 'assets',
-  		}
-	}
-})
+		plugins: [react()],
+		base: isProduction ? "/static/" : "/",
+		build: {
+			outDir: "../static",
+			assetsDir: "assets",
+			rollupOptions: {
+				output: {
+					manualChunks: {
+						vendor: [
+							"react",
+							"react-dom",
+							"@mui/material",
+							"@mui/icons-material",
+						],
+					},
+				},
+			},
+		},
+	};
+});

--- a/rpc/security/roles/models.py
+++ b/rpc/security/roles/models.py
@@ -1,4 +1,5 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
+
+class SecurityRolesRoles1(BaseModel):
+  roles: list[str]

--- a/rpc/security/roles/services.py
+++ b/rpc/security/roles/services.py
@@ -1,7 +1,21 @@
-from fastapi import Request
+from fastapi import HTTPException, Request
+
+from rpc.helpers import get_rpcrequest_from_request
+from rpc.models import RPCResponse
+from server.modules.authz_module import ROLE_NAMES
+from .models import SecurityRolesRoles1
+
 
 async def security_roles_get_roles_v1(request: Request):
-  raise NotImplementedError("urn:security:roles:get_roles:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  if "ROLE_SECURITY_ADMIN" not in auth_ctx.roles:
+    raise HTTPException(status_code=403, detail="Forbidden")
+  payload = SecurityRolesRoles1(roles=list(ROLE_NAMES))
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
 
 async def security_roles_upsert_role_v1(request: Request):
   raise NotImplementedError("urn:security:roles:upsert_role:1")

--- a/rpc/system/routes/models.py
+++ b/rpc/system/routes/models.py
@@ -2,3 +2,18 @@ from typing import Optional
 
 from pydantic import BaseModel
 
+
+class SystemRoutesRouteItem1(BaseModel):
+  path: str
+  name: str
+  icon: Optional[str] = None
+  sequence: int
+  required_roles: list[str] = []
+
+
+class SystemRoutesList1(BaseModel):
+  routes: list[SystemRoutesRouteItem1]
+
+
+class SystemRoutesDeleteRoute1(BaseModel):
+  path: str

--- a/rpc/system/routes/services.py
+++ b/rpc/system/routes/services.py
@@ -1,11 +1,75 @@
-from fastapi import Request
+from fastapi import HTTPException, Request
+
+from rpc.helpers import get_rpcrequest_from_request
+from rpc.models import RPCResponse
+from server.modules.db_module import DbModule
+from server.modules.authz_module import AuthzModule
+from .models import (
+  SystemRoutesRouteItem1,
+  SystemRoutesList1,
+  SystemRoutesDeleteRoute1,
+)
+
 
 async def system_routes_get_routes_v1(request: Request):
-  raise NotImplementedError("urn:system:routes:get_routes:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  if "ROLE_SYSTEM_ADMIN" not in auth_ctx.roles:
+    raise HTTPException(status_code=403, detail="Forbidden")
+  db: DbModule = request.app.state.db
+  authz: AuthzModule = request.app.state.authz
+  res = await db.run(rpc_request.op, {})
+  routes = []
+  for row in res.rows:
+    mask = int(row.get("element_roles", 0))
+    roles = authz.mask_to_names(mask)
+    item = SystemRoutesRouteItem1(
+      path=row.get("element_path", ""),
+      name=row.get("element_name", ""),
+      icon=row.get("element_icon"),
+      sequence=int(row.get("element_sequence", 0)),
+      required_roles=roles,
+    )
+    routes.append(item)
+  payload = SystemRoutesList1(routes=routes)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
 
 async def system_routes_upsert_route_v1(request: Request):
-  raise NotImplementedError("urn:system:routes:upsert_route:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  if "ROLE_SYSTEM_ADMIN" not in auth_ctx.roles:
+    raise HTTPException(status_code=403, detail="Forbidden")
+  payload = SystemRoutesRouteItem1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  authz: AuthzModule = request.app.state.authz
+  mask = authz.names_to_mask(payload.required_roles)
+  await db.run(rpc_request.op, {
+    "path": payload.path,
+    "name": payload.name,
+    "icon": payload.icon,
+    "sequence": payload.sequence,
+    "roles": mask,
+  })
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
 
 async def system_routes_delete_route_v1(request: Request):
-  raise NotImplementedError("urn:system:routes:delete_route:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  if "ROLE_SYSTEM_ADMIN" not in auth_ctx.roles:
+    raise HTTPException(status_code=403, detail="Forbidden")
+  payload = SystemRoutesDeleteRoute1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.run(rpc_request.op, {"path": payload.path})
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
 


### PR DESCRIPTION
## Summary
- add admin page for managing system routes and role assignments
- implement backend services and models for system routes and security roles
- enable basic vendor chunking in Vite build

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a298d4bff88325b4358bd04903c1a6