### PR TITLE
feat: add shared edit box component

### DIFF
--- a/frontend/src/EditBox.tsx
+++ b/frontend/src/EditBox.tsx
@@ -1,0 +1,66 @@
+import React, { useState, useEffect } from 'react';
+import TextField from '@mui/material/TextField';
+import Notification from './Notification';
+
+interface EditBoxProps {
+		value: string | number;
+		onCommit: (value: string | number) => Promise<void> | void;
+		width?: string | number;
+}
+
+const EditBox = ({ value, onCommit, width = '100%' }: EditBoxProps): JSX.Element => {
+		const [internal, setInternal] = useState<string | number>(value);
+		const [notify, setNotify] = useState(false);
+
+		useEffect(() => {
+				setInternal(value);
+		}, [value]);
+
+		const commit = async (): Promise<void> => {
+				if (internal !== value) {
+						await onCommit(internal);
+						setNotify(true);
+				}
+		};
+
+		const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+				if (e.key === 'Enter' || e.key === 'Tab') {
+						void commit();
+				}
+		};
+
+		const handleBlur = (): void => {
+				void commit();
+		};
+
+		const handleClose = (): void => {
+				setNotify(false);
+		};
+
+		const type = typeof value === 'number' ? 'number' : 'text';
+
+		return (
+				<>
+				<TextField
+				sx={{ width }}
+				type={type}
+				value={internal}
+				onChange={(e) => {
+					const target = e.target as HTMLInputElement;
+					const val = type === 'number' ? Number(target.value) : target.value;
+					setInternal(val);
+				}}
+				onKeyDown={handleKeyDown}
+				onBlur={handleBlur}
+			/>
+						<Notification
+								open={notify}
+								handleClose={handleClose}
+								severity='success'
+								message='Saved'
+						/>
+				</>
+		);
+};
+
+export default EditBox;

--- a/frontend/src/SystemRolesPage.tsx
+++ b/frontend/src/SystemRolesPage.tsx
@@ -7,10 +7,11 @@ import {
   TableCell,
   TableBody,
   IconButton,
-  TextField,
   Typography,
 } from "@mui/material";
+import TextField from "@mui/material/TextField";
 import { Delete, Add, ArrowUpward, ArrowDownward } from "@mui/icons-material";
