### PR TITLE
Refactor auth module for pluggable providers

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -1,4 +1,4 @@
-import aiohttp, base64, logging, uuid
+import base64, logging, uuid
 from datetime import datetime, timedelta, timezone
 from fastapi import FastAPI, HTTPException, status
 from jose import jwt, JWTError
@@ -7,129 +7,58 @@ from typing import Dict
 from server.modules import BaseModule
 from server.modules.env_module import EnvModule
 from server.modules.db_module import DbModule
+from server.modules.providers.auth_base import AuthProvider
+from server.modules.providers.microsoft import MicrosoftAuthProvider
 
 DEFAULT_SESSION_TOKEN_EXPIRY = 15 # minutes
 DEFAULT_ROTATION_TOKEN_EXPIRY = 90 # days
 
-async def fetch_ms_jwks_uri() -> str:
-  async with aiohttp.ClientSession() as session:
-    async with session.get("https://login.microsoftonline.com/consumers/v2.0/.well-known/openid-configuration") as response:
-      if response.status != 200:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Failed to fetch OpenID configuration.")
-      data = await response.json()
-      return data["jwks_uri"]
-
-async def fetch_ms_jwks(jwks_uri: str) -> Dict:
-  async with aiohttp.ClientSession() as session:
-    async with session.get(jwks_uri) as response:
-      if response.status != 200:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Failed to fetch JWKS.")
-      return await response.json()
-
 class AuthModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
-    self.ms_jwks: Dict | None = None
-    self.ms_jwks_fetched_at: datetime | None = None
-    self.ms_api_id: str | None = None
+    self.providers: dict[str, AuthProvider] = {}
     self.jwt_secret: str | None = None
-    self.jwt_algo_ms: str = "RS256"
     self.jwt_algo_int: str = "HS256"
+    self.jwks_cache_minutes: int = 60
 
   async def startup(self):
     self.env: EnvModule = self.app.state.env
     await self.env.on_ready()
     self.db: DbModule = self.app.state.db
     await self.db.on_ready()
-
-    res = await self.db.run("db:system:config:get_config:1", {"key": "MsApiId"})
-    if not res.rows:
-      raise ValueError("Missing config value for key: MsApiId")
-    self.ms_api_id = res.rows[0]["value"]
     self.jwt_secret = self.env.get("JWT_SECRET")
+    self.jwks_cache_minutes = int(self.env.get("JWKS_CACHE_MINUTES"))
 
+    providers_cfg = [p.strip() for p in self.env.get("AUTH_PROVIDERS").split(",") if p.strip()]
     try:
-      jwks_uri = await fetch_ms_jwks_uri()
-      self.ms_jwks = await fetch_ms_jwks(jwks_uri)
-      self.ms_jwks_fetched_at = datetime.now(timezone.utc)
+      if "microsoft" in providers_cfg:
+        res = await self.db.run("db:system:config:get_config:1", {"key": "MsApiId"})
+        if not res.rows:
+          raise ValueError("Missing config value for key: MsApiId")
+        ms_api_id = res.rows[0]["value"]
+        provider = await MicrosoftAuthProvider.create(api_id=ms_api_id, jwks_expiry=timedelta(minutes=self.jwks_cache_minutes))
+        await provider._get_jwks()
+        self.providers["microsoft"] = provider
       logging.info("Auth module loaded")
       self.mark_ready()
     except Exception as e:
-      logging.error(f"[AuthModule] Failed to load Microsoft JWKS: {e}")
+      logging.error(f"[AuthModule] Failed to load providers: {e}")
 
   async def shutdown(self):
     logging.info("Auth module shutdown")
 
