### PR TITLE
Remove console font from system roles page

### DIFF
--- a/frontend/src/SystemRolesPage.tsx
+++ b/frontend/src/SystemRolesPage.tsx
@@ -154,17 +154,17 @@ const SystemRolesPage = (): JSX.Element => {
             const bit = maskToBit(BigInt(i.mask));
             return (
               <TableRow key={i.name}>
-                <TableCell sx={{ width: '20%', '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}>
+                <TableCell sx={{ width: '20%' }}>
                   <TextField sx={{ width: '100%' }} value={i.mask} disabled />
                 </TableCell>
-                <TableCell sx={{ width: '25%', '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}>
+                <TableCell sx={{ width: '25%' }}>
                   <EditBox
                     width="100%"
                     value={i.name}
                     onCommit={(val) => updateItem(idx, 'name', String(val))}
                   />
                 </TableCell>
-                <TableCell sx={{ width: '25%', '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}>
+                <TableCell sx={{ width: '25%' }}>
                   <EditBox
                     width="100%"
                     value={i.display ?? ''}
@@ -196,10 +196,10 @@ const SystemRolesPage = (): JSX.Element => {
             );
           })}
           <TableRow>
-            <TableCell sx={{ width: '20%', '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}>
+            <TableCell sx={{ width: '20%' }}>
               <TextField sx={{ width: '100%' }} value="" disabled />
             </TableCell>
-            <TableCell sx={{ width: '25%', '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}>
+            <TableCell sx={{ width: '25%' }}>
               <TextField
                 sx={{ width: '100%' }}
                 value={newItem.name}
@@ -211,7 +211,7 @@ const SystemRolesPage = (): JSX.Element => {
                 }
               />
             </TableCell>
-            <TableCell sx={{ width: '25%', '& .MuiInputBase-input': { fontFamily: 'monospace', fontSize: '0.75rem', py: 0.5 } }}>
+            <TableCell sx={{ width: '25%' }}>
               <TextField
                 sx={{ width: '100%' }}
                 value={newItem.display ?? ''}


### PR DESCRIPTION
## Summary
- remove monospace font overrides from SystemRolesPage so inputs use default styling

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68ab80d32d9c83259cf0bae1ee7a7ab0