### PR TITLE
fix: use keyed Fragment in SystemRoutesPage

### DIFF
--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -124,8 +124,8 @@ const SystemRoutesPage = (): JSX.Element => {
         </TableHead>
       <TableBody>
                                         {routes.map((r, idx) => (
-                                                <>
-                                                        <TableRow key={r.path}>
+                                                <Fragment key={r.path}>
+                                                        <TableRow>
                                                                 <TableCell>
                                                                         <TextField
                                                                                 value={r.path}
@@ -198,7 +198,7 @@ const SystemRoutesPage = (): JSX.Element => {
                                                                         />
                                                                 </TableCell>
                                                         </TableRow>
-                                                </>
+                                                </Fragment>
                                         ))}
                                         <TableRow>
                                                 <TableCell>


### PR DESCRIPTION
## Summary
- wrap SystemRoutesPage entries in keyed React fragment to satisfy lint

## Testing
- `npm run lint`
- `npm run type-check`
- `npx vitest run --coverage`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3cd7d0f48325ae6cc0792efa0f4a