### PR TITLE
Fix Google OAuth client secret retrieval

### DIFF
--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -177,10 +177,10 @@ async def auth_google_oauth_login_v1(request: Request):
   client_id = google_provider.audience
 
   # Require client_secret from system config
-  res_secret = await db.run("urn:system:config:get_config:1", {"key": "GoogleApiId"})
-  if not res_secret.rows:
-      raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
-  client_secret = res_secret.rows[0]["value"]
+  try:
+    client_secret = await db.get_google_api_secret()
+  except ValueError:
+    raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
 
   # Require redirect_uri from system config
   res_redirect = await db.run("urn:system:config:get_config:1", {"key": "GoogleAuthRedirectLocalhost"})

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -52,10 +52,10 @@ async def users_providers_link_provider_v1(request: Request):
     if not google_provider or not google_provider.audience:
       raise HTTPException(status_code=500, detail="Google OAuth client_id not configured")
     client_id = google_provider.audience
-    res_secret = await db.run("urn:system:config:get_config:1", {"key": "GoogleApiId"})
-    if not res_secret.rows:
+    try:
+      client_secret = await db.get_google_api_secret()
+    except ValueError:
       raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
-    client_secret = res_secret.rows[0]["value"]
     res_redirect = await db.run("urn:system:config:get_config:1", {"key": "GoogleAuthRedirectLocalhost"})
     if not res_redirect.rows:
       raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -92,6 +92,14 @@ class DbModule(BaseModule):
       raise ValueError("Missing config value for key: GoogleApiId")
     return value
 
+  async def get_google_api_secret(self) -> str:
+    res = await self.run("db:system:config:get_config:1", {"key": "GoogleApiSecret"})
+    value = res.rows[0]["value"] if res.rows else None
+    logging.debug("[DbModule] GoogleApiSecret=%s", value)
+    if not value:
+      raise ValueError("Missing config value for key: GoogleApiSecret")
+    return value
+
   async def get_auth_providers(self) -> list[str]:
     res = await self.run("db:system:config:get_config:1", {"key": "AuthProviders"})
     value = res.rows[0]["value"] if res.rows else None

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -32,11 +32,14 @@ class DummyDb:
       return DBRes([{ "guid": "existing-guid" }], 1)
     if op == "urn:system:config:get_config:1":
       key = args.get("key")
-      if key == "GoogleApiId":
+      if key == "GoogleApiSecret":
         return DBRes([{ "value": "gsecret" }], 1)
       if key == "GoogleAuthRedirectLocalhost":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
     return DBRes()
+
+  async def get_google_api_secret(self):
+    return "gsecret"
 
 class DummyState:
   def __init__(self):

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -33,11 +33,14 @@ class DummyDb:
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
     if op == "urn:system:config:get_config:1":
       key = args.get("key")
-      if key == "GoogleApiId":
+      if key == "GoogleApiSecret":
         return DBRes([{ "value": "gsecret" }], 1)
       if key == "GoogleAuthRedirectLocalhost":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
     return DBRes()
+
+  async def get_google_api_secret(self):
+    return "gsecret"
 
 class DummyState:
   def __init__(self):

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -35,7 +35,7 @@ class DummyDb:
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
     if op == "urn:system:config:get_config:1":
       key = args.get("key")
-      if key == "GoogleApiId":
+      if key == "GoogleApiSecret":
         return DBRes([{ "value": "gsecret" }], 1)
       if key == "GoogleAuthRedirectLocalhost":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
@@ -48,6 +48,9 @@ class DummyDb:
     if op == "db:auth:session:create_session:1":
       return DBRes([], 1)
     return DBRes()
+
+  async def get_google_api_secret(self):
+    return "gsecret"
 
 class DummyState:
   def __init__(self):

--- a/tests/test_db_module_api_ids.py
+++ b/tests/test_db_module_api_ids.py
@@ -18,6 +18,19 @@ def test_get_google_api_id():
   assert asyncio.run(db.get_google_api_id()) == "gid"
 
 
+def test_get_google_api_secret():
+  app = FastAPI()
+  db = DbModule(app)
+
+  async def fake_run(op, args):
+    assert op == "db:system:config:get_config:1"
+    assert args == {"key": "GoogleApiSecret"}
+    return DBResult(rows=[{"value": "gsecret"}], rowcount=1)
+
+  db.run = fake_run
+  assert asyncio.run(db.get_google_api_secret()) == "gsecret"
+
+
 def test_get_ms_api_id():
   app = FastAPI()
   db = DbModule(app)

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -144,11 +144,14 @@ def test_link_provider_google_normalizes_identifier():
       self.calls.append((op, args))
       if op == "urn:system:config:get_config:1":
         key = args["key"]
-        if key == "GoogleApiId":
+        if key == "GoogleApiSecret":
           return DBRes(rows=[{"value": "secret"}])
         if key == "GoogleAuthRedirectLocalhost":
           return DBRes(rows=[{"value": "redirect"}])
       return DBRes()
+
+    async def get_google_api_secret(self):
+      return "secret"
 
   db = DummyDb()
   auth = DummyAuth()


### PR DESCRIPTION
## Summary
- load Google client secret from `GoogleApiSecret`
- use helper `get_google_api_secret` in Google auth flows
- cover new secret lookup in tests

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68a7f8424c9c832596abf19c4f1a4a38