### PR TITLE
Limit role updates to support namespace

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -33,7 +33,7 @@ All Support domain calls require `ROLE_SUPPORT`.
 
 ## Users Domain
 
-All Users domain calls require `ROLE_USERS_ENABLED`.
+All Users domain calls require `ROLE_REGISTERED`.
 
 ### `profile`
 
@@ -93,7 +93,7 @@ User focused calls used by the React application.
 
 ## Storage Domain
 
-Calls for user storage management. All Storage domain calls require `ROLE_STORAGE_ENABLED`.
+Calls for user storage management. All Storage domain calls require `ROLE_STORAGE`.
 
 ### `files`
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,10 @@ flags.
 | 1   | `0x0000000000000002`  | `ROLE_STORAGE`            | Allows access to the storage domain |
 | 0   | `0x0000000000000001`  | `ROLE_REGISTERED`         | Grants access to profile and provider management |
 
+The two lowest bits represent the base user roles: `ROLE_REGISTERED`
+for profile and provider access and `ROLE_STORAGE` for the storage
+domain.
+
 ## Role Macros
 
 `ROLE_GLOBAL_ADMIN = ROLE_SERVICE_ADMIN | ROLE_SYSTEM_ADMIN | ROLE_MODERATOR | ROLE_SUPPORT`

