### PR TITLE
refactor: move role checks to domain dispatchers

### DIFF
--- a/rpc/admin/handler.py
+++ b/rpc/admin/handler.py
@@ -6,12 +6,21 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
+from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
+from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
+REQUIRED_ROLE_MASK = 0x0400000000000000  # ROLE_ADMIN_SUPPORT
+
 
 async def handle_admin_request(parts: list[str], request: Request) -> RPCResponse:
+  _, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  auth: AuthModule = request.app.state.auth
+  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+    raise HTTPException(status_code=403, detail='Forbidden')
+
   subdomain = parts[0]
   handler = HANDLERS.get(subdomain)
   if not handler:

--- a/rpc/auth/handler.py
+++ b/rpc/auth/handler.py
@@ -10,6 +10,8 @@ from rpc.models import RPCResponse
 
 from . import HANDLERS
 
+REQUIRED_ROLE_MASK = 0
+
 
 async def handle_auth_request(parts: list[str], request: Request) -> RPCResponse:
   subdomain = parts[0]

--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -7,31 +7,8 @@ from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
 
 
-# Mapping of URN domains to the roles allowed to invoke them.
-# Sub-routes with special rules are specified using a ``:`` delimited
-# path excluding the terminal version component.
-DOMAIN_ROLE_MAP: dict[str, dict[str, list[str]]] = {
-  "admin": {"": ["ROLE_ADMIN_SUPPORT"]},
-  "security": {
-    "": ["ROLE_SECURITY_ADMIN"],
-    "roles:get_roles": ["ROLE_SECURITY_ADMIN", "ROLE_SYSTEM_ADMIN"],
-  },
-  "moderation": {"": ["ROLE_MODERATION_SUPPORT"]},
-  "service": {"": ["ROLE_SERVICE_ADMIN"]},
-  "storage": {
-    "": ["ROLE_STORAGE_ENABLED"],
-    "files:get_files": ["ROLE_STORAGE_ENABLED"],
-    "files:upload_files": ["ROLE_STORAGE_ENABLED"],
-    "files:delete_files": ["ROLE_STORAGE_ENABLED"],
-    "files:set_gallery": ["ROLE_STORAGE_ENABLED"],
-  },
-  "system": {"": ["ROLE_SYSTEM_ADMIN"]},
-  "users": {"": ["ROLE_USERS_ENABLED"]},
-}
-
-
 async def handle_rpc_request(request: Request) -> RPCResponse:
-  rpc_request, auth_ctx, parts = await get_rpcrequest_from_request(request)
+  rpc_request, _, parts = await get_rpcrequest_from_request(request)
 
   if parts[:1] != ["urn"]:
     raise HTTPException(400, "Invalid URN prefix")
@@ -39,16 +16,6 @@ async def handle_rpc_request(request: Request) -> RPCResponse:
   try:
     domain = parts[1]
     remainder = parts[2:]
-
-    rules = DOMAIN_ROLE_MAP.get(domain)
-    if rules:
-      subroute = ":".join(remainder[:-1]) if remainder else ""
-      role_names = rules.get(subroute, rules.get("", []))
-      if role_names:
-        auth = request.app.state.auth
-        required_mask = auth.names_to_mask(role_names)
-        if not (auth_ctx.role_mask & required_mask):
-          raise HTTPException(status_code=403, detail="Forbidden")
 
     handler = HANDLERS.get(domain)
     if not handler:

--- a/rpc/moderation/handler.py
+++ b/rpc/moderation/handler.py
@@ -6,12 +6,21 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
+from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
+from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
+REQUIRED_ROLE_MASK = 0x0800000000000000  # ROLE_MODERATION_SUPPORT
+
 
 async def handle_moderation_request(parts: list[str], request: Request) -> RPCResponse:
+  _, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  auth: AuthModule = request.app.state.auth
+  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+    raise HTTPException(status_code=403, detail='Forbidden')
+
   subdomain = parts[0]
   handler = HANDLERS.get(subdomain)
   if not handler:

--- a/rpc/public/handler.py
+++ b/rpc/public/handler.py
@@ -10,6 +10,8 @@ from rpc.models import RPCResponse
 
 from . import HANDLERS
 
