### PR TITLE
Remove per-function storage role check

### DIFF
--- a/rpc/storage/files/handler.py
+++ b/rpc/storage/files/handler.py
@@ -3,14 +3,32 @@
 Dispatches file operations requiring ROLE_STORAGE_ENABLED.
 """
 
+import logging
+
 from fastapi import HTTPException, Request
 
+from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
 
 from . import DISPATCHERS
 
 
 async def handle_files_request(parts: list[str], request: Request) -> RPCResponse:
+  _, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  auth = request.app.state.auth
+  required_mask = auth.roles.get("ROLE_STORAGE_ENABLED", 0)
+  expected_mask = 0x0000000000000002
+  has_role = (auth_ctx.role_mask & required_mask) == required_mask
+  logging.debug(
+    "[Storage] user roles=%s mask=%#018x required_mask=%#018x (ROLE_STORAGE_ENABLED expected %#018x) has_role=%s",
+    auth_ctx.roles,
+    auth_ctx.role_mask,
+    required_mask,
+    expected_mask,
+    has_role,
+  )
+  if not has_role:
+    raise HTTPException(status_code=403, detail='Forbidden')
   key = tuple(parts[:2])
   handler = DISPATCHERS.get(key)
   if not handler:

--- a/rpc/storage/files/services.py
+++ b/rpc/storage/files/services.py
@@ -1,13 +1,11 @@
 import base64
 import io
-import logging
 
 from fastapi import HTTPException, Request
 
 from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
 from server.modules.storage_module import StorageModule
-from server.modules.auth_module import AuthModule
 
 from .models import (
   StorageFilesDeleteFiles1,
@@ -18,26 +16,8 @@ from .models import (
 )
 
 
-def _require_storage_role(auth_ctx, request: Request):
-  auth: AuthModule = request.app.state.auth
-  required_mask = auth.roles.get("ROLE_STORAGE_ENABLED", 0)
-  expected_mask = 0x0000000000000002
-  has_role = (auth_ctx.role_mask & required_mask) == required_mask
-  logging.debug(
-    "[Storage] user roles=%s mask=%#018x required_mask=%#018x (ROLE_STORAGE_ENABLED expected %#018x) has_role=%s",
-    auth_ctx.roles,
-    auth_ctx.role_mask,
-    required_mask,
-    expected_mask,
-    has_role,
-  )
-  if not has_role:
-    raise HTTPException(status_code=403, detail="Forbidden")
-
-
 async def storage_files_get_files_v1(request: Request):
   rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  _require_storage_role(auth_ctx, request)
   storage: StorageModule = request.app.state.storage
   files = await storage.list_user_files(auth_ctx.user_guid)
   payload = StorageFilesFiles1(files=[StorageFilesFileItem1(**f) for f in files])
@@ -50,7 +30,6 @@ async def storage_files_get_files_v1(request: Request):
 
 async def storage_files_upload_files_v1(request: Request):
   rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  _require_storage_role(auth_ctx, request)
   data = StorageFilesUploadFiles1(**(rpc_request.payload or {}))
   storage: StorageModule = request.app.state.storage
   await storage.ensure_user_folder(auth_ctx.user_guid)
@@ -66,7 +45,6 @@ async def storage_files_upload_files_v1(request: Request):
 
 async def storage_files_delete_files_v1(request: Request):
   rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  _require_storage_role(auth_ctx, request)
   data = StorageFilesDeleteFiles1(**(rpc_request.payload or {}))
   storage: StorageModule = request.app.state.storage
   for name in data.files:
@@ -80,7 +58,6 @@ async def storage_files_delete_files_v1(request: Request):
 
 async def storage_files_set_gallery_v1(request: Request):
   rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  _require_storage_role(auth_ctx, request)
   data = StorageFilesSetGallery1(**(rpc_request.payload or {}))
   storage: StorageModule = request.app.state.storage
   files = await storage.list_user_files(auth_ctx.user_guid)

--- a/tests/test_storage_files_handler.py
+++ b/tests/test_storage_files_handler.py
@@ -1,0 +1,116 @@
+import asyncio
+import importlib.util
+import pathlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+# stub rpc package and models
+pkg = types.ModuleType("rpc")
+pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / "rpc")]
+sys.modules.setdefault("rpc", pkg)
+
+spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
+models = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(models)
+RPCRequest = models.RPCRequest
+RPCResponse = models.RPCResponse
+sys.modules["rpc.models"] = models
+
+# stub helpers for handler import
+helpers_stub = types.ModuleType("rpc.helpers")
+async def _stub(request):
+  raise NotImplementedError
+helpers_stub.get_rpcrequest_from_request = _stub
+sys.modules["rpc.helpers"] = helpers_stub
+
+# stub files package with dispatcher map
+files_pkg = types.ModuleType("rpc.storage.files")
+files_pkg.DISPATCHERS = {}
+sys.modules["rpc.storage.files"] = files_pkg
+
+# import handler with stubs
+handler_spec = importlib.util.spec_from_file_location("rpc.storage.files.handler", "rpc/storage/files/handler.py")
+handler_mod = importlib.util.module_from_spec(handler_spec)
+handler_spec.loader.exec_module(handler_mod)
+handle_files_request = handler_mod.handle_files_request
+
+# restore real helpers for other tests
+real_helpers_spec = importlib.util.spec_from_file_location("rpc.helpers", "rpc/helpers.py")
+real_helpers = importlib.util.module_from_spec(real_helpers_spec)
+real_helpers_spec.loader.exec_module(real_helpers)
+sys.modules["rpc.helpers"] = real_helpers
+
+
+class DummyAuth:
+  def __init__(self):
+    self.roles = {"ROLE_STORAGE_ENABLED": 0x2}
+
+
+class DummyState:
+  def __init__(self):
+    self.auth = DummyAuth()
+
+
+class DummyApp:
+  def __init__(self):
+    self.state = DummyState()
+
+
+class DummyRequest:
+  def __init__(self):
+    self.app = DummyApp()
+    self.headers = {}
+
+
+def test_handle_files_request_requires_role():
+  called = False
+
+  async def stub_service(request):
+    nonlocal called
+    called = True
+    return RPCResponse(op="ok", payload=None, version=1)
+
+  files_pkg.DISPATCHERS[("get_files", "1")] = stub_service
+
+  async def fake_get(request):
+    rpc = RPCRequest(op="urn:storage:files:get_files:1", payload=None, version=1)
+    auth = SimpleNamespace(roles=[], role_mask=0)
+    return rpc, auth, None
+
+  handler_mod.get_rpcrequest_from_request = fake_get
+  req = DummyRequest()
+
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(handle_files_request(["get_files", "1"], req))
+
+  assert exc.value.status_code == 403
+  assert not called
+
+
+def test_handle_files_request_dispatches():
+  called = False
+
+  async def stub_service(request):
+    nonlocal called
+    called = True
+    return RPCResponse(op="ok", payload=None, version=1)
+
+  files_pkg.DISPATCHERS[("get_files", "1")] = stub_service
+
+  async def fake_get(request):
+    rpc = RPCRequest(op="urn:storage:files:get_files:1", payload=None, version=1)
+    auth = SimpleNamespace(roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
+    return rpc, auth, None
+
+  handler_mod.get_rpcrequest_from_request = fake_get
+  req = DummyRequest()
+
+  resp = asyncio.run(handle_files_request(["get_files", "1"], req))
+
+  assert isinstance(resp, RPCResponse)
+  assert called
+


### PR DESCRIPTION
## Summary
- enforce ROLE_STORAGE_ENABLED in storage files dispatcher
- drop per-service role gate and keep existing logging
- add tests for dispatcher authorization

## Testing
- `python scripts/run_tests.py` (fails: vitest coverage step interrupted)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a53fe17eb4832598d2c682be79f490