### PR TITLE
Add system configuration admin page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import LoginPage from "./LoginPage";
 import UserPage from "./UserPage";
 import SystemRoutesPage from "./SystemRoutesPage";
 import FileManager from "./FileManager";
+import SystemConfigPage from "./SystemConfigPage";
 
 function App(): JSX.Element {
 	return (
@@ -34,6 +35,7 @@ function App(): JSX.Element {
 							<Route path="/loginpage" element={<LoginPage />} />
                                                         <Route path="/userpage" element={<UserPage />} />
                                                         <Route path="/system-routes" element={<SystemRoutesPage />} />
+                                                        <Route path="/system-config" element={<SystemConfigPage />} />
                                                         <Route path="/file-manager" element={<FileManager />} />
 						</Routes>
 					</Container>

--- a/frontend/src/SystemConfigPage.tsx
+++ b/frontend/src/SystemConfigPage.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from "react";
+import {
+    Box,
+    Table,
+    TableHead,
+    TableRow,
+    TableCell,
+    TableBody,
+    IconButton,
+    TextField,
+    Typography,
+} from "@mui/material";
+import { Delete, Add } from "@mui/icons-material";
+import type {
+    SystemConfigConfigItem1,
+    SystemConfigList1,
+} from "./shared/RpcModels";
+import {
+    fetchConfigs,
+    fetchUpsertConfig,
+    fetchDeleteConfig,
+} from "./rpc/system/config";
+import Notification from "./Notification";
+
+const SystemConfigPage = (): JSX.Element => {
+    const [items, setItems] = useState<SystemConfigConfigItem1[]>([]);
+    const [newItem, setNewItem] = useState<SystemConfigConfigItem1>({
+        key: "",
+        value: "",
+    });
+    const [notification, setNotification] = useState(false);
+    const [forbidden, setForbidden] = useState(false);
+    const handleNotificationClose = (): void => {
+        setNotification(false);
+    };
+
+    const load = async (): Promise<void> => {
+        try {
+            const res: SystemConfigList1 = await fetchConfigs();
+            setItems(res.items);
+        } catch (e: any) {
+            if (e?.response?.status === 403) {
+                setForbidden(true);
+            } else {
+                setItems([]);
+            }
+        }
+    };
+
+    useEffect(() => {
+        void load();
+    }, []);
+
+    if (forbidden) {
+        return (
+            <Box sx={{ p: 2 }}>
+                <Typography variant="h6">Forbidden</Typography>
+            </Box>
+        );
+    }
+
+    const updateItem = async (
+        index: number,
+        field: keyof SystemConfigConfigItem1,
+        value: string,
+    ): Promise<void> => {
+        const updated = [...items];
+        (updated[index] as any)[field] = value;
+        setItems(updated);
+        await fetchUpsertConfig(updated[index]);
+        setNotification(true);
+    };
+
+    const handleDelete = async (key: string): Promise<void> => {
+        await fetchDeleteConfig({ key });
+        void load();
+        setNotification(true);
+    };
+
+    const handleAdd = async (): Promise<void> => {
+        if (!newItem.key) return;
+        await fetchUpsertConfig(newItem);
+        setNewItem({ key: "", value: "" });
+        void load();
+        setNotification(true);
+    };
+
+    return (
+        <Box sx={{ p: 2 }}>
+            <Typography variant="h5">System Configuration</Typography>
+            <Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>Key</TableCell>
+                        <TableCell>Value</TableCell>
+                        <TableCell />
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {items.map((i, idx) => (
+                        <TableRow key={i.key}>
+                            <TableCell>
+                                <TextField
+                                    value={i.key}
+                                    onChange={(e) => updateItem(idx, "key", e.target.value)}
+                                />
+                            </TableCell>
+                            <TableCell>
+                                <TextField
+                                    value={i.value}
+                                    onChange={(e) => updateItem(idx, "value", e.target.value)}
+                                />
+                            </TableCell>
+                            <TableCell>
+                                <IconButton onClick={() => void handleDelete(i.key)}>
+                                    <Delete />
+                                </IconButton>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                    <TableRow>
+                        <TableCell>
+                            <TextField
+                                value={newItem.key}
+                                onChange={(e) => setNewItem({ ...newItem, key: e.target.value })}
+                            />
+                        </TableCell>
+                        <TableCell>
+                            <TextField
+                                value={newItem.value}
+                                onChange={(e) => setNewItem({ ...newItem, value: e.target.value })}
+                            />
+                        </TableCell>
+                        <TableCell>
+                            <IconButton onClick={() => void handleAdd()}>
+                                <Add />
+                            </IconButton>
+                        </TableCell>
+                    </TableRow>
+                </TableBody>
+            </Table>
+            <Notification
+                open={notification}
+                handleClose={handleNotificationClose}
+                severity="success"
+                message="Saved"
+            />
+        </Box>
+    );
+};
+
+export default SystemConfigPage;

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -21,6 +21,66 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
+export interface SecurityRolesDeleteRole1 {
+  name: string;
+}
+export interface SecurityRolesRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
+}
+export interface SecurityRolesRoleMembers1 {
+  members: SecurityRolesUserItem1[];
+  nonMembers: SecurityRolesUserItem1[];
+}
+export interface SecurityRolesRoles1 {
+  roles: string[];
+}
+export interface SecurityRolesUpsertRole1 {
+  name: string;
+  bit: number;
+  display: any;
+}
+export interface SecurityRolesUserItem1 {
+  guid: string;
+  displayName: string;
+}
+export interface UsersProvidersSetProvider1 {
+  provider: string;
+}
+export interface UsersProfileAuthProvider1 {
+  name: string;
+  display: string;
+}
+export interface UsersProfileProfile1 {
+  guid: string;
+  display_name: string;
+  email: string;
+  display_email: boolean;
+  credits: number;
+  profile_image: string | null;
+  default_provider: string;
+  auth_providers: UsersProfileAuthProvider1[];
+}
+export interface UsersProfileRoles1 {
+  roles: number;
+}
+export interface UsersProfileSetDisplay1 {
+  display_name: string;
+}
+export interface UsersProfileSetOptin1 {
+  display_email: boolean;
+}
+export interface UsersProfileSetProfileImage1 {
+  image_b64: string;
+  provider: string;
+}
+export interface AdminUsersGuid1 {
+  userGuid: string;
+}
+export interface AdminUsersSetCredits1 {
+  userGuid: string;
+  credits: number;
+}
 export interface AdminRolesMembers1 {
   members: AdminRolesUserItem1[];
   nonMembers: AdminRolesUserItem1[];
@@ -33,18 +93,28 @@ export interface AdminRolesUserItem1 {
   guid: string;
   displayName: string;
 }
-export interface AdminUsersGuid1 {
-  userGuid: string;
+export interface StorageFilesDeleteFiles1 {
+  files: string[];
 }
-export interface AdminUsersSetCredits1 {
-  userGuid: string;
-  credits: number;
+export interface StorageFilesFileItem1 {
+  name: string;
+  url: string;
+  content_type: string | null;
 }
-export interface AuthMicrosoftOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
-  credits: number;
-  profile_image: string | null;
+export interface StorageFilesFiles1 {
+  files: StorageFilesFileItem1[];
+}
+export interface StorageFilesSetGallery1 {
+  name: string;
+  gallery: boolean;
+}
+export interface StorageFilesUploadFile1 {
+  name: string;
+  content_b64: string;
+  content_type: string | null;
+}
+export interface StorageFilesUploadFiles1 {
+  files: StorageFilesUploadFile1[];
 }
 export interface PublicLinksHomeLinks1 {
   links: PublicLinksLinkItem1[];
@@ -76,51 +146,15 @@ export interface PublicVarsRepo1 {
 export interface PublicVarsVersion1 {
   version: string;
 }
-export interface SecurityRolesDeleteRole1 {
-  name: string;
+export interface SystemConfigConfigItem1 {
+  key: string;
+  value: string;
 }
-export interface SecurityRolesRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
+export interface SystemConfigDeleteConfig1 {
+  key: string;
 }
-export interface SecurityRolesRoleMembers1 {
-  members: SecurityRolesUserItem1[];
-  nonMembers: SecurityRolesUserItem1[];
-}
-export interface SecurityRolesRoles1 {
-  roles: string[];
-}
-export interface SecurityRolesUpsertRole1 {
-  name: string;
-  bit: number;
-  display: any;
-}
-export interface SecurityRolesUserItem1 {
-  guid: string;
-  displayName: string;
-}
-export interface StorageFilesDeleteFiles1 {
-  files: string[];
-}
-export interface StorageFilesFileItem1 {
-  name: string;
-  url: string;
-  content_type: string | null;
-}
-export interface StorageFilesFiles1 {
-  files: StorageFilesFileItem1[];
-}
-export interface StorageFilesSetGallery1 {
-  name: string;
-  gallery: boolean;
-}
-export interface StorageFilesUploadFile1 {
-  name: string;
-  content_b64: string;
-  content_type: string | null;
-}
-export interface StorageFilesUploadFiles1 {
-  files: StorageFilesUploadFile1[];
+export interface SystemConfigList1 {
+  items: SystemConfigConfigItem1[];
 }
 export interface SystemRoutesDeleteRoute1 {
   path: string;
@@ -135,35 +169,11 @@ export interface SystemRoutesRouteItem1 {
   sequence: number;
   required_roles: string[];
 }
-export interface UsersProfileAuthProvider1 {
-  name: string;
-  display: string;
-}
-export interface UsersProfileProfile1 {
-  guid: string;
+export interface AuthMicrosoftOauthLogin1 {
+  sessionToken: string;
   display_name: string;
-  email: string;
-  display_email: boolean;
   credits: number;
   profile_image: string | null;
-  default_provider: string;
-  auth_providers: UsersProfileAuthProvider1[];
-}
-export interface UsersProfileRoles1 {
-  roles: number;
-}
-export interface UsersProfileSetDisplay1 {
-  display_name: string;
-}
-export interface UsersProfileSetOptin1 {
-  display_email: boolean;
-}
-export interface UsersProfileSetProfileImage1 {
-  image_b64: string;
-  provider: string;
-}
-export interface UsersProvidersSetProvider1 {
-  provider: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/system/config/models.py
+++ b/rpc/system/config/models.py
@@ -1,4 +1,14 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
+
+class SystemConfigConfigItem1(BaseModel):
+  key: str
+  value: str
+
+
+class SystemConfigList1(BaseModel):
+  items: list[SystemConfigConfigItem1]
+
+
+class SystemConfigDeleteConfig1(BaseModel):
+  key: str

--- a/rpc/system/config/services.py
+++ b/rpc/system/config/services.py
@@ -1,11 +1,101 @@
-from fastapi import Request
+from fastapi import HTTPException, Request
+import logging
+
+from rpc.helpers import get_rpcrequest_from_request
+from rpc.models import RPCResponse
+from server.modules.db_module import DbModule
+from .models import (
+  SystemConfigConfigItem1,
+  SystemConfigList1,
+  SystemConfigDeleteConfig1,
+)
+
 
 async def system_config_get_configs_v1(request: Request):
-  raise NotImplementedError("urn:system:config:get_configs:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  logging.debug(
+    "[system_config_get_configs_v1] user=%s roles=%s",
+    auth_ctx.user_guid,
+    auth_ctx.roles,
+  )
+  if "ROLE_SYSTEM_ADMIN" not in auth_ctx.roles:
+    logging.debug(
+      "[system_config_get_configs_v1] forbidden for user=%s",
+      auth_ctx.user_guid,
+    )
+    raise HTTPException(status_code=403, detail="Forbidden")
+  db: DbModule = request.app.state.db
+  res = await db.run(rpc_request.op, {})
+  items = []
+  for row in res.rows:
+    item = SystemConfigConfigItem1(
+      key=row.get("element_key", ""),
+      value=row.get("element_value", ""),
+    )
+    items.append(item)
+  payload = SystemConfigList1(items=items)
+  logging.debug(
+    "[system_config_get_configs_v1] returning %d items",
+    len(items),
+  )
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
 
 async def system_config_upsert_config_v1(request: Request):
-  raise NotImplementedError("urn:system:config:upsert_config:1")
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  logging.debug(
+    "[system_config_upsert_config_v1] user=%s roles=%s payload=%s",
+    auth_ctx.user_guid,
+    auth_ctx.roles,
+    rpc_request.payload,
+  )
+  if "ROLE_SYSTEM_ADMIN" not in auth_ctx.roles:
+    logging.debug(
+      "[system_config_upsert_config_v1] forbidden for user=%s",
+      auth_ctx.user_guid,
+    )
+    raise HTTPException(status_code=403, detail="Forbidden")
+  payload = SystemConfigConfigItem1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.run(rpc_request.op, {"key": payload.key, "value": payload.value})
+  logging.debug(
+    "[system_config_upsert_config_v1] upserted config %s",
+    payload.key,
+  )
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
 
 async def system_config_delete_config_v1(request: Request):
-  raise NotImplementedError("urn:system:config:delete_config:1")
-
+  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  logging.debug(
+    "[system_config_delete_config_v1] user=%s roles=%s payload=%s",
+    auth_ctx.user_guid,
+    auth_ctx.roles,
+    rpc_request.payload,
+  )
+  if "ROLE_SYSTEM_ADMIN" not in auth_ctx.roles:
+    logging.debug(
+      "[system_config_delete_config_v1] forbidden for user=%s",
+      auth_ctx.user_guid,
+    )
+    raise HTTPException(status_code=403, detail="Forbidden")
+  payload = SystemConfigDeleteConfig1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.run(rpc_request.op, {"key": payload.key})
+  logging.debug(
+    "[system_config_delete_config_v1] deleted config %s",
+    payload.key,
+  )
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )


### PR DESCRIPTION
## Summary
- add system configuration models and RPC services guarded by system admin role
- implement system configuration page with add/edit/delete and forbidden handling
- wire up system-config route and regenerate RPC bindings

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68a50c073ad88325821612954a8558c7