+REQUIRED_ROLE_MASK = 0
+
 
 async def handle_public_request(parts: list[str], request: Request) -> RPCResponse:
   subdomain = parts[0]

--- a/rpc/security/handler.py
+++ b/rpc/security/handler.py
@@ -6,13 +6,31 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
+from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
+from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
+REQUIRED_ROLE_MASK = 0x1000000000000000  # ROLE_SECURITY_ADMIN
+SYSTEM_ADMIN_MASK = 0x2000000000000000  # ROLE_SYSTEM_ADMIN
+
 
 async def handle_security_request(parts: list[str], request: Request) -> RPCResponse:
+  _, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  auth: AuthModule = request.app.state.auth
+
   subdomain = parts[0]
+  action = parts[1] if len(parts) > 1 else ""
+  required = REQUIRED_ROLE_MASK
+
+  if subdomain == "roles" and action == "get_roles":
+    if await auth.user_has_role(auth_ctx.user_guid, SYSTEM_ADMIN_MASK):
+      required = 0
+
+  if required and not await auth.user_has_role(auth_ctx.user_guid, required):
+    raise HTTPException(status_code=403, detail='Forbidden')
+
   handler = HANDLERS.get(subdomain)
   if not handler:
     raise HTTPException(status_code=404, detail='Unknown RPC subdomain')

--- a/rpc/service/handler.py
+++ b/rpc/service/handler.py
@@ -5,12 +5,21 @@ Handles service operations requiring ROLE_SERVICE_ADMIN.
 
 from fastapi import HTTPException, Request
 
+from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
+from server.modules.auth_module import AuthModule
 
 from . import DISPATCHERS
 
+REQUIRED_ROLE_MASK = 0x4000000000000000  # ROLE_SERVICE_ADMIN
+
 
 async def handle_service_request(parts: list[str], request: Request) -> RPCResponse:
+  _, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  auth: AuthModule = request.app.state.auth
+  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+    raise HTTPException(status_code=403, detail="Forbidden")
+
   key = tuple(parts[:2])
   handler = DISPATCHERS.get(key)
   if not handler:

--- a/rpc/storage/handler.py
+++ b/rpc/storage/handler.py
@@ -6,12 +6,21 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
+from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
+from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
+REQUIRED_ROLE_MASK = 0x0000000000000002  # ROLE_STORAGE_ENABLED
+
 
 async def handle_storage_request(parts: list[str], request: Request) -> RPCResponse:
+  _, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  auth: AuthModule = request.app.state.auth
+  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+    raise HTTPException(status_code=403, detail='Forbidden')
+
   subdomain = parts[0]
   handler = HANDLERS.get(subdomain)
   if not handler:

--- a/rpc/system/handler.py
+++ b/rpc/system/handler.py
@@ -6,12 +6,21 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
+from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
+from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
+REQUIRED_ROLE_MASK = 0x2000000000000000  # ROLE_SYSTEM_ADMIN
+
 
 async def handle_system_request(parts: list[str], request: Request) -> RPCResponse:
+  _, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  auth: AuthModule = request.app.state.auth
+  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+    raise HTTPException(status_code=403, detail="Forbidden")
+
   subdomain = parts[0]
   handler = HANDLERS.get(subdomain)
   if not handler:

--- a/rpc/users/handler.py
+++ b/rpc/users/handler.py
@@ -6,12 +6,21 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
+from rpc.helpers import get_rpcrequest_from_request
 from rpc.models import RPCResponse
+from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
+REQUIRED_ROLE_MASK = 0x0000000000000001  # ROLE_USERS_ENABLED
+
 
 async def handle_users_request(parts: list[str], request: Request) -> RPCResponse:
+  _, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  auth: AuthModule = request.app.state.auth
+  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+    raise HTTPException(status_code=403, detail='Forbidden')
+
   subdomain = parts[0]
   handler = HANDLERS.get(subdomain)
   if not handler:

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -198,6 +198,23 @@ class AuthModule(BaseModule):
     logging.debug("[AuthModule] Roles for %s: %s (mask=%#018x)", guid, names, mask)
     return names, mask
 
