### PR TITLE
Enable Google login and account linking

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,8 @@
 	<link rel="icon" href="/favicon.ico" />
 	<meta name="description" content="The Elideus Group - AI Engineering and Consulting Services">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<script type="module" src="/src/index.tsx"></script>
+        <script src="https://accounts.google.com/gsi/client" async defer></script>
+        <script type="module" src="/src/index.tsx"></script>
 </head>
 <body>
 	<div id="root"></div>

--- a/frontend/src/config/google.ts
+++ b/frontend/src/config/google.ts
@@ -1,0 +1,5 @@
+export const googleConfig = {
+	clientId: 'google-client-id-placeholder',
+	scope: 'openid profile email',
+};
+export default googleConfig;

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -21,35 +21,56 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
-export interface StorageFilesDeleteFiles1 {
-  files: string[];
-}
-export interface StorageFilesFileItem1 {
-  name: string;
-  url: string;
-  content_type: string | null;
-}
-export interface StorageFilesFiles1 {
-  files: StorageFilesFileItem1[];
-}
-export interface StorageFilesSetGallery1 {
-  name: string;
-  gallery: boolean;
-}
-export interface StorageFilesUploadFile1 {
-  name: string;
-  content_b64: string;
-  content_type: string | null;
-}
-export interface StorageFilesUploadFiles1 {
-  files: StorageFilesUploadFile1[];
-}
-export interface SupportUsersGuid1 {
-  userGuid: string;
-}
-export interface SupportUsersSetCredits1 {
-  userGuid: string;
+export interface AuthMicrosoftOauthLogin1 {
+  sessionToken: string;
+  display_name: string;
   credits: number;
+  profile_image: string | null;
+}
+export interface AuthGoogleOauthLogin1 {
+  sessionToken: string;
+  display_name: string;
+  credits: number;
+  profile_image: string | null;
+}
+export interface SystemRolesDeleteRole1 {
+  name: string;
+}
+export interface SystemRolesList1 {
+  roles: SystemRolesRoleItem1[];
+}
+export interface SystemRolesRoleItem1 {
+  name: string;
+  mask: string;
+  display: any;
+}
+export interface SystemRolesUpsertRole1 {
+  name: string;
+  mask: string;
+  display: any;
+}
+export interface SystemConfigConfigItem1 {
+  key: string;
+  value: string;
+}
+export interface SystemConfigDeleteConfig1 {
+  key: string;
+}
+export interface SystemConfigList1 {
+  items: SystemConfigConfigItem1[];
+}
+export interface SystemRoutesDeleteRoute1 {
+  path: string;
+}
+export interface SystemRoutesList1 {
+  routes: SystemRoutesRouteItem1[];
+}
+export interface SystemRoutesRouteItem1 {
+  path: string;
+  name: string;
+  icon: string | null;
+  sequence: number;
+  required_roles: string[];
 }
 export interface SupportRolesMembers1 {
   members: SupportRolesUserItem1[];
@@ -62,6 +83,65 @@ export interface SupportRolesRoleMemberUpdate1 {
 export interface SupportRolesUserItem1 {
   guid: string;
   displayName: string;
+}
+export interface SupportUsersGuid1 {
+  userGuid: string;
+}
+export interface SupportUsersSetCredits1 {
+  userGuid: string;
+  credits: number;
+}
+export interface PublicVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface PublicVarsHostname1 {
+  hostname: string;
+}
+export interface PublicVarsOdbcVersion1 {
+  odbc_version: string;
+}
+export interface PublicVarsRepo1 {
+  repo: string;
+}
+export interface PublicVarsVersion1 {
+  version: string;
+}
+export interface PublicLinksHomeLinks1 {
+  links: PublicLinksLinkItem1[];
+}
+export interface PublicLinksLinkItem1 {
+  title: string;
+  url: string;
+}
+export interface PublicLinksNavBarRoute1 {
+  path: string;
+  name: string;
+  icon: string | null;
+}
+export interface PublicLinksNavBarRoutes1 {
+  routes: PublicLinksNavBarRoute1[];
+}
+export interface UsersProvidersCreateFromProvider1 {
+  provider: string;
+  provider_identifier: string;
+  provider_email: string;
+  provider_displayname: string;
+  provider_profile_image: any;
+}
+export interface UsersProvidersGetByProviderIdentifier1 {
+  provider: string;
+  provider_identifier: string;
+}
+export interface UsersProvidersLinkProvider1 {
+  provider: string;
+  id_token: string;
+  access_token: string;
+}
+export interface UsersProvidersSetProvider1 {
+  provider: string;
+}
+export interface UsersProvidersUnlinkProvider1 {
+  provider: string;
 }
 export interface UsersProfileAuthProvider1 {
   name: string;
@@ -90,58 +170,6 @@ export interface UsersProfileSetProfileImage1 {
   image_b64: string;
   provider: string;
 }
-export interface UsersProvidersCreateFromProvider1 {
-  provider: string;
-  provider_identifier: string;
-  provider_email: string;
-  provider_displayname: string;
-  provider_profile_image: any;
-}
-export interface UsersProvidersGetByProviderIdentifier1 {
-  provider: string;
-  provider_identifier: string;
-}
-export interface UsersProvidersLinkProvider1 {
-  provider: string;
-  id_token: string;
-  access_token: string;
-}
-export interface UsersProvidersSetProvider1 {
-  provider: string;
-}
-export interface UsersProvidersUnlinkProvider1 {
-  provider: string;
-}
-export interface PublicLinksHomeLinks1 {
-  links: PublicLinksLinkItem1[];
-}
-export interface PublicLinksLinkItem1 {
-  title: string;
-  url: string;
-}
-export interface PublicLinksNavBarRoute1 {
-  path: string;
-  name: string;
-  icon: string | null;
-}
-export interface PublicLinksNavBarRoutes1 {
-  routes: PublicLinksNavBarRoute1[];
-}
-export interface PublicVarsFfmpegVersion1 {
-  ffmpeg_version: string;
-}
-export interface PublicVarsHostname1 {
-  hostname: string;
-}
-export interface PublicVarsOdbcVersion1 {
-  odbc_version: string;
-}
-export interface PublicVarsRepo1 {
-  repo: string;
-}
-export interface PublicVarsVersion1 {
-  version: string;
-}
 export interface ServiceRolesDeleteRole1 {
   name: string;
 }
@@ -165,56 +193,28 @@ export interface ServiceRolesUserItem1 {
   guid: string;
   displayName: string;
 }
-export interface SystemRoutesDeleteRoute1 {
-  path: string;
+export interface StorageFilesDeleteFiles1 {
+  files: string[];
 }
-export interface SystemRoutesList1 {
-  routes: SystemRoutesRouteItem1[];
-}
-export interface SystemRoutesRouteItem1 {
-  path: string;
+export interface StorageFilesFileItem1 {
   name: string;
-  icon: string | null;
-  sequence: number;
-  required_roles: string[];
+  url: string;
+  content_type: string | null;
 }
-export interface SystemConfigConfigItem1 {
-  key: string;
-  value: string;
+export interface StorageFilesFiles1 {
+  files: StorageFilesFileItem1[];
 }
-export interface SystemConfigDeleteConfig1 {
-  key: string;
-}
-export interface SystemConfigList1 {
-  items: SystemConfigConfigItem1[];
-}
-export interface SystemRolesDeleteRole1 {
+export interface StorageFilesSetGallery1 {
   name: string;
+  gallery: boolean;
 }
-export interface SystemRolesList1 {
-  roles: SystemRolesRoleItem1[];
-}
-export interface SystemRolesRoleItem1 {
+export interface StorageFilesUploadFile1 {
   name: string;
-  mask: string;
-  display: any;
+  content_b64: string;
+  content_type: string | null;
 }
-export interface SystemRolesUpsertRole1 {
-  name: string;
-  mask: string;
-  display: any;
-}
-export interface AuthGoogleOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
-  credits: number;
-  profile_image: string | null;
-}
-export interface AuthMicrosoftOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
-  credits: number;
-  profile_image: string | null;
+export interface StorageFilesUploadFiles1 {
+  files: StorageFilesUploadFile1[];
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/frontend/src/shared/UserContext.tsx
+++ b/frontend/src/shared/UserContext.tsx
@@ -1,16 +1,20 @@
 import { createContext } from 'react';
-import type { AuthMicrosoftOauthLogin1 } from './RpcModels';
+import type { AuthMicrosoftOauthLogin1, AuthGoogleOauthLogin1 } from './RpcModels';
+
+export type AuthTokens = (AuthMicrosoftOauthLogin1 | AuthGoogleOauthLogin1) & {
+	provider: string;
+};
 
 export interface UserContext {
-        userData: AuthMicrosoftOauthLogin1 | null;
-        setUserData: (data: AuthMicrosoftOauthLogin1) => void;
-        clearUserData: () => void;
+	userData: AuthTokens | null;
+	setUserData: (data: AuthTokens) => void;
+	clearUserData: () => void;
 }
 
 const defaultContext: UserContext = {
-        userData: null,
-        setUserData: () => {},
-        clearUserData: () => {},
+	userData: null,
+	setUserData: () => {},
+	clearUserData: () => {},
 };
 
 const UserContextObject = createContext<UserContext>(defaultContext);


### PR DESCRIPTION
## Summary
- enable Google identity script and configuration
- add Google sign-in flow and user linking
- store auth provider in user context

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a73d8e3ec0832598cafe0b02521fa4