### PR TITLE
Ensure database and storage resources close on shutdown

### DIFF
--- a/server/modules/providers/mssql_provider/logic.py
+++ b/server/modules/providers/mssql_provider/logic.py
@@ -16,7 +16,8 @@ async def init_pool(*, dsn: str | None = None, **cfg):
 async def close_pool():
   global _pool
   if _pool:
-    await _pool.close()
+    _pool.close()
+    await _pool.wait_closed()
     _pool = None
     logging.info("MSSQL ODBC Connection Pool Closed")
 

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -37,7 +37,9 @@ class StorageModule(BaseModule):
     self.mark_ready()
 
   async def shutdown(self):
-    self.client = None
+    if self.client:
+      await self.client.close()
+      self.client = None
     logging.info("Storage module shutdown")
 
   async def write_buffer(self, buffer: io.BytesIO, user_guid: str, filename: str, content_type: str | None = None):


### PR DESCRIPTION
## Summary
- close MSSQL aioodbc pool during DbModule shutdown
- wait for ODBC pool to fully close
- close Azure Blob storage client on shutdown

## Testing
- `python scripts/run_tests.py` *(fails: Unable to connect to database: ('01000', "[01000] [unixODBC][Driver Manager]Can't open lib 'ODBC Driver 18 for SQL Server' : file not found (0) (SQLDriverConnect)"))*

------
https://chatgpt.com/codex/tasks/task_e_68a4cebd36208325b783883e685babc0