### PR TITLE
chore: add storage role debug logs

### DIFF
--- a/rpc/helpers.py
+++ b/rpc/helpers.py
@@ -51,6 +51,7 @@ async def _process_rpcrequest(request: Request) -> tuple[RPCRequest, AuthContext
     rpc_request.user_guid = auth_ctx.user_guid
     rpc_request.roles = roles
     rpc_request.role_mask = mask
+    logging.debug("[RPC] Resolved roles for %s: %s (mask=%#018x)", auth_ctx.user_guid, roles, mask)
   else:
     if domain not in ('public', 'auth'):
       raise HTTPException(status_code=401, detail='Missing or invalid authorization header')

--- a/rpc/storage/files/services.py
+++ b/rpc/storage/files/services.py
@@ -1,11 +1,13 @@
 import base64
 import io
+import logging
 
 from fastapi import HTTPException, Request
 
 from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
 from server.modules.storage_module import StorageModule
+from server.modules.auth_module import AuthModule
 
 from .models import (
   StorageFilesDeleteFiles1,
@@ -16,10 +18,26 @@ from .models import (
 )
 
 
+def _require_storage_role(auth_ctx, request: Request):
+  auth: AuthModule = request.app.state.auth
+  required_mask = auth.roles.get("ROLE_STORAGE_ENABLED", 0)
+  expected_mask = 0x0000000000000002
+  has_role = (auth_ctx.role_mask & required_mask) == required_mask
+  logging.debug(
+    "[Storage] user roles=%s mask=%#018x required_mask=%#018x (ROLE_STORAGE_ENABLED expected %#018x) has_role=%s",
+    auth_ctx.roles,
+    auth_ctx.role_mask,
+    required_mask,
+    expected_mask,
+    has_role,
+  )
+  if not has_role:
+    raise HTTPException(status_code=403, detail="Forbidden")
+
+
 async def storage_files_get_files_v1(request: Request):
   rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  if "ROLE_STORAGE_ENABLED" not in auth_ctx.roles:
-    raise HTTPException(status_code=403, detail="Forbidden")
+  _require_storage_role(auth_ctx, request)
   storage: StorageModule = request.app.state.storage
   files = await storage.list_user_files(auth_ctx.user_guid)
   payload = StorageFilesFiles1(files=[StorageFilesFileItem1(**f) for f in files])
@@ -32,8 +50,7 @@ async def storage_files_get_files_v1(request: Request):
 
 async def storage_files_upload_files_v1(request: Request):
   rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  if "ROLE_STORAGE_ENABLED" not in auth_ctx.roles:
-    raise HTTPException(status_code=403, detail="Forbidden")
+  _require_storage_role(auth_ctx, request)
   data = StorageFilesUploadFiles1(**(rpc_request.payload or {}))
   storage: StorageModule = request.app.state.storage
   await storage.ensure_user_folder(auth_ctx.user_guid)
@@ -49,8 +66,7 @@ async def storage_files_upload_files_v1(request: Request):
 
 async def storage_files_delete_files_v1(request: Request):
   rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  if "ROLE_STORAGE_ENABLED" not in auth_ctx.roles:
-    raise HTTPException(status_code=403, detail="Forbidden")
+  _require_storage_role(auth_ctx, request)
   data = StorageFilesDeleteFiles1(**(rpc_request.payload or {}))
   storage: StorageModule = request.app.state.storage
   for name in data.files:
@@ -64,8 +80,7 @@ async def storage_files_delete_files_v1(request: Request):
 
 async def storage_files_set_gallery_v1(request: Request):
   rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  if "ROLE_STORAGE_ENABLED" not in auth_ctx.roles:
-    raise HTTPException(status_code=403, detail="Forbidden")
+  _require_storage_role(auth_ctx, request)
   data = StorageFilesSetGallery1(**(rpc_request.payload or {}))
   storage: StorageModule = request.app.state.storage
   files = await storage.list_user_files(auth_ctx.user_guid)

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -195,7 +195,7 @@ class AuthModule(BaseModule):
     mask = int(res.rows[0].get("element_roles", 0)) if res.rows else 0
     names = self.mask_to_names(mask)
     self._user_roles[guid] = (names, mask)
-    logging.debug("[AuthModule] Roles for %s: %s", guid, names)
+    logging.debug("[AuthModule] Roles for %s: %s (mask=%#018x)", guid, names, mask)
     return names, mask
 
   async def refresh_user_roles(self, guid: str):

--- a/tests/test_storage_files_services.py
+++ b/tests/test_storage_files_services.py
@@ -77,9 +77,15 @@ storage_files_upload_files_v1 = svc_mod.storage_files_upload_files_v1
 storage_files_delete_files_v1 = svc_mod.storage_files_delete_files_v1
 storage_files_set_gallery_v1 = svc_mod.storage_files_set_gallery_v1
 
+class DummyAuth:
+  def __init__(self):
+    self.roles = {"ROLE_STORAGE_ENABLED": 0x2}
+
+
 class DummyState:
   def __init__(self, storage):
     self.storage = storage
+    self.auth = DummyAuth()
 
 class DummyApp:
   def __init__(self, state):
@@ -94,7 +100,7 @@ class DummyRequest:
 def test_get_files_returns_list():
   async def fake_get(request):
     rpc = RPCRequest(op="urn:storage:files:get_files:1", payload=None, version=1)
-    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"])
+    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
     return rpc, auth, None
   svc_mod.get_rpcrequest_from_request = fake_get
   storage = StorageModule()
@@ -112,7 +118,7 @@ def test_upload_files_calls_storage():
       payload={"files": [{"name": "a.txt", "content_b64": "YQ==", "content_type": "text/plain"}]},
       version=1,
     )
-    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"])
+    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
     return rpc, auth, None
   svc_mod.get_rpcrequest_from_request = fake_up
   storage = StorageModule()
@@ -129,7 +135,7 @@ def test_delete_files_calls_storage():
       payload={"files": ["a.txt", "b.txt"]},
       version=1,
     )
-    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"])
+    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
     return rpc, auth, None
   svc_mod.get_rpcrequest_from_request = fake_del
   storage = StorageModule()
@@ -147,7 +153,7 @@ def test_set_gallery_validates_file():
       payload={"name": "a.txt", "gallery": True},
       version=1,
     )
-    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"])
+    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
     return rpc, auth, None
   svc_mod.get_rpcrequest_from_request = fake_set
   storage = StorageModule()


### PR DESCRIPTION
## Summary
- log resolved user roles and masks when processing RPC requests
- validate storage access by checking role mask 0x0000000000000002 with debug output
- update tests for new role-mask checks

## Testing
- `python scripts/run_tests.py`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4bc24e0408325a73611ab6954381a