### PR TITLE
feat: add shared edit box component

### DIFF
--- a/frontend/src/EditBox.tsx
+++ b/frontend/src/EditBox.tsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from 'react';
+import TextField from '@mui/material/TextField';
+import Notification from './Notification';
+
+interface EditBoxProps {
+		value: string | number;
+		onCommit: (value: string | number) => Promise<void> | void;
+		width?: string | number;
+}
+
+const EditBox = ({ value, onCommit, width = '100%' }: EditBoxProps): JSX.Element => {
+		const [internal, setInternal] = useState<string | number>(value);
+		const [notify, setNotify] = useState(false);
+
+		useEffect(() => {
+				setInternal(value);
+		}, [value]);
+
+		const commit = async (): Promise<void> => {
+				if (internal !== value) {
+						await onCommit(internal);
+						setNotify(true);
+				}
+		};
+
+		const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+				if (e.key === 'Enter' || e.key === 'Tab') {
+						void commit();
+				}
+		};
+
+		const handleBlur = (): void => {
+				void commit();
+		};
+
+		const handleClose = (): void => {
+				setNotify(false);
+		};
+
+		const type = typeof value === 'number' ? 'number' : 'text';
+
+		return (
+				<>
+				<TextField
+				size='small'
+				sx={{ width, '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}
+				type={type}
+				value={internal}
+				onChange={(e) => {
+					const target = e.target as HTMLInputElement;
+					const val = type === 'number' ? Number(target.value) : target.value;
+					setInternal(val);
+				}}
+				onKeyDown={handleKeyDown}
+				onBlur={handleBlur}
+			/>
+						<Notification
+								open={notify}
+								handleClose={handleClose}
+								severity='success'
+								message='Saved'
+						/>
+				</>
+		);
+};
+
+export default EditBox;

--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -1,28 +1,29 @@
 import { useEffect, useState, Fragment } from "react";
 import {
-        Box,
-        Divider,
-        Table,
-        TableHead,
-        TableRow,
-        TableCell,
-        TableBody,
-        TextField,
-        IconButton,
-        Typography,
-} from "@mui/material";
+		Box,
+		Divider,
+		Table,
+		TableHead,
+		TableRow,
+		TableCell,
+		TableBody,
+		TextField,
+		IconButton,
+		Typography,
+				} from "@mui/material";
 import { Delete, Add } from "@mui/icons-material";
 import RolesSelector from "./RolesSelector";