-  async def verify_ms_id_token(self, id_token: str) -> Dict:
-    now = datetime.now(timezone.utc)
-    if not self.ms_jwks or not self.ms_jwks_fetched_at or now - self.ms_jwks_fetched_at > timedelta(hours=1):
-      try:
-        jwks_uri = await fetch_ms_jwks_uri()
-        self.ms_jwks = await fetch_ms_jwks(jwks_uri)
-        self.ms_jwks_fetched_at = now
-      except Exception:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Microsoft keys unavailable")
-    try:
-      unverified_header = jwt.get_unverified_header(id_token)
-    except Exception:
-      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid ID token.")
-    rsa_key = next(
-      ({
-        "kty": key["kty"],
-        "kid": key["kid"],
-        "use": key["use"],
-        "n": key["n"],
-        "e": key["e"],
-      } for key in self.ms_jwks.get("keys", []) if key["kid"] == unverified_header["kid"]),
-      None,
-    )
-    if not rsa_key:
-      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token header.")
-    try:
-      payload = jwt.decode(
-        id_token,
-        rsa_key,
-        algorithms=[self.jwt_algo_ms],
-        audience=self.ms_api_id,
-        issuer="https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
-      )
-      return payload
-    except jwt.ExpiredSignatureError:
-      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired.")
-    except jwt.JWTClaimsError:
-      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect claims. Please check the audience and issuer.")
-    except Exception:
-      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token validation failed.")
-
-  async def fetch_ms_user_profile(self, access_token: str) -> Dict:
-    async with aiohttp.ClientSession() as session:
-      headers = {"Authorization": f"Bearer {access_token}"}
-      async with session.get("https://graph.microsoft.com/v1.0/me", headers=headers) as response:
-        if response.status != 200:
-          error_message = await response.text()
-          raise HTTPException(status_code=500, detail=f"Failed to fetch user profile. Status: {response.status}, Error: {error_message}")
-        user = await response.json()
-      profile_picture_base64 = None
-      async with session.get("https://graph.microsoft.com/v1.0/me/photo/$value", headers=headers) as response:
-        if response.status == 200:
-          picture_bytes = await response.read()
-          profile_picture_base64 = base64.b64encode(picture_bytes).decode("utf-8")
-      return {
-        "email": user.get("mail") or user.get("userPrincipalName"),
-        "username": user.get("displayName"),
-        "profilePicture": profile_picture_base64,
-      }
 
   async def handle_auth_login(self, provider: str, id_token: str, access_token: str):
-    if provider == "microsoft":
-      payload = await self.verify_ms_id_token(id_token)
-      guid = payload.get("oid") or payload.get("sub")
-      if not guid:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload.")
-      profile = await self.fetch_ms_user_profile(access_token)
-      logging.info(f"Processing login for: {profile['username']}, {profile['email']}")
-      return guid, profile, payload
-    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported auth provider")
+    strategy = self.providers.get(provider)
+    if not strategy:
+      raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported auth provider")
+    payload = await strategy.verify_id_token(id_token)
+    guid = strategy.extract_guid(payload)
+    if not guid:
+      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload.")
+    profile = await strategy.fetch_user_profile(access_token)
+    logging.info(f"Processing login for: {profile['username']}, {profile['email']}")
+    return guid, profile, payload
 
   def make_session_token(self, guid: str, rotation_token: str, roles: list[str], provider: str) -> tuple[str, datetime]:
     now = datetime.now(timezone.utc)

--- a/server/modules/env_module.py
+++ b/server/modules/env_module.py
@@ -16,6 +16,8 @@ class EnvModule(BaseModule):
     self._getenv("POSTGRES_CONNECTION_STRING", "MISSING_ENV_POSTGRES_CONNECTION_STRING")
     self._getenv("AZURE_SQL_CONNECTION_STRING", "MISSING_ENV_AZURE_SQL_CONNECTION_STRING")
     self._getenv("AZURE_BLOB_CONNECTION_STRING", "MISSING_ENV_AZURE_BLOB_CONNECTION_STRING")
+    self._getenv("AUTH_PROVIDERS", "microsoft")
+    self._getenv("JWKS_CACHE_MINUTES", "60")
     
     logging.info("Environment module loaded")
     self.mark_ready()

