### PR TITLE
Refactor Microsoft auth services into helpers

### DIFF
--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -11,25 +11,7 @@ from server.modules.db_module import DbModule
 from .models import AuthMicrosoftOauthLogin1
 
 
-async def auth_microsoft_oauth_login_v1(request: Request):
-  rpc_request, _, _ = await get_rpcrequest_from_request(request)
-  req_payload = rpc_request.payload or {}
-
-  provider = req_payload.get("provider", "microsoft")
-  id_token = req_payload.get("idToken") or req_payload.get("id_token")
-  access_token = req_payload.get("accessToken") or req_payload.get("access_token")
-  logging.debug(f"[auth_microsoft_oauth_login_v1] provider={provider}")
-  logging.debug(f"[auth_microsoft_oauth_login_v1] id_token={id_token[:40] if id_token else None}")
-  logging.debug(f"[auth_microsoft_oauth_login_v1] access_token={access_token[:40] if access_token else None}")
-  if not id_token or not access_token:
-    raise HTTPException(status_code=400, detail="Missing credentials")
-
-  auth: AuthModule = request.app.state.auth
-  db: DbModule = request.app.state.db
-
-  provider_uid, profile, payload = await auth.handle_auth_login(provider, id_token, access_token)
-  logging.debug(f"[auth_microsoft_oauth_login_v1] provider_uid={provider_uid[:40] if provider_uid else None}")
-
+def extract_identifiers(provider_uid: str | None, payload: dict) -> list[str]:
   identifiers = []
   if provider_uid:
     identifiers.append(provider_uid)
@@ -39,17 +21,26 @@ async def auth_microsoft_oauth_login_v1(request: Request):
     identifiers.append(oid)
   if sub and sub not in identifiers:
     identifiers.append(sub)
-
   base_id = oid or sub or provider_uid
   if base_id:
     try:
-      home_account_id = base64.urlsafe_b64encode(b"\x00" * 16 + uuid.UUID(base_id).bytes).decode("utf-8").rstrip("=")
+      home_account_id = base64.urlsafe_b64encode(
+        b"\x00" * 16 + uuid.UUID(base_id).bytes
+      ).decode("utf-8").rstrip("=")
+    except Exception as e:
+      logging.exception(
+        f"[extract_identifiers] home_account_id generation failed for {base_id}: {e}"
+      )
+    else:
       if home_account_id not in identifiers:
         identifiers.append(home_account_id)
-      logging.debug(f"[auth_microsoft_oauth_login_v1] home_account_id={home_account_id[:40]}")
-    except Exception as e:
-      logging.debug(f"[auth_microsoft_oauth_login_v1] home_account_id generation failed: {e}")
+      logging.debug(
+        f"[extract_identifiers] home_account_id={home_account_id[:40]}"
+      )
+  return identifiers
 
+
+async def lookup_user(db: DbModule, provider: str, identifiers: list[str]):
   def _norm(pid: str) -> str | None:
     try:
       return str(uuid.UUID(pid))
@@ -63,22 +54,91 @@ async def auth_microsoft_oauth_login_v1(request: Request):
         return None
     return None
 
-  user = None
   checked = set()
   for pid in identifiers:
     uid = _norm(pid)
     if not uid or uid in checked:
       continue
     checked.add(uid)
-    logging.debug(f"[auth_microsoft_oauth_login_v1] checking identifier={pid[:40]}")
+    logging.debug(f"[lookup_user] checking identifier={pid[:40]}")
     res = await db.run(
       "urn:users:providers:get_by_provider_identifier:1",
       {"provider": provider, "provider_identifier": uid},
     )
     if res.rows:
