### PR TITLE
feat: add shared page title component

### DIFF
--- a/frontend/src/FileManager.tsx
+++ b/frontend/src/FileManager.tsx
@@ -13,6 +13,7 @@ import {
 	fetchDeleteFiles,
 	fetchSetGallery,
 } from './rpc/storage/files';
+import PageTitle from './PageTitle';
 
 interface StorageFile {
 	name: string;
@@ -69,7 +70,7 @@ const FileManager = (): JSX.Element => {
 
 	return (
 		<Box>
-			<h2>File Manager</h2>
+			<PageTitle>File Manager</PageTitle>
 			<input type="file" multiple onChange={handleUpload} />
 			<List>
 				{files.map((file) => (

--- a/frontend/src/Gallery.tsx
+++ b/frontend/src/Gallery.tsx
@@ -1,6 +1,12 @@
 import type { JSX } from 'react';
+import PageTitle from './PageTitle';
 
 // TODO: Implement gallery component
 export default function Gallery(): JSX.Element {
-	return <div>Gallery placeholder</div>;
+	return (
+		<div>
+			<PageTitle>Gallery</PageTitle>
+			Gallery placeholder
+		</div>
+	);
 }

--- a/frontend/src/PageTitle.tsx
+++ b/frontend/src/PageTitle.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+import { Typography } from '@mui/material';
+
+interface PageTitleProps {
+	children: ReactNode;
+}
+
+export default function PageTitle({ children }: PageTitleProps): JSX.Element {
+	return <Typography variant="pageTitle">{children}</Typography>;
+}

--- a/frontend/src/SystemConfigPage.tsx
+++ b/frontend/src/SystemConfigPage.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
 import {
-	Box,
-	Table,
-	TableHead,
-	TableRow,
-	TableCell,
-	TableBody,
-	IconButton,
-	Typography,
+        Box,
+        Table,
+        TableHead,
+        TableRow,
+        TableCell,
+        TableBody,
+        IconButton,
+        Typography,
 } from "@mui/material";
 import { Delete, Add } from "@mui/icons-material";
 import EditBox from "./EditBox";
@@ -21,6 +21,7 @@ import {
 	fetchDeleteConfig,
 } from "./rpc/system/config";
 import Notification from "./Notification";
+import PageTitle from "./PageTitle";
 
 const SystemConfigPage = (): JSX.Element => {
 	const [items, setItems] = useState<SystemConfigConfigItem1[]>([]);
@@ -87,12 +88,12 @@ const SystemConfigPage = (): JSX.Element => {
 
 	return (
 		<Box sx={{ p: 2 }}>
-			<Typography variant="h5">System Configuration</Typography>
+			<PageTitle>System Configuration</PageTitle>
 			<Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
-                        <TableHead>
-                                <TableRow>
-                                        <TableCell sx={{ width: "30%" }}>Key</TableCell>
-                                        <TableCell sx={{ width: "60%" }}>Value</TableCell>
+			<TableHead>
+				<TableRow>
+					<TableCell sx={{ width: "30%" }}>Key</TableCell>
+					<TableCell sx={{ width: "60%" }}>Value</TableCell>
                                         <TableCell sx={{ width: "10%" }} />
                                 </TableRow>
                         </TableHead>

--- a/frontend/src/SystemRolesPage.tsx
+++ b/frontend/src/SystemRolesPage.tsx
@@ -1,246 +1,247 @@
 import { useEffect, useState } from "react";
 import {
-  Box,
-  Table,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableBody,
-  IconButton,
-  Typography,
+Box,
+Table,
+TableHead,
+TableRow,
+TableCell,
+TableBody,
+IconButton,
+Typography,
 } from "@mui/material";
 import TextField from "@mui/material/TextField";
 import { Delete, Add, ArrowUpward, ArrowDownward } from "@mui/icons-material";
 import EditBox from "./EditBox";
+import PageTitle from "./PageTitle";
 import type {
-  SystemRolesRoleItem1,
-  SystemRolesList1,
+SystemRolesRoleItem1,
+SystemRolesList1,
 } from "./shared/RpcModels";
 import {
-  fetchRoles,
-  fetchUpsertRole,
-  fetchDeleteRole
+fetchRoles,
+fetchUpsertRole,
+fetchDeleteRole
 } from "./rpc/system/roles";
 import Notification from "./Notification";
 
 const HIGH_BIT_MASK = (-(1n << 63n)).toString();
 
 const maskToBit = (mask: bigint): number =>
-  mask < 0n ? 63 : mask.toString(2).length - 1;
+mask < 0n ? 63 : mask.toString(2).length - 1;
 
 const bitToMask = (bit: number): string =>
-  bit === 63 ? HIGH_BIT_MASK : (1n << BigInt(bit)).toString();
+bit === 63 ? HIGH_BIT_MASK : (1n << BigInt(bit)).toString();
 
 const nextMask = (roles: SystemRolesRoleItem1[]): string => {
-  const used = new Set(roles.map((r) => maskToBit(BigInt(r.mask))));
-  for (let bit = 0; bit < 64; bit++) {
-    if (!used.has(bit)) return bitToMask(bit);
-  }
-  return bitToMask(0);
+const used = new Set(roles.map((r) => maskToBit(BigInt(r.mask))));
+for (let bit = 0; bit < 64; bit++) {
+if (!used.has(bit)) return bitToMask(bit);
+}
+	return bitToMask(0);
 };
 
 const SystemRolesPage = (): JSX.Element => {
-  const [items, setItems] = useState<SystemRolesRoleItem1[]>([]);
-  const [newItem, setNewItem] = useState<SystemRolesRoleItem1>({
-    name: "",
-    mask: "",
-    display: "",
-  });
-  const [notification, setNotification] = useState(false);
-  const [forbidden, setForbidden] = useState(false);
-  const handleNotificationClose = (): void => {
-    setNotification(false);
-  };
+const [items, setItems] = useState<SystemRolesRoleItem1[]>([]);
+const [newItem, setNewItem] = useState<SystemRolesRoleItem1>({
+name: "",
+mask: "",
+display: "",
+});
+const [notification, setNotification] = useState(false);
+const [forbidden, setForbidden] = useState(false);
+const handleNotificationClose = (): void => {
+setNotification(false);
+};
 
-  const load = async (): Promise<void> => {
-    try {
-      const res: SystemRolesList1 = await fetchRoles();
-      const sorted = res.roles.sort(
-        (a, b) => maskToBit(BigInt(a.mask)) - maskToBit(BigInt(b.mask)),
-      );
-      setItems(sorted);
-    } catch (e: any) {
-      if (e?.response?.status === 403) {
-        setForbidden(true);
-      } else {
-        setItems([]);
-      }
-    }
-  };
+const load = async (): Promise<void> => {
+try {
+const res: SystemRolesList1 = await fetchRoles();
+const sorted = res.roles.sort(
+	(a, b) => maskToBit(BigInt(a.mask)) - maskToBit(BigInt(b.mask)),
+);
+setItems(sorted);
+} catch (e: any) {
+if (e?.response?.status === 403) {
+	setForbidden(true);
+} else {
+	setItems([]);
+}
+}
+};
 
-  useEffect(() => {
-    void load();
-  }, []);
+useEffect(() => {
+void load();
+}, []);
 
-  if (forbidden) {
-    return (
-      <Box sx={{ p: 2 }}>
-        <Typography variant="h6">Forbidden</Typography>
-      </Box>
-    );
-  }
+if (forbidden) {
+	return (
+		<Box sx={{ p: 2 }}>
+	<Typography variant="h6">Forbidden</Typography>
+</Box>
+);
+}
 
-  const updateItem = async (
-    index: number,
-    field: keyof SystemRolesRoleItem1,
-    value: string,
-  ): Promise<void> => {
-    const updated = [...items];
-    (updated[index] as any)[field] = value;
-    setItems(updated);
-    await fetchUpsertRole(updated[index]);
-    setNotification(true);
-  };
+const updateItem = async (
+index: number,
+field: keyof SystemRolesRoleItem1,
+value: string,
+): Promise<void> => {
+const updated = [...items];
+(updated[index] as any)[field] = value;
+setItems(updated);
+await fetchUpsertRole(updated[index]);
+setNotification(true);
+};
 
-  const handleDelete = async (name: string): Promise<void> => {
-    await fetchDeleteRole({ name });
-    void load();
-    setNotification(true);
-  };
+const handleDelete = async (name: string): Promise<void> => {
+await fetchDeleteRole({ name });
+void load();
+setNotification(true);
+};
 
-  const handleAdd = async (): Promise<void> => {
-    if (!newItem.name) return;
-    await fetchUpsertRole({
-      name: newItem.name,
-      display: newItem.display,
-      mask: nextMask(items),
-    });
-    setNewItem({ name: "", display: "", mask: "" });
-    void load();
-    setNotification(true);
-  };
+const handleAdd = async (): Promise<void> => {
+if (!newItem.name) return;
+await fetchUpsertRole({
+name: newItem.name,
+display: newItem.display,
+mask: nextMask(items),
+});
+setNewItem({ name: "", display: "", mask: "" });
+void load();
+setNotification(true);
+};
 
-  const move = async (index: number, dir: number): Promise<void> => {
-    const current = items[index];
-    const bit = maskToBit(BigInt(current.mask));
-    const targetBit = bit + dir;
-    if (targetBit < 0 || targetBit > 63) return;
-    const updated = [...items];
-    const targetIdx = items.findIndex(
-      (r) => maskToBit(BigInt(r.mask)) === targetBit,
-    );
-    const promises: Array<Promise<any>> = [];
-    updated[index] = { ...current, mask: bitToMask(targetBit) };
-    promises.push(fetchUpsertRole(updated[index]));
-    if (targetIdx !== -1) {
-      const other = items[targetIdx];
-      updated[targetIdx] = { ...other, mask: current.mask };
-      promises.push(fetchUpsertRole(updated[targetIdx]));
-    }
-    updated.sort(
-      (a, b) => maskToBit(BigInt(a.mask)) - maskToBit(BigInt(b.mask)),
-    );
-    setItems(updated);
-    await Promise.all(promises);
-    setNotification(true);
-  };
+const move = async (index: number, dir: number): Promise<void> => {
+const current = items[index];
+const bit = maskToBit(BigInt(current.mask));
+const targetBit = bit + dir;
+if (targetBit < 0 || targetBit > 63) return;
+const updated = [...items];
+const targetIdx = items.findIndex(
+(r) => maskToBit(BigInt(r.mask)) === targetBit,
+);
+const promises: Array<Promise<any>> = [];
+updated[index] = { ...current, mask: bitToMask(targetBit) };
+promises.push(fetchUpsertRole(updated[index]));
+if (targetIdx !== -1) {
+const other = items[targetIdx];
+updated[targetIdx] = { ...other, mask: current.mask };
+promises.push(fetchUpsertRole(updated[targetIdx]));
+}
+updated.sort(
+(a, b) => maskToBit(BigInt(a.mask)) - maskToBit(BigInt(b.mask)),
+);
+setItems(updated);
+await Promise.all(promises);
+setNotification(true);
+};
 
-  return (
-    <Box sx={{ p: 2 }}>
-      <Typography variant="h5">System Roles</Typography>
-      <Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
-        <TableHead>
-          <TableRow>
-            <TableCell sx={{ width: '20%' }}>Mask</TableCell>
-            <TableCell sx={{ width: '25%' }}>Name</TableCell>
-            <TableCell sx={{ width: '25%' }}>Display</TableCell>
-            <TableCell sx={{ width: '10%' }} />
-            <TableCell sx={{ width: '10%' }} />
-            <TableCell sx={{ width: '10%' }} />
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {items.map((i, idx) => {
-            const bit = maskToBit(BigInt(i.mask));
-            return (
-              <TableRow key={i.name}>
-                <TableCell sx={{ width: '20%' }}>
-                  <TextField sx={{ width: '100%' }} value={i.mask} disabled />
-                </TableCell>
-                <TableCell sx={{ width: '25%' }}>
-                  <EditBox
-                    width="100%"
-                    value={i.name}
-                    onCommit={(val) => updateItem(idx, 'name', String(val))}
-                  />
-                </TableCell>
-                <TableCell sx={{ width: '25%' }}>
-                  <EditBox
-                    width="100%"
-                    value={i.display ?? ''}
-                    onCommit={(val) => updateItem(idx, 'display', String(val))}
-                  />
-                </TableCell>
-                <TableCell sx={{ width: '10%' }}>
-                  <IconButton
-                    onClick={() => void move(idx, -1)}
-                    disabled={bit === 0}
-                  >
-                    <ArrowUpward />
-                  </IconButton>
-                </TableCell>
-                <TableCell sx={{ width: '10%' }}>
-                  <IconButton
-                    onClick={() => void move(idx, 1)}
-                    disabled={bit === 63}
-                  >
-                    <ArrowDownward />
-                  </IconButton>
-                </TableCell>
-                <TableCell sx={{ width: '10%' }}>
-                  <IconButton onClick={() => void handleDelete(i.name)}>
-                    <Delete />
-                  </IconButton>
-                </TableCell>
-              </TableRow>
-            );
-          })}
-          <TableRow>
-            <TableCell sx={{ width: '20%' }}>
-              <TextField sx={{ width: '100%' }} value="" disabled />
-            </TableCell>
-            <TableCell sx={{ width: '25%' }}>
-              <TextField
-                sx={{ width: '100%' }}
-                value={newItem.name}
-                onChange={(e) =>
-                  setNewItem({
-                    ...newItem,
-                    name: e.target.value,
-                  })
-                }
-              />
-            </TableCell>
-            <TableCell sx={{ width: '25%' }}>
-              <TextField
-                sx={{ width: '100%' }}
-                value={newItem.display ?? ''}
-                onChange={(e) =>
-                  setNewItem({
-                    ...newItem,
-                    display: e.target.value,
-                  })
-                }
-              />
-            </TableCell>
-            <TableCell sx={{ width: '10%' }} />
-            <TableCell sx={{ width: '10%' }} />
-            <TableCell sx={{ width: '10%' }}>
-              <IconButton onClick={() => void handleAdd()}>
-                <Add />
-              </IconButton>
-            </TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
-      <Notification
-        open={notification}
-        handleClose={handleNotificationClose}
-        severity="success"
-        message="Saved"
-      />
-    </Box>
-  );
+	return (
+		<Box sx={{ p: 2 }}>
+			<PageTitle>System Roles</PageTitle>
+			<Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
+	<TableHead>
+	<TableRow>
+	<TableCell sx={{ width: '20%' }}>Mask</TableCell>
+	<TableCell sx={{ width: '25%' }}>Name</TableCell>
+	<TableCell sx={{ width: '25%' }}>Display</TableCell>
+	<TableCell sx={{ width: '10%' }} />
+	<TableCell sx={{ width: '10%' }} />
+	<TableCell sx={{ width: '10%' }} />
+	</TableRow>
+	</TableHead>
+	<TableBody>
+	{items.map((i, idx) => {
+	const bit = maskToBit(BigInt(i.mask));
+	return (
+	<TableRow key={i.name}>
+		<TableCell sx={{ width: '20%' }}>
+		<TextField sx={{ width: '100%' }} value={i.mask} disabled />
+		</TableCell>
+		<TableCell sx={{ width: '25%' }}>
+		<EditBox
+		width="100%"
+		value={i.name}
+		onCommit={(val) => updateItem(idx, 'name', String(val))}
+		/>
+		</TableCell>
+		<TableCell sx={{ width: '25%' }}>
+		<EditBox
+		width="100%"
+		value={i.display ?? ''}
+		onCommit={(val) => updateItem(idx, 'display', String(val))}
+		/>
+		</TableCell>
+		<TableCell sx={{ width: '10%' }}>
+		<IconButton
+		onClick={() => void move(idx, -1)}
+		disabled={bit === 0}
+		>
+		<ArrowUpward />
+		</IconButton>
+		</TableCell>
+		<TableCell sx={{ width: '10%' }}>
+		<IconButton
+		onClick={() => void move(idx, 1)}
+		disabled={bit === 63}
+		>
+		<ArrowDownward />
+		</IconButton>
+		</TableCell>
+		<TableCell sx={{ width: '10%' }}>
+		<IconButton onClick={() => void handleDelete(i.name)}>
+		<Delete />
+		</IconButton>
+		</TableCell>
+	</TableRow>
+	);
+	})}
+	<TableRow>
+	<TableCell sx={{ width: '20%' }}>
+	<TextField sx={{ width: '100%' }} value="" disabled />
+	</TableCell>
+	<TableCell sx={{ width: '25%' }}>
+	<TextField
+		sx={{ width: '100%' }}
+		value={newItem.name}
+		onChange={(e) =>
+		setNewItem({
+		...newItem,
+		name: e.target.value,
+		})
+		}
+	/>
+	</TableCell>
+	<TableCell sx={{ width: '25%' }}>
+	<TextField
+		sx={{ width: '100%' }}
+		value={newItem.display ?? ''}
+		onChange={(e) =>
+		setNewItem({
+		...newItem,
+		display: e.target.value,
+		})
+		}
+	/>
+	</TableCell>
+	<TableCell sx={{ width: '10%' }} />
+	<TableCell sx={{ width: '10%' }} />
+	<TableCell sx={{ width: '10%' }}>
+	<IconButton onClick={() => void handleAdd()}>
+		<Add />
+	</IconButton>
+	</TableCell>
+	</TableRow>
+	</TableBody>
+</Table>
+<Notification
+	open={notification}
+	handleClose={handleNotificationClose}
+	severity="success"
+	message="Saved"
+/>
+</Box>
+);
 };
 
 export default SystemRolesPage;

--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -1,16 +1,17 @@
 import { useEffect, useState, Fragment } from "react";
 import {
-		Box,
-		Divider,
-		Table,
-		TableHead,
-		TableRow,
-		TableCell,
-		TableBody,
-		TextField,
-		IconButton,
-		Typography,
-				} from "@mui/material";
+                Box,
+                Divider,
+                Table,
+                TableHead,
+                TableRow,
+                TableCell,
+                TableBody,
+                TextField,
+                IconButton,
+                Typography,
+                                } from "@mui/material";
+import PageTitle from "./PageTitle";
 import { Delete, Add } from "@mui/icons-material";
 import RolesSelector from "./RolesSelector";
 import EditBox from "./EditBox";
@@ -111,7 +112,7 @@ const SystemRoutesPage = (): JSX.Element => {
 
 	return (
 		<Box sx={{ p: 2 }}>
-			<Typography variant="h5">System Routes</Typography>
+			<PageTitle>System Routes</PageTitle>
 			<Divider sx={{ mb: 2 }} />
 						<Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
 								<TableHead>

--- a/frontend/src/shared/ElideusTheme.tsx
+++ b/frontend/src/shared/ElideusTheme.tsx
@@ -56,9 +56,12 @@ const ElideusTheme: Theme = createTheme({
                                 {
                                         props: { variant: 'pageTitle' },
                                         style: {
-                                                fontSize: '1.75rem',
-                                                fontWeight: 600,
-                                                marginBottom: '30px'
+                                                fontSize: '2rem',
+                                                fontWeight: 700,
+                                                marginBottom: '30px',
+                                                textAlign: 'right',
+                                                fontFamily: 'Georgia, "Times New Roman", serif',
+                                                color: '#f5f5f2'
                                         }
                                 },
                                 {

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -21,6 +21,65 @@ export interface RPCResponse {
   version: number;
   timestamp: string | null;
 }
+export interface AuthGoogleOauthLogin1 {
+  sessionToken: string;
+  display_name: string;
+  credits: number;
+  profile_image: string | null;
+}
+export interface AuthGoogleOauthLoginPayload1 {
+  provider: string;
+  code: string;
+  fingerprint: any;
+}
+export interface AuthMicrosoftOauthLogin1 {
+  sessionToken: string;
+  display_name: string;
+  credits: number;
+  profile_image: string | null;
+}
+export interface SupportUsersGuid1 {
+  userGuid: string;
+}
+export interface SupportUsersSetCredits1 {
+  userGuid: string;
+  credits: number;
+}
+export interface SupportRolesMembers1 {
+  members: SupportRolesUserItem1[];
+  nonMembers: SupportRolesUserItem1[];
+}
+export interface SupportRolesRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
+}
+export interface SupportRolesUserItem1 {
+  guid: string;
+  displayName: string;
+}
+export interface ServiceRolesDeleteRole1 {
+  name: string;
+}
+export interface ServiceRolesRoleMemberUpdate1 {
+  role: string;
+  userGuid: string;
+}
+export interface ServiceRolesRoleMembers1 {
+  members: ServiceRolesUserItem1[];
+  nonMembers: ServiceRolesUserItem1[];
+}
+export interface ServiceRolesRoles1 {
+  roles: string[];
+}
+export interface ServiceRolesUpsertRole1 {
+  name: string;
+  bit: number;
+  display: any;
+}
+export interface ServiceRolesUserItem1 {
+  guid: string;
+  displayName: string;
+}
 export interface StorageFilesDeleteFiles1 {
   files: string[];
 }
@@ -44,42 +103,6 @@ export interface StorageFilesUploadFile1 {
 export interface StorageFilesUploadFiles1 {
   files: StorageFilesUploadFile1[];
 }
-export interface SupportUsersGuid1 {
-  userGuid: string;
-}
-export interface SupportUsersSetCredits1 {
-  userGuid: string;
-  credits: number;
-}
-export interface SupportRolesMembers1 {
-  members: SupportRolesUserItem1[];
-  nonMembers: SupportRolesUserItem1[];
-}
-export interface SupportRolesRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface SupportRolesUserItem1 {
-  guid: string;
-  displayName: string;
-}
-export interface AuthMicrosoftOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
-  credits: number;
-  profile_image: string | null;
-}
-export interface AuthGoogleOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
-  credits: number;
-  profile_image: string | null;
-}
-export interface AuthGoogleOauthLoginPayload1 {
-  provider: string;
-  code: string;
-  fingerprint: any;
-}
 export interface SystemRoutesDeleteRoute1 {
   path: string;
 }
@@ -92,6 +115,16 @@ export interface SystemRoutesRouteItem1 {
   icon: string | null;
   sequence: number;
   required_roles: string[];
+}
+export interface SystemConfigConfigItem1 {
+  key: string;
+  value: string;
+}
+export interface SystemConfigDeleteConfig1 {
+  key: string;
+}
+export interface SystemConfigList1 {
+  items: SystemConfigConfigItem1[];
 }
 export interface SystemRolesDeleteRole1 {
   name: string;
@@ -109,15 +142,26 @@ export interface SystemRolesUpsertRole1 {
   mask: string;
   display: any;
 }
-export interface SystemConfigConfigItem1 {
-  key: string;
-  value: string;
+export interface UsersProvidersCreateFromProvider1 {
+  provider: string;
+  provider_identifier: string;
+  provider_email: string;
+  provider_displayname: string;
+  provider_profile_image: any;
 }
-export interface SystemConfigDeleteConfig1 {
-  key: string;
+export interface UsersProvidersGetByProviderIdentifier1 {
+  provider: string;
+  provider_identifier: string;
 }
-export interface SystemConfigList1 {
-  items: SystemConfigConfigItem1[];
+export interface UsersProvidersLinkProvider1 {
+  provider: string;
+  code: string;
+}
+export interface UsersProvidersSetProvider1 {
+  provider: string;
+}
+export interface UsersProvidersUnlinkProvider1 {
+  provider: string;
 }
 export interface UsersProfileAuthProvider1 {
   name: string;
@@ -146,42 +190,6 @@ export interface UsersProfileSetProfileImage1 {
   image_b64: string;
   provider: string;
 }
-export interface UsersProvidersCreateFromProvider1 {
-  provider: string;
-  provider_identifier: string;
-  provider_email: string;
-  provider_displayname: string;
-  provider_profile_image: any;
-}
-export interface UsersProvidersGetByProviderIdentifier1 {
-  provider: string;
-  provider_identifier: string;
-}
-export interface UsersProvidersLinkProvider1 {
-  provider: string;
-  code: string;
-}
-export interface UsersProvidersSetProvider1 {
-  provider: string;
-}
-export interface UsersProvidersUnlinkProvider1 {
-  provider: string;
-}
-export interface PublicLinksHomeLinks1 {
-  links: PublicLinksLinkItem1[];
-}
-export interface PublicLinksLinkItem1 {
-  title: string;
-  url: string;
-}
-export interface PublicLinksNavBarRoute1 {
-  path: string;
-  name: string;
-  icon: string | null;
-}
-export interface PublicLinksNavBarRoutes1 {
-  routes: PublicLinksNavBarRoute1[];
-}
 export interface PublicVarsFfmpegVersion1 {
   ffmpeg_version: string;
 }
@@ -197,28 +205,20 @@ export interface PublicVarsRepo1 {
 export interface PublicVarsVersion1 {
   version: string;
 }
-export interface ServiceRolesDeleteRole1 {
+export interface PublicLinksHomeLinks1 {
+  links: PublicLinksLinkItem1[];
+}
+export interface PublicLinksLinkItem1 {
+  title: string;
+  url: string;
+}
+export interface PublicLinksNavBarRoute1 {
+  path: string;
   name: string;
+  icon: string | null;
 }
-export interface ServiceRolesRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface ServiceRolesRoleMembers1 {
-  members: ServiceRolesUserItem1[];
-  nonMembers: ServiceRolesUserItem1[];
-}
-export interface ServiceRolesRoles1 {
-  roles: string[];
-}
-export interface ServiceRolesUpsertRole1 {
-  name: string;
-  bit: number;
-  display: any;
-}
-export interface ServiceRolesUserItem1 {
-  guid: string;
-  displayName: string;
+export interface PublicLinksNavBarRoutes1 {
+  routes: PublicLinksNavBarRoute1[];
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {


### PR DESCRIPTION
## Summary
- create `PageTitle` component with serif, bold, right-aligned styling
- apply `PageTitle` across Gallery, File Manager, System Routes, System Config, and System Roles pages
- define shared `pageTitle` typography variant in Elideus theme

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab8713edf08325a445fa35a541f345