### PR TITLE
Update session metadata on token validation

### DIFF
--- a/server/modules/providers/mssql_provider/registry.py
+++ b/server/modules/providers/mssql_provider/registry.py
@@ -341,6 +341,18 @@ def _auth_session_get_by_access_token(args: Dict[str, Any]):
     """
     return ("json_one", sql, (token,))
 
+@register("db:auth:session:update_session:1")
+def _auth_session_update_session(args: Dict[str, Any]):
+    token = args["access_token"]
+    ip_address = args.get("ip_address")
+    user_agent = args.get("user_agent")
+    sql = """
+      UPDATE sessions_devices
+      SET element_ip_last_seen = ?, element_user_agent = ?
+      WHERE element_token = ?;
+    """
+    return ("exec", sql, (ip_address, user_agent, token))
+
 # -------------------- SYSTEM CONFIG --------------------
 
 @register("db:system:config:get_config:1")

--- a/tests/test_auth_session_get_session.py
+++ b/tests/test_auth_session_get_session.py
@@ -37,7 +37,8 @@ class DummyApp:
 class DummyRequest:
   def __init__(self):
     self.app = DummyApp()
-    self.headers = {"authorization": "Bearer tok"}
+    self.headers = {"authorization": "Bearer tok", "user-agent": "ua"}
+    self.client = SimpleNamespace(host="127.0.0.1")
 
 
 def test_get_session(monkeypatch):
@@ -72,4 +73,6 @@ def test_get_session(monkeypatch):
   req = DummyRequest()
   resp = asyncio.run(auth_session_get_session_v1(req))
   assert isinstance(resp, RPCResponse)
-  assert any(op == "db:auth:session:get_by_access_token:1" for op, _ in req.app.state.db.calls)
+  calls = [op for op, _ in req.app.state.db.calls]
+  assert "db:auth:session:get_by_access_token:1" in calls
+  assert "db:auth:session:update_session:1" in calls


### PR DESCRIPTION
## Summary
- refresh `ip_last_seen` and `user_agent` each time a session token is validated
- add MSSQL handler for updating session metadata
- cover session update flow in unit tests

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d1c5fb088325bf76da3f19e1dc44