+  async def user_has_role(self, guid: str, required_mask: int) -> bool:
+    """Check if a user possesses a required role mask.
+
+    Args:
+      guid: The user's GUID.
+      required_mask: Bitmask representing required roles.
+
+    Returns:
+      True if the user has at least one of the required roles, otherwise False.
+    """
+    if not required_mask:
+      return True
+    if not guid:
+      return False
+    _, mask = await self.get_user_roles(guid)
+    return bool(mask & required_mask)
+
   async def refresh_user_roles(self, guid: str):
     logging.debug("[AuthModule] Refreshing user roles for %s", guid)
     await self.get_user_roles(guid, refresh=True)

--- a/tests/test_security_roles_services.py
+++ b/tests/test_security_roles_services.py
@@ -1,18 +1,33 @@
-import sys, types, asyncio, importlib.util, pathlib
+import asyncio
+import importlib.util
+import types
 from types import SimpleNamespace
-from fastapi import HTTPException
+import sys
+
 import pytest
+from fastapi import HTTPException
+
+from rpc.models import RPCRequest, RPCResponse
+import rpc.handler as handler_mod
+import rpc.security as security_pkg
+import rpc.security.handler as security_handler
+import rpc.helpers as helpers
+
+handle_rpc_request = handler_mod.handle_rpc_request
+
 
 class DBRes:
   def __init__(self, rows=None, rowcount=0):
     self.rows = rows or []
     self.rowcount = rowcount
 
+
 class DummyDb:
   def __init__(self, members=None, non_members=None):
     self.calls = []
     self.members = members or []
     self.non_members = non_members or []
+
   async def run(self, op, args):
     self.calls.append((op, args))
     if op == "db:security:roles:get_role_members:1":
@@ -21,74 +36,66 @@ class DummyDb:
       return DBRes(self.non_members, len(self.non_members))
     return DBRes()
 
+
 class DummyAuth:
   def __init__(self):
     self.loaded = False
     self.roles = {"ROLE_SECURITY_ADMIN": 1, "ROLE_SYSTEM_ADMIN": 2}
+    self.user_roles: dict[str, int] = {}
+
   async def refresh_role_cache(self):
     self.loaded = True
+
   def get_role_names(self, exclude_registered=False):
     return ["ROLE_SECURITY_ADMIN"]
+
   def names_to_mask(self, names):
     mask = 0
     for n in names:
       mask |= self.roles.get(n, 0)
     return mask
 
+  async def user_has_role(self, guid: str, mask: int) -> bool:
+    return bool(self.user_roles.get(guid, 0) & mask)
+
+
 class DummyState:
   def __init__(self, db, auth):
     self.db = db
     self.auth = auth
 
+
 class DummyApp:
   def __init__(self, state):
     self.state = state
+
 
 class DummyRequest:
   def __init__(self, state):
     self.app = DummyApp(state)
     self.headers = {}
 
-pkg = types.ModuleType("rpc")
-pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / "rpc")]
-pkg.HANDLERS = {}
-sys.modules.setdefault("rpc", pkg)
 
-spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
-models = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(models)
-RPCRequest = models.RPCRequest
-RPCResponse = models.RPCResponse
-sys.modules["rpc.models"] = models
-
-helpers = types.ModuleType("rpc.helpers")
-helpers.bit_to_mask = lambda b: 1 << b
-async def _stub(request):
-  raise NotImplementedError
-helpers.get_rpcrequest_from_request = _stub
-sys.modules["rpc.helpers"] = helpers
-
-handler_spec = importlib.util.spec_from_file_location("rpc.handler", "rpc/handler.py")
-handler_mod = importlib.util.module_from_spec(handler_spec)
-handler_spec.loader.exec_module(handler_mod)
-handle_rpc_request = handler_mod.handle_rpc_request
-sys.modules["rpc.handler"] = handler_mod
-
+# Stub server modules for services
 auth_module_pkg = types.ModuleType("server.modules.auth_module")
 class AuthModule: ...
 auth_module_pkg.AuthModule = AuthModule
 modules_pkg = types.ModuleType("server.modules")
 modules_pkg.auth_module = auth_module_pkg
