### PR TITLE
Remove redundant admin role checks

### DIFF
--- a/rpc/admin/roles/services.py
+++ b/rpc/admin/roles/services.py
@@ -10,7 +10,7 @@ from .models import (
 )
 
 
-async def _fetch_role_members(db: DbModule, role: str) -> AdminRolesMembers1:
+async def fetch_role_members(db: DbModule, role: str) -> AdminRolesMembers1:
   mem_res = await db.run("db:security:roles:get_role_members:1", {"role": role})
   non_res = await db.run("db:security:roles:get_role_non_members:1", {"role": role})
   members = [
@@ -31,33 +31,33 @@ async def _fetch_role_members(db: DbModule, role: str) -> AdminRolesMembers1:
 
 
 async def admin_roles_get_members_v1(request: Request):
-  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  if "ROLE_ADMIN_SUPPORT" not in auth_ctx.roles:
-    raise HTTPException(status_code=403, detail="Forbidden")
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
   payload = rpc_request.payload or {}
   role = payload.get("role")
   if not role:
     raise HTTPException(status_code=400, detail="Missing role")
   db: DbModule = request.app.state.db
-  members = await _fetch_role_members(db, role)
+  members = await fetch_role_members(db, role)
   return RPCResponse(
     op=rpc_request.op,
     payload=members.model_dump(),
     version=rpc_request.version,
   )
+
+
+async def add_role_member(db: DbModule, role: str, user_guid: str) -> AdminRolesMembers1:
+  await db.run(
+    "db:security:roles:add_role_member:1",
+    {"role": role, "user_guid": user_guid},
+  )
+  return await fetch_role_members(db, role)
 
 
 async def admin_roles_add_member_v1(request: Request):
-  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  if "ROLE_ADMIN_SUPPORT" not in auth_ctx.roles:
-    raise HTTPException(status_code=403, detail="Forbidden")
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
   data = AdminRolesRoleMemberUpdate1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run(
-    "db:security:roles:add_role_member:1",
-    {"role": data.role, "user_guid": data.userGuid},
-  )
-  members = await _fetch_role_members(db, data.role)
+  members = await add_role_member(db, data.role, data.userGuid)
   return RPCResponse(
     op=rpc_request.op,
     payload=members.model_dump(),
@@ -65,17 +65,19 @@ async def admin_roles_add_member_v1(request: Request):
   )
 
 
-async def admin_roles_remove_member_v1(request: Request):
-  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  if "ROLE_ADMIN_SUPPORT" not in auth_ctx.roles:
-    raise HTTPException(status_code=403, detail="Forbidden")
-  data = AdminRolesRoleMemberUpdate1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
+async def remove_role_member(db: DbModule, role: str, user_guid: str) -> AdminRolesMembers1:
   await db.run(
     "db:security:roles:remove_role_member:1",
-    {"role": data.role, "user_guid": data.userGuid},
+    {"role": role, "user_guid": user_guid},
   )
-  members = await _fetch_role_members(db, data.role)
+  return await fetch_role_members(db, role)
+
+
+async def admin_roles_remove_member_v1(request: Request):
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  data = AdminRolesRoleMemberUpdate1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  members = await remove_role_member(db, data.role, data.userGuid)
   return RPCResponse(
     op=rpc_request.op,
     payload=members.model_dump(),

--- a/rpc/admin/users/services.py
+++ b/rpc/admin/users/services.py
@@ -1,5 +1,4 @@
 from fastapi import HTTPException, Request
-
 from importlib import import_module
 import gc
 
@@ -10,13 +9,8 @@ from server.modules.storage_module import StorageModule
 from .models import AdminUsersGuid1, AdminUsersSetCredits1
 
 
-async def admin_users_get_profile_v1(request: Request):
-  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  if "ROLE_ADMIN_SUPPORT" not in auth_ctx.roles:
-    raise HTTPException(status_code=403, detail="Forbidden")
-  data = AdminUsersGuid1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  res = await db.run("db:users:profile:get_profile:1", {"guid": data.userGuid})
+async def get_profile(db: DbModule, guid: str) -> UsersProfileProfile1:
+  res = await db.run("db:users:profile:get_profile:1", {"guid": guid})
   if not res.rows:
     raise HTTPException(status_code=404, detail="Profile not found")
   row = res.rows[0]
@@ -25,7 +19,30 @@ async def admin_users_get_profile_v1(request: Request):
   if isinstance(auth_providers, str):
     import json
     row["auth_providers"] = json.loads(auth_providers) if auth_providers else []
-  profile = UsersProfileProfile1(**row)
+  return UsersProfileProfile1(**row)
+
+
+async def set_credits(db: DbModule, guid: str, credits: int) -> None:
+  await db.run(
+    "db:admin:users:set_credits:1",
+    {"guid": guid, "credits": credits},
+  )
+
+
+async def reset_display(db: DbModule, guid: str) -> None:
+  await db.run("db:admin:users:reset_display:1", {"guid": guid})
+
+
+async def enable_storage(db: DbModule, storage: StorageModule, guid: str) -> None:
+  await db.run("db:admin:users:enable_storage:1", {"guid": guid})
+  await storage.ensure_user_folder(guid)
+
+
+async def admin_users_get_profile_v1(request: Request):
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  data = AdminUsersGuid1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  profile = await get_profile(db, data.userGuid)
   RPCResponse = _get_rpc_response_class()
   return RPCResponse(
     op=rpc_request.op,
@@ -35,15 +52,10 @@ async def admin_users_get_profile_v1(request: Request):
 
 
 async def admin_users_set_credits_v1(request: Request):
-  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  if "ROLE_ADMIN_SUPPORT" not in auth_ctx.roles:
-    raise HTTPException(status_code=403, detail="Forbidden")
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
   data = AdminUsersSetCredits1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run(
-    "db:admin:users:set_credits:1",
-    {"guid": data.userGuid, "credits": data.credits},
-  )
+  await set_credits(db, data.userGuid, data.credits)
   RPCResponse = _get_rpc_response_class()
   return RPCResponse(
     op=rpc_request.op,
@@ -53,12 +65,10 @@ async def admin_users_set_credits_v1(request: Request):
 
 
 async def admin_users_reset_display_v1(request: Request):
-  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  if "ROLE_ADMIN_SUPPORT" not in auth_ctx.roles:
-    raise HTTPException(status_code=403, detail="Forbidden")
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
   data = AdminUsersGuid1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run("db:admin:users:reset_display:1", {"guid": data.userGuid})
+  await reset_display(db, data.userGuid)
   RPCResponse = _get_rpc_response_class()
   return RPCResponse(
     op=rpc_request.op,
@@ -68,14 +78,11 @@ async def admin_users_reset_display_v1(request: Request):
 
 
 async def admin_users_enable_storage_v1(request: Request):
-  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  if "ROLE_ADMIN_SUPPORT" not in auth_ctx.roles:
-    raise HTTPException(status_code=403, detail="Forbidden")
+  rpc_request, _, _ = await get_rpcrequest_from_request(request)
   data = AdminUsersGuid1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run("db:admin:users:enable_storage:1", {"guid": data.userGuid})
   storage: StorageModule = request.app.state.storage
-  await storage.ensure_user_folder(data.userGuid)
+  await enable_storage(db, storage, data.userGuid)
   RPCResponse = _get_rpc_response_class()
   return RPCResponse(
     op=rpc_request.op,

--- a/tests/test_admin_services.py
+++ b/tests/test_admin_services.py
@@ -145,7 +145,7 @@ class DummyRequest:
     self.headers = {}
 
 
-def test_admin_roles_permission_required():
+def test_admin_roles_no_permission_required():
   roles_mod = _load_module("rpc/admin/roles/services.py", "admin_roles_services")
 
   async def fake_get(request):
@@ -155,9 +155,10 @@ def test_admin_roles_permission_required():
   orig = helpers.get_rpcrequest_from_request
   helpers.get_rpcrequest_from_request = fake_get
   roles_mod.get_rpcrequest_from_request = fake_get
-  req = DummyRequest(DummyState(DummyDb()))
-  with pytest.raises(HTTPException):
-    asyncio.run(roles_mod.admin_roles_add_member_v1(req))
+  db = DummyDb()
+  req = DummyRequest(DummyState(db))
+  resp = asyncio.run(roles_mod.admin_roles_add_member_v1(req))
+  assert resp is not None
   helpers.get_rpcrequest_from_request = orig
   roles_mod.get_rpcrequest_from_request = orig
 
@@ -202,7 +203,7 @@ def test_admin_roles_add_and_remove_member():
   roles_mod.get_rpcrequest_from_request = orig
 
 
-def test_admin_users_permission_required():
+def test_admin_users_no_permission_required():
   users_mod = _load_module("rpc/admin/users/services.py", "admin_users_services")
 
   async def fake_get(request):
@@ -212,9 +213,10 @@ def test_admin_users_permission_required():
   orig = helpers.get_rpcrequest_from_request
   helpers.get_rpcrequest_from_request = fake_get
   users_mod.get_rpcrequest_from_request = fake_get
-  req = DummyRequest(DummyState(DummyDb()))
-  with pytest.raises(HTTPException):
-    asyncio.run(users_mod.admin_users_set_credits_v1(req))
+  db = DummyDb()
+  req = DummyRequest(DummyState(db))
+  resp = asyncio.run(users_mod.admin_users_set_credits_v1(req))
+  assert resp is not None
   helpers.get_rpcrequest_from_request = orig
   users_mod.get_rpcrequest_from_request = orig
 


### PR DESCRIPTION
## Summary
- drop ROLE_ADMIN_SUPPORT checks from admin user and role services
- expose internal helpers for admin user and role operations
- update admin service tests to reflect dispatcher-based authorization

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68a52f322abc83259e8082c56fd48486