### PR TITLE
Add MSSQL helper module for consistent DBResult handling

### DIFF
--- a/server/modules/providers/mssql_provider/__init__.py
+++ b/server/modules/providers/mssql_provider/__init__.py
@@ -1,30 +1,27 @@
 # providers/mssql_provider/__init__.py
 from typing import Any, Dict
-from .logic import init_pool, close_pool, fetch_json_one, fetch_json_many, fetch_row_one, exec_
+from .logic import init_pool, close_pool
+from .db_helpers import fetch_rows, fetch_json, exec_query
 from .registry import get_handler
 
 async def init(**cfg):
-    # pass: dsn="...", etc.
-    await init_pool(**cfg)
+  # pass: dsn="...", etc.
+  await init_pool(**cfg)
 
 async def dispatch(op: str, args: Dict[str, Any]):
-    handler = get_handler(op)
-    spec = handler(args)
-    # async handler path
-    if hasattr(spec, "__await__"):
-        return await spec  # expected {"rows":[...], "rowcount":N}
-    # tuple path: (mode, sql, params)
-    mode, sql, params = spec
-    if mode == "json_one":
-        row = await fetch_json_one(sql, params)
-        return {"rows": [row] if row else [], "rowcount": 1 if row else 0}
-    if mode == "row_one":
-        row = await fetch_row_one(sql, params)
-        return {"rows": [row] if row else [], "rowcount": 1 if row else 0}
-    if mode == "json_many":
-        rows = await fetch_json_many(sql, params)
-        return {"rows": rows, "rowcount": len(rows)}
-    if mode == "exec":
-        rc = await exec_(sql, params)
-        return {"rows": [], "rowcount": rc}
-    raise ValueError(f"Unknown mode: {mode}")
+  handler = get_handler(op)
+  spec = handler(args)
+  # async handler path
+  if hasattr(spec, "__await__"):
+    return await spec
+  # tuple path: (mode, sql, params)
+  mode, sql, params = spec
+  if mode == "json_one":
+    return await fetch_json(sql, params)
+  if mode == "row_one":
+    return await fetch_rows(sql, params, one=True)
+  if mode == "json_many":
+    return await fetch_json(sql, params, many=True)
+  if mode == "exec":
+    return await exec_query(sql, params)
+  raise ValueError(f"Unknown mode: {mode}")

