### PR TITLE
fix: improve SystemRoutesPage list layout

### DIFF
--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -124,9 +124,9 @@ const SystemRoutesPage = (): JSX.Element => {
         </TableHead>
       <TableBody>
                                         {routes.map((r, idx) => (
-                                                <>
-                                                        <TableRow key={r.path}>
-                                                                <TableCell>
+                                                <Fragment key={r.path}>
+                                                        <TableRow sx={{ "& > *": { borderBottom: "none" } }}>
+                                                               <TableCell>
                                                                         <TextField
                                                                                 value={r.path}
                                                                                 onChange={(e) =>
@@ -198,7 +198,7 @@ const SystemRoutesPage = (): JSX.Element => {
                                                                         />
                                                                 </TableCell>
                                                         </TableRow>
-                                                </>
+                                                </Fragment>
                                         ))}
                                         <TableRow>
                                                 <TableCell>


### PR DESCRIPTION
## Summary
- wrap SystemRoutesPage entries in keyed React fragment to satisfy lint
- remove divider line between route fields and roles to clarify grouping

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3cd7d0f48325ae6cc0792efa0f4a