### PR TITLE
Centralize RPC authorization checks

### DIFF
--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -7,8 +7,25 @@ from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
 
 
+# Mapping of URN domains to the roles allowed to invoke them.
+# Sub-routes with special rules are specified using a ``:`` delimited
+# path excluding the terminal version component.
+DOMAIN_ROLE_MAP: dict[str, dict[str, list[str]]] = {
+  "admin": {"": ["ROLE_ADMIN_SUPPORT"]},
+  "security": {
+    "": ["ROLE_SECURITY_ADMIN"],
+    "roles:get_roles": ["ROLE_SECURITY_ADMIN", "ROLE_SYSTEM_ADMIN"],
+  },
+  "moderation": {"": ["ROLE_MODERATION_SUPPORT"]},
+  "service": {"": ["ROLE_SERVICE_ADMIN"]},
+  "storage": {"": ["ROLE_STORAGE_ENABLED"]},
+  "system": {"": ["ROLE_SYSTEM_ADMIN"]},
+  "users": {"": ["ROLE_USERS_ENABLED"]},
+}
+
+
 async def handle_rpc_request(request: Request) -> RPCResponse:
-  rpc_request, _auth_ctx, parts = await get_rpcrequest_from_request(request)
+  rpc_request, auth_ctx, parts = await get_rpcrequest_from_request(request)
 
   if parts[:1] != ["urn"]:
     raise HTTPException(400, "Invalid URN prefix")
@@ -16,6 +33,16 @@ async def handle_rpc_request(request: Request) -> RPCResponse:
   try:
     domain = parts[1]
     remainder = parts[2:]
+
+    rules = DOMAIN_ROLE_MAP.get(domain)
+    if rules:
+      subroute = ":".join(remainder[:-1]) if remainder else ""
+      role_names = rules.get(subroute, rules.get("", []))
+      if role_names:
+        auth = request.app.state.auth
+        required_mask = auth.names_to_mask(role_names)
+        if not (auth_ctx.role_mask & required_mask):
+          raise HTTPException(status_code=403, detail="Forbidden")
 
     handler = HANDLERS.get(domain)
     if not handler:


### PR DESCRIPTION
## Summary
- enforce URN domain role requirements in a central rpc handler
- allow operations to accept multiple roles and fail with 403 when missing
- add tests for centralized authorization logic

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68a53d1657b48325b5d1fb2261356d27