--- a/server/modules/providers/auth_base.py
+++ b/server/modules/providers/auth_base.py
@@ -1,0 +1,61 @@
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Any
+
+import aiohttp
+from fastapi import HTTPException, status
+from jose import jwt
+
+class AuthProvider:
+  def __init__(self, *, audience: str, issuer: str, jwks_uri: str, algorithm: str = "RS256", jwks_expiry: timedelta | None = None):
+    self.audience = audience
+    self.issuer = issuer
+    self.jwks_uri = jwks_uri
+    self.algorithm = algorithm
+    self.jwks_expiry = jwks_expiry or timedelta(hours=1)
+    self._jwks: Dict[str, Any] | None = None
+    self._jwks_fetched_at: datetime | None = None
+
+  async def fetch_jwks(self):
+    async with aiohttp.ClientSession() as session:
+      async with session.get(self.jwks_uri) as response:
+        if response.status != 200:
+          raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Failed to fetch JWKS.")
+        self._jwks = await response.json()
+        self._jwks_fetched_at = datetime.now(timezone.utc)
+
+  async def _get_jwks(self) -> Dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    if not self._jwks or not self._jwks_fetched_at or now - self._jwks_fetched_at > self.jwks_expiry:
+      await self.fetch_jwks()
+    return self._jwks
+
+  async def verify_id_token(self, id_token: str) -> Dict[str, Any]:
+    jwks = await self._get_jwks()
+    try:
+      unverified_header = jwt.get_unverified_header(id_token)
+    except Exception:
+      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid ID token.")
+    rsa_key = next(({
+      "kty": key["kty"],
+      "kid": key["kid"],
+      "use": key["use"],
+      "n": key["n"],
+      "e": key["e"],
+    } for key in jwks.get("keys", []) if key["kid"] == unverified_header["kid"]), None)
+    if not rsa_key:
+      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token header.")
+    try:
+      payload = jwt.decode(id_token, rsa_key, algorithms=[self.algorithm], audience=self.audience, issuer=self.issuer)
+      return payload
+    except jwt.ExpiredSignatureError:
+      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired.")
+    except jwt.JWTClaimsError:
+      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect claims. Please check the audience and issuer.")
+    except Exception:
+      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token validation failed.")
+
+  async def fetch_user_profile(self, access_token: str) -> Dict[str, Any]:
+    raise NotImplementedError
+
+  def extract_guid(self, payload: Dict[str, Any]) -> str | None:
+    return payload.get("sub")

--- a/server/modules/providers/microsoft.py
+++ b/server/modules/providers/microsoft.py
@@ -1,0 +1,52 @@
+import base64
+from datetime import timedelta
+from typing import Dict, Any
+
+import aiohttp
+
+from .auth_base import AuthProvider
+from fastapi import HTTPException, status
+
+MICROSOFT_OPENID_CONFIG = "https://login.microsoftonline.com/consumers/v2.0/.well-known/openid-configuration"
+MICROSOFT_GRAPH_USER = "https://graph.microsoft.com/v1.0/me"
+MICROSOFT_GRAPH_PHOTO = "https://graph.microsoft.com/v1.0/me/photo/$value"
+MICROSOFT_ISSUER = "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"
+
+async def _fetch_openid_config() -> Dict[str, Any]:
+  async with aiohttp.ClientSession() as session:
+    async with session.get(MICROSOFT_OPENID_CONFIG) as response:
+      if response.status != 200:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Failed to fetch OpenID configuration.")
+      return await response.json()
+
+class MicrosoftAuthProvider(AuthProvider):
+  def __init__(self, *, api_id: str, jwks_uri: str, jwks_expiry: timedelta):
+    super().__init__(audience=api_id, issuer=MICROSOFT_ISSUER, jwks_uri=jwks_uri, jwks_expiry=jwks_expiry)
+
+  @classmethod
+  async def create(cls, *, api_id: str, jwks_expiry: timedelta):
+    config = await _fetch_openid_config()
+    jwks_uri = config["jwks_uri"]
+    return cls(api_id=api_id, jwks_uri=jwks_uri, jwks_expiry=jwks_expiry)
+
+  async def fetch_user_profile(self, access_token: str) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+      headers = {"Authorization": f"Bearer {access_token}"}
+      async with session.get(MICROSOFT_GRAPH_USER, headers=headers) as response:
+        if response.status != 200:
+          error_message = await response.text()
+          raise HTTPException(status_code=500, detail=f"Failed to fetch user profile. Status: {response.status}, Error: {error_message}")
+        user = await response.json()
+      profile_picture_base64 = None
+      async with session.get(MICROSOFT_GRAPH_PHOTO, headers=headers) as response:
+        if response.status == 200:
+          picture_bytes = await response.read()
+          profile_picture_base64 = base64.b64encode(picture_bytes).decode("utf-8")
+      return {
+        "email": user.get("mail") or user.get("userPrincipalName"),
+        "username": user.get("displayName"),
+        "profilePicture": profile_picture_base64,
+      }
+
+  def extract_guid(self, payload: Dict[str, Any]) -> str | None:
+    return payload.get("oid") or payload.get("sub")

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -1,26 +1,23 @@
 import asyncio
