### PR TITLE
Load auth configuration from database

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -32,9 +32,9 @@ class AuthModule(BaseModule):
     self.db: DbModule = self.app.state.db
     await self.db.on_ready()
     self.jwt_secret = self.env.get("JWT_SECRET")
-    self.jwks_cache_minutes = int(self.env.get("JWKS_CACHE_MINUTES"))
+    self.jwks_cache_minutes = await self.db.get_jwks_cache_time()
 
-    providers_cfg = [p.strip() for p in self.env.get("AUTH_PROVIDERS").split(",") if p.strip()]
+    providers_cfg = await self.db.get_auth_providers()
     logging.debug(f"[AuthModule] Provider configuration: {providers_cfg}")
     try:
       if "microsoft" in providers_cfg:

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -91,3 +91,17 @@ class DbModule(BaseModule):
     if not value:
       raise ValueError("Missing config value for key: GoogleApiId")
     return value
+
+  async def get_auth_providers(self) -> list[str]:
+    res = await self.run("db:system:config:get_config:1", {"key": "AuthProviders"})
+    value = res.rows[0]["value"] if res.rows else None
+    if value is None:
+      raise ValueError("Missing config value for key: AuthProviders")
+    return [p.strip() for p in value.split(',') if p.strip()]
+
+  async def get_jwks_cache_time(self) -> int:
+    res = await self.run("db:system:config:get_config:1", {"key": "JwksCacheTime"})
+    value = res.rows[0]["value"] if res.rows else None
+    if value is None:
+      raise ValueError("Missing config value for key: JwksCacheTime")
+    return int(value)

--- a/server/modules/env_module.py
+++ b/server/modules/env_module.py
@@ -17,8 +17,6 @@ class EnvModule(BaseModule):
     if provider == "mssql":
       self._getenv("AZURE_SQL_CONNECTION_STRING", "MISSING_ENV_AZURE_SQL_CONNECTION_STRING")
     self._getenv("AZURE_BLOB_CONNECTION_STRING", "MISSING_ENV_AZURE_BLOB_CONNECTION_STRING")
-    self._getenv("AUTH_PROVIDERS", "microsoft")
-    self._getenv("JWKS_CACHE_MINUTES", "60")
     
     logging.info("Environment module loaded")
     self.mark_ready()

--- a/tests/test_db_module_api_ids.py
+++ b/tests/test_db_module_api_ids.py
@@ -30,3 +30,29 @@ def test_get_ms_api_id():
   db.run = fake_run
   assert asyncio.run(db.get_ms_api_id()) == "mid"
 
+
+def test_get_auth_providers():
+  app = FastAPI()
+  db = DbModule(app)
+
+  async def fake_run(op, args):
+    assert op == "db:system:config:get_config:1"
+    assert args == {"key": "AuthProviders"}
+    return DBResult(rows=[{"value": "microsoft,google"}], rowcount=1)
+
+  db.run = fake_run
+  assert asyncio.run(db.get_auth_providers()) == ["microsoft", "google"]
+
+
+def test_get_jwks_cache_time():
+  app = FastAPI()
+  db = DbModule(app)
+
+  async def fake_run(op, args):
+    assert op == "db:system:config:get_config:1"
+    assert args == {"key": "JwksCacheTime"}
+    return DBResult(rows=[{"value": "45"}], rowcount=1)
+
+  db.run = fake_run
+  assert asyncio.run(db.get_jwks_cache_time()) == 45
+


### PR DESCRIPTION
## Summary
- source auth providers and JWKS cache duration from system configuration
- drop unused AUTH_PROVIDERS and JWKS_CACHE_MINUTES env variables
- add database helpers and tests for new config keys

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68a76ba164d48325b2a28fe2bf3d5515