+import EditBox from "./EditBox";
 import type {
 	SystemRoutesRouteItem1,
 	SystemRoutesList1,
-        ServiceRolesRoles1,
-} from "./shared/RpcModels";
+		ServiceRolesRoles1,
+				} from "./shared/RpcModels";
 import {
 	fetchRoutes,
 	fetchUpsertRoute,
 	fetchDeleteRoute,
-} from "./rpc/system/routes";
+				} from "./rpc/system/routes";
 import { fetchRoles } from "./rpc/service/roles";
 
 const SystemRoutesPage = (): JSX.Element => {
@@ -50,7 +51,7 @@ const SystemRoutesPage = (): JSX.Element => {
 						}
 				}
 				try {
-                                                const roles: ServiceRolesRoles1 = await fetchRoles();
+												const roles: ServiceRolesRoles1 = await fetchRoles();
 						setRoleNames(roles.roles);
 						console.debug("[SystemRoutesPage] loaded roles");
 				} catch (e: any) {
@@ -98,176 +99,167 @@ const SystemRoutesPage = (): JSX.Element => {
 		if (!newRoute.path) return;
 				console.debug("[SystemRoutesPage] adding route", newRoute);
 				await fetchUpsertRoute(newRoute);
-                setNewRoute({
-                                path: "",
-                                name: "",
-                                icon: "",
-                                sequence: 0,
-                                required_roles: [],
-                });
-                void load();
-        };
+				setNewRoute({
+								path: "",
+								name: "",
+								icon: "",
+								sequence: 0,
+								required_roles: [],
+				});
+				void load();
+		};
 
 	return (
 		<Box sx={{ p: 2 }}>
 			<Typography variant="h5">System Routes</Typography>
 			<Divider sx={{ mb: 2 }} />
-			<Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
-				<TableHead>
-					<TableRow>
-            <TableCell>Path</TableCell>
-            <TableCell>Name</TableCell>
-            <TableCell>Icon</TableCell>
-            <TableCell>Sequence</TableCell>
-            <TableCell />
-          </TableRow>
-        </TableHead>
-      <TableBody>
-                                        {routes.map((r, idx) => (
-                                                <Fragment key={r.path}>
-                                                        <TableRow sx={{ "& > *": { borderBottom: "none" } }}>
-                                                               <TableCell>
-                                                                        <TextField
-                                                                                value={r.path}
-                                                                                onChange={(e) =>
-                                                                                        updateRoute(
-                                                                                                idx,
-                                                                                                "path",
-                                                                                                e.target.value,
-                                                                                        )
-                                                                                }
-                                                                        />
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                        <TextField
-                                                                                value={r.name}
-                                                                                onChange={(e) =>
-                                                                                        updateRoute(
-                                                                                                idx,
-                                                                                                "name",
-                                                                                                e.target.value,
-                                                                                        )
-                                                                                }
-                                                                        />
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                        <TextField
-                                                                                value={r.icon ?? ""}
-                                                                                onChange={(e) =>
-                                                                                        updateRoute(
-                                                                                                idx,
-                                                                                                "icon",
-                                                                                                e.target.value,
-                                                                                        )
-                                                                                }
-                                                                        />
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                        <TextField
-                                                                                type="number"
-                                                                                value={r.sequence}
-                                                                                onChange={(e) =>
-                                                                                        updateRoute(
-                                                                                                idx,
-                                                                                                "sequence",
-                                                                                                Number(e.target.value),
-                                                                                        )
-                                                                                }
-                                                                        />
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                        <IconButton
-                                                                                onClick={() => handleDelete(r.path)}
-                                                                        >
-                                                                                <Delete />
-                                                                        </IconButton>
-                                                                </TableCell>
-                                                        </TableRow>
-                                                        <TableRow>
-                                                                <TableCell colSpan={5}>
-                                                                        <RolesSelector
-                                                                                allRoles={roleNames}
-                                                                                value={r.required_roles}
-                                                                                onChange={(roles) =>
-                                                                                        void updateRoute(
-                                                                                                idx,
-                                                                                                "required_roles",
-                                                                                                roles,
-                                                                                        )
-                                                                                }
-                                                                        />
-                                                                </TableCell>
-                                                        </TableRow>
-                                                </Fragment>
-                                        ))}
-                                        <TableRow>
-                                                <TableCell>
-                                                        <TextField
-								value={newRoute.path}
-								onChange={(e) =>
-									setNewRoute({
-										...newRoute,
-										path: e.target.value,
-									})
-								}
-							/>
-						</TableCell>
-						<TableCell>
-							<TextField
-								value={newRoute.name}
-								onChange={(e) =>
-									setNewRoute({
-										...newRoute,
-										name: e.target.value,
-									})
-								}
-							/>
-						</TableCell>
-						<TableCell>
-							<TextField
-								value={newRoute.icon ?? ""}
-								onChange={(e) =>
-									setNewRoute({
-										...newRoute,
-										icon: e.target.value,
-									})
-								}
-							/>
-						</TableCell>
-						<TableCell>
-							<TextField
-								type="number"
-								value={newRoute.sequence}
-								onChange={(e) =>
-									setNewRoute({
-										...newRoute,
-										sequence: Number(e.target.value),
-									})
-								}
-							/>
-						</TableCell>
-                  <TableCell>
-                          <RolesSelector
-                                  allRoles={roleNames}
-                                  value={newRoute.required_roles}
-                                  onChange={(roles) =>
-                                          setNewRoute({
-                                                  ...newRoute,
-                                                  required_roles: roles,
-                                          })
-                                  }
-                          />
-                  </TableCell>
-                  <TableCell>
-                          <IconButton onClick={handleAdd}>
-                                  <Add />
-                          </IconButton>
-                  </TableCell>
-          </TableRow>
-				</TableBody>
-			</Table>
+						<Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
+								<TableHead>
+										<TableRow>
+												<TableCell sx={{ width: '30%' }}>Path</TableCell>
+												<TableCell sx={{ width: '30%' }}>Name</TableCell>
+												<TableCell sx={{ width: '20%' }}>Icon</TableCell>
+												<TableCell sx={{ width: '15%' }}>Sequence</TableCell>
+												<TableCell sx={{ width: '5%' }} />
+										</TableRow>
+								</TableHead>
+								<TableBody>
+										{routes.map((r, idx) => (
+												<Fragment key={r.path}>
+														<TableRow sx={{ "& > *": { borderBottom: 'none' } }}>
+																<TableCell sx={{ width: '30%' }}>
+																		<EditBox
+																				value={r.path}
+																				onCommit={(val) =>
+																						updateRoute(idx, 'path', val)
+																				}
+																				width="95%"
+																		/>
+																</TableCell>
+																<TableCell sx={{ width: '30%' }}>
+																		<EditBox
+																				value={r.name}
+																				onCommit={(val) =>
+																						updateRoute(idx, 'name', val)
+																				}
+																				width="95%"
+																		/>
+																</TableCell>
+																<TableCell sx={{ width: '20%' }}>
+																		<EditBox
+																				value={r.icon ?? ''}
+																				onCommit={(val) =>
+																						updateRoute(idx, 'icon', val)
+																				}
+																				width="95%"
+																		/>
+																</TableCell>
+																<TableCell sx={{ width: '15%' }}>
+																		<EditBox
+																				value={r.sequence}
+																				onCommit={(val) =>
+																						updateRoute(idx, 'sequence', val)
+																				}
+																				width="95%"
+																		/>
+																</TableCell>
+																<TableCell sx={{ width: '5%' }}>
+																		<IconButton onClick={() => handleDelete(r.path)}>
+																				<Delete />
+																		</IconButton>
+																</TableCell>
+														</TableRow>
+														<TableRow>
+																<TableCell colSpan={5}>
+																		<RolesSelector
+																				allRoles={roleNames}
+																				value={r.required_roles}
+																				onChange={(roles) =>
+																						void updateRoute(idx, 'required_roles', roles)
+																				}
+																		/>
+																</TableCell>
+														</TableRow>
+												</Fragment>
+										))}
+										<TableRow>
+												<TableCell sx={{ width: '30%' }}>
+				<TextField
+				size='small'
+				sx={{ width: '95%', '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}
+				value={newRoute.path}
+				onChange={(e) =>
+				setNewRoute({
+					...newRoute,
+					path: e.target.value,
+				})
+				}
+			/>
+												</TableCell>
+												<TableCell sx={{ width: '30%' }}>
+<TextField
+				size='small'
+				sx={{ width: '95%', '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}
+				value={newRoute.name}
+				onChange={(e) =>
+				setNewRoute({
+					...newRoute,
+					name: e.target.value,
+				})
+				}
+			/>
+												</TableCell>
+												<TableCell sx={{ width: '20%' }}>
+<TextField
+				size='small'
+				sx={{ width: '95%', '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}
+				value={newRoute.icon ?? ''}
+				onChange={(e) =>
+				setNewRoute({
+					...newRoute,
+					icon: e.target.value,
+				})
+				}
+			/>
+												</TableCell>
+												<TableCell sx={{ width: '15%' }}>
+<TextField
+				size='small'
+				sx={{ width: '95%', '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}
+type="number"
+				value={newRoute.sequence}
+				onChange={(e) =>
+				setNewRoute({
+					...newRoute,
+					sequence: Number(e.target.value),
+				})
+				}
+			/>
+												</TableCell>
+												<TableCell sx={{ width: '5%' }}>
+														<IconButton onClick={handleAdd}>
+																<Add />
+														</IconButton>
+												</TableCell>
+										</TableRow>
+										<TableRow>
+												<TableCell colSpan={5}>
+														<RolesSelector
+																allRoles={roleNames}
+																value={newRoute.required_roles}
+																onChange={(roles) =>
+																		setNewRoute({
+																				...newRoute,
+																				required_roles: roles,
+																		})
+																}
+														/>
+												</TableCell>
+										</TableRow>
+								</TableBody>
+						</Table>
 		</Box>
 	);
-};
+				};
 
 export default SystemRoutesPage;


### PR DESCRIPTION
## Summary
- add reusable EditBox component with commit-on-blur or Enter behavior
- use EditBox in SystemRoutesPage to standardize route field editing
- allocate SystemRoutesPage columns at 30/30/20/15/5 widths for path, name, icon, sequence, and delete
- tighten input fields with 95% width and compact monospace text

## Testing
- `npm run lint -- --fix`
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4427834c83259079d86345181095