### PR TITLE
refactor: extract role selector component

### DIFF
--- a/frontend/src/RolesSelector.tsx
+++ b/frontend/src/RolesSelector.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import {
+	Stack,
+	List,
+	ListItemButton,
+	ListItemText,
+	IconButton,
+} from "@mui/material";
+import { ArrowForwardIos, ArrowBackIos } from "@mui/icons-material";
+
+interface RolesSelectorProps {
+	allRoles: string[];
+	value: string[];
+	onChange: (roles: string[]) => void;
+	maxHeight?: number;
+}
+
+const RolesSelector = ({
+	allRoles,
+	value,
+	onChange,
+	maxHeight = 120,
+}: RolesSelectorProps): JSX.Element => {
+	const [left, setLeft] = useState<string | null>(null);
+	const [right, setRight] = useState<string | null>(null);
+	const available = allRoles.filter((r) => !value.includes(r));
+	const moveRight = (): void => {
+		if (!left) return;
+		onChange([...value, left]);
+		setLeft(null);
+	};
+	const moveLeft = (): void => {
+		if (!right) return;
+		onChange(value.filter((r) => r !== right));
+		setRight(null);
+	};
+        return (
+                <Stack direction="row" spacing={1} sx={{ width: "100%" }}>
+                        <List
+                                sx={{
+                                        flex: 1,
+                                        minWidth: 200,
+                                        maxHeight,
+                                        overflow: "auto",
+                                        border: 1,
+                                }}
+                        >
+				{available.map((role) => (
+					<ListItemButton
+						key={role}
+						selected={left === role}
+						onClick={() => setLeft(role)}
+					>
+						<ListItemText primary={role} />
+					</ListItemButton>
+				))}
+			</List>
+			<Stack spacing={1} justifyContent="center">
+				<IconButton onClick={moveRight}>
+					<ArrowForwardIos />
+				</IconButton>
+				<IconButton onClick={moveLeft}>
+					<ArrowBackIos />
+				</IconButton>
+			</Stack>
+                        <List
+                                sx={{
+                                        flex: 1,
+                                        minWidth: 200,
+                                        maxHeight,
+                                        overflow: "auto",
+                                        border: 1,
+                                }}
+                        >
+				{value.map((role) => (
+					<ListItemButton
+						key={role}
+						selected={right === role}
+						onClick={() => setRight(role)}
+					>
+						<ListItemText primary={role} />
+					</ListItemButton>
+				))}
+			</List>
+		</Stack>
+	);
+};
+
+export default RolesSelector;
+

--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -1,26 +1,18 @@
 import { useEffect, useState } from "react";
 import {
-	Box,
-	Divider,
-	Table,
-	TableHead,
-	TableRow,
-	TableCell,
-	TableBody,
-	TextField,
-	IconButton,
-	Stack,
-	List,
-	ListItemButton,
-	ListItemText,
-	Typography,
+        Box,
+        Divider,
+        Table,
+        TableHead,
+        TableRow,
+        TableCell,
+        TableBody,
+        TextField,
+        IconButton,
+        Typography,
 } from "@mui/material";