+import EditBox from "./EditBox";
 import type {
   SystemRolesRoleItem1,
   SystemRolesList1,
@@ -151,19 +152,21 @@ const SystemRolesPage = (): JSX.Element => {
             const bit = maskToBit(BigInt(i.mask));
             return (
               <TableRow key={i.name}>
-                <TableCell>
-                  <TextField value={i.mask} disabled />
+                <TableCell sx={{ '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}>
+                  <TextField sx={{ width: '95%' }} value={i.mask} disabled />
                 </TableCell>
-                <TableCell>
-                  <TextField
+                <TableCell sx={{ '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}>
+                  <EditBox
+                    width="95%"
                     value={i.name}
-                    onChange={(e) => updateItem(idx, "name", e.target.value)}
+                    onCommit={(val) => updateItem(idx, "name", String(val))}
                   />
                 </TableCell>
-                <TableCell>
-                  <TextField
+                <TableCell sx={{ '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}>
+                  <EditBox
+                    width="95%"
                     value={i.display ?? ""}
-                    onChange={(e) => updateItem(idx, "display", e.target.value)}
+                    onCommit={(val) => updateItem(idx, "display", String(val))}
                   />
                 </TableCell>
                 <TableCell>
@@ -187,11 +190,12 @@ const SystemRolesPage = (): JSX.Element => {
             );
           })}
           <TableRow>
-            <TableCell>
-              <TextField value="" disabled />
+            <TableCell sx={{ '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}>
+              <TextField sx={{ width: '95%' }} value="" disabled />
             </TableCell>
-            <TableCell>
+            <TableCell sx={{ '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}>
               <TextField
+                sx={{ width: '95%' }}
                 value={newItem.name}
                 onChange={(e) =>
                   setNewItem({
@@ -201,8 +205,9 @@ const SystemRolesPage = (): JSX.Element => {
                 }
               />
             </TableCell>
-            <TableCell>
+            <TableCell sx={{ '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}>
               <TextField
+                sx={{ width: '95%' }}
                 value={newItem.display ?? ""}
                 onChange={(e) =>
                   setNewItem({

--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -1,28 +1,29 @@
 import { useEffect, useState, Fragment } from "react";
 import {
-        Box,
-        Divider,
-        Table,
-        TableHead,
-        TableRow,
-        TableCell,
-        TableBody,
-        TextField,
-        IconButton,
-        Typography,
-} from "@mui/material";
+		Box,
+		Divider,
+		Table,
+		TableHead,
+		TableRow,
+		TableCell,
+		TableBody,
+		TextField,
+		IconButton,
+		Typography,
+				} from "@mui/material";
 import { Delete, Add } from "@mui/icons-material";
 import RolesSelector from "./RolesSelector";
+import EditBox from "./EditBox";
 import type {
 	SystemRoutesRouteItem1,
 	SystemRoutesList1,
-        ServiceRolesRoles1,
-} from "./shared/RpcModels";
+		ServiceRolesRoles1,
+				} from "./shared/RpcModels";
 import {
 	fetchRoutes,
 	fetchUpsertRoute,
 	fetchDeleteRoute,
-} from "./rpc/system/routes";
+				} from "./rpc/system/routes";
 import { fetchRoles } from "./rpc/service/roles";
 
 const SystemRoutesPage = (): JSX.Element => {
@@ -50,7 +51,7 @@ const SystemRoutesPage = (): JSX.Element => {
 						}
 				}
 				try {
-                                                const roles: ServiceRolesRoles1 = await fetchRoles();
+												const roles: ServiceRolesRoles1 = await fetchRoles();
 						setRoleNames(roles.roles);
 						console.debug("[SystemRoutesPage] loaded roles");
 				} catch (e: any) {
@@ -98,176 +99,163 @@ const SystemRoutesPage = (): JSX.Element => {
 		if (!newRoute.path) return;
 				console.debug("[SystemRoutesPage] adding route", newRoute);
 				await fetchUpsertRoute(newRoute);
-                setNewRoute({
-                                path: "",
-                                name: "",
-                                icon: "",
-                                sequence: 0,
-                                required_roles: [],
-                });
-                void load();
-        };
+				setNewRoute({
+								path: "",
+								name: "",
+								icon: "",
+								sequence: 0,
+								required_roles: [],
+				});
+				void load();
+		};
 
 	return (
 		<Box sx={{ p: 2 }}>
 			<Typography variant="h5">System Routes</Typography>
 			<Divider sx={{ mb: 2 }} />
-			<Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
-				<TableHead>
-					<TableRow>
-            <TableCell>Path</TableCell>
-            <TableCell>Name</TableCell>
-            <TableCell>Icon</TableCell>
-            <TableCell>Sequence</TableCell>
-            <TableCell />
-          </TableRow>
-        </TableHead>
-      <TableBody>
-                                        {routes.map((r, idx) => (
-                                                <Fragment key={r.path}>
-                                                        <TableRow sx={{ "& > *": { borderBottom: "none" } }}>
-                                                               <TableCell>
-                                                                        <TextField
-                                                                                value={r.path}
-                                                                                onChange={(e) =>
-                                                                                        updateRoute(
-                                                                                                idx,
-                                                                                                "path",
-                                                                                                e.target.value,
-                                                                                        )
-                                                                                }
-                                                                        />
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                        <TextField
-                                                                                value={r.name}
-                                                                                onChange={(e) =>
-                                                                                        updateRoute(
-                                                                                                idx,
-                                                                                                "name",
-                                                                                                e.target.value,
-                                                                                        )
-                                                                                }
-                                                                        />
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                        <TextField
-                                                                                value={r.icon ?? ""}
-                                                                                onChange={(e) =>
-                                                                                        updateRoute(
-                                                                                                idx,
-                                                                                                "icon",
-                                                                                                e.target.value,
-                                                                                        )
-                                                                                }
-                                                                        />
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                        <TextField
-                                                                                type="number"
-                                                                                value={r.sequence}
-                                                                                onChange={(e) =>
-                                                                                        updateRoute(
-                                                                                                idx,
-                                                                                                "sequence",
-                                                                                                Number(e.target.value),
-                                                                                        )
-                                                                                }
-                                                                        />
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                        <IconButton
-                                                                                onClick={() => handleDelete(r.path)}
-                                                                        >
-                                                                                <Delete />
-                                                                        </IconButton>
-                                                                </TableCell>
-                                                        </TableRow>
-                                                        <TableRow>
-                                                                <TableCell colSpan={5}>
-                                                                        <RolesSelector
-                                                                                allRoles={roleNames}
-                                                                                value={r.required_roles}
-                                                                                onChange={(roles) =>
-                                                                                        void updateRoute(
-                                                                                                idx,
-                                                                                                "required_roles",
-                                                                                                roles,
-                                                                                        )
-                                                                                }
-                                                                        />
-                                                                </TableCell>
-                                                        </TableRow>
-                                                </Fragment>
-                                        ))}
-                                        <TableRow>
-                                                <TableCell>
-                                                        <TextField
-								value={newRoute.path}
-								onChange={(e) =>
-									setNewRoute({
-										...newRoute,
-										path: e.target.value,
-									})
-								}
-							/>
-						</TableCell>
-						<TableCell>
-							<TextField
-								value={newRoute.name}
-								onChange={(e) =>
-									setNewRoute({
-										...newRoute,
-										name: e.target.value,
-									})
-								}
-							/>
-						</TableCell>
-						<TableCell>
-							<TextField
-								value={newRoute.icon ?? ""}
-								onChange={(e) =>
-									setNewRoute({
-										...newRoute,
-										icon: e.target.value,
-									})
-								}
-							/>
-						</TableCell>
-						<TableCell>
-							<TextField
-								type="number"
-								value={newRoute.sequence}
-								onChange={(e) =>
-									setNewRoute({
-										...newRoute,
-										sequence: Number(e.target.value),
-									})
-								}
-							/>
-						</TableCell>
-                  <TableCell>
-                          <RolesSelector
-                                  allRoles={roleNames}
-                                  value={newRoute.required_roles}
-                                  onChange={(roles) =>
-                                          setNewRoute({
-                                                  ...newRoute,
-                                                  required_roles: roles,
-                                          })
-                                  }
-                          />
-                  </TableCell>
-                  <TableCell>
-                          <IconButton onClick={handleAdd}>
-                                  <Add />
-                          </IconButton>
-                  </TableCell>
-          </TableRow>
-				</TableBody>
-			</Table>
+						<Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
+								<TableHead>
+										<TableRow>
+												<TableCell sx={{ width: '30%' }}>Path</TableCell>
+												<TableCell sx={{ width: '30%' }}>Name</TableCell>
+												<TableCell sx={{ width: '20%' }}>Icon</TableCell>
+												<TableCell sx={{ width: '15%' }}>Sequence</TableCell>
+												<TableCell sx={{ width: '5%' }} />
+										</TableRow>
+								</TableHead>
+								<TableBody>
+										{routes.map((r, idx) => (
+												<Fragment key={r.path}>
+														<TableRow sx={{ "& > *": { borderBottom: 'none' } }}>
+																<TableCell sx={{ width: '30%' }}>
+																		<EditBox
+																				value={r.path}
+																				onCommit={(val) =>
+																						updateRoute(idx, 'path', val)
+																				}
+																				width="95%"
+																		/>
+																</TableCell>
+																<TableCell sx={{ width: '30%' }}>
+																		<EditBox
+																				value={r.name}
+																				onCommit={(val) =>
+																						updateRoute(idx, 'name', val)
+																				}
+																				width="95%"
+																		/>
+																</TableCell>
+																<TableCell sx={{ width: '20%' }}>
+																		<EditBox
+																				value={r.icon ?? ''}
+																				onCommit={(val) =>
+																						updateRoute(idx, 'icon', val)
+																				}
+																				width="95%"
+																		/>
+																</TableCell>
+																<TableCell sx={{ width: '15%' }}>
+																		<EditBox
+																				value={r.sequence}
+																				onCommit={(val) =>
+																						updateRoute(idx, 'sequence', val)
+																				}
+																				width="95%"
+																		/>
+																</TableCell>
+																<TableCell sx={{ width: '5%' }}>
+																		<IconButton onClick={() => handleDelete(r.path)}>
+																				<Delete />
+																		</IconButton>
+																</TableCell>
+														</TableRow>
+														<TableRow>
+																<TableCell colSpan={5}>
+																		<RolesSelector
+																				allRoles={roleNames}
+																				value={r.required_roles}
+																				onChange={(roles) =>
+																						void updateRoute(idx, 'required_roles', roles)
+																				}
+																		/>
+																</TableCell>
+														</TableRow>
+												</Fragment>
+										))}
+										<TableRow>
+												<TableCell sx={{ width: '30%' }}>
+<TextField
+sx={{ width: '95%' }}
+value={newRoute.path}
+				onChange={(e) =>
+				setNewRoute({
+					...newRoute,
+					path: e.target.value,
+				})
+				}
+			/>
+												</TableCell>
+												<TableCell sx={{ width: '30%' }}>
+<TextField
+sx={{ width: '95%' }}
+value={newRoute.name}
+				onChange={(e) =>
+				setNewRoute({
+					...newRoute,
+					name: e.target.value,
+				})
+				}
+			/>
+												</TableCell>
+												<TableCell sx={{ width: '20%' }}>
+<TextField
+sx={{ width: '95%' }}
+value={newRoute.icon ?? ''}
+				onChange={(e) =>
+				setNewRoute({
+					...newRoute,
+					icon: e.target.value,
+				})
+				}
+			/>
+												</TableCell>
+												<TableCell sx={{ width: '15%' }}>
+<TextField
+sx={{ width: '95%' }}
+type="number"
+value={newRoute.sequence}
+				onChange={(e) =>
+				setNewRoute({
+					...newRoute,
+					sequence: Number(e.target.value),
+				})
+				}
+			/>
+												</TableCell>
+												<TableCell sx={{ width: '5%' }}>
+														<IconButton onClick={handleAdd}>
+																<Add />
+														</IconButton>
+												</TableCell>
+										</TableRow>
+										<TableRow>
+												<TableCell colSpan={5}>
+														<RolesSelector
+																allRoles={roleNames}
+																value={newRoute.required_roles}
+																onChange={(roles) =>
+																		setNewRoute({
+																				...newRoute,
+																				required_roles: roles,
+																		})
+																}
+														/>
+												</TableCell>
+										</TableRow>
+								</TableBody>
+						</Table>
 		</Box>
 	);
-};
+				};
 
 export default SystemRoutesPage;


### PR DESCRIPTION
## Summary
- remove compact styling from EditBox so width is the only exposed prop
- apply tightened monospace styling to role edits using EditBox
- revert new-route inputs to standard TextField styling

## Testing
- `npm run lint -- --fix`
- `npm run type-check`
- `npm test`
- `python3 scripts/run_tests.py --test` *(fails: ModuleNotFoundError: No module named 'aioodbc')*


------
https://chatgpt.com/codex/tasks/task_e_68ab4427834c83259079d86345181095