### PR TITLE
Compact role selector text

### DIFF
--- a/frontend/src/RolesSelector.tsx
+++ b/frontend/src/RolesSelector.tsx
@@ -51,7 +51,13 @@ const RolesSelector = ({
 						selected={left === role}
 						onClick={() => setLeft(role)}
 					>
-						<ListItemText primary={role} />
+						<ListItemText
+							primary={role}
+							primaryTypographyProps={{
+								fontFamily: "monospace",
+								variant: "body2",
+							}}
+						/>
 					</ListItemButton>
 				))}
 			</List>
@@ -78,7 +84,13 @@ const RolesSelector = ({
 						selected={right === role}
 						onClick={() => setRight(role)}
 					>
-						<ListItemText primary={role} />
+						<ListItemText
+							primary={role}
+							primaryTypographyProps={{
+								fontFamily: "monospace",
+								variant: "body2",
+							}}
+						/>
 					</ListItemButton>
 				))}
 			</List>


### PR DESCRIPTION
## Summary
- Render role names in monospace body text for compact display in role assignment lists

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68ab515edb3483259fa465120721b9b4