-sys.modules.setdefault("server.modules", modules_pkg)
-sys.modules["server.modules.auth_module"] = auth_module_pkg
+sys_modules = sys.modules
+sys_modules.setdefault("server.modules", modules_pkg)
+sys_modules["server.modules.auth_module"] = auth_module_pkg
 
 db_module_pkg = types.ModuleType("server.modules.db_module")
 class DbModule: ...
 db_module_pkg.DbModule = DbModule
 modules_pkg.db_module = db_module_pkg
-sys.modules["server.modules.db_module"] = db_module_pkg
+sys_modules["server.modules.db_module"] = db_module_pkg
 
-svc_spec = importlib.util.spec_from_file_location("rpc.security.roles.services", "rpc/security/roles/services.py")
+# Import services after stubbing
+svc_spec = importlib.util.spec_from_file_location(
+  "rpc.security.roles.services", "rpc/security/roles/services.py"
+)
 svc_mod = importlib.util.module_from_spec(svc_spec)
 svc_spec.loader.exec_module(svc_mod)
 
@@ -100,16 +107,22 @@ security_roles_remove_role_member_v1 = svc_mod.security_roles_remove_role_member
 def test_get_roles_requires_admin():
   async def fake_get(request):
     rpc = RPCRequest(op="urn:security:roles:get_roles:1", payload=None, version=1)
-    auth = SimpleNamespace(role_mask=0)
+    auth = SimpleNamespace(user_guid="u1")
+    request.app.state.auth.user_roles["u1"] = 0
     parts = rpc.op.split(":")
     return rpc, auth, parts
+
   handler_mod.get_rpcrequest_from_request = fake_get
+  security_handler.get_rpcrequest_from_request = fake_get
+
   called = False
+
   async def stub(parts, request):
     nonlocal called
     called = True
     return RPCResponse(op="ok", payload=None, version=1)
-  handler_mod.HANDLERS["security"] = stub
+
+  security_pkg.HANDLERS["roles"] = stub
   req = DummyRequest(DummyState(DummyDb(), DummyAuth()))
   with pytest.raises(HTTPException) as exc:
     asyncio.run(handle_rpc_request(req))
@@ -120,16 +133,22 @@ def test_get_roles_requires_admin():
 def test_get_roles_allows_system_admin():
   async def fake_get(request):
     rpc = RPCRequest(op="urn:security:roles:get_roles:1", payload=None, version=1)
-    auth = SimpleNamespace(role_mask=2)
+    auth = SimpleNamespace(user_guid="u1")
+    request.app.state.auth.user_roles["u1"] = 0x2000000000000000
     parts = rpc.op.split(":")
     return rpc, auth, parts
+
   handler_mod.get_rpcrequest_from_request = fake_get
+  security_handler.get_rpcrequest_from_request = fake_get
+
   called = False
+
   async def stub(parts, request):
     nonlocal called
     called = True
     return RPCResponse(op="ok", payload=None, version=1)
-  handler_mod.HANDLERS["security"] = stub
+
+  security_pkg.HANDLERS["roles"] = stub
   req = DummyRequest(DummyState(DummyDb(), DummyAuth()))
   resp = asyncio.run(handle_rpc_request(req))
   assert isinstance(resp, RPCResponse)
@@ -138,22 +157,43 @@ def test_get_roles_allows_system_admin():
 
 def test_permission_required():
   async def fake_get(request):
-    rpc = RPCRequest(op="urn:security:roles:upsert_role:1", payload={"name": "R", "bit": 1}, version=1)
-    auth = SimpleNamespace(role_mask=0)
+    rpc = RPCRequest(
+      op="urn:security:roles:upsert_role:1",
+      payload={"name": "R", "bit": 1},
+      version=1,
+    )
+    auth = SimpleNamespace(user_guid="u1")
+    request.app.state.auth.user_roles["u1"] = 0
     parts = rpc.op.split(":")
     return rpc, auth, parts
+
   handler_mod.get_rpcrequest_from_request = fake_get
