### PR TITLE
Add DB helpers for provider API IDs

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -39,10 +39,7 @@ class AuthModule(BaseModule):
     try:
       if "microsoft" in providers_cfg:
         logging.debug("[AuthModule] Loading Microsoft provider")
-        res = await self.db.run("db:system:config:get_config:1", {"key": "MsApiId"})
-        if not res.rows:
-          raise ValueError("Missing config value for key: MsApiId")
-        ms_api_id = res.rows[0]["value"]
+        ms_api_id = await self.db.get_ms_api_id()
         logging.debug("[AuthModule] MsApiId=%s", ms_api_id)
         provider = await MicrosoftAuthProvider.create(api_id=ms_api_id, jwks_expiry=timedelta(minutes=self.jwks_cache_minutes))
         await provider._get_jwks()
@@ -50,10 +47,7 @@ class AuthModule(BaseModule):
         logging.debug("[AuthModule] Microsoft provider ready")
       if "google" in providers_cfg:
         logging.debug("[AuthModule] Loading Google provider")
-        res = await self.db.run("db:system:config:get_config:1", {"key": "GoogleApiId"})
-        if not res.rows:
-          raise ValueError("Missing config value for key: GoogleApiId")
-        google_api_id = res.rows[0]["value"]
+        google_api_id = await self.db.get_google_api_id()
         logging.debug("[AuthModule] GoogleApiId=%s", google_api_id)
         provider = await GoogleAuthProvider.create(api_id=google_api_id, jwks_expiry=timedelta(minutes=self.jwks_cache_minutes))
         await provider._get_jwks()

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -76,3 +76,15 @@ class DbModule(BaseModule):
 
   async def run(self, op: str, args: Dict[str, Any]) -> DBResult:
     return await run(op, args)
+
+  async def get_ms_api_id(self) -> str:
+    res = await self.run("db:system:config:get_config:1", {"key": "MsApiId"})
+    if not res.rows:
+      raise ValueError("Missing config value for key: MsApiId")
+    return res.rows[0]["value"]
+
+  async def get_google_api_id(self) -> str:
+    res = await self.run("db:system:config:get_config:1", {"key": "GoogleApiId"})
+    if not res.rows:
+      raise ValueError("Missing config value for key: GoogleApiId")
+    return res.rows[0]["value"]

--- a/tests/test_db_module_api_ids.py
+++ b/tests/test_db_module_api_ids.py
@@ -1,0 +1,32 @@
+import asyncio
+from fastapi import FastAPI
+
+from server.modules.db_module import DbModule
+from server.modules.providers.models import DBResult
+
+
+def test_get_google_api_id():
+  app = FastAPI()
+  db = DbModule(app)
+
+  async def fake_run(op, args):
+    assert op == "db:system:config:get_config:1"
+    assert args == {"key": "GoogleApiId"}
+    return DBResult(rows=[{"value": "gid"}], rowcount=1)
+
+  db.run = fake_run
+  assert asyncio.run(db.get_google_api_id()) == "gid"
+
+
+def test_get_ms_api_id():
+  app = FastAPI()
+  db = DbModule(app)
+
+  async def fake_run(op, args):
+    assert op == "db:system:config:get_config:1"
+    assert args == {"key": "MsApiId"}
+    return DBResult(rows=[{"value": "mid"}], rowcount=1)
+
+  db.run = fake_run
+  assert asyncio.run(db.get_ms_api_id()) == "mid"
+


### PR DESCRIPTION
## Summary
- add DbModule helpers to retrieve Google and Microsoft API IDs
- use new helpers when initializing auth providers
- cover API ID lookups with unit tests

## Testing
- `python scripts/generate_rpc_client.py`
- `python scripts/generate_rpc_library.py`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68a74821951883259cee3a3ccbec3c22