-import {
-	Delete,
-	Add,
-	ArrowForwardIos,
-	ArrowBackIos,
-} from "@mui/icons-material";
+import { Delete, Add } from "@mui/icons-material";
+import RolesSelector from "./RolesSelector";
 import type {
 	SystemRoutesRouteItem1,
 	SystemRoutesList1,
@@ -33,17 +25,9 @@ import {
 } from "./rpc/system/routes";
 import { fetchRoles } from "./rpc/service/roles";
 
-const MAX_HEIGHT = 120;
-
 const SystemRoutesPage = (): JSX.Element => {
 	const [routes, setRoutes] = useState<SystemRoutesRouteItem1[]>([]);
 	const [roleNames, setRoleNames] = useState<string[]>([]);
-	const [selectedLeft, setSelectedLeft] = useState<Record<number, string>>(
-		{},
-	);
-	const [selectedRight, setSelectedRight] = useState<Record<number, string>>(
-		{},
-	);
 	const [newRoute, setNewRoute] = useState<SystemRoutesRouteItem1>({
 		path: "",
 		name: "",
@@ -51,8 +35,6 @@ const SystemRoutesPage = (): JSX.Element => {
 		sequence: 0,
 		required_roles: [],
 	});
-		const [newLeft, setNewLeft] = useState<string | null>(null);
-		const [newRight, setNewRight] = useState<string | null>(null);
 		const [forbidden, setForbidden] = useState(false);
 
 		const load = async (): Promise<void> => {
@@ -107,67 +89,25 @@ const SystemRoutesPage = (): JSX.Element => {
 				void load();
 		};
 
-	const moveRight = async (idx: number): Promise<void> => {
-		const role = selectedLeft[idx];
-		if (!role) return;
-		const updatedRoles = [...routes[idx].required_roles, role];
-				setSelectedLeft({ ...selectedLeft, [idx]: "" });
-				await updateRoute(idx, "required_roles", updatedRoles);
-				console.debug("[SystemRoutesPage] moved role to required", role);
-		};
-
-	const moveLeft = async (idx: number): Promise<void> => {
-		const role = selectedRight[idx];
-		if (!role) return;
-		const updatedRoles = routes[idx].required_roles.filter(
-			(r) => r !== role,
-		);
-				setSelectedRight({ ...selectedRight, [idx]: "" });
-				await updateRoute(idx, "required_roles", updatedRoles);
-				console.debug("[SystemRoutesPage] removed role from required", role);
-		};
-
 	const handleDelete = async (path: string): Promise<void> => {
 				console.debug("[SystemRoutesPage] deleting route", path);
 				await fetchDeleteRoute({ path });
 				void load();
 		};
 
-	const addMoveRight = (role: string | null): void => {
-		if (!role) return;
-				setNewRoute({
-						...newRoute,
-						required_roles: [...newRoute.required_roles, role],
-				});
-				console.debug("[SystemRoutesPage] added role to new route", role);
-				setNewLeft(null);
-		};
-
-	const addMoveLeft = (role: string | null): void => {
-		if (!role) return;
-				setNewRoute({
-						...newRoute,
-						required_roles: newRoute.required_roles.filter((r) => r !== role),
-				});
-				console.debug("[SystemRoutesPage] removed role from new route", role);
-				setNewRight(null);
-		};
-
 	const handleAdd = async (): Promise<void> => {
 		if (!newRoute.path) return;
 				console.debug("[SystemRoutesPage] adding route", newRoute);
 				await fetchUpsertRoute(newRoute);
-				setNewRoute({
-						path: "",
-						name: "",
-			icon: "",
-			sequence: 0,
-			required_roles: [],
-		});
-		setNewLeft(null);
-		setNewRight(null);
-		void load();
-	};
+                setNewRoute({
+                                path: "",
+                                name: "",
+                                icon: "",
+                                sequence: 0,
+                                required_roles: [],
+                });
+                void load();
+        };
 
 	return (
 		<Box sx={{ p: 2 }}>
@@ -176,162 +116,94 @@ const SystemRoutesPage = (): JSX.Element => {
 			<Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
 				<TableHead>
 					<TableRow>
-						<TableCell>Path</TableCell>
-						<TableCell>Name</TableCell>
-						<TableCell>Icon</TableCell>
-						<TableCell>Sequence</TableCell>
-						<TableCell>Roles</TableCell>
-						<TableCell />
-					</TableRow>
-				</TableHead>
-				<TableBody>
-					{routes.map((r, idx) => {
-						const available = roleNames.filter(
-							(n) => !r.required_roles.includes(n),
-						);
-						return (
-							<TableRow key={r.path}>
-								<TableCell>
-									<TextField
-										value={r.path}
-										onChange={(e) =>
-											updateRoute(
-												idx,
-												"path",
-												e.target.value,
-											)
-										}
-									/>
-								</TableCell>
-								<TableCell>
-									<TextField
-										value={r.name}
-										onChange={(e) =>
-											updateRoute(
-												idx,
-												"name",
-												e.target.value,
-											)
-										}
-									/>
-								</TableCell>
-								<TableCell>
-									<TextField
-										value={r.icon ?? ""}
-										onChange={(e) =>
-											updateRoute(
-												idx,
-												"icon",
-												e.target.value,
-											)
-										}
-									/>
-								</TableCell>
-								<TableCell>
-									<TextField
-										type="number"
-										value={r.sequence}
-										onChange={(e) =>
-											updateRoute(
-												idx,
-												"sequence",
-												Number(e.target.value),
-											)
-										}
-									/>
-								</TableCell>
-								<TableCell>
-									<Stack direction="row" spacing={1}>
-										<List
-											sx={{
-												width: 120,
-												maxHeight: MAX_HEIGHT,
-												overflow: "auto",
-												border: 1,
-											}}
-										>
-											{available.map((role) => (
-												<ListItemButton
-													key={role}
-													selected={
-														selectedLeft[idx] ===
-														role
-													}
-													onClick={() =>
-														setSelectedLeft({
-															...selectedLeft,
-															[idx]: role,
-														})
-													}
-												>
-													<ListItemText
-														primary={role}
-													/>
-												</ListItemButton>
-											))}
-										</List>
-										<Stack
-											spacing={1}
-											justifyContent="center"
-										>
-											<IconButton
-												onClick={() =>
-													void moveRight(idx)
-												}
-											>
-												<ArrowForwardIos />
-											</IconButton>
-											<IconButton
-												onClick={() =>
-													void moveLeft(idx)
-												}
-											>
-												<ArrowBackIos />
-											</IconButton>
-										</Stack>
-										<List
-											sx={{
-												width: 120,
-												maxHeight: MAX_HEIGHT,
-												overflow: "auto",
-												border: 1,
-											}}
-										>
-											{r.required_roles.map((role) => (
-												<ListItemButton
-													key={role}
-													selected={
-														selectedRight[idx] ===
-														role
-													}
-													onClick={() =>
-														setSelectedRight({
-															...selectedRight,
-															[idx]: role,
-														})
-													}
-												>
-													<ListItemText
-														primary={role}
-													/>
-												</ListItemButton>
-											))}
-										</List>
-									</Stack>
-								</TableCell>
-								<TableCell>
-									<IconButton
-										onClick={() => handleDelete(r.path)}
-									>
-										<Delete />
-									</IconButton>
-								</TableCell>
-							</TableRow>
-						);
-					})}
-					<TableRow>
-						<TableCell>
-							<TextField
+                                                <TableCell>Path</TableCell>
+                                                <TableCell>Name</TableCell>
+                                                <TableCell>Icon</TableCell>
+                                                <TableCell>Sequence</TableCell>
+                                                <TableCell />
+                                        </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                        {routes.map((r, idx) => (
+                                                <>
+                                                        <TableRow key={r.path}>
+                                                                <TableCell>
+                                                                        <TextField
+                                                                                value={r.path}
+                                                                                onChange={(e) =>
+                                                                                        updateRoute(
+                                                                                                idx,
+                                                                                                "path",
+                                                                                                e.target.value,
+                                                                                        )
+                                                                                }
+                                                                        />
+                                                                </TableCell>
+                                                                <TableCell>
+                                                                        <TextField
+                                                                                value={r.name}
+                                                                                onChange={(e) =>
+                                                                                        updateRoute(
+                                                                                                idx,
+                                                                                                "name",
+                                                                                                e.target.value,
+                                                                                        )
+                                                                                }
+                                                                        />
+                                                                </TableCell>
+                                                                <TableCell>
+                                                                        <TextField
+                                                                                value={r.icon ?? ""}
+                                                                                onChange={(e) =>
+                                                                                        updateRoute(
+                                                                                                idx,
+                                                                                                "icon",
+                                                                                                e.target.value,
+                                                                                        )
+                                                                                }
+                                                                        />
+                                                                </TableCell>
+                                                                <TableCell>
+                                                                        <TextField
+                                                                                type="number"
+                                                                                value={r.sequence}
+                                                                                onChange={(e) =>
+                                                                                        updateRoute(
+                                                                                                idx,
+                                                                                                "sequence",
+                                                                                                Number(e.target.value),
+                                                                                        )
+                                                                                }
+                                                                        />
+                                                                </TableCell>
+                                                                <TableCell>
+                                                                        <IconButton
+                                                                                onClick={() => handleDelete(r.path)}
+                                                                        >
+                                                                                <Delete />
+                                                                        </IconButton>
+                                                                </TableCell>
+                                                        </TableRow>
+                                                        <TableRow>
+                                                                <TableCell colSpan={5}>
+                                                                        <RolesSelector
+                                                                                allRoles={roleNames}
+                                                                                value={r.required_roles}
+                                                                                onChange={(roles) =>
+                                                                                        void updateRoute(
+                                                                                                idx,
+                                                                                                "required_roles",
+                                                                                                roles,
+                                                                                        )
+                                                                                }
+                                                                        />
+                                                                </TableCell>
+                                                        </TableRow>
+                                                </>
+                                        ))}
+                                        <TableRow>
+                                                <TableCell>
+                                                        <TextField
 								value={newRoute.path}
 								onChange={(e) =>
 									setNewRoute({
@@ -375,71 +247,24 @@ const SystemRoutesPage = (): JSX.Element => {
 								}
 							/>
 						</TableCell>
-						<TableCell>
-							<Stack direction="row" spacing={1}>
-								<List
-									sx={{
-										width: 120,
-										maxHeight: MAX_HEIGHT,
-										overflow: "auto",
-										border: 1,
-									}}
-								>
-									{roleNames
-										.filter(
-											(r) =>
-												!newRoute.required_roles.includes(
-													r,
-												),
-										)
-										.map((role) => (
-											<ListItemButton
-												key={role}
-												selected={newLeft === role}
-												onClick={() => setNewLeft(role)}
-											>
-												<ListItemText primary={role} />
-											</ListItemButton>
-										))}
-								</List>
-								<Stack spacing={1} justifyContent="center">
-									<IconButton
-										onClick={() => addMoveRight(newLeft)}
-									>
-										<ArrowForwardIos />
-									</IconButton>
-									<IconButton
-										onClick={() => addMoveLeft(newRight)}
-									>
-										<ArrowBackIos />
-									</IconButton>
-								</Stack>
-								<List
-									sx={{
-										width: 120,
-										maxHeight: MAX_HEIGHT,
-										overflow: "auto",
-										border: 1,
-									}}
-								>
-									{newRoute.required_roles.map((role) => (
-										<ListItemButton
-											key={role}
-											selected={newRight === role}
-											onClick={() => setNewRight(role)}
-										>
-											<ListItemText primary={role} />
-										</ListItemButton>
-									))}
-								</List>
-							</Stack>
-						</TableCell>
-						<TableCell>
-							<IconButton onClick={handleAdd}>
-								<Add />
-							</IconButton>
-						</TableCell>
-					</TableRow>
+                                                <TableCell>
+                                                        <RolesSelector
+                                                                allRoles={roleNames}
+                                                                value={newRoute.required_roles}
+                                                                onChange={(roles) =>
+                                                                        setNewRoute({
+                                                                                ...newRoute,
+                                                                                required_roles: roles,
+                                                                        })
+                                                                }
+                                                        />
+                                                </TableCell>
+                                                <TableCell>
+                                                        <IconButton onClick={handleAdd}>
+                                                                <Add />
+                                                        </IconButton>
+                                                </TableCell>
+                                        </TableRow>
 				</TableBody>
 			</Table>
 		</Box>


### PR DESCRIPTION
## Summary
- restyle SystemRoutesPage form so roles editor sits below path/name/icon/sequence
- introduce shared RolesSelector component for editing role membership
- expand role selector lists to fill container for readable role names

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ab33667cfc832583c55ceff01f3d50