-from fastapi import FastAPI
+import pytest
+from fastapi import FastAPI, HTTPException, status
 from datetime import datetime, timedelta, timezone
 
-from server.modules import auth_module
 from server.modules.auth_module import AuthModule
+from server.modules.providers import auth_base
+from server.modules.providers.microsoft import MicrosoftAuthProvider
 
 
-def test_verify_ms_id_token_refreshes_jwks(monkeypatch):
-  app = FastAPI()
-  module = AuthModule(app)
-  module.ms_jwks = {"keys": [{"kid": "kid1", "kty": "RSA", "use": "sig", "n": "n", "e": "e"}]}
-  module.ms_jwks_fetched_at = datetime.now(timezone.utc) - timedelta(hours=2)
-  module.ms_api_id = "api"
+def test_verify_id_token_refreshes_jwks(monkeypatch):
+  provider = MicrosoftAuthProvider(api_id="api", jwks_uri="uri", jwks_expiry=timedelta(minutes=60))
+  provider._jwks = {"keys": [{"kid": "kid1", "kty": "RSA", "use": "sig", "n": "n", "e": "e"}]}
+  provider._jwks_fetched_at = datetime.now(timezone.utc) - timedelta(hours=2)
 
-  async def fake_fetch_ms_jwks_uri():
-    return "uri"
+  async def fake_fetch_jwks():
+    provider._jwks = {"keys": [{"kid": "kid1", "kty": "RSA", "use": "sig", "n": "n", "e": "e"}]}
+    provider._jwks_fetched_at = datetime.now(timezone.utc)
 
-  async def fake_fetch_ms_jwks(uri):
-    return {"keys": [{"kid": "kid1", "kty": "RSA", "use": "sig", "n": "n", "e": "e"}]}
-
-  monkeypatch.setattr(auth_module, "fetch_ms_jwks_uri", fake_fetch_ms_jwks_uri)
-  monkeypatch.setattr(auth_module, "fetch_ms_jwks", fake_fetch_ms_jwks)
+  monkeypatch.setattr(provider, "fetch_jwks", fake_fetch_jwks)
 
   def fake_get_unverified_header(token):
     return {"kid": "kid1"}
@@ -28,25 +25,28 @@ def test_verify_ms_id_token_refreshes_jwks(monkeypatch):
   def fake_decode(token, key, algorithms, audience, issuer):
     return {"sub": "123"}
 
-  monkeypatch.setattr(auth_module.jwt, "get_unverified_header", fake_get_unverified_header)
-  monkeypatch.setattr(auth_module.jwt, "decode", fake_decode)
+  monkeypatch.setattr(auth_base.jwt, "get_unverified_header", fake_get_unverified_header)
+  monkeypatch.setattr(auth_base.jwt, "decode", fake_decode)
 
-  asyncio.run(module.verify_ms_id_token("token"))
-  assert module.ms_jwks_fetched_at > datetime.now(timezone.utc) - timedelta(minutes=5)
+  asyncio.run(provider.verify_id_token("token"))
+  assert provider._jwks_fetched_at > datetime.now(timezone.utc) - timedelta(minutes=5)
 
 
 def test_handle_auth_login_prefers_oid(monkeypatch):
   app = FastAPI()
   module = AuthModule(app)
 
