### PR TITLE
refactor: update tests for unbox_request

### DIFF
--- a/rpc/public/links/services.py
+++ b/rpc/public/links/services.py
@@ -16,7 +16,7 @@ _helpers_spec = importlib.util.spec_from_file_location(
 _helpers_mod = importlib.util.module_from_spec(_helpers_spec)
 _helpers_spec.loader.exec_module(_helpers_mod)
 sys.modules["rpc.helpers"] = _helpers_mod
-get_rpcrequest_from_request = _helpers_mod.get_rpcrequest_from_request
+unbox_request = _helpers_mod.unbox_request
 
 from rpc.models import RPCResponse
 from server.modules.db_module import DbModule
@@ -29,7 +29,7 @@ from .models import (
 
 
 async def public_links_get_home_links_v1(request: Request):
-  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  rpc_request, _, _ = await unbox_request(request)
   db: DbModule = request.app.state.db
   res = await db.run(rpc_request.op, rpc_request.payload or {})
   links = [PublicLinksLinkItem1(**row) for row in res.rows]
@@ -41,7 +41,7 @@ async def public_links_get_home_links_v1(request: Request):
   )
 
 async def public_links_get_navbar_routes_v1(request: Request):
-  rpc_request, auth_ctx, _ = await get_rpcrequest_from_request(request)
+  rpc_request, auth_ctx, _ = await unbox_request(request)
   db: DbModule = request.app.state.db
   res = await db.run("urn:public:links:get_navbar_routes:1", {"role_mask": auth_ctx.role_mask})
   routes = [PublicLinksNavBarRoute1(**row) for row in res.rows]

--- a/rpc/public/vars/services.py
+++ b/rpc/public/vars/services.py
@@ -14,7 +14,7 @@ _helpers_spec = importlib.util.spec_from_file_location(
 _helpers_mod = importlib.util.module_from_spec(_helpers_spec)
 _helpers_spec.loader.exec_module(_helpers_mod)
 sys.modules["rpc.helpers"] = _helpers_mod
-get_rpcrequest_from_request = _helpers_mod.get_rpcrequest_from_request
+unbox_request = _helpers_mod.unbox_request
 
 from rpc.models import RPCResponse
 from server.modules.db_module import DbModule
@@ -43,7 +43,7 @@ async def _run_command(*cmd: str):
 
 
 async def public_vars_get_version_v1(request: Request):
-  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  rpc_request, _, _ = await unbox_request(request)
   db: DbModule = request.app.state.db
   res = await db.run(rpc_request.op, rpc_request.payload or {})
   version = res.rows[0].get("version") if res.rows else ""
@@ -55,7 +55,7 @@ async def public_vars_get_version_v1(request: Request):
   )
 
 async def public_vars_get_hostname_v1(request: Request):
-  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  rpc_request, _, _ = await unbox_request(request)
   db: DbModule = request.app.state.db
   res = await db.run(rpc_request.op, rpc_request.payload or {})
   hostname = res.rows[0].get("hostname") if res.rows else ""
@@ -67,7 +67,7 @@ async def public_vars_get_hostname_v1(request: Request):
   )
 
 async def public_vars_get_repo_v1(request: Request):
-  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  rpc_request, _, _ = await unbox_request(request)
   db: DbModule = request.app.state.db
   res = await db.run(rpc_request.op, rpc_request.payload or {})
   repo = res.rows[0].get("repo") if res.rows else ""
@@ -79,7 +79,7 @@ async def public_vars_get_repo_v1(request: Request):
   )
 
 async def public_vars_get_ffmpeg_version_v1(request: Request):
-  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  rpc_request, _, _ = await unbox_request(request)
   try:
     stdout, stderr = await _run_command("ffmpeg", "-version")
     if stdout:
@@ -99,7 +99,7 @@ async def public_vars_get_ffmpeg_version_v1(request: Request):
   )
 
 async def public_vars_get_odbc_version_v1(request: Request):
-  rpc_request, _, _ = await get_rpcrequest_from_request(request)
+  rpc_request, _, _ = await unbox_request(request)
   system = __import__("platform").system()
   try:
     if system == "Windows":

--- a/tests/test_auth_microsoft_home_account_lookup.py
+++ b/tests/test_auth_microsoft_home_account_lookup.py
@@ -53,10 +53,10 @@ def test_lookup_with_home_account_id(monkeypatch):
   RPCResponse = models.RPCResponse
 
   helpers = types.ModuleType("rpc.helpers")
-  async def fake_get_rpcrequest_from_request(request):
+  async def fake_unbox_request(request):
     rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
     return rpc, None, None