-  handler_mod.HANDLERS["security"] = lambda parts, req: RPCResponse(op="ok", payload=None, version=1)
+  security_handler.get_rpcrequest_from_request = fake_get
+
+  called = False
+
+  async def stub(parts, request):
+    nonlocal called
+    called = True
+    return RPCResponse(op="ok", payload=None, version=1)
+
+  security_pkg.HANDLERS["roles"] = stub
   req = DummyRequest(DummyState(DummyDb(), DummyAuth()))
   with pytest.raises(HTTPException) as exc:
     asyncio.run(handle_rpc_request(req))
   assert exc.value.status_code == 403
+  assert not called
 
 
 def test_upsert_role_calls_db_and_loads_roles():
   async def fake_get(request):
-    rpc = RPCRequest(op="urn:security:roles:upsert_role:1", payload={"name": "ROLE_NEW", "bit": 2, "display": "New"}, version=1)
+    rpc = RPCRequest(
+      op="urn:security:roles:upsert_role:1",
+      payload={"name": "ROLE_NEW", "bit": 2, "display": "New"},
+      version=1,
+    )
     return rpc, SimpleNamespace(roles=["ROLE_SECURITY_ADMIN"]), None
+
   helpers.get_rpcrequest_from_request = fake_get
   svc_mod.get_rpcrequest_from_request = fake_get
   db = DummyDb()
@@ -161,7 +201,10 @@ def test_upsert_role_calls_db_and_loads_roles():
   req = DummyRequest(DummyState(db, auth))
   resp = asyncio.run(security_roles_upsert_role_v1(req))
   assert isinstance(resp, RPCResponse)
-  assert ("db:security:roles:upsert_role:1", {"name": "ROLE_NEW", "mask": 4, "display": "New"}) in db.calls
+  assert (
+    "db:security:roles:upsert_role:1",
+    {"name": "ROLE_NEW", "mask": 4, "display": "New"},
+  ) in db.calls
   assert auth.loaded
 
 
@@ -174,8 +217,13 @@ def test_add_and_remove_member():
   req = DummyRequest(state)
 
   async def fake_get_add(request):
-    rpc = RPCRequest(op="urn:security:roles:add_role_member:1", payload={"role": "ROLE_X", "userGuid": "u1"}, version=1)
+    rpc = RPCRequest(
+      op="urn:security:roles:add_role_member:1",
+      payload={"role": "ROLE_X", "userGuid": "u1"},
+      version=1,
+    )
     return rpc, SimpleNamespace(roles=["ROLE_SECURITY_ADMIN"]), None
+
   helpers.get_rpcrequest_from_request = fake_get_add
   svc_mod.get_rpcrequest_from_request = fake_get_add
   resp = asyncio.run(security_roles_add_role_member_v1(req))
@@ -185,11 +233,19 @@ def test_add_and_remove_member():
 
   db.calls.clear()
   db.members = []
-  db.non_members = [{"guid": "u1", "display_name": "User 1"}, {"guid": "u2", "display_name": "User 2"}]
+  db.non_members = [
+    {"guid": "u1", "display_name": "User 1"},
+    {"guid": "u2", "display_name": "User 2"},
+  ]
 
   async def fake_get_remove(request):
-    rpc = RPCRequest(op="urn:security:roles:remove_role_member:1", payload={"role": "ROLE_X", "userGuid": "u1"}, version=1)
+    rpc = RPCRequest(
+      op="urn:security:roles:remove_role_member:1",
+      payload={"role": "ROLE_X", "userGuid": "u1"},
+      version=1,
+    )
     return rpc, SimpleNamespace(roles=["ROLE_SECURITY_ADMIN"]), None
+
   helpers.get_rpcrequest_from_request = fake_get_remove
   svc_mod.get_rpcrequest_from_request = fake_get_remove
   resp2 = asyncio.run(security_roles_remove_role_member_v1(req))
@@ -199,3 +255,4 @@ def test_add_and_remove_member():
     {"guid": "u1", "displayName": "User 1"},
     {"guid": "u2", "displayName": "User 2"},
   ]
+


### PR DESCRIPTION
## Summary
- authorize RPC domains via per-dispatcher role masks
- add `user_has_role` helper on AuthModule for mask checks
- adjust tests for domain-level authorization changes

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68a54af2b3c48325adb6adf4fe5b7f3a