### PR TITLE
Pass access token to ID token verification

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -72,7 +72,7 @@ class AuthModule(BaseModule):
     if not id_token or not access_token:
       logging.error("[AuthModule] Missing credentials for provider %s", provider)
       raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing credentials")
-    payload = await strategy.verify_id_token(id_token)
+    payload = await strategy.verify_id_token(id_token, access_token)
     guid = strategy.extract_guid(payload)
     if not guid:
       logging.error("[AuthModule] Missing guid in token for provider %s", provider)

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -80,7 +80,7 @@ def test_handle_auth_login_prefers_oid(monkeypatch):
   module = AuthModule(app)
 
   class FakeProvider:
-    async def verify_id_token(self, token):
+    async def verify_id_token(self, token, access_token):
       return {"oid": "oid123", "sub": "sub456"}
 
     async def fetch_user_profile(self, token):
@@ -103,7 +103,7 @@ def test_handle_auth_login_falls_back_to_sub(monkeypatch):
   module = AuthModule(app)
 
   class FakeProvider:
-    async def verify_id_token(self, token):
+    async def verify_id_token(self, token, access_token):
       return {"sub": "sub456"}
 
     async def fetch_user_profile(self, token):
@@ -127,7 +127,7 @@ def test_handle_auth_login_selects_provider():
     def __init__(self):
       self.called = False
 
-    async def verify_id_token(self, token):
+    async def verify_id_token(self, token, access_token):
       self.called = True
       return {"sub": "a"}
 
@@ -138,7 +138,7 @@ def test_handle_auth_login_selects_provider():
       return payload.get("sub")
 
   class ProviderB(ProviderA):
-    async def verify_id_token(self, token):
+    async def verify_id_token(self, token, access_token):
       self.called = True
       return {"sub": "b"}
 


### PR DESCRIPTION
## Summary
- include access token when verifying ID tokens to validate at_hash claim
- use access token in auth login flow
- adjust auth module tests for new verify_id_token signature

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8b81cf2108325bf4202fb9aec6fe0