### PR TITLE
Track provider in session devices

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -14,8 +14,9 @@ JOIN users_roles ur ON au.element_guid = ur.users_guid
 JOIN users_profileimg up ON au.element_guid = up.users_guid
 JOIN auth_providers ap ON au.providers_recid = ap.recid
 JOIN sessions_devices sd ON us.element_guid = sd.sessions_guid
+JOIN auth_providers ap2 ON sd.providers_recid = ap2.recid
 
-`users_sessions` records only map a user to a session identifier and creation time. Token data and device metadata live in `sessions_devices`, which references the session via `sessions_guid`.
+`users_sessions` records only map a user to a session identifier and creation time. Token data, device metadata, and the issuing provider live in `sessions_devices`, which references the session via `sessions_guid`.
 
 Note: `users_auth.element_identifier` is a `UNIQUEIDENTIFIER` and must be unique across all providers.
 
@@ -53,6 +54,8 @@ SELECT
     us.element_guid             AS session_guid,
     us.element_created_at       AS session_created_at,
     sd.element_guid             AS device_guid,
+    sd.providers_recid,
+    ap.element_name             AS provider_name,
     sd.element_token,
     sd.element_token_iat,
     sd.element_token_exp,
@@ -62,6 +65,7 @@ SELECT
     sd.element_ip_last_seen
 FROM account_users AS au
 JOIN users_sessions AS us ON au.element_guid = us.users_guid
-JOIN sessions_devices AS sd ON us.element_guid = sd.sessions_guid;
+JOIN sessions_devices AS sd ON us.element_guid = sd.sessions_guid
+JOIN auth_providers AS ap ON sd.providers_recid = ap.recid;
 ```
 

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -100,6 +100,7 @@ async def create_session(
       "user_agent": user_agent,
       "ip_address": ip_address,
       "user_guid": user_guid,
+      "provider": provider,
     },
   )
   return session_token, session_exp

--- a/scripts/MSSQL_schema.sql
+++ b/scripts/MSSQL_schema.sql
@@ -42,6 +42,7 @@ CREATE TABLE frontend_routes (
 CREATE TABLE sessions_devices (
     element_guid UNIQUEIDENTIFIER PRIMARY KEY,
     sessions_guid UNIQUEIDENTIFIER NOT NULL,
+    providers_recid INT NOT NULL,
     element_token NVARCHAR(MAX) NOT NULL,
     element_token_iat DATETIMEOFFSET NOT NULL DEFAULT SYSDATETIMEOFFSET(),
     element_token_exp DATETIMEOFFSET NOT NULL,
@@ -50,6 +51,7 @@ CREATE TABLE sessions_devices (
     element_ip_last_seen NVARCHAR(64) NULL,
     element_revoked_at DATETIMEOFFSET NULL,
     FOREIGN KEY (sessions_guid) REFERENCES users_sessions(element_guid),
+    FOREIGN KEY (providers_recid) REFERENCES auth_providers(recid),
     UNIQUE (sessions_guid)
 );
 

--- a/scripts/MSSQL_scripts.sql
+++ b/scripts/MSSQL_scripts.sql
@@ -7,6 +7,7 @@ JOIN users_roles ur ON au.element_guid = ur.users_guid
 JOIN users_profileimg up ON au.element_guid = up.users_guid
 JOIN auth_providers ap ON au.providers_recid = ap.recid
 JOIN sessions_devices sd ON us.element_guid = sd.sessions_guid
+JOIN auth_providers apd ON sd.providers_recid = apd.recid
 
 
 -- DELETE JOINED RECORD --

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -77,7 +77,9 @@ def test_mssql_get_rotkey_uses_security_view():
 def test_mssql_get_by_access_token_uses_security_view():
   handler = get_mssql_handler("db:auth:session:get_by_access_token:1")
   _, sql, _ = handler({"access_token": "tok"})
-  assert "vw_account_user_security" in sql.lower()
+  sql = sql.lower()
+  assert "vw_account_user_security" in sql
+  assert "providers_recid" in sql
 
 
 def test_fetch_rows_returns_empty_on_error(monkeypatch):

--- a/tests/test_users_session_upsert.py
+++ b/tests/test_users_session_upsert.py
@@ -45,12 +45,16 @@ spec.loader.exec_module(registry_mod)
 
 def test_create_session_updates_existing(monkeypatch):
   executed: list[str] = []
+  fetch_calls: list[int] = []
 
   class DummyCur:
     async def execute(self, sql, params):
       executed.append(sql.lower())
     async def fetchone(self):
-      return {"element_guid": "sess"}
+      if not fetch_calls:
+        fetch_calls.append(1)
+        return (1,)
+      return ("sess",)
 
   @asynccontextmanager
   async def fake_tx():
@@ -65,6 +69,7 @@ def test_create_session_updates_existing(monkeypatch):
     "user_agent": None,
     "ip_address": None,
     "user_guid": "user",
+    "provider": "microsoft",
   }
   asyncio.run(handler(args))
   assert any("update users_sessions" in q for q in executed)


### PR DESCRIPTION
## Summary
- record provider relationship in `sessions_devices` and associated view
- pass provider through session creation flow and update tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68aa096257f4832596acf3cd6717a0d5