--- a/server/modules/providers/mssql_provider/db_helpers.py
+++ b/server/modules/providers/mssql_provider/db_helpers.py
@@ -1,0 +1,69 @@
+import json, logging
+from typing import Any, Iterable, AsyncIterator
+from . import logic
+from ..models import DBResult
+
+def _rowdict(cols: Iterable[str], row: Iterable[Any]):
+  return dict(zip(cols, row))
+
+async def fetch_rows(query: str, params: tuple[Any, ...] = (), *, one: bool = False, stream: bool = False) -> DBResult | AsyncIterator[dict]:
+  assert logic._pool, "MSSQL pool not initialized"
+  if stream:
+    async def _stream() -> AsyncIterator[dict]:
+      try:
+        async with logic._pool.acquire() as conn:
+          async with conn.cursor() as cur:
+            await cur.execute(query, params)
+            cols = [c[0] for c in cur.description]
+            while True:
+              row = await cur.fetchone()
+              if not row:
+                break
+              yield _rowdict(cols, row)
+      except Exception as e:
+        logging.debug(f"Stream failed:\n{query}\nArgs: {params}\nError: {e}")
+    return _stream()
+  try:
+    async with logic._pool.acquire() as conn:
+      async with conn.cursor() as cur:
+        await cur.execute(query, params)
+        cols = [c[0] for c in cur.description]
+        if one:
+          row = await cur.fetchone()
+          if not row:
+            return DBResult()
+          return DBResult(rows=[_rowdict(cols, row)], rowcount=1)
+        rows_raw = await cur.fetchall()
+        rows = [_rowdict(cols, r) for r in rows_raw]
+        return DBResult(rows=rows, rowcount=len(rows))
+  except Exception as e:
+    logging.debug(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
+    return DBResult()
+
+async def fetch_json(query: str, params: tuple[Any, ...] = (), *, many: bool = False) -> DBResult:
+  assert logic._pool, "MSSQL pool not initialized"
+  try:
+    async with logic._pool.acquire() as conn:
+      async with conn.cursor() as cur:
+        await cur.execute(query, params)
+        row = await cur.fetchone()
+        if not row or not row[0]:
+          return DBResult()
+        data = json.loads(row[0])
+        if many and isinstance(data, list):
+          return DBResult(rows=data, rowcount=len(data))
+        return DBResult(rows=[data], rowcount=1)
+  except Exception as e:
+    logging.debug(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
+    return DBResult()
+
+async def exec_query(query: str, params: tuple[Any, ...] = ()) -> DBResult:
+  assert logic._pool, "MSSQL pool not initialized"
+  try:
+    async with logic._pool.acquire() as conn:
+      async with conn.cursor() as cur:
+        await cur.execute(query, params)
+        return DBResult(rowcount=cur.rowcount or 0)
+  except Exception as e:
+    logging.debug(f"Exec failed:\n{query}\nArgs: {params}\nError: {e}")
+    return DBResult()

--- a/server/modules/providers/mssql_provider/logic.py
+++ b/server/modules/providers/mssql_provider/logic.py
@@ -1,7 +1,7 @@
 # providers/mssql_provider/logic.py
 import aioodbc, logging
 from contextlib import asynccontextmanager
-from typing import Any, Callable, Iterable, Optional
+from typing import Callable, Optional
 
 _pool: aioodbc.pool.Pool | None = None
 
@@ -14,89 +14,28 @@ async def init_pool(*, dsn: str | None = None, **cfg):
     logging.info("MSSQL ODBC Connection Pool Created")
 
 async def close_pool():
-    global _pool
-    if _pool:
-        await _pool.close()
-        _pool = None
-        logging.info("MSSQL ODBC Connection Pool Closed")
+  global _pool
+  if _pool:
+    await _pool.close()
+    _pool = None
+    logging.info("MSSQL ODBC Connection Pool Closed")
 
 @asynccontextmanager
 async def transaction():
-    assert _pool, "MSSQL pool not initialized"
-    async with _pool.acquire() as conn:
-        async with conn.cursor() as cur:
-            # aioodbc connections created with autocommit=True do not support
-            # explicit transaction begin. Temporarily disable autocommit so
-            # commit/rollback can manage the transaction scope.
-            orig_autocommit = conn.autocommit
-            conn.autocommit = False
-            try:
-                yield cur
-                await conn.commit()
-            except Exception as e:
-                await conn.rollback()
-                logging.debug(f"[TRANSACTION ERROR] Rolled back due to: {e}")
-                raise
-            finally:
-                conn.autocommit = orig_autocommit
-
-def _rowdict(cols: Iterable[str], row: Iterable[Any]):  # no JSON decode here
-    return dict(zip(cols, row))
-
-async def fetch_row_one(query: str, params: tuple[Any, ...] = ()):
-    assert _pool, "MSSQL pool not initialized"
-    try:
-        async with _pool.acquire() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(query, params)
-                row = await cur.fetchone()
-                if not row:
-                    return None
-                cols = [c[0] for c in cur.description]
-                return _rowdict(cols, row)
-    except Exception as e:
-        logging.debug(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
-        return None
-
-async def fetch_json_one(query: str, params: tuple[Any, ...] = ()):
-    """Assumes SELECT ... FOR JSON ... WITHOUT_ARRAY_WRAPPER"""
-    assert _pool, "MSSQL pool not initialized"
-    try:
-        async with _pool.acquire() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(query, params)
-                row = await cur.fetchone()
-                if not row or not row[0]:
-                    return None
-                import json
-                return json.loads(row[0])
-    except Exception as e:
-        logging.debug(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
-        return None
-
-async def fetch_json_many(query: str, params: tuple[Any, ...] = ()):
-    """Assumes SELECT ... FOR JSON PATH (array)"""
-    assert _pool, "MSSQL pool not initialized"
-    try:
-        async with _pool.acquire() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(query, params)
-                row = await cur.fetchone()
-                if not row or not row[0]:
-                    return []
-                import json
-                return json.loads(row[0])
-    except Exception as e:
-        logging.debug(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
-        return []
-
-async def exec_(query: str, params: tuple[Any, ...] = ()):
-    assert _pool, "MSSQL pool not initialized"
-    try:
-        async with _pool.acquire() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute(query, params)
-                return cur.rowcount or 0
-    except Exception as e:
-        logging.debug(f"Exec failed:\n{query}\nArgs: {params}\nError: {e}")
-        return 0
+  assert _pool, "MSSQL pool not initialized"
+  async with _pool.acquire() as conn:
+    async with conn.cursor() as cur:
+      # aioodbc connections created with autocommit=True do not support
+      # explicit transaction begin. Temporarily disable autocommit so
+      # commit/rollback can manage the transaction scope.
+      orig_autocommit = conn.autocommit
+      conn.autocommit = False
+      try:
+        yield cur
+        await conn.commit()
+      except Exception as e:
+        await conn.rollback()
+        logging.debug(f"[TRANSACTION ERROR] Rolled back due to: {e}")
+        raise
+      finally:
+        conn.autocommit = orig_autocommit

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -1,6 +1,8 @@
 from uuid import uuid4
 from server.modules.providers.mssql_provider.registry import get_handler as get_mssql_handler
 from server.modules.providers.postgres_provider.registry import get_handler as get_pg_handler
+from server.modules.providers.mssql_provider import db_helpers
+import asyncio
 
 def test_mssql_get_by_provider_identifier_uses_user_view():
   handler = get_mssql_handler("urn:users:providers:get_by_provider_identifier:1")
@@ -40,3 +42,99 @@ def test_mssql_get_by_access_token_uses_security_view():
   handler = get_mssql_handler("db:auth:session:get_by_access_token:1")
   _, sql, _ = handler({"access_token": "tok"})
   assert "vw_account_user_security" in sql.lower()
+
+
+def test_fetch_rows_returns_empty_on_error(monkeypatch):
+  class Cur:
+    async def execute(self, q, p):
+      raise Exception("boom")
+
+  class Conn:
+    async def cursor(self):
+      return Cur()
+
+  class Pool:
+    async def acquire(self):
+      return Conn()
+
+  monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
+  res = asyncio.run(db_helpers.fetch_rows("SELECT 1"))
+  assert res.rows == []
+  assert res.rowcount == 0
+
+
+def test_fetch_json_returns_empty_on_error(monkeypatch):
+  class Cur:
+    async def execute(self, q, p):
+      raise Exception("boom")
+    async def fetchone(self):
+      return None
+
+  class Conn:
+    async def cursor(self):
+      return Cur()
+
+  class Pool:
+    async def acquire(self):
+      return Conn()
+
+  monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
+  res = asyncio.run(db_helpers.fetch_json("SELECT 1"))
+  assert res.rows == []
+  assert res.rowcount == 0
+
+
+def test_exec_query_returns_empty_on_error(monkeypatch):
+  class Cur:
+    async def execute(self, q, p):
+      raise Exception("boom")
+
+  class Conn:
+    async def cursor(self):
+      return Cur()
+
+  class Pool:
+    async def acquire(self):
+      return Conn()
+
+  monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
+  res = asyncio.run(db_helpers.exec_query("UPDATE x SET y=1"))
+  assert res.rows == []
+  assert res.rowcount == 0
+
+
+def test_fetch_rows_stream(monkeypatch):
+  class Cur:
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, exc_type, exc, tb):
+      pass
+    async def execute(self, q, p):
+      pass
+    async def fetchone(self):
+      return None
+
+  class Conn:
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, exc_type, exc, tb):
+      pass
+    async def cursor(self):
+      return Cur()
+
+  class Pool:
+    async def acquire(self):
+      class _Ctx:
+        async def __aenter__(self_inner):
+          return Conn()
+        async def __aexit__(self_inner, exc_type, exc, tb):
+          pass
+      return _Ctx()
+
+  monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
+
+  async def run():
+    gen = await db_helpers.fetch_rows("SELECT", stream=True)
+    return hasattr(gen, "__aiter__")
+
+  assert asyncio.run(run())


### PR DESCRIPTION
## Summary
- factor reusable `fetch_rows`, `fetch_json`, and `exec_query` helpers for MSSQL with streaming and error handling
- refactor provider dispatch and handlers to use new helpers and return `DBResult`
- test helper behavior for errors and streaming cursor fallback

## Testing
- `python scripts/run_tests.py` *(fails: ImportError and missing ODBC Driver)*

------
https://chatgpt.com/codex/tasks/task_e_68a37b70c3688325bed6002082270250