-  async def fake_verify_ms_id_token(token):
-    return {"oid": "oid123", "sub": "sub456"}
+  class FakeProvider:
+    async def verify_id_token(self, token):
+      return {"oid": "oid123", "sub": "sub456"}
 
-  async def fake_fetch_ms_user_profile(token):
-    return {"email": "user@example.com", "username": "User"}
+    async def fetch_user_profile(self, token):
+      return {"email": "user@example.com", "username": "User"}
 
-  monkeypatch.setattr(module, "verify_ms_id_token", fake_verify_ms_id_token)
-  monkeypatch.setattr(module, "fetch_ms_user_profile", fake_fetch_ms_user_profile)
+    def extract_guid(self, payload):
+      return payload.get("oid") or payload.get("sub")
+
+  module.providers["microsoft"] = FakeProvider()
 
   guid, profile, payload = asyncio.run(module.handle_auth_login("microsoft", "id", "access"))
   assert guid == "oid123"
@@ -59,15 +59,70 @@ def test_handle_auth_login_falls_back_to_sub(monkeypatch):
   app = FastAPI()
   module = AuthModule(app)
 
-  async def fake_verify_ms_id_token(token):
-    return {"sub": "sub456"}
+  class FakeProvider:
+    async def verify_id_token(self, token):
+      return {"sub": "sub456"}
 
-  async def fake_fetch_ms_user_profile(token):
-    return {"email": "user@example.com", "username": "User"}
+    async def fetch_user_profile(self, token):
+      return {"email": "user@example.com", "username": "User"}
 
-  monkeypatch.setattr(module, "verify_ms_id_token", fake_verify_ms_id_token)
-  monkeypatch.setattr(module, "fetch_ms_user_profile", fake_fetch_ms_user_profile)
+    def extract_guid(self, payload):
+      return payload.get("oid") or payload.get("sub")
+
+  module.providers["microsoft"] = FakeProvider()
 
   guid, _, payload = asyncio.run(module.handle_auth_login("microsoft", "id", "access"))
   assert guid == "sub456"
   assert payload["sub"] == "sub456"
+
+
+def test_handle_auth_login_selects_provider():
+  app = FastAPI()
+  module = AuthModule(app)
+
+  class ProviderA:
+    def __init__(self):
+      self.called = False
+
+    async def verify_id_token(self, token):
+      self.called = True
+      return {"sub": "a"}
+
+    async def fetch_user_profile(self, token):
+      return {"email": "a@example.com", "username": "A"}
+
+    def extract_guid(self, payload):
+      return payload.get("sub")
+
+  class ProviderB(ProviderA):
+    async def verify_id_token(self, token):
+      self.called = True
+      return {"sub": "b"}
+
+    async def fetch_user_profile(self, token):
+      return {"email": "b@example.com", "username": "B"}
+
+  module.providers["a"] = ProviderA()
+  module.providers["b"] = ProviderB()
+
+  guid, profile, _ = asyncio.run(module.handle_auth_login("b", "id", "access"))
+  assert guid == "b"
+  assert profile["username"] == "B"
+  assert module.providers["b"].called is True
+  assert module.providers["a"].called is False
+
+
+def test_jwks_refresh_failure(monkeypatch):
+  provider = MicrosoftAuthProvider(api_id="api", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
+  provider._jwks = {"keys": []}
+  provider._jwks_fetched_at = datetime.now(timezone.utc) - timedelta(hours=2)
+
+  async def fake_fetch_jwks():
+    raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="fail")
+
+  monkeypatch.setattr(provider, "fetch_jwks", fake_fetch_jwks)
+
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(provider.verify_id_token("token"))
+
+  assert exc.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE


### PR DESCRIPTION
## Summary
- delegate AuthModule login to pluggable provider strategies
- add MicrosoftAuthProvider and base strategy with JWKS caching
- support provider registration via env config and JWKS cache expiry
- test multi-provider login selection and JWKS refresh failures

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68a343ee61608325a02640c2d12ddb8d