### PR TITLE
Use authorization code for provider linking

### DIFF
--- a/frontend/src/UserPage.tsx
+++ b/frontend/src/UserPage.tsx
@@ -13,13 +13,13 @@ google: any;
 }
 
 const UserPage = (): JSX.Element => {
-        const { userData, setUserData, clearUserData } = useContext(UserContext);
-        const [profile, setProfile] = useState<UsersProfileProfile1 | null>(null);
-        const [displayEmail, setDisplayEmail] = useState(false);
-        const [displayName, setDisplayName] = useState('');
-        const [provider, setProvider] = useState('microsoft');
-        const [dirty, setDirty] = useState(false);
-        const [providers, setProviders] = useState<string[]>([]);
+		const { userData, setUserData, clearUserData } = useContext(UserContext);
+		const [profile, setProfile] = useState<UsersProfileProfile1 | null>(null);
+		const [displayEmail, setDisplayEmail] = useState(false);
+		const [displayName, setDisplayName] = useState('');
+		const [provider, setProvider] = useState('microsoft');
+		const [dirty, setDirty] = useState(false);
+		const [providers, setProviders] = useState<string[]>([]);
 
 	const normalizeGuid = (guid: unknown): string => {
 		if (typeof guid === 'string') return guid;
@@ -43,183 +43,191 @@ const UserPage = (): JSX.Element => {
 				const res: any = await fetchProfile();
 				const profileData: UsersProfileProfile1 = { ...res, guid: normalizeGuid(res.guid) };
 				setProfile(profileData);
-                                setDisplayName(profileData.display_name);
-                                setDisplayEmail(profileData.display_email);
-                                setProvider(profileData.default_provider);
-                                setProviders(profileData.auth_providers?.map(p => p.name) ?? []);
+								setDisplayName(profileData.display_name);
+								setDisplayEmail(profileData.display_email);
+								setProvider(profileData.default_provider);
+								setProviders(profileData.auth_providers?.map(p => p.name) ?? []);
 			} catch {
 				setProfile(null);
 			}
 		})();
 	}, [userData]);
 
-        const handleToggle = (): void => {
-                setDisplayEmail(!displayEmail);
-                setDirty(true);
-        };
+		const handleToggle = (): void => {
+				setDisplayEmail(!displayEmail);
+				setDirty(true);
+		};
 
-        const handleNameChange = (e: ChangeEvent<HTMLInputElement>): void => {
-                setDisplayName(e.target.value);
-                setDirty(true);
-        };
+		const handleNameChange = (e: ChangeEvent<HTMLInputElement>): void => {
+				setDisplayName(e.target.value);
+				setDirty(true);
+		};
 
-        const handleProviderChange = (e: ChangeEvent<HTMLInputElement>): void => {
-                setProvider(e.target.value);
-                setDirty(true);
-        };
+		const handleProviderChange = (e: ChangeEvent<HTMLInputElement>): void => {
+				setProvider(e.target.value);
+				setDirty(true);
+		};
 
-        const handleCancel = (): void => {
-                if (profile) {
-                        setDisplayName(profile.display_name);
-                        setDisplayEmail(profile.display_email);
-                        setProvider(profile.default_provider);
-                }
-                setDirty(false);
-        };
+		const handleCancel = (): void => {
+				if (profile) {
+						setDisplayName(profile.display_name);
+						setDisplayEmail(profile.display_email);
+						setProvider(profile.default_provider);
+				}
+				setDirty(false);
+		};
 
-        const handleApply = async (): Promise<void> => {
-                try {
-                        await fetchSetDisplay({ display_name: displayName });
-                        await fetchSetOptin({ display_email: displayEmail });
-                        await fetchSetProvider({ provider });
-                        if (userData) setUserData({ ...userData, display_name: displayName });
-                        if (profile) setProfile({ ...profile, display_name: displayName, display_email: displayEmail, default_provider: provider });
-                        setDirty(false);
-                } catch (err) {
+		const handleApply = async (): Promise<void> => {
+				try {
+						await fetchSetDisplay({ display_name: displayName });
+						await fetchSetOptin({ display_email: displayEmail });
+						await fetchSetProvider({ provider });
+						if (userData) setUserData({ ...userData, display_name: displayName });
+						if (profile) setProfile({ ...profile, display_name: displayName, display_email: displayEmail, default_provider: provider });
+						setDirty(false);
+				} catch (err) {
 console.error('Failed to update profile', err);
-                }
-        };
+				}
+		};
 
