### PR TITLE
Remove internal role check from system services

### DIFF
--- a/rpc/system/config/services.py
+++ b/rpc/system/config/services.py
@@ -1,4 +1,4 @@
-from fastapi import HTTPException, Request
+from fastapi import Request
 import logging
 
 from rpc.helpers import get_rpcrequest_from_request
@@ -18,12 +18,6 @@ async def system_config_get_configs_v1(request: Request):
     auth_ctx.user_guid,
     auth_ctx.roles,
   )
-  if "ROLE_SYSTEM_ADMIN" not in auth_ctx.roles:
-    logging.debug(
-      "[system_config_get_configs_v1] forbidden for user=%s",
-      auth_ctx.user_guid,
-    )
-    raise HTTPException(status_code=403, detail="Forbidden")
   db: DbModule = request.app.state.db
   res = await db.run(rpc_request.op, {})
   items = []
@@ -53,12 +47,6 @@ async def system_config_upsert_config_v1(request: Request):
     auth_ctx.roles,
     rpc_request.payload,
   )
-  if "ROLE_SYSTEM_ADMIN" not in auth_ctx.roles:
-    logging.debug(
-      "[system_config_upsert_config_v1] forbidden for user=%s",
-      auth_ctx.user_guid,
-    )
-    raise HTTPException(status_code=403, detail="Forbidden")
   payload = SystemConfigConfigItem1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
   await db.run(rpc_request.op, {"key": payload.key, "value": payload.value})
@@ -81,12 +69,6 @@ async def system_config_delete_config_v1(request: Request):
     auth_ctx.roles,
     rpc_request.payload,
   )
-  if "ROLE_SYSTEM_ADMIN" not in auth_ctx.roles:
-    logging.debug(
-      "[system_config_delete_config_v1] forbidden for user=%s",
-      auth_ctx.user_guid,
-    )
-    raise HTTPException(status_code=403, detail="Forbidden")
   payload = SystemConfigDeleteConfig1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
   await db.run(rpc_request.op, {"key": payload.key})

--- a/rpc/system/routes/services.py
+++ b/rpc/system/routes/services.py
@@ -1,4 +1,4 @@
-from fastapi import HTTPException, Request
+from fastapi import Request
 import logging
 
 from rpc.helpers import get_rpcrequest_from_request
@@ -19,12 +19,6 @@ async def system_routes_get_routes_v1(request: Request):
     auth_ctx.user_guid,
     auth_ctx.roles,
   )
-  if "ROLE_SYSTEM_ADMIN" not in auth_ctx.roles:
-    logging.debug(
-      "[system_routes_get_routes_v1] forbidden for user=%s",
-      auth_ctx.user_guid,
-    )
-    raise HTTPException(status_code=403, detail="Forbidden")
   db: DbModule = request.app.state.db
   auth: AuthModule = request.app.state.auth
   res = await db.run(rpc_request.op, {})
@@ -60,12 +54,6 @@ async def system_routes_upsert_route_v1(request: Request):
     auth_ctx.roles,
     rpc_request.payload,
   )
-  if "ROLE_SYSTEM_ADMIN" not in auth_ctx.roles:
-    logging.debug(
-      "[system_routes_upsert_route_v1] forbidden for user=%s",
-      auth_ctx.user_guid,
-    )
-    raise HTTPException(status_code=403, detail="Forbidden")
   payload = SystemRoutesRouteItem1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
   auth: AuthModule = request.app.state.auth
@@ -96,12 +84,6 @@ async def system_routes_delete_route_v1(request: Request):
     auth_ctx.roles,
     rpc_request.payload,
   )
-  if "ROLE_SYSTEM_ADMIN" not in auth_ctx.roles:
-    logging.debug(
-      "[system_routes_delete_route_v1] forbidden for user=%s",
-      auth_ctx.user_guid,
-    )
-    raise HTTPException(status_code=403, detail="Forbidden")
   payload = SystemRoutesDeleteRoute1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
   await db.run(rpc_request.op, {"path": payload.path})

--- a/tests/test_system_config_services.py
+++ b/tests/test_system_config_services.py
@@ -60,7 +60,7 @@ async def fake_get(request: Request):
   op = body.get('op')
   payload = body.get('payload')
   rpc_req = SimpleNamespace(op=op, payload=payload, version=1)
-  auth_ctx = SimpleNamespace(user_guid='u1', roles=['ROLE_SYSTEM_ADMIN'])
+  auth_ctx = SimpleNamespace(user_guid='u1', roles=[])
   return rpc_req, auth_ctx, None
 
 svc.get_rpcrequest_from_request = fake_get


### PR DESCRIPTION
## Summary
- drop ROLE_SYSTEM_ADMIN gating from system route and config RPC handlers
- rely on request context for authorization and adjust tests accordingly

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68a527ea5f3c8325bbee429f84452a12