### PR TITLE
Log Google OAuth redirect details

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from server import lifespan, rpc_router, web_router, configure_root_logging
 
-configure_root_logging()
+configure_root_logging(True)
 
 app = FastAPI(lifespan=lifespan.lifespan)
 app.mount("/static", StaticFiles(directory="static"), name="static")

--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -28,6 +28,10 @@ async def exchange_code_for_tokens(
     "redirect_uri": redirect_uri,
     "grant_type": "authorization_code",
   }
+  logging.debug(
+    "[exchange_code_for_tokens] data=%s",
+    {k: v for k, v in data.items() if k != "client_secret"}
+  )
   logging.debug("[exchange_code_for_tokens] exchanging code for tokens")
   async with aiohttp.ClientSession() as session:
     async with session.post(GOOGLE_TOKEN_ENDPOINT, data=data) as resp:
@@ -183,8 +187,8 @@ async def auth_google_oauth_login_v1(request: Request):
   if not res_redirect.rows:
       raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
   redirect_uri = res_redirect.rows[0]["value"]
-
   logging.debug("[auth_google_oauth_login_v1] GoogleApiId=%s", client_id)
+  logging.debug("[auth_google_oauth_login_v1] redirect_uri=%s", redirect_uri)
 
   id_token, access_token = await exchange_code_for_tokens(
     code, client_id, client_secret, redirect_uri


### PR DESCRIPTION
## Summary
- Enable root logging at debug level for verbose console output
- Log redirect URI and client ID when handling Google OAuth login
- Log OAuth token request data (excluding client secret) to debug redirect mismatches

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68a8b588fce08325be08cb0c3b6f9c4d