--- a/frontend/src/rpc/users/profile/index.ts
+++ b/frontend/src/rpc/users/profile/index.ts
@@ -10,5 +10,4 @@ export const fetchProfile = (payload: any = null): Promise<any> => rpcCall('urn:
 export const fetchSetDisplay = (payload: any = null): Promise<any> => rpcCall('urn:users:profile:set_display:1', payload);
 export const fetchSetOptin = (payload: any = null): Promise<any> => rpcCall('urn:users:profile:set_optin:1', payload);
 export const fetchRoles = (payload: any = null): Promise<any> => rpcCall('urn:users:profile:get_roles:1', payload);
-export const fetchSetRoles = (payload: any = null): Promise<any> => rpcCall('urn:users:profile:set_roles:1', payload);
 export const fetchSetProfileImage = (payload: any = null): Promise<any> => rpcCall('urn:users:profile:set_profile_image:1', payload);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -21,28 +21,41 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
-export interface StorageFilesDeleteFiles1 {
-  files: string[];
-}
-export interface StorageFilesFileItem1 {
+export interface UsersProfileAuthProvider1 {
   name: string;
-  url: string;
-  content_type: string | null;
+  display: string;
 }
-export interface StorageFilesFiles1 {
-  files: StorageFilesFileItem1[];
+export interface UsersProfileProfile1 {
+  guid: string;
+  display_name: string;
+  email: string;
+  display_email: boolean;
+  credits: number;
+  profile_image: string | null;
+  default_provider: string;
+  auth_providers: UsersProfileAuthProvider1[];
 }
-export interface StorageFilesSetGallery1 {
-  name: string;
-  gallery: boolean;
+export interface UsersProfileRoles1 {
+  roles: number;
 }
-export interface StorageFilesUploadFile1 {
-  name: string;
-  content_b64: string;
-  content_type: string | null;
+export interface UsersProfileSetDisplay1 {
+  display_name: string;
 }
-export interface StorageFilesUploadFiles1 {
-  files: StorageFilesUploadFile1[];
+export interface UsersProfileSetOptin1 {
+  display_email: boolean;
+}
+export interface UsersProfileSetProfileImage1 {
+  image_b64: string;
+  provider: string;
+}
+export interface UsersProvidersSetProvider1 {
+  provider: string;
+}
+export interface AuthMicrosoftOauthLogin1 {
+  sessionToken: string;
+  display_name: string;
+  credits: number;
+  profile_image: string | null;
 }
 export interface ServiceRolesDeleteRole1 {
   name: string;
@@ -66,29 +79,6 @@ export interface ServiceRolesUpsertRole1 {
 export interface ServiceRolesUserItem1 {
   guid: string;
   displayName: string;
-}
-export interface SystemConfigConfigItem1 {
-  key: string;
-  value: string;
-}
-export interface SystemConfigDeleteConfig1 {
-  key: string;
-}
-export interface SystemConfigList1 {
-  items: SystemConfigConfigItem1[];
-}
-export interface SystemRoutesDeleteRoute1 {
-  path: string;
-}
-export interface SystemRoutesList1 {
-  routes: SystemRoutesRouteItem1[];
-}
-export interface SystemRoutesRouteItem1 {
-  path: string;
-  name: string;
-  icon: string | null;
-  sequence: number;
-  required_roles: string[];
 }
 export interface PublicVarsFfmpegVersion1 {
   ffmpeg_version: string;
@@ -120,11 +110,58 @@ export interface PublicLinksNavBarRoute1 {
 export interface PublicLinksNavBarRoutes1 {
   routes: PublicLinksNavBarRoute1[];
 }
-export interface AuthMicrosoftOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
+export interface SystemConfigConfigItem1 {
+  key: string;
+  value: string;
+}
+export interface SystemConfigDeleteConfig1 {
+  key: string;
+}
+export interface SystemConfigList1 {
+  items: SystemConfigConfigItem1[];
+}
+export interface SystemRoutesDeleteRoute1 {
+  path: string;
+}
+export interface SystemRoutesList1 {
+  routes: SystemRoutesRouteItem1[];
+}
+export interface SystemRoutesRouteItem1 {
+  path: string;
+  name: string;
+  icon: string | null;
+  sequence: number;
+  required_roles: string[];
+}
+export interface StorageFilesDeleteFiles1 {
+  files: string[];
+}
+export interface StorageFilesFileItem1 {
+  name: string;
+  url: string;
+  content_type: string | null;
+}
+export interface StorageFilesFiles1 {
+  files: StorageFilesFileItem1[];
+}
+export interface StorageFilesSetGallery1 {
+  name: string;
+  gallery: boolean;
+}
+export interface StorageFilesUploadFile1 {
+  name: string;
+  content_b64: string;
+  content_type: string | null;
+}
+export interface StorageFilesUploadFiles1 {
+  files: StorageFilesUploadFile1[];
+}
+export interface SupportUsersGuid1 {
+  userGuid: string;
+}
+export interface SupportUsersSetCredits1 {
+  userGuid: string;
   credits: number;
-  profile_image: string | null;
 }
 export interface SupportRolesMembers1 {
   members: SupportRolesUserItem1[];
@@ -137,43 +174,6 @@ export interface SupportRolesRoleMemberUpdate1 {
 export interface SupportRolesUserItem1 {
   guid: string;
   displayName: string;
-}
-export interface SupportUsersGuid1 {
-  userGuid: string;
-}
-export interface SupportUsersSetCredits1 {
-  userGuid: string;
-  credits: number;
-}
-export interface UsersProfileAuthProvider1 {
-  name: string;
-  display: string;
-}
-export interface UsersProfileProfile1 {
-  guid: string;
-  display_name: string;
-  email: string;
-  display_email: boolean;
-  credits: number;
-  profile_image: string | null;
-  default_provider: string;
-  auth_providers: UsersProfileAuthProvider1[];
-}
-export interface UsersProfileRoles1 {
-  roles: number;
-}
-export interface UsersProfileSetDisplay1 {
-  display_name: string;
-}
-export interface UsersProfileSetOptin1 {
-  display_email: boolean;
-}
-export interface UsersProfileSetProfileImage1 {
-  image_b64: string;
-  provider: string;
-}
-export interface UsersProvidersSetProvider1 {
-  provider: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/storage/__init__.py
+++ b/rpc/storage/__init__.py
@@ -1,6 +1,6 @@
 """Storage namespace for file handling operations.
 
-Requires ROLE_STORAGE_ENABLED.
+Requires ROLE_STORAGE.
 """
 
 from .files.handler import handle_files_request

--- a/rpc/storage/files/__init__.py
+++ b/rpc/storage/files/__init__.py
@@ -1,6 +1,6 @@
 """File storage RPC namespace.
 
-Requires ROLE_STORAGE_ENABLED.
+Requires ROLE_STORAGE.
 """
 
 from .services import (

--- a/rpc/storage/files/handler.py
+++ b/rpc/storage/files/handler.py
@@ -1,6 +1,6 @@
 """Storage files RPC handler.
 
-Dispatches file operations requiring ROLE_STORAGE_ENABLED.
+Dispatches file operations requiring ROLE_STORAGE.
 """
 
 from fastapi import HTTPException, Request

--- a/rpc/storage/handler.py
+++ b/rpc/storage/handler.py
@@ -1,6 +1,6 @@
 """Storage RPC namespace.
 
-Provides storage operations requiring ROLE_STORAGE_ENABLED.
+Provides storage operations requiring ROLE_STORAGE.
 Auth and public domains are exempt from role checks.
 """
 
@@ -12,7 +12,7 @@ from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
-REQUIRED_ROLE_MASK = 0x0000000000000002  # ROLE_STORAGE_ENABLED
+REQUIRED_ROLE_MASK = 0x0000000000000002  # ROLE_STORAGE
 
 
 async def handle_storage_request(parts: list[str], request: Request) -> RPCResponse:

--- a/rpc/users/__init__.py
+++ b/rpc/users/__init__.py
@@ -1,6 +1,6 @@
 """User namespace for profiles and authentication providers.
 
-All subdomains require ROLE_USERS_ENABLED.
+All subdomains require ROLE_REGISTERED.
 """
 
 from .profile.handler import handle_profile_request

--- a/rpc/users/handler.py
+++ b/rpc/users/handler.py
@@ -1,6 +1,6 @@
 """Users RPC namespace.
 
-Manages user operations requiring ROLE_USERS_ENABLED.
+Manages user operations requiring ROLE_REGISTERED.
 Auth and public domains are exempt from role checks.
 """
 
@@ -12,7 +12,7 @@ from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
-REQUIRED_ROLE_MASK = 0x0000000000000001  # ROLE_USERS_ENABLED
+REQUIRED_ROLE_MASK = 0x0000000000000001  # ROLE_REGISTERED
 
 
 async def handle_users_request(parts: list[str], request: Request) -> RPCResponse:

--- a/rpc/users/profile/__init__.py
+++ b/rpc/users/profile/__init__.py
@@ -1,6 +1,6 @@
 """Users profile RPC namespace.
 
-Requires ROLE_USERS_ENABLED.
+Requires ROLE_REGISTERED.
 """
 
 from .services import (
@@ -8,7 +8,6 @@ from .services import (
   users_profile_set_display_v1,
   users_profile_set_optin_v1,
   users_profile_get_roles_v1,
-  users_profile_set_roles_v1,
   users_profile_set_profile_image_v1
 )
 
@@ -18,7 +17,6 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("set_display", "1"): users_profile_set_display_v1,
   ("set_optin", "1"): users_profile_set_optin_v1,
   ("get_roles", "1"): users_profile_get_roles_v1,
-  ("set_roles", "1"): users_profile_set_roles_v1,
   ("set_profile_image", "1"): users_profile_set_profile_image_v1
 }
 

--- a/rpc/users/profile/handler.py
+++ b/rpc/users/profile/handler.py
@@ -1,6 +1,6 @@
 """Users profile RPC handler.
 
-Dispatches profile operations requiring ROLE_USERS_ENABLED.
+Dispatches profile operations requiring ROLE_REGISTERED.
 """
 
 from fastapi import HTTPException, Request

--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -95,21 +95,6 @@ async def users_profile_get_roles_v1(request: Request):
     version=rpc_request.version,
   )
 
-async def users_profile_set_roles_v1(request: Request):
-  rpc_request, auth_ctx, _ = await unbox_request(request)
-  user_guid = auth_ctx.user_guid
-  if user_guid is None:
-    raise HTTPException(status_code=400, detail="Missing user GUID")
-
-  payload = UsersProfileRoles1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  await db.run(rpc_request.op, {"guid": user_guid, "roles": payload.roles})
-  return RPCResponse(
-    op=rpc_request.op,
-    payload=payload.model_dump(),
-    version=rpc_request.version,
-  )
-
 async def users_profile_set_profile_image_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   user_guid = auth_ctx.user_guid

--- a/rpc/users/providers/__init__.py
+++ b/rpc/users/providers/__init__.py
@@ -1,7 +1,7 @@
 """Users providers RPC namespace.
 
 Manage authentication providers for a user. Requires
-ROLE_USERS_ENABLED.
+ROLE_REGISTERED.
 """
 
 from .services import (

--- a/rpc/users/providers/handler.py
+++ b/rpc/users/providers/handler.py
@@ -1,6 +1,6 @@
 """Users providers RPC handler.
 
-Dispatches provider management operations. Requires ROLE_USERS_ENABLED.
+Dispatches provider management operations. Requires ROLE_REGISTERED.
 """
 
 from fastapi import HTTPException, Request

--- a/tests/test_storage_files_services.py
+++ b/tests/test_storage_files_services.py
@@ -92,7 +92,7 @@ storage_files_set_gallery_v1 = svc_mod.storage_files_set_gallery_v1
 
 class DummyAuth:
   def __init__(self):
-    self.roles = {"ROLE_STORAGE_ENABLED": 0x2}
+    self.roles = {"ROLE_STORAGE": 0x2}
 
 
 class DummyState:
@@ -113,7 +113,7 @@ class DummyRequest:
 def test_get_files_returns_list():
   async def fake_get(request):
     rpc = RPCRequest(op="urn:storage:files:get_files:1", payload=None, version=1)
-    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
+    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE"], role_mask=0x2)
     return rpc, auth, None
   svc_mod.unbox_request = fake_get
   storage = StorageModule()
@@ -131,7 +131,7 @@ def test_upload_files_calls_storage():
       payload={"files": [{"name": "a.txt", "content_b64": "YQ==", "content_type": "text/plain"}]},
       version=1,
     )
-    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
+    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE"], role_mask=0x2)
     return rpc, auth, None
   svc_mod.unbox_request = fake_up
   storage = StorageModule()
@@ -148,7 +148,7 @@ def test_delete_files_calls_storage():
       payload={"files": ["a.txt", "b.txt"]},
       version=1,
     )
-    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
+    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE"], role_mask=0x2)
     return rpc, auth, None
   svc_mod.unbox_request = fake_del
   storage = StorageModule()
@@ -166,7 +166,7 @@ def test_set_gallery_validates_file():
       payload={"name": "a.txt", "gallery": True},
       version=1,
     )
-    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE_ENABLED"], role_mask=0x2)
+    auth = SimpleNamespace(user_guid="u1", roles=["ROLE_STORAGE"], role_mask=0x2)
     return rpc, auth, None
   svc_mod.unbox_request = fake_set
   storage = StorageModule()

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -61,7 +61,6 @@ svc_spec.loader.exec_module(svc_mod)
 sys.modules["rpc.helpers"] = real_helpers
 
 users_profile_get_roles_v1 = svc_mod.users_profile_get_roles_v1
-users_profile_set_roles_v1 = svc_mod.users_profile_set_roles_v1
 users_profile_set_profile_image_v1 = svc_mod.users_profile_set_profile_image_v1
 
 class DBRes:
@@ -77,9 +76,6 @@ class DummyDb:
     self.calls.append((op, args))
     if op == "urn:users:profile:get_roles:1":
       return DBRes([{"element_roles": self.roles}], 1)
-    if op == "urn:users:profile:set_roles:1":
-      self.roles = args["roles"]
-      return DBRes([], 1)
     if op == "urn:users:profile:set_profile_image:1":
       return DBRes([], 1)
     return DBRes()
@@ -108,17 +104,6 @@ def test_get_roles_service_returns_mask():
   assert isinstance(resp, RPCResponse)
   assert resp.payload["roles"] == 5
   assert ("urn:users:profile:get_roles:1", {"guid": "u1"}) in db.calls
-
-def test_set_roles_service_calls_db():
-  async def fake_set(request):
-    rpc = RPCRequest(op="urn:users:profile:set_roles:1", payload={"roles": 7}, version=1)
-    return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.unbox_request = fake_set
-  db = DummyDb()
-  req = DummyRequest(DummyState(db))
-  resp = asyncio.run(users_profile_set_roles_v1(req))
-  assert ("urn:users:profile:set_roles:1", {"guid": "u1", "roles": 7}) in db.calls
-  assert resp.payload["roles"] == 7
 
 def test_set_profile_image_calls_db():
   async def fake_img(request):


### PR DESCRIPTION
## Summary
- remove users_profile_set_roles_v1 to prevent self-escalation
- regenerate RPC bindings after endpoint removal
- update tests to reflect read-only user role access
- rename ROLE_USERS_ENABLED to ROLE_REGISTERED and ROLE_STORAGE_ENABLED to ROLE_STORAGE
- clarify base roles in SECURITY.md

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68a610e32d108325a773dca0fc7b1dc9