### PR TITLE
Remove redundant auth check in provider service

### DIFF
--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -1,0 +1,114 @@
+import asyncio
+import importlib.util
+import pathlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+# stub rpc package
+pkg = types.ModuleType("rpc")
+pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / "rpc")]
+sys.modules.setdefault("rpc", pkg)
+
+spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
+models = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(models)
+RPCRequest = models.RPCRequest
+RPCResponse = models.RPCResponse
+sys.modules["rpc.models"] = models
+
+# stub server packages
+server_pkg = types.ModuleType("server")
+modules_pkg = types.ModuleType("server.modules")
+db_module_pkg = types.ModuleType("server.modules.db_module")
+class DbModule: ...
+db_module_pkg.DbModule = DbModule
+modules_pkg.db_module = db_module_pkg
+server_pkg.modules = modules_pkg
+models_pkg = types.ModuleType("server.models")
+class AuthContext:
+  def __init__(self, **data):
+    self.role_mask = 0
+    self.__dict__.update(data)
+models_pkg.AuthContext = AuthContext
+server_pkg.models = models_pkg
+
+sys.modules.setdefault("server", server_pkg)
+sys.modules.setdefault("server.modules", modules_pkg)
+sys.modules.setdefault("server.modules.db_module", db_module_pkg)
+sys.modules.setdefault("server.models", models_pkg)
+
+# load real helpers then override for service import
+real_helpers_spec = importlib.util.spec_from_file_location("rpc.helpers", "rpc/helpers.py")
+real_helpers = importlib.util.module_from_spec(real_helpers_spec)
+real_helpers_spec.loader.exec_module(real_helpers)
+
+helpers_stub = types.ModuleType("rpc.helpers")
+async def _stub(request):
+  raise NotImplementedError
+helpers_stub.get_rpcrequest_from_request = _stub
+sys.modules["rpc.helpers"] = helpers_stub
+
+# import services with stubbed helpers
+svc_spec = importlib.util.spec_from_file_location("rpc.users.providers.services", "rpc/users/providers/services.py")
+svc_mod = importlib.util.module_from_spec(svc_spec)
+svc_spec.loader.exec_module(svc_mod)
+
+# restore real helpers
+sys.modules["rpc.helpers"] = real_helpers
+
+users_providers_set_provider_v1 = svc_mod.users_providers_set_provider_v1
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+class DummyDb:
+  def __init__(self):
+    self.calls = []
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    return DBRes()
+
+class DummyState:
+  def __init__(self, db):
+    self.db = db
+
+class DummyApp:
+  def __init__(self, state):
+    self.state = state
+
+class DummyRequest:
+  def __init__(self, state):
+    self.app = DummyApp(state)
+    self.headers = {}
+
+
+def test_set_provider_calls_db():
+  async def fake_get(request):
+    rpc = RPCRequest(op="urn:users:providers:set_provider:1", payload={"provider": "microsoft"}, version=1)
+    return rpc, SimpleNamespace(user_guid="u1"), None
+  svc_mod.get_rpcrequest_from_request = fake_get
+  db = DummyDb()
+  req = DummyRequest(DummyState(db))
+  resp = asyncio.run(users_providers_set_provider_v1(req))
+  assert ("urn:users:providers:set_provider:1", {"guid": "u1", "provider": "microsoft"}) in db.calls
+  assert isinstance(resp, RPCResponse)
+  assert resp.payload["provider"] == "microsoft"
+
+
+def test_set_provider_missing_provider_raises():
+  async def fake_get(request):
+    rpc = RPCRequest(op="urn:users:providers:set_provider:1", payload={}, version=1)
+    return rpc, SimpleNamespace(user_guid="u1"), None
+  svc_mod.get_rpcrequest_from_request = fake_get
+  db = DummyDb()
+  req = DummyRequest(DummyState(db))
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(users_providers_set_provider_v1(req))
+  assert exc.value.status_code == 400
+


### PR DESCRIPTION
## Summary
- assume auth context in `users_providers_set_provider_v1`
- validate required parameters and raise HTTP 400 on missing provider
- add tests for provider service behavior

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68a5d7d757688325b7a45fe9a0d190ce