### PR TITLE
Add debug logging for Google auth

### DIFF
--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -124,6 +124,10 @@ async def auth_google_oauth_login_v1(request: Request):
 
   auth: AuthModule = request.app.state.auth
   db: DbModule = request.app.state.db
+  providers = getattr(auth, "providers", {})
+  google_provider = providers.get("google") if isinstance(providers, dict) else None
+  if google_provider:
+    logging.debug("[auth_google_oauth_login_v1] GoogleApiId=%s", google_provider.audience)
 
   provider_uid, profile, payload = await auth.handle_auth_login(
     provider, id_token, access_token

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -3,6 +3,7 @@
 from importlib import import_module
 from typing import Any, Dict, cast, Awaitable, Callable
 from fastapi import FastAPI
+import logging
 
 from . import BaseModule
 from .env_module import EnvModule
@@ -85,6 +86,8 @@ class DbModule(BaseModule):
 
   async def get_google_api_id(self) -> str:
     res = await self.run("db:system:config:get_config:1", {"key": "GoogleApiId"})
-    if not res.rows:
+    value = res.rows[0]["value"] if res.rows else None
+    logging.debug("[DbModule] GoogleApiId=%s", value)
+    if not value:
       raise ValueError("Missing config value for key: GoogleApiId")
-    return res.rows[0]["value"]
+    return value

--- a/server/modules/providers/google.py
+++ b/server/modules/providers/google.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from typing import Dict, Any
 
 from fastapi import HTTPException, status
+import logging
 
 from server.modules.providers import AuthProvider
 
@@ -11,11 +12,14 @@ GOOGLE_ISSUER = "https://accounts.google.com"
 
 
 async def _fetch_openid_config() -> Dict[str, Any]:
+  logging.debug("[GoogleAuthProvider] Fetching OpenID configuration from %s", GOOGLE_OPENID_CONFIG)
   async with aiohttp.ClientSession() as session:
     async with session.get(GOOGLE_OPENID_CONFIG) as response:
       if response.status != 200:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Failed to fetch OpenID configuration.")
-      return await response.json()
+      config = await response.json()
+      logging.debug("[GoogleAuthProvider] OpenID configuration fetched")
+      return config
 
 
 class GoogleAuthProvider(AuthProvider):
@@ -25,6 +29,7 @@ class GoogleAuthProvider(AuthProvider):
 
   @classmethod
   async def create(cls, *, api_id: str, jwks_expiry: timedelta):
+    logging.debug("[GoogleAuthProvider] Creating provider with api_id=%s", api_id)
     config = await _fetch_openid_config()
     jwks_uri = config["jwks_uri"]
     provider = cls(api_id=api_id, jwks_uri=jwks_uri, jwks_expiry=jwks_expiry)
@@ -34,6 +39,8 @@ class GoogleAuthProvider(AuthProvider):
   async def fetch_user_profile(self, access_token: str) -> Dict[str, Any]:
     if not self.userinfo_endpoint:
       raise HTTPException(status_code=500, detail="Userinfo endpoint not configured")
+    logging.debug("[GoogleAuthProvider] Fetching user profile from %s", self.userinfo_endpoint)
+    logging.debug("[GoogleAuthProvider] access_token=%s", access_token[:40])
     async with aiohttp.ClientSession() as session:
       headers = {"Authorization": f"Bearer {access_token}"}
       async with session.get(self.userinfo_endpoint, headers=headers) as response:
@@ -41,8 +48,8 @@ class GoogleAuthProvider(AuthProvider):
           error_message = await response.text()
           raise HTTPException(status_code=500, detail=f"Failed to fetch user profile. Status: {response.status}, Error: {error_message}")
         user = await response.json()
-      return {
-        "email": user.get("email"),
-        "username": user.get("name"),
-        "profilePicture": user.get("picture"),
-      }
+    return {
+      "email": user.get("email"),
+      "username": user.get("name"),
+      "profilePicture": user.get("picture"),
+    }


### PR DESCRIPTION
## Summary
- add GoogleApiId debug log in database module
- expand debug logging throughout Google auth provider and token verification
- log GoogleApiId in Google OAuth service

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68a74d06015483258785e478c4361e44