-      user = res.rows[0]
-      logging.debug(f"[auth_microsoft_oauth_login_v1] user found with identifier={pid[:40]}")
-      break
+      logging.debug(f"[lookup_user] user found with identifier={pid[:40]}")
+      return res.rows[0]
+  return None
+
+
+async def create_session(
+  auth: AuthModule,
+  authz: AuthzModule,
+  db: DbModule,
+  user_guid: str,
+  provider: str,
+  fingerprint: str | None,
+  user_agent: str | None,
+  ip_address: str | None,
+):
+  rotation_token, rot_exp = auth.make_rotation_token(user_guid)
+  logging.debug(f"[create_session] rotation_token={rotation_token[:40]}")
+  now = datetime.now(timezone.utc)
+  await db.run(
+    "db:users:session:set_rotkey:1",
+    {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
+  )
+  roles_res = await db.run("urn:users:profile:get_roles:1", {"guid": user_guid})
+  role_mask = int(roles_res.rows[0].get("element_roles", 0)) if roles_res.rows else 0
+  roles = authz.mask_to_names(role_mask)
+  session_token, session_exp = auth.make_session_token(
+    user_guid, rotation_token, roles, provider
+  )
+  logging.debug(f"[create_session] session_token={session_token[:40]}")
+  await db.run(
+    "db:auth:session:create_session:1",
+    {
+      "access_token": session_token,
+      "expires": session_exp,
+      "fingerprint": fingerprint,
+      "user_agent": user_agent,
+      "ip_address": ip_address,
+      "user_guid": user_guid,
+    },
+  )
+  return session_token, session_exp
+
+
+async def auth_microsoft_oauth_login_v1(request: Request):
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  req_payload = rpc_request.payload or {}
+
+  provider = req_payload.get("provider", "microsoft")
+  id_token = req_payload.get("idToken") or req_payload.get("id_token")
+  access_token = req_payload.get("accessToken") or req_payload.get("access_token")
+  logging.debug(f"[auth_microsoft_oauth_login_v1] provider={provider}")
+  logging.debug(
+    f"[auth_microsoft_oauth_login_v1] id_token={id_token[:40] if id_token else None}"
+  )
+  logging.debug(
+    f"[auth_microsoft_oauth_login_v1] access_token={access_token[:40] if access_token else None}"
+  )
+  if not id_token or not access_token:
+    raise HTTPException(status_code=400, detail="Missing credentials")
+
+  auth: AuthModule = request.app.state.auth
+  db: DbModule = request.app.state.db
+  authz: AuthzModule = request.app.state.authz
+
+  provider_uid, profile, payload = await auth.handle_auth_login(
+    provider, id_token, access_token
+  )
+  logging.debug(
+    f"[auth_microsoft_oauth_login_v1] provider_uid={provider_uid[:40] if provider_uid else None}"
+  )
+
+  identifiers = extract_identifiers(provider_uid, payload)
+  user = await lookup_user(db, provider, identifiers)
 
   if not user:
     logging.debug("[auth_microsoft_oauth_login_v1] user not found, creating new user")
@@ -109,34 +169,11 @@ async def auth_microsoft_oauth_login_v1(request: Request):
     raise HTTPException(status_code=500, detail="Unable to create user")
 
   user_guid = user["guid"]
-  rotation_token, rot_exp = auth.make_rotation_token(user_guid)
-  logging.debug(f"[auth_microsoft_oauth_login_v1] rotation_token={rotation_token[:40]}")
-  now = datetime.now(timezone.utc)
-  await db.run(
-    "db:users:session:set_rotkey:1",
-    {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
-  )
-
-  roles_res = await db.run("urn:users:profile:get_roles:1", {"guid": user_guid})
-  role_mask = int(roles_res.rows[0].get("element_roles", 0)) if roles_res.rows else 0
-  authz: AuthzModule = request.app.state.authz
-  roles = authz.mask_to_names(role_mask)
-  session_token, session_exp = auth.make_session_token(user_guid, rotation_token, roles, provider)
-  logging.debug(f"[auth_microsoft_oauth_login_v1] session_token={session_token[:40]}")
-
   fingerprint = req_payload.get("fingerprint")
   user_agent = request.headers.get("user-agent")
   ip_address = request.client.host if request.client else None
-  await db.run(
-    "db:auth:session:create_session:1",
-    {
-      "access_token": session_token,
-      "expires": session_exp,
-      "fingerprint": fingerprint,
-      "user_agent": user_agent,
-      "ip_address": ip_address,
-      "user_guid": user_guid,
-    },
+  session_token, session_exp = await create_session(
+    auth, authz, db, user_guid, provider, fingerprint, user_agent, ip_address
   )
 
   payload = AuthMicrosoftOauthLogin1(

--- a/tests/test_microsoft_services_helpers.py
+++ b/tests/test_microsoft_services_helpers.py
@@ -1,0 +1,55 @@
+import asyncio, logging, uuid
+from types import SimpleNamespace
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from rpc.auth.microsoft.services import extract_identifiers, lookup_user, create_session
+
+
+def test_extract_identifiers_bad_base(caplog):
+  caplog.set_level(logging.ERROR)
+  ids = extract_identifiers("not-a-uuid", {})
+  assert "not-a-uuid" in ids
+  assert len(ids) == 1
+  assert any("home_account_id generation failed" in r.message for r in caplog.records)
+
+
+class DummyDb:
+  def __init__(self):
+    self.calls = []
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    return SimpleNamespace(rows=[])
+
+
+def test_lookup_user_skips_invalid_identifier():
+  db = DummyDb()
+  user = asyncio.run(lookup_user(db, "microsoft", ["bad-id"]))
+  assert user is None
+  assert db.calls == []
+
+
+class DummyAuth:
+  def make_rotation_token(self, guid):
+    return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, guid, rot, roles, provider):
+    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+
+
+class DummyAuthz:
+  def mask_to_names(self, mask):
+    return []
+
+
+def test_create_session_handles_missing_roles():
+  db = DummyDb()
+  auth = DummyAuth()
+  authz = DummyAuthz()
+  token, exp = asyncio.run(
+    create_session(auth, authz, db, str(uuid.uuid4()), "microsoft", None, None, None)
+  )
+  assert token == "sess"
+  ops = [op for op, _ in db.calls]
+  assert "db:auth:session:create_session:1" in ops
+


### PR DESCRIPTION
## Summary
- factor identifier extraction, user lookup, and session creation into helpers
- harden home-account ID derivation with detailed logging
- add unit tests for helper functions handling malformed payloads

## Testing
- `python scripts/generate_rpc_client.py`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68a340c76e3483259e8ecce574f1166f