### PR TITLE
Implement security role management services

### DIFF
--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -18,6 +18,42 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
+export interface SystemRoutesDeleteRoute1 {
+  path: string;
+}
+export interface SystemRoutesList1 {
+  routes: SystemRoutesRouteItem1[];
+}
+export interface SystemRoutesRouteItem1 {
+  path: string;
+  name: string;
+  icon: string | null;
+  sequence: number;
+  required_roles: string[];
+}
+export interface SecurityRolesDeleteRole1 {
+  name: string;
+}
+export interface SecurityRolesRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
+}
+export interface SecurityRolesRoleMembers1 {
+  members: SecurityRolesUserItem1[];
+  nonMembers: SecurityRolesUserItem1[];
+}
+export interface SecurityRolesRoles1 {
+  roles: string[];
+}
+export interface SecurityRolesUpsertRole1 {
+  name: string;
+  bit: number;
+  display: any;
+}
+export interface SecurityRolesUserItem1 {
+  guid: string;
+  displayName: string;
+}
 export interface AuthMicrosoftOauthLogin1 {
   sessionToken: string;
   display_name: string;
@@ -54,19 +90,6 @@ export interface PublicVarsRepo1 {
 export interface PublicVarsVersion1 {
   version: string;
 }
-export interface SystemRoutesDeleteRoute1 {
-  path: string;
-}
-export interface SystemRoutesList1 {
-  routes: SystemRoutesRouteItem1[];
-}
-export interface SystemRoutesRouteItem1 {
-  path: string;
-  name: string;
-  icon: string | null;
-  sequence: number;
-  required_roles: string[];
-}
 export interface UsersProvidersSetProvider1 {
   provider: string;
 }
@@ -89,9 +112,6 @@ export interface UsersProfileSetDisplay1 {
 }
 export interface UsersProfileSetOptin1 {
   display_email: boolean;
-}
-export interface SecurityRolesRoles1 {
-  roles: string[];
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/security/roles/models.py
+++ b/rpc/security/roles/models.py
@@ -3,3 +3,28 @@ from pydantic import BaseModel
 
 class SecurityRolesRoles1(BaseModel):
   roles: list[str]
+
+
+class SecurityRolesUpsertRole1(BaseModel):
+  name: str
+  bit: int
+  display: str | None = None
+
+
+class SecurityRolesDeleteRole1(BaseModel):
+  name: str
+
+
+class SecurityRolesRoleMemberUpdate1(BaseModel):
+  role: str
+  userGuid: str
+
+
+class SecurityRolesUserItem1(BaseModel):
+  guid: str
+  displayName: str
+
+
+class SecurityRolesRoleMembers1(BaseModel):
+  members: list[SecurityRolesUserItem1]
+  nonMembers: list[SecurityRolesUserItem1]

--- a/rpc/security/roles/services.py
+++ b/rpc/security/roles/services.py
@@ -1,9 +1,17 @@
 from fastapi import HTTPException, Request
 
-from rpc.helpers import get_rpcrequest_from_request
+from rpc.helpers import get_rpcrequest_from_request, bit_to_mask
 from rpc.models import RPCResponse
-from server.modules.authz_module import ROLE_NAMES
-from .models import SecurityRolesRoles1
+from server.modules.db_module import DbModule
+from server.modules.authz_module import ROLE_NAMES, AuthzModule
+from .models import (
+  SecurityRolesRoles1,
+  SecurityRolesUpsertRole1,
+  SecurityRolesDeleteRole1,
+  SecurityRolesRoleMemberUpdate1,
+  SecurityRolesRoleMembers1,
+  SecurityRolesUserItem1,
+)
 
 
 async def security_roles_get_roles_v1(request: Request):
@@ -18,17 +26,110 @@ async def security_roles_get_roles_v1(request: Request):
   )
 
 async def security_roles_upsert_role_v1(request: Request):
-  raise NotImplementedError("urn:security:roles:upsert_role:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  if "ROLE_SECURITY_ADMIN" not in auth_ctx.roles:
+    raise HTTPException(status_code=403, detail="Forbidden")
+  data = SecurityRolesUpsertRole1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.run("db:security:roles:upsert_role:1", {
+    "name": data.name,
+    "mask": bit_to_mask(data.bit),
+    "display": data.display,
+  })
+  authz: AuthzModule = request.app.state.authz
+  await authz.load_roles()
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=data.model_dump(),
+    version=rpc_request.version,
+  )
+
 
 async def security_roles_delete_role_v1(request: Request):
-  raise NotImplementedError("urn:security:roles:delete_role:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  if "ROLE_SECURITY_ADMIN" not in auth_ctx.roles:
+    raise HTTPException(status_code=403, detail="Forbidden")
+  data = SecurityRolesDeleteRole1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.run("db:security:roles:delete_role:1", {"name": data.name})
+  authz: AuthzModule = request.app.state.authz
+  await authz.load_roles()
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=data.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def _fetch_role_members(db: DbModule, role: str) -> SecurityRolesRoleMembers1:
+  mem_res = await db.run("db:security:roles:get_role_members:1", {"role": role})
+  non_res = await db.run("db:security:roles:get_role_non_members:1", {"role": role})
+  members = [
+    SecurityRolesUserItem1(
+      guid=r.get("guid", ""),
+      displayName=r.get("display_name", ""),
+    )
+    for r in mem_res.rows
+  ]
+  non_members = [
+    SecurityRolesUserItem1(
+      guid=r.get("guid", ""),
+      displayName=r.get("display_name", ""),
+    )
+    for r in non_res.rows
+  ]
+  return SecurityRolesRoleMembers1(members=members, nonMembers=non_members)
+
 
 async def security_roles_get_role_members_v1(request: Request):
-  raise NotImplementedError("urn:security:roles:get_role_members:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  if "ROLE_SECURITY_ADMIN" not in auth_ctx.roles:
+    raise HTTPException(status_code=403, detail="Forbidden")
+  payload = rpc_request.payload or {}
+  role = payload.get("role")
+  if not role:
+    raise HTTPException(status_code=400, detail="Missing role")
+  db: DbModule = request.app.state.db
+  members = await _fetch_role_members(db, role)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=members.model_dump(),
+    version=rpc_request.version,
+  )
+
 
 async def security_roles_add_role_member_v1(request: Request):
-  raise NotImplementedError("urn:security:roles:add_role_member:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  if "ROLE_SECURITY_ADMIN" not in auth_ctx.roles:
+    raise HTTPException(status_code=403, detail="Forbidden")
+  data = SecurityRolesRoleMemberUpdate1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.run("db:security:roles:add_role_member:1", {
+    "role": data.role,
+    "user_guid": data.userGuid,
+  })
+  members = await _fetch_role_members(db, data.role)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=members.model_dump(),
+    version=rpc_request.version,
+  )
+
 
 async def security_roles_remove_role_member_v1(request: Request):
-  raise NotImplementedError("urn:security:roles:remove_role_member:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  if "ROLE_SECURITY_ADMIN" not in auth_ctx.roles:
+    raise HTTPException(status_code=403, detail="Forbidden")
+  data = SecurityRolesRoleMemberUpdate1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.run("db:security:roles:remove_role_member:1", {
+    "role": data.role,
+    "user_guid": data.userGuid,
+  })
+  members = await _fetch_role_members(db, data.role)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=members.model_dump(),
+    version=rpc_request.version,
+  )
 

--- a/tests/test_security_roles_services.py
+++ b/tests/test_security_roles_services.py
@@ -1,0 +1,143 @@
+import sys, types, asyncio, importlib.util
+from types import SimpleNamespace
+from fastapi import HTTPException
+import pytest
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+class DummyDb:
+  def __init__(self, members=None, non_members=None):
+    self.calls = []
+    self.members = members or []
+    self.non_members = non_members or []
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    if op == "db:security:roles:get_role_members:1":
+      return DBRes(self.members, len(self.members))
+    if op == "db:security:roles:get_role_non_members:1":
+      return DBRes(self.non_members, len(self.non_members))
+    return DBRes()
+
+class DummyAuthz:
+  def __init__(self):
+    self.loaded = False
+  async def load_roles(self):
+    self.loaded = True
+
+class DummyState:
+  def __init__(self, db, authz):
+    self.db = db
+    self.authz = authz
+
+class DummyApp:
+  def __init__(self, state):
+    self.state = state
+
+class DummyRequest:
+  def __init__(self, state):
+    self.app = DummyApp(state)
+    self.headers = {}
+
+spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
+models = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(models)
+RPCRequest = models.RPCRequest
+RPCResponse = models.RPCResponse
+sys.modules["rpc.models"] = models
+
+helpers = types.ModuleType("rpc.helpers")
+helpers.bit_to_mask = lambda b: 1 << b
+async def _stub(request):
+  raise NotImplementedError
+helpers.get_rpcrequest_from_request = _stub
+sys.modules["rpc.helpers"] = helpers
+
+authz_module_pkg = types.ModuleType("server.modules.authz_module")
+authz_module_pkg.ROLE_NAMES = ["ROLE_SECURITY_ADMIN"]
+class AuthzModule: ...
+authz_module_pkg.AuthzModule = AuthzModule
+modules_pkg = types.ModuleType("server.modules")
+modules_pkg.authz_module = authz_module_pkg
+sys.modules.setdefault("server.modules", modules_pkg)
+sys.modules["server.modules.authz_module"] = authz_module_pkg
+
+db_module_pkg = types.ModuleType("server.modules.db_module")
+class DbModule: ...
+db_module_pkg.DbModule = DbModule
+modules_pkg.db_module = db_module_pkg
+sys.modules["server.modules.db_module"] = db_module_pkg
+
+svc_spec = importlib.util.spec_from_file_location("rpc.security.roles.services", "rpc/security/roles/services.py")
+svc_mod = importlib.util.module_from_spec(svc_spec)
+svc_spec.loader.exec_module(svc_mod)
+
+security_roles_upsert_role_v1 = svc_mod.security_roles_upsert_role_v1
+security_roles_add_role_member_v1 = svc_mod.security_roles_add_role_member_v1
+security_roles_remove_role_member_v1 = svc_mod.security_roles_remove_role_member_v1
+
+
+def test_permission_required():
+  async def fake_get(request):
+    rpc = RPCRequest(op="urn:security:roles:upsert_role:1", payload={"name": "R", "bit": 1}, version=1)
+    return rpc, SimpleNamespace(roles=[]), None
+  helpers.get_rpcrequest_from_request = fake_get
+  svc_mod.get_rpcrequest_from_request = fake_get
+  db = DummyDb()
+  req = DummyRequest(DummyState(db, DummyAuthz()))
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(security_roles_upsert_role_v1(req))
+  assert exc.value.status_code == 403
+
+
+def test_upsert_role_calls_db_and_loads_roles():
+  async def fake_get(request):
+    rpc = RPCRequest(op="urn:security:roles:upsert_role:1", payload={"name": "ROLE_NEW", "bit": 2, "display": "New"}, version=1)
+    return rpc, SimpleNamespace(roles=["ROLE_SECURITY_ADMIN"]), None
+  helpers.get_rpcrequest_from_request = fake_get
+  svc_mod.get_rpcrequest_from_request = fake_get
+  db = DummyDb()
+  authz = DummyAuthz()
+  req = DummyRequest(DummyState(db, authz))
+  resp = asyncio.run(security_roles_upsert_role_v1(req))
+  assert isinstance(resp, RPCResponse)
+  assert ("db:security:roles:upsert_role:1", {"name": "ROLE_NEW", "mask": 4, "display": "New"}) in db.calls
+  assert authz.loaded
+
+
+def test_add_and_remove_member():
+  members = [{"guid": "u1", "display_name": "User 1"}]
+  non_members = [{"guid": "u2", "display_name": "User 2"}]
+  db = DummyDb(members, non_members)
+  authz = DummyAuthz()
+  state = DummyState(db, authz)
+  req = DummyRequest(state)
+
+  async def fake_get_add(request):
+    rpc = RPCRequest(op="urn:security:roles:add_role_member:1", payload={"role": "ROLE_X", "userGuid": "u1"}, version=1)
+    return rpc, SimpleNamespace(roles=["ROLE_SECURITY_ADMIN"]), None
+  helpers.get_rpcrequest_from_request = fake_get_add
+  svc_mod.get_rpcrequest_from_request = fake_get_add
+  resp = asyncio.run(security_roles_add_role_member_v1(req))
+  assert any(op == "db:security:roles:add_role_member:1" for op, _ in db.calls)
+  assert resp.payload["members"] == [{"guid": "u1", "displayName": "User 1"}]
+  assert resp.payload["nonMembers"] == [{"guid": "u2", "displayName": "User 2"}]
+
+  db.calls.clear()
+  db.members = []
+  db.non_members = [{"guid": "u1", "display_name": "User 1"}, {"guid": "u2", "display_name": "User 2"}]
+
+  async def fake_get_remove(request):
+    rpc = RPCRequest(op="urn:security:roles:remove_role_member:1", payload={"role": "ROLE_X", "userGuid": "u1"}, version=1)
+    return rpc, SimpleNamespace(roles=["ROLE_SECURITY_ADMIN"]), None
+  helpers.get_rpcrequest_from_request = fake_get_remove
+  svc_mod.get_rpcrequest_from_request = fake_get_remove
+  resp2 = asyncio.run(security_roles_remove_role_member_v1(req))
+  assert any(op == "db:security:roles:remove_role_member:1" for op, _ in db.calls)
+  assert resp2.payload["members"] == []
+  assert resp2.payload["nonMembers"] == [
+    {"guid": "u1", "displayName": "User 1"},
+    {"guid": "u2", "displayName": "User 2"},
+  ]


### PR DESCRIPTION
## Summary
- add Pydantic models and service implementations for security role CRUD and membership management
- implement MSSQL handlers for auth role definitions and memberships
- cover role creation, permission checks, and membership add/remove in tests

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68a336ff48ec83259a188c529705d759