### PR TITLE
Fix OAuth login loop and disable unsupported providers

### DIFF
--- a/frontend/src/LoginPage.tsx
+++ b/frontend/src/LoginPage.tsx
@@ -86,13 +86,13 @@ setNotification({ open: true, severity: 'error', message: `Login failed: ${error
 				<Typography component='h1' variant='h5' align='center'>
 					Sign in
 				</Typography>
-				<Typography variant='body2' align='center' sx={{ mt: 2 }}>
-					Only OAuth providers are supported. Please sign in using one of the following services:
-					<br />
-					Microsoft, Discord, Google, or Apple.
-					<br />
-					<strong>Note:</strong> Email-only login is not available.
-				</Typography>
+                                <Typography variant='body2' align='center' sx={{ mt: 2 }}>
+                                        Only OAuth providers are supported. Please sign in using Microsoft or Google.
+                                        <br />
+                                        Discord and Apple support are coming soon.
+                                        <br />
+                                        <strong>Note:</strong> Email-only login is not available.
+                                </Typography>
 				<Stack spacing={2} sx={{ mt: 4 }}>
 					<Button variant='contained' fullWidth onClick={handleMicrosoftLogin}>
 						Sign in with Microsoft


### PR DESCRIPTION
## Summary
- avoid repeated Microsoft login refreshes by guarding token update logic
- restrict account linking to Microsoft and Google and mark Discord/Apple as coming soon
- clarify supported providers on the login page

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68a7423e7ea8832598bacd9aea9df96a