-  helpers.get_rpcrequest_from_request = fake_get_rpcrequest_from_request
+  helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers
 
   sys.modules.setdefault("rpc", types.ModuleType("rpc"))

--- a/tests/test_auth_microsoft_oauth_login_creation.py
+++ b/tests/test_auth_microsoft_oauth_login_creation.py
@@ -61,10 +61,10 @@ def test_fetch_user_after_create(monkeypatch):
   RPCResponse = models.RPCResponse
 
   helpers = types.ModuleType("rpc.helpers")
-  async def fake_get_rpcrequest_from_request(request):
+  async def fake_unbox_request(request):
     rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
     return rpc, None, None
-  helpers.get_rpcrequest_from_request = fake_get_rpcrequest_from_request
+  helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers
 
   sys.modules.setdefault("rpc", types.ModuleType("rpc"))

--- a/tests/test_auth_session_get_session.py
+++ b/tests/test_auth_session_get_session.py
@@ -50,10 +50,10 @@ def test_get_session(monkeypatch):
   RPCResponse = models.RPCResponse
 
   helpers = types.ModuleType("rpc.helpers")
-  async def fake_get_rpcrequest_from_request(request):
+  async def fake_unbox_request(request):
     rpc = RPCRequest(op="urn:auth:session:get_session:1", payload=None, version=1)
     return rpc, SimpleNamespace(), None
-  helpers.get_rpcrequest_from_request = fake_get_rpcrequest_from_request
+  helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers
 
   sys.modules.setdefault("server", types.ModuleType("server"))

--- a/tests/test_service_roles_services.py
+++ b/tests/test_service_roles_services.py
@@ -138,7 +138,7 @@ def test_upsert_role_calls_db_and_loads_roles():
     return rpc, None, None
 
   helpers.unbox_request = fake_get
-  svc_mod.get_rpcrequest_from_request = fake_get
+  svc_mod.unbox_request = fake_get
   db = DummyDb()
   auth = DummyAuth()
   req = DummyRequest(DummyState(db, auth))
@@ -168,7 +168,7 @@ def test_add_and_remove_member():
     return rpc, None, None
 
   helpers.unbox_request = fake_get_add
-  svc_mod.get_rpcrequest_from_request = fake_get_add
+  svc_mod.unbox_request = fake_get_add
   resp = asyncio.run(service_roles_add_role_member_v1(req))
   assert any(op == "db:security:roles:add_role_member:1" for op, _ in db.calls)
   assert resp.payload["members"] == [{"guid": "u1", "displayName": "User 1"}]
@@ -190,7 +190,7 @@ def test_add_and_remove_member():
     return rpc, None, None
 
   helpers.unbox_request = fake_get_remove
-  svc_mod.get_rpcrequest_from_request = fake_get_remove
+  svc_mod.unbox_request = fake_get_remove
   resp2 = asyncio.run(service_roles_remove_role_member_v1(req))
   assert any(op == "db:security:roles:remove_role_member:1" for op, _ in db.calls)
   assert resp2.payload["members"] == []

--- a/tests/test_storage_files_services.py
+++ b/tests/test_storage_files_services.py
@@ -61,7 +61,7 @@ real_helpers_spec.loader.exec_module(real_helpers)
 helpers_stub = types.ModuleType("rpc.helpers")
 async def _stub(request):
   raise NotImplementedError
-helpers_stub.get_rpcrequest_from_request = _stub
+helpers_stub.unbox_request = _stub
 sys.modules["rpc.helpers"] = helpers_stub
 
 # import services with stubbed helpers
@@ -102,7 +102,7 @@ def test_get_files_returns_list():
     rpc = RPCRequest(op="urn:storage:files:get_files:1", payload=None, version=1)
     auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
     return rpc, auth, None
-  svc_mod.get_rpcrequest_from_request = fake_get
+  svc_mod.unbox_request = fake_get
   storage = StorageModule()
   storage.files = [{"name": "a.txt", "url": "http://x/a.txt", "content_type": "text/plain"}]
   req = DummyRequest(storage)
@@ -120,7 +120,7 @@ def test_upload_files_calls_storage():
     )
     auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
     return rpc, auth, None
-  svc_mod.get_rpcrequest_from_request = fake_up
+  svc_mod.unbox_request = fake_up
   storage = StorageModule()
   req = DummyRequest(storage)
   resp = asyncio.run(storage_files_upload_files_v1(req))
@@ -137,7 +137,7 @@ def test_delete_files_calls_storage():
     )
     auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
     return rpc, auth, None
-  svc_mod.get_rpcrequest_from_request = fake_del
+  svc_mod.unbox_request = fake_del
   storage = StorageModule()
   req = DummyRequest(storage)
   resp = asyncio.run(storage_files_delete_files_v1(req))
