### PR TITLE
Reduce spacing in role selector

### DIFF
--- a/frontend/src/RolesSelector.tsx
+++ b/frontend/src/RolesSelector.tsx
@@ -43,6 +43,7 @@ const RolesSelector = ({
                                         maxHeight,
                                         overflow: "auto",
                                         border: 1,
+                                        p: 0.25,
                                 }}
                         >
 				{available.map((role) => (
@@ -50,6 +51,11 @@ const RolesSelector = ({
 						key={role}
 						selected={left === role}
 						onClick={() => setLeft(role)}
+					sx={{
+						py: 0.25,
+						px: 0.5,
+						minHeight: 0,
+					}}
 					>
 						<ListItemText
 							primary={role}
@@ -76,6 +82,7 @@ const RolesSelector = ({
                                         maxHeight,
                                         overflow: "auto",
                                         border: 1,
+                                        p: 0.25,
                                 }}
                         >
 				{value.map((role) => (
@@ -83,6 +90,11 @@ const RolesSelector = ({
 						key={role}
 						selected={right === role}
 						onClick={() => setRight(role)}
+					sx={{
+						py: 0.25,
+						px: 0.5,
+						minHeight: 0,
+					}}
 					>
 						<ListItemText
 							primary={role}


### PR DESCRIPTION
## Summary
- tighten list item spacing in RolesSelector for console font

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab66cbddc48325827e5ded2fdb0b1d