-        const handleUnlink = async (name: string): Promise<void> => {
-                if (providers.length <= 1 && !window.confirm('This will delete your account. Continue?')) return;
-                try {
-                        await fetchUnlinkProvider({ provider: name });
-                        const updated = providers.filter(p => p !== name);
-                        setProviders(updated);
-                        if (profile) {
-                                const authProviders = profile.auth_providers?.filter(p => p.name !== name) ?? [];
-                                setProfile({ ...profile, auth_providers: authProviders });
-                        }
-                        if (updated.length === 0) clearUserData();
-                } catch (err) {
+		const handleUnlink = async (name: string): Promise<void> => {
+				if (providers.length <= 1 && !window.confirm('This will delete your account. Continue?')) return;
+				try {
+						await fetchUnlinkProvider({ provider: name });
+						const updated = providers.filter(p => p !== name);
+						setProviders(updated);
+						if (profile) {
+								const authProviders = profile.auth_providers?.filter(p => p.name !== name) ?? [];
+								setProfile({ ...profile, auth_providers: authProviders });
+						}
+						if (updated.length === 0) clearUserData();
+				} catch (err) {
 console.error('Failed to unlink provider', err);
-                }
-        };
+				}
+		};
 
-        const handleLink = async (name: string): Promise<void> => {
-                if (name !== 'microsoft' && name !== 'google') return;
-                try {
-                        if (name === 'google') {
-                               if (!window.google) throw new Error('Google API not loaded');
-                               const accessToken = await new Promise<string>((resolve) => {
-                                       const tokenClientConfig = {
-                                               client_id: googleConfig.clientId,
-                                               scope: googleConfig.scope,
-                                               callback: (resp: any) => resolve(resp.access_token),
-                                       };
-console.debug('[UserPage] initTokenClient config', tokenClientConfig);
-                                       const client = window.google.accounts.oauth2.initTokenClient(tokenClientConfig);
-                                       const requestOpts = { prompt: 'consent' };
-console.debug('[UserPage] requestAccessToken opts', requestOpts);
-                                       client.requestAccessToken(requestOpts);
-                               });
-console.debug('[UserPage] accessToken received', accessToken);
-                               const idToken = await new Promise<string>((resolve) => {
-                                       const idInitConfig = {
-                                               client_id: googleConfig.clientId,
-                                               callback: (resp: any) => resolve(resp.credential),
-                                       };
-console.debug('[UserPage] id.initialize config', idInitConfig);
-                                       window.google.accounts.id.initialize(idInitConfig);
-console.debug('[UserPage] id.prompt called');
-                                       window.google.accounts.id.prompt();
-                               });
-console.debug('[UserPage] idToken received', idToken);
-                               await fetchLinkProvider({ provider: name, id_token: idToken, access_token: accessToken });
-                       } else {
-                               await fetchLinkProvider({ provider: name });
-                       }
-                        const updated = [...providers, name];
-                        setProviders(updated);
-                        if (profile) {
-                                const authProviders = [...(profile.auth_providers ?? []), { name, display: name.charAt(0).toUpperCase() + name.slice(1) }];
-                                setProfile({ ...profile, auth_providers: authProviders });
-                        }
-                } catch (err) {
+		const handleLink = async (name: string): Promise<void> => {
+				if (name !== 'microsoft' && name !== 'google') return;
+				try {
+					   if (name === 'google') {
+							   if (!window.google || !window.crypto) throw new Error('Google API not loaded');
+							   const base64UrlEncode = (buffer: ArrayBuffer): string => {
+									   const bytes = new Uint8Array(buffer);
+									   let binary = '';
+									   for (const b of bytes) binary += String.fromCharCode(b);
+									   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+							   };
+							   const generateVerifier = (): string => {
+									   const array = new Uint8Array(32);
+									   window.crypto.getRandomValues(array);
+									   return base64UrlEncode(array.buffer);
+							   };
+							   const pkceChallenge = async (verifier: string): Promise<string> => {
+									   const data = new TextEncoder().encode(verifier);
+									   const digest = await window.crypto.subtle.digest('SHA-256', data);
+									   return base64UrlEncode(digest);
+							   };
+							   const codeVerifier = generateVerifier();
+							   const codeChallenge = await pkceChallenge(codeVerifier);
+							   const code = await new Promise<string>((resolve) => {
+									   const codeClientConfig = {
+											   client_id: googleConfig.clientId,
+											   scope: googleConfig.scope,
+											   redirect_uri: googleConfig.redirectUri,
+											   code_challenge: codeChallenge,
+											   code_challenge_method: 'S256',
+											   callback: (resp: any) => resolve(resp.code),
+									   };
+console.debug('[UserPage] initCodeClient config', codeClientConfig);
+									   const client = window.google.accounts.oauth2.initCodeClient(codeClientConfig);
+									   client.requestCode();
+							   });
+console.debug('[UserPage] authorization code received', code);
+							   await fetchLinkProvider({ provider: name, code, code_verifier: codeVerifier });
+					   } else {
+							   await fetchLinkProvider({ provider: name });
+					   }
+						const updated = [...providers, name];
+						setProviders(updated);
+						if (profile) {
+								const authProviders = [...(profile.auth_providers ?? []), { name, display: name.charAt(0).toUpperCase() + name.slice(1) }];
+								setProfile({ ...profile, auth_providers: authProviders });
+						}
+				} catch (err) {
 console.error('Link provider not implemented', err);
-                }
-        };
+				}
+		};
 
