### PR TITLE
Include provider in session creation args

### DIFF
--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -146,6 +146,7 @@ async def create_session(
       "user_agent": user_agent,
       "ip_address": ip_address,
       "user_guid": user_guid,
+      "provider": provider,
     },
   )
   return session_token, session_exp

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -128,6 +128,7 @@ async def auth_session_get_token_v1(request: Request):
       "user_agent": user_agent,
       "ip_address": ip_address,
       "user_guid": user_guid,
+      "provider": provider,
     },
   )
 

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -131,7 +131,10 @@ def test_fetch_user_after_create(monkeypatch):
   assert isinstance(resp, RPCResponse)
   calls = [op for op, _ in req.app.state.db.calls if op == "urn:users:providers:get_by_provider_identifier:1"]
   assert len(calls) == 2
-  assert any(op == "db:auth:session:create_session:1" for op, _ in req.app.state.db.calls)
+  assert any(
+    op == "db:auth:session:create_session:1" and args.get("provider") == "google"
+    for op, args in req.app.state.db.calls
+  )
   expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "google-id"))
   assert any(
     op == "urn:users:providers:create_from_provider:1" and args["provider_identifier"] == expected

--- a/tests/test_auth_microsoft_oauth_login_creation.py
+++ b/tests/test_auth_microsoft_oauth_login_creation.py
@@ -106,7 +106,10 @@ def test_fetch_user_after_create(monkeypatch):
   assert isinstance(resp, RPCResponse)
   calls = [op for op, _ in req.app.state.db.calls if op == "urn:users:providers:get_by_provider_identifier:1"]
   assert len(calls) == 2
-  assert any(op == "db:auth:session:create_session:1" for op, _ in req.app.state.db.calls)
+  assert any(
+    op == "db:auth:session:create_session:1" and args.get("provider") == "microsoft"
+    for op, args in req.app.state.db.calls
+  )
 
 
 

--- a/tests/test_auth_session_db_profile.py
+++ b/tests/test_auth_session_db_profile.py
@@ -74,3 +74,7 @@ def test_auth_session_returns_db_profile(monkeypatch):
   profile = data["payload"]["profile"]
   assert profile["display_name"] == "DB"
   assert profile["email"] == "db@example.com"
+  assert any(
+    op == "db:auth:session:create_session:1" and args.get("provider") == "google"
+    for op, args in req.app.state.db.calls
+  )

--- a/tests/test_google_services_helpers.py
+++ b/tests/test_google_services_helpers.py
@@ -105,3 +105,5 @@ def test_create_session_handles_missing_roles():
   assert token == "sess"
   ops = [op for op, _ in db.calls]
   assert "db:auth:session:create_session:1" in ops
+  args = [a for op, a in db.calls if op == "db:auth:session:create_session:1"][0]
+  assert args["provider"] == "google"

--- a/tests/test_microsoft_services_helpers.py
+++ b/tests/test_microsoft_services_helpers.py
@@ -106,4 +106,6 @@ def test_create_session_handles_missing_roles():
   assert token == "sess"
   ops = [op for op, _ in db.calls]
   assert "db:auth:session:create_session:1" in ops
+  args = [a for op, a in db.calls if op == "db:auth:session:create_session:1"][0]
+  assert args["provider"] == "microsoft"
 


### PR DESCRIPTION
## Summary
- include provider field when creating auth sessions
- ensure session services propagate provider and tests validate it

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68aa7705dc7c83259ce64a88bd32e8b2