### PR TITLE
feat: add shared edit box component

### DIFF
--- a/frontend/src/EditBox.tsx
+++ b/frontend/src/EditBox.tsx
@@ -1,0 +1,66 @@
+import React, { useState, useEffect } from 'react';
+import TextField from '@mui/material/TextField';
+import Notification from './Notification';
+
+interface EditBoxProps {
+        value: string | number;
+        onCommit: (value: string | number) => Promise<void> | void;
+        width?: string | number;
+}
+
+const EditBox = ({ value, onCommit, width = '100%' }: EditBoxProps): JSX.Element => {
+        const [internal, setInternal] = useState<string | number>(value);
+        const [notify, setNotify] = useState(false);
+
+        useEffect(() => {
+                setInternal(value);
+        }, [value]);
+
+        const commit = async (): Promise<void> => {
+                if (internal !== value) {
+                        await onCommit(internal);
+                        setNotify(true);
+                }
+        };
+
+        const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+                if (e.key === 'Enter' || e.key === 'Tab') {
+                        void commit();
+                }
+        };
+
+        const handleBlur = (): void => {
+                void commit();
+        };
+
+        const handleClose = (): void => {
+                setNotify(false);
+        };
+
+        const type = typeof value === 'number' ? 'number' : 'text';
+
+        return (
+                <>
+                        <TextField
+                                sx={{ width }}
+                                type={type}
+                                value={internal}
+                                onChange={(e) => {
+                                        const target = e.target as HTMLInputElement;
+                                        const val = type === 'number' ? Number(target.value) : target.value;
+                                        setInternal(val);
+                                }}
+                                onKeyDown={handleKeyDown}
+                                onBlur={handleBlur}
+                        />
+                        <Notification
+                                open={notify}
+                                handleClose={handleClose}
+                                severity='success'
+                                message='Saved'
+                        />
+                </>
+        );
+};
+
+export default EditBox;

--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -13,6 +13,7 @@ import {
 } from "@mui/material";
 import { Delete, Add } from "@mui/icons-material";
 import RolesSelector from "./RolesSelector";
+import EditBox from "./EditBox";
 import type {
 	SystemRoutesRouteItem1,
 	SystemRoutesList1,
@@ -127,52 +128,55 @@ const SystemRoutesPage = (): JSX.Element => {
                                                 <Fragment key={r.path}>
                                                         <TableRow sx={{ "& > *": { borderBottom: "none" } }}>
                                                                <TableCell>
-                                                                        <TextField
+                                                                        <EditBox
                                                                                 value={r.path}
-                                                                                onChange={(e) =>
+                                                                                onCommit={(val) =>
                                                                                         updateRoute(
                                                                                                 idx,
                                                                                                 "path",
-                                                                                                e.target.value,
+                                                                                                val,
                                                                                         )
                                                                                 }
+                                                                                width="100%"
                                                                         />
                                                                 </TableCell>
                                                                 <TableCell>
-                                                                        <TextField
+                                                                        <EditBox
                                                                                 value={r.name}
-                                                                                onChange={(e) =>
+                                                                                onCommit={(val) =>
                                                                                         updateRoute(
                                                                                                 idx,
                                                                                                 "name",
-                                                                                                e.target.value,
+                                                                                                val,
                                                                                         )
                                                                                 }
+                                                                                width="100%"
                                                                         />
                                                                 </TableCell>
                                                                 <TableCell>
-                                                                        <TextField
+                                                                        <EditBox
                                                                                 value={r.icon ?? ""}
-                                                                                onChange={(e) =>
+                                                                                onCommit={(val) =>
                                                                                         updateRoute(
                                                                                                 idx,
                                                                                                 "icon",
-                                                                                                e.target.value,
+                                                                                                val,
                                                                                         )
                                                                                 }
+                                                                                width="100%"
                                                                         />
                                                                 </TableCell>
                                                                 <TableCell>
-                                                                        <TextField
-                                                                                type="number"
+                                                                        <EditBox
                                                                                 value={r.sequence}
-                                                                                onChange={(e) =>
+                                                                                onCommit={(val) =>
                                                                                         updateRoute(
                                                                                                 idx,
                                                                                                 "sequence",
-                                                                                                Number(e.target.value),
+                                                                                                val,
                                                                                         )
                                                                                 }
+                                                                                width="100%"
                                                                         />
                                                                 </TableCell>
                                                                 <TableCell>


### PR DESCRIPTION
## Summary
- add reusable EditBox component with commit-on-blur or Enter behavior
- use EditBox in SystemRoutesPage to standardize route field editing

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4427834c83259079d86345181095