-        const allProviders = [
-                { name: 'microsoft', display: 'Microsoft', enabled: true },
-                { name: 'google', display: 'Google', enabled: true },
-                { name: 'discord', display: 'Discord', enabled: false },
-                { name: 'apple', display: 'Apple', enabled: false }
-        ];
+		const allProviders = [
+				{ name: 'microsoft', display: 'Microsoft', enabled: true },
+				{ name: 'google', display: 'Google', enabled: true },
+				{ name: 'discord', display: 'Discord', enabled: false },
+				{ name: 'apple', display: 'Apple', enabled: false }
+		];
 
-        return (
-                <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-                        <Box sx={{ maxWidth: 400, width: '100%' }}>
-                                <Stack spacing={2} sx={{ mt: 2, display: 'flex', alignItems: 'flex-end', textAlign: 'right' }}>
-                                        <Typography variant='h5' gutterBottom>User Profile</Typography>
+		return (
+				<Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+						<Box sx={{ maxWidth: 400, width: '100%' }}>
+								<Stack spacing={2} sx={{ mt: 2, display: 'flex', alignItems: 'flex-end', textAlign: 'right' }}>
+										<Typography variant='h5' gutterBottom>User Profile</Typography>
 
-                                        {profile && (
-                                                <Stack spacing={2} sx={{ mt: 2, alignItems: 'flex-end', width: '100%' }}>
-                                                        <Avatar src={profile.profile_image ? `data:image/png;base64,${profile.profile_image}` : undefined} sx={{ width: 80, height: 80 }} />
+										{profile && (
+												<Stack spacing={2} sx={{ mt: 2, alignItems: 'flex-end', width: '100%' }}>
+														<Avatar src={profile.profile_image ? `data:image/png;base64,${profile.profile_image}` : undefined} sx={{ width: 80, height: 80 }} />
 
-                                                        <TextField
-                                                                label='Display Name'
-                                                                value={displayName}
-                                                                onChange={handleNameChange}
-                                                                fullWidth
-                                                                slotProps={{
-                                                                        input: {
-                                                                                style: { textAlign: 'right' }
-                                                                        }
-                                                                }}
-                                                        />
+														<TextField
+																label='Display Name'
+																value={displayName}
+																onChange={handleNameChange}
+																fullWidth
+																slotProps={{
+																		input: {
+																				style: { textAlign: 'right' }
+																		}
+																}}
+														/>
 
-                                                        <Typography>Credits: {profile.credits ?? 0}</Typography>
-                                                        <Typography>Email: {profile.email}</Typography>
+														<Typography>Credits: {profile.credits ?? 0}</Typography>
+														<Typography>Email: {profile.email}</Typography>
 
-                                                        <RadioGroup value={provider} onChange={handleProviderChange} sx={{ alignItems: 'flex-end' }}>
-                                                                {allProviders.filter(p => p.enabled && providers.includes(p.name)).map(p => (
-                                                                        <FormControlLabel key={p.name} value={p.name} control={<Radio />} label={p.display} />
-                                                                ))}
-                                                        </RadioGroup>
+														<RadioGroup value={provider} onChange={handleProviderChange} sx={{ alignItems: 'flex-end' }}>
+																{allProviders.filter(p => p.enabled && providers.includes(p.name)).map(p => (
+																		<FormControlLabel key={p.name} value={p.name} control={<Radio />} label={p.display} />
+																))}
+														</RadioGroup>
 
-                                                        {allProviders.map(p => {
-                                                                const linked = providers.includes(p.name);
-                                                                return (
-                                                                        <Stack key={p.name} direction='row' spacing={1} sx={{ justifyContent: 'flex-end', width: '100%' }}>
-                                                                                <Typography>{p.display}</Typography>
-                                                                                {linked ? (
-                                                                                        <Button variant='outlined' onClick={() => handleUnlink(p.name)}>{providers.length === 1 ? 'Delete' : 'Unlink'}</Button>
-                                                                                ) : (
-                                                                                        <Button variant='contained' onClick={() => handleLink(p.name)} disabled={!p.enabled}>{p.enabled ? 'Link' : 'Link (Coming Soon)'}</Button>
-                                                                                )}
-                                                                        </Stack>
-                                                                );
-                                                        })}
+														{allProviders.map(p => {
+																const linked = providers.includes(p.name);
+																return (
+																		<Stack key={p.name} direction='row' spacing={1} sx={{ justifyContent: 'flex-end', width: '100%' }}>
+																				<Typography>{p.display}</Typography>
+																				{linked ? (
+																						<Button variant='outlined' onClick={() => handleUnlink(p.name)}>{providers.length === 1 ? 'Delete' : 'Unlink'}</Button>
+																				) : (
+																						<Button variant='contained' onClick={() => handleLink(p.name)} disabled={!p.enabled}>{p.enabled ? 'Link' : 'Link (Coming Soon)'}</Button>
+																				)}
+																		</Stack>
+																);
+														})}
 
-                                                        <FormControlLabel
-                                                                control={<Switch checked={displayEmail} onChange={handleToggle} />}
-                                                                label='Display email publicly'
-                                                                labelPlacement='start'
-                                                                sx={{ alignSelf: 'flex-end' }}
-                                                        />
+														<FormControlLabel
+																control={<Switch checked={displayEmail} onChange={handleToggle} />}
+																label='Display email publicly'
+																labelPlacement='start'
+																sx={{ alignSelf: 'flex-end' }}
+														/>
 
-                                                        <Stack direction='row' spacing={2} sx={{ justifyContent: 'flex-end', width: '100%' }}>
-                                                                <Button variant='contained' onClick={handleApply} disabled={!dirty}>Apply</Button>
-                                                                <Button variant='outlined' onClick={handleCancel} disabled={!dirty}>Cancel</Button>
-                                                                <Button variant='contained' color='error'>Delete</Button>
-                                                        </Stack>
-                                                </Stack>
-                                        )}
-                                </Stack>
-                        </Box>
-                </Box>
-        );
+														<Stack direction='row' spacing={2} sx={{ justifyContent: 'flex-end', width: '100%' }}>
+																<Button variant='contained' onClick={handleApply} disabled={!dirty}>Apply</Button>
+																<Button variant='outlined' onClick={handleCancel} disabled={!dirty}>Cancel</Button>
+																<Button variant='contained' color='error'>Delete</Button>
+														</Stack>
+												</Stack>
+										)}
+								</Stack>
+						</Box>
+				</Box>
+		);
 };
 
 export default UserPage;

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -21,25 +21,6 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
-export interface SupportUsersGuid1 {
-  userGuid: string;
-}
-export interface SupportUsersSetCredits1 {
-  userGuid: string;
-  credits: number;
-}
-export interface SupportRolesMembers1 {
-  members: SupportRolesUserItem1[];
-  nonMembers: SupportRolesUserItem1[];
-}
-export interface SupportRolesRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface SupportRolesUserItem1 {
-  guid: string;
-  displayName: string;
-}
 export interface UsersProvidersCreateFromProvider1 {
   provider: string;
   provider_identifier: string;
@@ -53,8 +34,8 @@ export interface UsersProvidersGetByProviderIdentifier1 {
 }
 export interface UsersProvidersLinkProvider1 {
   provider: string;
-  id_token: string;
-  access_token: string;
+  code: string;
+  code_verifier: any;
 }
 export interface UsersProvidersSetProvider1 {
   provider: string;
@@ -112,35 +93,15 @@ export interface ServiceRolesUserItem1 {
   guid: string;
   displayName: string;
 }
-export interface PublicVarsFfmpegVersion1 {
-  ffmpeg_version: string;
+export interface SystemConfigConfigItem1 {
+  key: string;
+  value: string;
 }
-export interface PublicVarsHostname1 {
-  hostname: string;
+export interface SystemConfigDeleteConfig1 {
+  key: string;
 }
-export interface PublicVarsOdbcVersion1 {
-  odbc_version: string;
-}
-export interface PublicVarsRepo1 {
-  repo: string;
-}
-export interface PublicVarsVersion1 {
-  version: string;
-}
-export interface PublicLinksHomeLinks1 {
-  links: PublicLinksLinkItem1[];
-}
-export interface PublicLinksLinkItem1 {
-  title: string;
-  url: string;
-}
-export interface PublicLinksNavBarRoute1 {
-  path: string;
-  name: string;
-  icon: string | null;
-}
-export interface PublicLinksNavBarRoutes1 {
-  routes: PublicLinksNavBarRoute1[];
+export interface SystemConfigList1 {
+  items: SystemConfigConfigItem1[];
 }
 export interface SystemRoutesDeleteRoute1 {
   path: string;
@@ -171,15 +132,72 @@ export interface SystemRolesUpsertRole1 {
   mask: string;
   display: any;
 }
-export interface SystemConfigConfigItem1 {
-  key: string;
-  value: string;
+export interface SupportUsersGuid1 {
+  userGuid: string;
 }
-export interface SystemConfigDeleteConfig1 {
-  key: string;
+export interface SupportUsersSetCredits1 {
+  userGuid: string;
+  credits: number;
 }
-export interface SystemConfigList1 {
-  items: SystemConfigConfigItem1[];
+export interface SupportRolesMembers1 {
+  members: SupportRolesUserItem1[];
+  nonMembers: SupportRolesUserItem1[];
+}
+export interface SupportRolesRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
+}
+export interface SupportRolesUserItem1 {
+  guid: string;
+  displayName: string;
+}
+export interface AuthMicrosoftOauthLogin1 {
+  sessionToken: string;
+  display_name: string;
+  credits: number;
+  profile_image: string | null;
+}
+export interface AuthGoogleOauthLogin1 {
+  sessionToken: string;
+  display_name: string;
+  credits: number;
+  profile_image: string | null;
+}
+export interface AuthGoogleOauthLoginPayload1 {
+  provider: string;
+  code: string;
+  code_verifier: any;
+  fingerprint: any;
+}
+export interface PublicLinksHomeLinks1 {
+  links: PublicLinksLinkItem1[];
+}
+export interface PublicLinksLinkItem1 {
+  title: string;
+  url: string;
+}
+export interface PublicLinksNavBarRoute1 {
+  path: string;
+  name: string;
+  icon: string | null;
+}
+export interface PublicLinksNavBarRoutes1 {
+  routes: PublicLinksNavBarRoute1[];
+}
+export interface PublicVarsFfmpegVersion1 {
+  ffmpeg_version: string;
+}
+export interface PublicVarsHostname1 {
+  hostname: string;
+}
+export interface PublicVarsOdbcVersion1 {
+  odbc_version: string;
+}
+export interface PublicVarsRepo1 {
+  repo: string;
+}
+export interface PublicVarsVersion1 {
+  version: string;
 }
 export interface StorageFilesDeleteFiles1 {
   files: string[];
@@ -204,59 +222,41 @@ export interface StorageFilesUploadFile1 {
 export interface StorageFilesUploadFiles1 {
   files: StorageFilesUploadFile1[];
 }
-export interface AuthMicrosoftOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
-  credits: number;
-  profile_image: string | null;
-}
-export interface AuthGoogleOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
-  credits: number;
-  profile_image: string | null;
-}
-export interface AuthGoogleOauthLoginPayload1 {
-  provider: string;
-  code: string;
-  code_verifier: any;
-  fingerprint: any;
-}
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {
-    const request: RPCRequest = {
-        op,
-        payload,
-        version: 1,
-        timestamp: new Date().toISOString(),
-        user_guid: null,
-        roles: [],
-        role_mask: 0
-    };
-    const headers: Record<string, string> = {};
-    if (typeof localStorage !== 'undefined') {
-        try {
-            const raw = localStorage.getItem('authTokens');
-            if (raw) {
-                const { sessionToken } = JSON.parse(raw);
-                if (sessionToken) headers.Authorization = `Bearer ${sessionToken}`;
-            }
-        } catch {
-            /* ignore token parsing errors */
-        }
-    }
-    try {
-        const response = await axios.post<RPCResponse>('/rpc', request, { headers });
-        return response.data.payload as T;
-    } catch (err: any) {
-        if (axios.isAxiosError(err) && err.response?.status === 401) {
-            if (typeof localStorage !== 'undefined') {
-                localStorage.removeItem('authTokens');
-            }
-            if (typeof window !== 'undefined') {
-                window.dispatchEvent(new Event('sessionExpired'));
-            }
-        }
-        throw err;
-    }
+	const request: RPCRequest = {
+		op,
+		payload,
+		version: 1,
+		timestamp: new Date().toISOString(),
+		user_guid: null,
+		roles: [],
+		role_mask: 0
+	};
+	const headers: Record<string, string> = {};
+	if (typeof localStorage !== 'undefined') {
+		try {
+			const raw = localStorage.getItem('authTokens');
+			if (raw) {
+				const { sessionToken } = JSON.parse(raw);
+				if (sessionToken) headers.Authorization = `Bearer ${sessionToken}`;
+			}
+		} catch {
+			/* ignore token parsing errors */
+		}
+	}
+	try {
+		const response = await axios.post<RPCResponse>('/rpc', request, { headers });
+		return response.data.payload as T;
+	} catch (err: any) {
+		if (axios.isAxiosError(err) && err.response?.status === 401) {
+			if (typeof localStorage !== 'undefined') {
+				localStorage.removeItem('authTokens');
+			}
+			if (typeof window !== 'undefined') {
+				window.dispatchEvent(new Event('sessionExpired'));
+			}
+		}
+		throw err;
+	}
 }

--- a/rpc/users/providers/models.py
+++ b/rpc/users/providers/models.py
@@ -7,8 +7,8 @@ class UsersProvidersSetProvider1(BaseModel):
 
 class UsersProvidersLinkProvider1(BaseModel):
   provider: str
-  id_token: str
-  access_token: str
+  code: str
+  code_verifier: str | None = None
 
 
 class UsersProvidersUnlinkProvider1(BaseModel):

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -13,6 +13,7 @@ from .models import (
   UsersProvidersGetByProviderIdentifier1,
   UsersProvidersCreateFromProvider1,
 )
+from rpc.auth.google.services import exchange_code_for_tokens
 
 
 def normalize_provider_identifier(pid: str) -> str:
@@ -46,7 +47,29 @@ async def users_providers_link_provider_v1(request: Request):
     raise HTTPException(status_code=400, detail=str(e))
   auth: AuthModule = request.app.state.auth
   db: DbModule = request.app.state.db
-  provider_uid, _, _ = await auth.handle_auth_login(payload.provider, payload.id_token, payload.access_token)
+  if payload.provider == "google":
+    google_provider = getattr(auth, "providers", {}).get("google")
+    if not google_provider or not google_provider.audience:
+      raise HTTPException(status_code=500, detail="Google OAuth client_id not configured")
+    client_id = google_provider.audience
+    res_secret = await db.run("urn:system:config:get_config:1", {"key": "GoogleApiId"})
+    if not res_secret.rows:
+      raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
+    client_secret = res_secret.rows[0]["value"]
+    res_redirect = await db.run("urn:system:config:get_config:1", {"key": "GoogleAuthRedirectLocalhost"})
+    if not res_redirect.rows:
+      raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
+    redirect_uri = res_redirect.rows[0]["value"]
+    id_token, access_token = await exchange_code_for_tokens(
+      payload.code,
+      client_id,
+      client_secret,
+      redirect_uri,
+      payload.code_verifier,
+    )
+  else:
+    raise HTTPException(status_code=400, detail="Unsupported auth provider")
+  provider_uid, _, _ = await auth.handle_auth_login(payload.provider, id_token, access_token)
   provider_uid = normalize_provider_identifier(provider_uid)
   res = await db.run(
     "urn:users:providers:get_by_provider_identifier:1",

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -13,6 +13,8 @@ class DummyAuth:
     return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
+  def __init__(self):
+    self.providers = {"google": SimpleNamespace(audience="gid")}
 
 class DBRes:
   def __init__(self, rows=None, rowcount=0):
@@ -29,7 +31,11 @@ class DummyDb:
     if op == "urn:users:providers:get_user_by_email:1":
       return DBRes([{ "guid": "existing-guid" }], 1)
     if op == "urn:system:config:get_config:1":
-      return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
+      key = args.get("key")
+      if key == "GoogleApiId":
+        return DBRes([{ "value": "gsecret" }], 1)
+      if key == "GoogleAuthRedirectLocalhost":
+        return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
     return DBRes()
 
 class DummyState:

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -16,6 +16,8 @@ class DummyAuth:
     return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
+  def __init__(self):
+    self.providers = {"google": SimpleNamespace(audience="gid")}
 
 class DBRes:
   def __init__(self, rows=None, rowcount=0):
@@ -30,7 +32,11 @@ class DummyDb:
     if op == "urn:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
     if op == "urn:system:config:get_config:1":
-      return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
+      key = args.get("key")
+      if key == "GoogleApiId":
+        return DBRes([{ "value": "gsecret" }], 1)
+      if key == "GoogleAuthRedirectLocalhost":
+        return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
     return DBRes()
 
 class DummyState:

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -16,6 +16,8 @@ class DummyAuth:
     return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
+  def __init__(self):
+    self.providers = {"google": SimpleNamespace(audience="gid")}
 
 class DBRes:
   def __init__(self, rows=None, rowcount=0):
@@ -32,7 +34,11 @@ class DummyDb:
         return DBRes([], 0)
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
     if op == "urn:system:config:get_config:1":
-      return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
+      key = args.get("key")
+      if key == "GoogleApiId":
+        return DBRes([{ "value": "gsecret" }], 1)
+      if key == "GoogleAuthRedirectLocalhost":
+        return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
     if op == "urn:users:providers:create_from_provider:1":
       return DBRes([], 1)
     if op == "db:users:session:set_rotkey:1":


### PR DESCRIPTION
## Summary
- Switch UserPage Google linking to use initCodeClient and send auth code to server
- Allow linking service to exchange auth codes and updated RPC models for new payload
- Adjust Google auth tests for server-side token exchange

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7f1f3e3588325b9bcff7ddcc4aec9