### PR TITLE
fix: fetch Google API secret

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -93,11 +93,13 @@ class DbModule(BaseModule):
     return value
 
   async def get_google_api_secret(self) -> str:
-    res = await self.run("db:system:config:get_config:1", {"key": "GoogleApiSecret"})
+    # Note: legacy naming stores the Google OAuth client secret under
+    # the "GoogleApiId" key in system_config.
+    res = await self.run("db:system:config:get_config:1", {"key": "GoogleApiId"})
     value = res.rows[0]["value"] if res.rows else None
     logging.debug("[DbModule] GoogleApiSecret=%s", value)
     if not value:
-      raise ValueError("Missing config value for key: GoogleApiSecret")
+      raise ValueError("Missing config value for key: GoogleApiId")
     return value
 
   async def get_auth_providers(self) -> list[str]:

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -32,7 +32,7 @@ class DummyDb:
       return DBRes([{ "guid": "existing-guid" }], 1)
     if op == "urn:system:config:get_config:1":
       key = args.get("key")
-      if key == "GoogleApiSecret":
+      if key == "GoogleApiId":
         return DBRes([{ "value": "gsecret" }], 1)
       if key == "GoogleAuthRedirectLocalhost":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -33,7 +33,7 @@ class DummyDb:
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
     if op == "urn:system:config:get_config:1":
       key = args.get("key")
-      if key == "GoogleApiSecret":
+      if key == "GoogleApiId":
         return DBRes([{ "value": "gsecret" }], 1)
       if key == "GoogleAuthRedirectLocalhost":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -35,7 +35,7 @@ class DummyDb:
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
     if op == "urn:system:config:get_config:1":
       key = args.get("key")
-      if key == "GoogleApiSecret":
+      if key == "GoogleApiId":
         return DBRes([{ "value": "gsecret" }], 1)
       if key == "GoogleAuthRedirectLocalhost":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)

--- a/tests/test_db_module_api_ids.py
+++ b/tests/test_db_module_api_ids.py
@@ -24,7 +24,7 @@ def test_get_google_api_secret():
 
   async def fake_run(op, args):
     assert op == "db:system:config:get_config:1"
-    assert args == {"key": "GoogleApiSecret"}
+    assert args == {"key": "GoogleApiId"}
     return DBResult(rows=[{"value": "gsecret"}], rowcount=1)
 
   db.run = fake_run

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -144,7 +144,7 @@ def test_link_provider_google_normalizes_identifier():
       self.calls.append((op, args))
       if op == "urn:system:config:get_config:1":
         key = args["key"]
-        if key == "GoogleApiSecret":
+        if key == "GoogleApiId":
           return DBRes(rows=[{"value": "secret"}])
         if key == "GoogleAuthRedirectLocalhost":
           return DBRes(rows=[{"value": "redirect"}])


### PR DESCRIPTION
## Summary
- fix Google OAuth client secret lookup to use `GoogleApiId` key
- update related tests

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7fba540a88325973b55a2b018575f