### PR TITLE
fix: remove deprecated DISPATCHERS import

### DIFF
--- a/rpc/service/handler.py
+++ b/rpc/service/handler.py
@@ -11,7 +11,7 @@ from rpc.helpers import unbox_request
 from rpc.models import RPCResponse
 from server.modules.auth_module import AuthModule
 
-from . import DISPATCHERS, HANDLERS
+from . import HANDLERS
 
 REQUIRED_ROLE_MASK = 0x4000000000000000  # ROLE_SERVICE_ADMIN
 


### PR DESCRIPTION
## Summary
- remove leftover DISPATCHERS import from service RPC handler to avoid missing symbol error

## Testing
- `python scripts/generate_rpc_client.py`
- `python scripts/generate_rpc_library.py`
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68a60b04e194832589062eb9715374c6