### PR TITLE
Load Google OAuth client ID from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ These items were previously implemented and are on the rebuild roadmap.
 - The project contains a startup.sh which will be executed by the environment on activation.
 - The project contains a dev.cmd script that supports `generate`, `start`, `fast`, and `test` subcommands for local development on Windows.
 - Environment variables are configured in .env for local work, but are set up as environment variables on the web app.
-- Set `VITE_GOOGLE_CLIENT_ID` to the Google OAuth client ID for your deployment. The origin must be authorized in the Google Cloud console.
 - The database provider can be selected with the `DATABASE_PROVIDER` environment variable. The architecture supports multiple providers; currently only `mssql` is implemented.
 - You must configure Always On and enable SCM Basic Auth Publishing Credentials for GitHub Actions.
 - Deploy the Azure Web App Container Quickstart configuration.

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,14 +1,6 @@
 /// <reference types='vite/client' />
 
 declare module '*.png' {
-	const src: string;
-	export default src;
-}
-
-interface ImportMetaEnv {
-	readonly VITE_GOOGLE_CLIENT_ID?: string;
-}
-
-interface ImportMeta {
-	readonly env: ImportMetaEnv;
+        const src: string;
+        export default src;
 }

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -47,9 +47,9 @@ class AuthModule(BaseModule):
         logging.debug("[AuthModule] Microsoft provider ready")
       if "google" in providers_cfg:
         logging.debug("[AuthModule] Loading Google provider")
-        google_api_id = await self.db.get_google_api_id()
-        logging.debug("[AuthModule] GoogleApiId=%s", google_api_id)
-        provider = await GoogleAuthProvider.create(api_id=google_api_id, jwks_expiry=timedelta(minutes=self.jwks_cache_minutes))
+        google_client_id = await self.db.get_google_client_id()
+        logging.debug("[AuthModule] GoogleClientId=%s", google_client_id)
+        provider = await GoogleAuthProvider.create(api_id=google_client_id, jwks_expiry=timedelta(minutes=self.jwks_cache_minutes))
         await provider._get_jwks()
         self.providers["google"] = provider
         logging.debug("[AuthModule] Google provider ready")

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -84,6 +84,14 @@ class DbModule(BaseModule):
       raise ValueError("Missing config value for key: MsApiId")
     return res.rows[0]["value"]
 
+  async def get_google_client_id(self) -> str:
+    res = await self.run("db:system:config:get_config:1", {"key": "GoogleClientId"})
+    value = res.rows[0]["value"] if res.rows else None
+    logging.debug("[DbModule] GoogleClientId=%s", value)
+    if not value:
+      raise ValueError("Missing config value for key: GoogleClientId")
+    return value
+
   async def get_google_api_id(self) -> str:
     res = await self.run("db:system:config:get_config:1", {"key": "GoogleApiId"})
     value = res.rows[0]["value"] if res.rows else None

--- a/server/modules/env_module.py
+++ b/server/modules/env_module.py
@@ -24,7 +24,7 @@ class EnvModule(BaseModule):
     if provider == "mysql":
       self._getenv("MYSQL_SQL_CONNECTION_STRING", "MISSING_MYSQL_SQL_CONNECTION_STRING")
     self._getenv("AZURE_BLOB_CONNECTION_STRING", "MISSING_ENV_AZURE_BLOB_CONNECTION_STRING")
-    
+
     logging.info("Environment module loaded")
     self.mark_ready()
 

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -115,8 +115,6 @@ def test_email_exists(monkeypatch):
   svc_mod.exchange_code_for_tokens = fake_exchange
   auth_google_oauth_login_v1 = svc_mod.auth_google_oauth_login_v1
 
-  monkeypatch.setenv("GOOGLE_CLIENT_ID", "gid")
-  monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "gsecret")
   req = DummyRequest()
   with pytest.raises(HTTPException) as exc:
     asyncio.run(auth_google_oauth_login_v1(req))

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -117,8 +117,6 @@ def test_lookup_existing_user(monkeypatch):
   svc_mod.exchange_code_for_tokens = fake_exchange
   auth_google_oauth_login_v1 = svc_mod.auth_google_oauth_login_v1
 
-  monkeypatch.setenv("GOOGLE_CLIENT_ID", "gid")
-  monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "gsecret")
   req = DummyRequest()
   resp = asyncio.run(auth_google_oauth_login_v1(req))
   assert isinstance(resp, RPCResponse)

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -127,8 +127,6 @@ def test_fetch_user_after_create(monkeypatch):
   svc_mod.exchange_code_for_tokens = fake_exchange
   auth_google_oauth_login_v1 = svc_mod.auth_google_oauth_login_v1
 
-  monkeypatch.setenv("GOOGLE_CLIENT_ID", "gid")
-  monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "gsecret")
   req = DummyRequest()
   resp = asyncio.run(auth_google_oauth_login_v1(req))
   assert isinstance(resp, RPCResponse)

--- a/tests/test_db_module_api_ids.py
+++ b/tests/test_db_module_api_ids.py
@@ -5,17 +5,17 @@ from server.modules.db_module import DbModule
 from server.modules.providers.models import DBResult
 
 
-def test_get_google_api_id():
+def test_get_google_client_id():
   app = FastAPI()
   db = DbModule(app)
 
   async def fake_run(op, args):
     assert op == "db:system:config:get_config:1"
-    assert args == {"key": "GoogleApiId"}
+    assert args == {"key": "GoogleClientId"}
     return DBResult(rows=[{"value": "gid"}], rowcount=1)
 
   db.run = fake_run
-  assert asyncio.run(db.get_google_api_id()) == "gid"
+  assert asyncio.run(db.get_google_client_id()) == "gid"
 
 
 def test_get_google_api_secret():


### PR DESCRIPTION
## Summary
- load Google OAuth client ID from `system_config.GoogleClientId`
- remove obsolete `GOOGLE_CLIENT_ID` environment variable and docs
- update tests for database lookup

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68a884484b808325ab24628033bfcd75