### PR TITLE
Remove PKCE code verifier usage

### DIFF
--- a/frontend/src/UserPage.tsx
+++ b/frontend/src/UserPage.tsx
@@ -109,44 +109,24 @@ console.error('Failed to unlink provider', err);
 		const handleLink = async (name: string): Promise<void> => {
 				if (name !== 'microsoft' && name !== 'google') return;
 				try {
-					   if (name === 'google') {
-							   if (!window.google || !window.crypto) throw new Error('Google API not loaded');
-							   const base64UrlEncode = (buffer: ArrayBuffer): string => {
-									   const bytes = new Uint8Array(buffer);
-									   let binary = '';
-									   for (const b of bytes) binary += String.fromCharCode(b);
-									   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-							   };
-							   const generateVerifier = (): string => {
-									   const array = new Uint8Array(32);
-									   window.crypto.getRandomValues(array);
-									   return base64UrlEncode(array.buffer);
-							   };
-							   const pkceChallenge = async (verifier: string): Promise<string> => {
-									   const data = new TextEncoder().encode(verifier);
-									   const digest = await window.crypto.subtle.digest('SHA-256', data);
-									   return base64UrlEncode(digest);
-							   };
-							   const codeVerifier = generateVerifier();
-							   const codeChallenge = await pkceChallenge(codeVerifier);
-							   const code = await new Promise<string>((resolve) => {
-									   const codeClientConfig = {
-											   client_id: googleConfig.clientId,
-											   scope: googleConfig.scope,
-											   redirect_uri: googleConfig.redirectUri,
-											   code_challenge: codeChallenge,
-											   code_challenge_method: 'S256',
-											   callback: (resp: any) => resolve(resp.code),
-									   };
+                                if (name === 'google') {
+                                                if (!window.google) throw new Error('Google API not loaded');
+                                                const code = await new Promise<string>((resolve) => {
+                                                                const codeClientConfig = {
+                                                                                client_id: googleConfig.clientId,
+                                                                                scope: googleConfig.scope,
+                                                                                redirect_uri: googleConfig.redirectUri,
+                                                                                callback: (resp: any) => resolve(resp.code),
+                                                                };
 console.debug('[UserPage] initCodeClient config', codeClientConfig);
-									   const client = window.google.accounts.oauth2.initCodeClient(codeClientConfig);
-									   client.requestCode();
-							   });
+                                                                const client = window.google.accounts.oauth2.initCodeClient(codeClientConfig);
+                                                                client.requestCode();
+                                                });
 console.debug('[UserPage] authorization code received', code);
-							   await fetchLinkProvider({ provider: name, code, code_verifier: codeVerifier });
-					   } else {
-							   await fetchLinkProvider({ provider: name });
-					   }
+                                                await fetchLinkProvider({ provider: name, code });
+                                } else {
+                                                await fetchLinkProvider({ provider: name });
+                                }
 						const updated = [...providers, name];
 						setProviders(updated);
 						if (profile) {

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -21,116 +21,28 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
-export interface UsersProvidersCreateFromProvider1 {
-  provider: string;
-  provider_identifier: string;
-  provider_email: string;
-  provider_displayname: string;
-  provider_profile_image: any;
+export interface StorageFilesDeleteFiles1 {
+  files: string[];
 }
-export interface UsersProvidersGetByProviderIdentifier1 {
-  provider: string;
-  provider_identifier: string;
-}
-export interface UsersProvidersLinkProvider1 {
-  provider: string;
-  code: string;
-  code_verifier: any;
-}
-export interface UsersProvidersSetProvider1 {
-  provider: string;
-}
-export interface UsersProvidersUnlinkProvider1 {
-  provider: string;
-}
-export interface UsersProfileAuthProvider1 {
+export interface StorageFilesFileItem1 {
   name: string;
-  display: string;
+  url: string;
+  content_type: string | null;
 }
-export interface UsersProfileProfile1 {
-  guid: string;
-  display_name: string;
-  email: string;
-  display_email: boolean;
-  credits: number;
-  profile_image: string | null;
-  default_provider: string;
-  auth_providers: UsersProfileAuthProvider1[];
+export interface StorageFilesFiles1 {
+  files: StorageFilesFileItem1[];
 }
-export interface UsersProfileRoles1 {
-  roles: number;
-}
-export interface UsersProfileSetDisplay1 {
-  display_name: string;
-}
-export interface UsersProfileSetOptin1 {
-  display_email: boolean;
-}
-export interface UsersProfileSetProfileImage1 {
-  image_b64: string;
-  provider: string;
-}
-export interface ServiceRolesDeleteRole1 {
+export interface StorageFilesSetGallery1 {
   name: string;
+  gallery: boolean;
 }
-export interface ServiceRolesRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface ServiceRolesRoleMembers1 {
-  members: ServiceRolesUserItem1[];
-  nonMembers: ServiceRolesUserItem1[];
-}
-export interface ServiceRolesRoles1 {
-  roles: string[];
-}
-export interface ServiceRolesUpsertRole1 {
+export interface StorageFilesUploadFile1 {
   name: string;
-  bit: number;
-  display: any;
+  content_b64: string;
+  content_type: string | null;
 }
-export interface ServiceRolesUserItem1 {
-  guid: string;
-  displayName: string;
-}
-export interface SystemConfigConfigItem1 {
-  key: string;
-  value: string;
-}
-export interface SystemConfigDeleteConfig1 {
-  key: string;
-}
-export interface SystemConfigList1 {
-  items: SystemConfigConfigItem1[];
-}
-export interface SystemRoutesDeleteRoute1 {
-  path: string;
-}
-export interface SystemRoutesList1 {
-  routes: SystemRoutesRouteItem1[];
-}
-export interface SystemRoutesRouteItem1 {
-  path: string;
-  name: string;
-  icon: string | null;
-  sequence: number;
-  required_roles: string[];
-}
-export interface SystemRolesDeleteRole1 {
-  name: string;
-}
-export interface SystemRolesList1 {
-  roles: SystemRolesRoleItem1[];
-}
-export interface SystemRolesRoleItem1 {
-  name: string;
-  mask: string;
-  display: any;
-}
-export interface SystemRolesUpsertRole1 {
-  name: string;
-  mask: string;
-  display: any;
+export interface StorageFilesUploadFiles1 {
+  files: StorageFilesUploadFile1[];
 }
 export interface SupportUsersGuid1 {
   userGuid: string;
@@ -166,8 +78,94 @@ export interface AuthGoogleOauthLogin1 {
 export interface AuthGoogleOauthLoginPayload1 {
   provider: string;
   code: string;
-  code_verifier: any;
   fingerprint: any;
+}
+export interface SystemRoutesDeleteRoute1 {
+  path: string;
+}
+export interface SystemRoutesList1 {
+  routes: SystemRoutesRouteItem1[];
+}
+export interface SystemRoutesRouteItem1 {
+  path: string;
+  name: string;
+  icon: string | null;
+  sequence: number;
+  required_roles: string[];
+}
+export interface SystemRolesDeleteRole1 {
+  name: string;
+}
+export interface SystemRolesList1 {
+  roles: SystemRolesRoleItem1[];
+}
+export interface SystemRolesRoleItem1 {
+  name: string;
+  mask: string;
+  display: any;
+}
+export interface SystemRolesUpsertRole1 {
+  name: string;
+  mask: string;
+  display: any;
+}
+export interface SystemConfigConfigItem1 {
+  key: string;
+  value: string;
+}
+export interface SystemConfigDeleteConfig1 {
+  key: string;
+}
+export interface SystemConfigList1 {
+  items: SystemConfigConfigItem1[];
+}
+export interface UsersProfileAuthProvider1 {
+  name: string;
+  display: string;
+}
+export interface UsersProfileProfile1 {
+  guid: string;
+  display_name: string;
+  email: string;
+  display_email: boolean;
+  credits: number;
+  profile_image: string | null;
+  default_provider: string;
+  auth_providers: UsersProfileAuthProvider1[];
+}
+export interface UsersProfileRoles1 {
+  roles: number;
+}
+export interface UsersProfileSetDisplay1 {
+  display_name: string;
+}
+export interface UsersProfileSetOptin1 {
+  display_email: boolean;
+}
+export interface UsersProfileSetProfileImage1 {
+  image_b64: string;
+  provider: string;
+}
+export interface UsersProvidersCreateFromProvider1 {
+  provider: string;
+  provider_identifier: string;
+  provider_email: string;
+  provider_displayname: string;
+  provider_profile_image: any;
+}
+export interface UsersProvidersGetByProviderIdentifier1 {
+  provider: string;
+  provider_identifier: string;
+}
+export interface UsersProvidersLinkProvider1 {
+  provider: string;
+  code: string;
+}
+export interface UsersProvidersSetProvider1 {
+  provider: string;
+}
+export interface UsersProvidersUnlinkProvider1 {
+  provider: string;
 }
 export interface PublicLinksHomeLinks1 {
   links: PublicLinksLinkItem1[];
@@ -199,64 +197,64 @@ export interface PublicVarsRepo1 {
 export interface PublicVarsVersion1 {
   version: string;
 }
-export interface StorageFilesDeleteFiles1 {
-  files: string[];
-}
-export interface StorageFilesFileItem1 {
+export interface ServiceRolesDeleteRole1 {
   name: string;
-  url: string;
-  content_type: string | null;
 }
-export interface StorageFilesFiles1 {
-  files: StorageFilesFileItem1[];
+export interface ServiceRolesRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
 }
-export interface StorageFilesSetGallery1 {
+export interface ServiceRolesRoleMembers1 {
+  members: ServiceRolesUserItem1[];
+  nonMembers: ServiceRolesUserItem1[];
+}
+export interface ServiceRolesRoles1 {
+  roles: string[];
+}
+export interface ServiceRolesUpsertRole1 {
   name: string;
-  gallery: boolean;
+  bit: number;
+  display: any;
 }
-export interface StorageFilesUploadFile1 {
-  name: string;
-  content_b64: string;
-  content_type: string | null;
-}
-export interface StorageFilesUploadFiles1 {
-  files: StorageFilesUploadFile1[];
+export interface ServiceRolesUserItem1 {
+  guid: string;
+  displayName: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {
-	const request: RPCRequest = {
-		op,
-		payload,
-		version: 1,
-		timestamp: new Date().toISOString(),
-		user_guid: null,
-		roles: [],
-		role_mask: 0
-	};
-	const headers: Record<string, string> = {};
-	if (typeof localStorage !== 'undefined') {
-		try {
-			const raw = localStorage.getItem('authTokens');
-			if (raw) {
-				const { sessionToken } = JSON.parse(raw);
-				if (sessionToken) headers.Authorization = `Bearer ${sessionToken}`;
-			}
-		} catch {
-			/* ignore token parsing errors */
-		}
-	}
-	try {
-		const response = await axios.post<RPCResponse>('/rpc', request, { headers });
-		return response.data.payload as T;
-	} catch (err: any) {
-		if (axios.isAxiosError(err) && err.response?.status === 401) {
-			if (typeof localStorage !== 'undefined') {
-				localStorage.removeItem('authTokens');
-			}
-			if (typeof window !== 'undefined') {
-				window.dispatchEvent(new Event('sessionExpired'));
-			}
-		}
-		throw err;
-	}
+    const request: RPCRequest = {
+        op,
+        payload,
+        version: 1,
+        timestamp: new Date().toISOString(),
+        user_guid: null,
+        roles: [],
+        role_mask: 0
+    };
+    const headers: Record<string, string> = {};
+    if (typeof localStorage !== 'undefined') {
+        try {
+            const raw = localStorage.getItem('authTokens');
+            if (raw) {
+                const { sessionToken } = JSON.parse(raw);
+                if (sessionToken) headers.Authorization = `Bearer ${sessionToken}`;
+            }
+        } catch {
+            /* ignore token parsing errors */
+        }
+    }
+    try {
+        const response = await axios.post<RPCResponse>('/rpc', request, { headers });
+        return response.data.payload as T;
+    } catch (err: any) {
+        if (axios.isAxiosError(err) && err.response?.status === 401) {
+            if (typeof localStorage !== 'undefined') {
+                localStorage.removeItem('authTokens');
+            }
+            if (typeof window !== 'undefined') {
+                window.dispatchEvent(new Event('sessionExpired'));
+            }
+        }
+        throw err;
+    }
 }

--- a/rpc/auth/google/models.py
+++ b/rpc/auth/google/models.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 class AuthGoogleOauthLoginPayload1(BaseModel):
   provider: str = "google"
   code: str
-  code_verifier: str | None = None
   fingerprint: str | None = None
 
 

--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -20,7 +20,6 @@ async def exchange_code_for_tokens(
   client_id: str,
   client_secret: str,
   redirect_uri: str = "http://localhost:8000/userpage",
-  code_verifier: str | None = None,
 ) -> tuple[str, str]:
   data = {
     "code": code,
@@ -29,8 +28,6 @@ async def exchange_code_for_tokens(
     "redirect_uri": redirect_uri,
     "grant_type": "authorization_code",
   }
-  if code_verifier:
-    data["code_verifier"] = code_verifier
   logging.debug("[exchange_code_for_tokens] exchanging code for tokens")
   async with aiohttp.ClientSession() as session:
     async with session.post(GOOGLE_TOKEN_ENDPOINT, data=data) as resp:
@@ -159,7 +156,6 @@ async def auth_google_oauth_login_v1(request: Request):
 
   provider = req_payload.provider
   code = req_payload.code
-  code_verifier = req_payload.code_verifier
   logging.debug(f"[auth_google_oauth_login_v1] provider={provider}")
   logging.debug(
     f"[auth_google_oauth_login_v1] code={code[:40] if code else None}"
@@ -191,7 +187,7 @@ async def auth_google_oauth_login_v1(request: Request):
   logging.debug("[auth_google_oauth_login_v1] GoogleApiId=%s", client_id)
 
   id_token, access_token = await exchange_code_for_tokens(
-    code, client_id, client_secret, redirect_uri, code_verifier
+    code, client_id, client_secret, redirect_uri
   )
 
   provider_uid, profile, payload = await auth.handle_auth_login(

--- a/rpc/users/providers/models.py
+++ b/rpc/users/providers/models.py
@@ -8,7 +8,6 @@ class UsersProvidersSetProvider1(BaseModel):
 class UsersProvidersLinkProvider1(BaseModel):
   provider: str
   code: str
-  code_verifier: str | None = None
 
 
 class UsersProvidersUnlinkProvider1(BaseModel):

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -65,7 +65,6 @@ async def users_providers_link_provider_v1(request: Request):
       client_id,
       client_secret,
       redirect_uri,
-      payload.code_verifier,
     )
   else:
     raise HTTPException(status_code=400, detail="Unsupported auth provider")

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -80,7 +80,6 @@ def test_email_exists(monkeypatch):
   class AuthGoogleOauthLoginPayload1(BaseModel):
     provider: str = "google"
     code: str
-    code_verifier: str | None = None
     fingerprint: str | None = None
   class AuthGoogleOauthLogin1(BaseModel):
     sessionToken: str
@@ -108,7 +107,7 @@ def test_email_exists(monkeypatch):
   )
   svc_mod = importlib.util.module_from_spec(svc_spec)
   svc_spec.loader.exec_module(svc_mod)
-  async def fake_exchange(code, client_id, client_secret, redirect_uri, code_verifier=None):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri):
     assert code == "auth-code"
     assert redirect_uri == "http://localhost:8000/userpage"
     return "id", "acc"

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -82,7 +82,6 @@ def test_lookup_existing_user(monkeypatch):
   class AuthGoogleOauthLoginPayload1(BaseModel):
     provider: str = "google"
     code: str
-    code_verifier: str | None = None
     fingerprint: str | None = None
   class AuthGoogleOauthLogin1(BaseModel):
     sessionToken: str
@@ -110,7 +109,7 @@ def test_lookup_existing_user(monkeypatch):
   )
   svc_mod = importlib.util.module_from_spec(svc_spec)
   svc_spec.loader.exec_module(svc_mod)
-  async def fake_exchange(code, client_id, client_secret, redirect_uri, code_verifier=None):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri):
     assert code == "auth-code"
     assert redirect_uri == "http://localhost:8000/userpage"
     return "id", "acc"

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -92,7 +92,6 @@ def test_fetch_user_after_create(monkeypatch):
   class AuthGoogleOauthLoginPayload1(BaseModel):
     provider: str = "google"
     code: str
-    code_verifier: str | None = None
     fingerprint: str | None = None
   class AuthGoogleOauthLogin1(BaseModel):
     sessionToken: str
@@ -120,7 +119,7 @@ def test_fetch_user_after_create(monkeypatch):
   )
   svc_mod = importlib.util.module_from_spec(svc_spec)
   svc_spec.loader.exec_module(svc_mod)
-  async def fake_exchange(code, client_id, client_secret, redirect_uri, code_verifier=None):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri):
     assert code == "auth-code"
     assert redirect_uri == "http://localhost:8000/userpage"
     return "id", "acc"

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -121,13 +121,13 @@ def test_link_provider_google_normalizes_identifier():
   async def fake_get(request):
     rpc = RPCRequest(
       op="urn:users:providers:link_provider:1",
-      payload={"provider": "google", "code": "authcode", "code_verifier": "ver"},
+      payload={"provider": "google", "code": "authcode"},
       version=1,
     )
     return rpc, SimpleNamespace(user_guid="u1"), None
   svc_mod.unbox_request = fake_get
 
-  async def fake_exchange(code, client_id, client_secret, redirect_uri, code_verifier):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri):
     return "id", "acc"
   svc_mod.exchange_code_for_tokens = fake_exchange
 


### PR DESCRIPTION
## Summary
- drop custom PKCE verifier generation for Google OAuth login and provider linking
- remove `code_verifier` from auth models and services
- regenerate RPC bindings and adjust tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8973773d083259b2a65e92f8c3d8e