### PR TITLE
Centralize storage role checks in domain map

### DIFF
--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -18,7 +18,13 @@ DOMAIN_ROLE_MAP: dict[str, dict[str, list[str]]] = {
   },
   "moderation": {"": ["ROLE_MODERATION_SUPPORT"]},
   "service": {"": ["ROLE_SERVICE_ADMIN"]},
-  "storage": {"": ["ROLE_STORAGE_ENABLED"]},
+  "storage": {
+    "": ["ROLE_STORAGE_ENABLED"],
+    "files:get_files": ["ROLE_STORAGE_ENABLED"],
+    "files:upload_files": ["ROLE_STORAGE_ENABLED"],
+    "files:delete_files": ["ROLE_STORAGE_ENABLED"],
+    "files:set_gallery": ["ROLE_STORAGE_ENABLED"],
+  },
   "system": {"": ["ROLE_SYSTEM_ADMIN"]},
   "users": {"": ["ROLE_USERS_ENABLED"]},
 }

--- a/rpc/storage/files/handler.py
+++ b/rpc/storage/files/handler.py
@@ -3,32 +3,14 @@
 Dispatches file operations requiring ROLE_STORAGE_ENABLED.
 """
 
-import logging
-
 from fastapi import HTTPException, Request
 
-from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
 
 from . import DISPATCHERS
 
 
 async def handle_files_request(parts: list[str], request: Request) -> RPCResponse:
-  _, auth_ctx, _ = await get_rpcrequest_from_request(request)
-  auth = request.app.state.auth
-  required_mask = auth.roles.get("ROLE_STORAGE_ENABLED", 0)
-  expected_mask = 0x0000000000000002
-  has_role = (auth_ctx.role_mask & required_mask) == required_mask
-  logging.debug(
-    "[Storage] user roles=%s mask=%#018x required_mask=%#018x (ROLE_STORAGE_ENABLED expected %#018x) has_role=%s",
-    auth_ctx.roles,
-    auth_ctx.role_mask,
-    required_mask,
-    expected_mask,
-    has_role,
-  )
-  if not has_role:
-    raise HTTPException(status_code=403, detail='Forbidden')
   key = tuple(parts[:2])
   handler = DISPATCHERS.get(key)
   if not handler:

--- a/tests/test_storage_files_handler.py
+++ b/tests/test_storage_files_handler.py
@@ -3,10 +3,6 @@ import importlib.util
 import pathlib
 import sys
 import types
-from types import SimpleNamespace
-
-import pytest
-from fastapi import HTTPException
 
 # stub rpc package and models
 pkg = types.ModuleType("rpc")
@@ -16,16 +12,8 @@ sys.modules.setdefault("rpc", pkg)
 spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
 models = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(models)
-RPCRequest = models.RPCRequest
 RPCResponse = models.RPCResponse
 sys.modules["rpc.models"] = models
-
-# stub helpers for handler import
-helpers_stub = types.ModuleType("rpc.helpers")
-async def _stub(request):
-  raise NotImplementedError
-helpers_stub.get_rpcrequest_from_request = _stub
-sys.modules["rpc.helpers"] = helpers_stub
 
 # stub files package with dispatcher map
 files_pkg = types.ModuleType("rpc.storage.files")
@@ -38,57 +26,11 @@ handler_mod = importlib.util.module_from_spec(handler_spec)
 handler_spec.loader.exec_module(handler_mod)
 handle_files_request = handler_mod.handle_files_request
 
-# restore real helpers for other tests
-real_helpers_spec = importlib.util.spec_from_file_location("rpc.helpers", "rpc/helpers.py")
-real_helpers = importlib.util.module_from_spec(real_helpers_spec)
-real_helpers_spec.loader.exec_module(real_helpers)
-sys.modules["rpc.helpers"] = real_helpers
-
-
-class DummyAuth:
-  def __init__(self):
-    self.roles = {"ROLE_STORAGE_ENABLED": 0x2}
-
-
-class DummyState:
-  def __init__(self):
-    self.auth = DummyAuth()
-
-
-class DummyApp:
-  def __init__(self):
-    self.state = DummyState()
-
 
 class DummyRequest:
   def __init__(self):
-    self.app = DummyApp()
+    self.app = types.SimpleNamespace()
     self.headers = {}
-
-
-def test_handle_files_request_requires_role():
-  called = False
-
-  async def stub_service(request):
-    nonlocal called
-    called = True
-    return RPCResponse(op="ok", payload=None, version=1)
-
-  files_pkg.DISPATCHERS[("get_files", "1")] = stub_service
-
-  async def fake_get(request):
-    rpc = RPCRequest(op="urn:storage:files:get_files:1", payload=None, version=1)
-    auth = SimpleNamespace(roles=[], role_mask=0)
-    return rpc, auth, None
-
-  handler_mod.get_rpcrequest_from_request = fake_get
-  req = DummyRequest()
-
-  with pytest.raises(HTTPException) as exc:
-    asyncio.run(handle_files_request(["get_files", "1"], req))
-
-  assert exc.value.status_code == 403
-  assert not called
 
 
 def test_handle_files_request_dispatches():
@@ -100,17 +42,9 @@ def test_handle_files_request_dispatches():
     return RPCResponse(op="ok", payload=None, version=1)
 
   files_pkg.DISPATCHERS[("get_files", "1")] = stub_service
-
-  async def fake_get(request):
-    rpc = RPCRequest(op="urn:storage:files:get_files:1", payload=None, version=1)
-    auth = SimpleNamespace(roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
-    return rpc, auth, None
-
-  handler_mod.get_rpcrequest_from_request = fake_get
   req = DummyRequest()
 
   resp = asyncio.run(handle_files_request(["get_files", "1"], req))
 
   assert isinstance(resp, RPCResponse)
   assert called
-


### PR DESCRIPTION
## Summary
- Remove direct ROLE_STORAGE_ENABLED verification from storage files handler
- Require ROLE_STORAGE_ENABLED for storage file routes via DOMAIN_ROLE_MAP
- Update storage file handler test to match new behavior

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68a5462727d883259caeec883b8ffaa5