@@ -155,7 +155,7 @@ def test_set_gallery_validates_file():
     )
     auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
     return rpc, auth, None
-  svc_mod.get_rpcrequest_from_request = fake_set
+  svc_mod.unbox_request = fake_set
   storage = StorageModule()
   storage.files = [{"name": "a.txt", "url": "http://x/a.txt"}]
   req = DummyRequest(storage)

--- a/tests/test_system_config_services.py
+++ b/tests/test_system_config_services.py
@@ -63,7 +63,7 @@ async def fake_get(request: Request):
   auth_ctx = SimpleNamespace(user_guid='u1', roles=[])
   return rpc_req, auth_ctx, None
 
-svc.get_rpcrequest_from_request = fake_get
+svc.unbox_request = fake_get
 
 class DummyDb:
   def __init__(self):

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -49,7 +49,7 @@ real_helpers_spec.loader.exec_module(real_helpers)
 helpers_stub = types.ModuleType("rpc.helpers")
 async def _stub(request):
   raise NotImplementedError
-helpers_stub.get_rpcrequest_from_request = _stub
+helpers_stub.unbox_request = _stub
 sys.modules["rpc.helpers"] = helpers_stub
 
 # import services with stubbed helpers
@@ -101,7 +101,7 @@ def test_get_roles_service_returns_mask():
   async def fake_get(request):
     rpc = RPCRequest(op="urn:users:profile:get_roles:1", payload=None, version=1)
     return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.get_rpcrequest_from_request = fake_get
+  svc_mod.unbox_request = fake_get
   db = DummyDb(roles=5)
   req = DummyRequest(DummyState(db))
   resp = asyncio.run(users_profile_get_roles_v1(req))
@@ -113,7 +113,7 @@ def test_set_roles_service_calls_db():
   async def fake_set(request):
     rpc = RPCRequest(op="urn:users:profile:set_roles:1", payload={"roles": 7}, version=1)
     return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.get_rpcrequest_from_request = fake_set
+  svc_mod.unbox_request = fake_set
   db = DummyDb()
   req = DummyRequest(DummyState(db))
   resp = asyncio.run(users_profile_set_roles_v1(req))
@@ -124,7 +124,7 @@ def test_set_profile_image_calls_db():
   async def fake_img(request):
     rpc = RPCRequest(op="urn:users:profile:set_profile_image:1", payload={"image_b64": "abc", "provider": "microsoft"}, version=1)
     return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.get_rpcrequest_from_request = fake_img
+  svc_mod.unbox_request = fake_img
   db = DummyDb()
   req = DummyRequest(DummyState(db))
   resp = asyncio.run(users_profile_set_profile_image_v1(req))
@@ -136,7 +136,7 @@ def test_missing_user_guid_raises():
   async def fake_get(request):
     rpc = RPCRequest(op="urn:users:profile:get_roles:1", payload=None, version=1)
     return rpc, SimpleNamespace(user_guid=None), None
-  svc_mod.get_rpcrequest_from_request = fake_get
+  svc_mod.unbox_request = fake_get
   db = DummyDb()
   req = DummyRequest(DummyState(db))
   with pytest.raises(HTTPException) as exc:

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -49,7 +49,7 @@ real_helpers_spec.loader.exec_module(real_helpers)
 helpers_stub = types.ModuleType("rpc.helpers")
 async def _stub(request):
   raise NotImplementedError
-helpers_stub.get_rpcrequest_from_request = _stub
+helpers_stub.unbox_request = _stub
 sys.modules["rpc.helpers"] = helpers_stub
 
 # import services with stubbed helpers
@@ -92,7 +92,7 @@ def test_set_provider_calls_db():
   async def fake_get(request):
     rpc = RPCRequest(op="urn:users:providers:set_provider:1", payload={"provider": "microsoft"}, version=1)
     return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.get_rpcrequest_from_request = fake_get
+  svc_mod.unbox_request = fake_get
   db = DummyDb()
   req = DummyRequest(DummyState(db))
   resp = asyncio.run(users_providers_set_provider_v1(req))
@@ -105,7 +105,7 @@ def test_set_provider_missing_provider_raises():
   async def fake_get(request):
     rpc = RPCRequest(op="urn:users:providers:set_provider:1", payload={}, version=1)
     return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.get_rpcrequest_from_request = fake_get
+  svc_mod.unbox_request = fake_get
   db = DummyDb()
   req = DummyRequest(DummyState(db))
   with pytest.raises(HTTPException) as exc:


### PR DESCRIPTION
## Summary
- update remaining tests to use `unbox_request`
- switch public links/vars services to `unbox_request`

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5ee52782c83258cc4a0bc022f535a