### PR TITLE
feat: reuse column header component

### DIFF
--- a/frontend/src/ColumnHeader.tsx
+++ b/frontend/src/ColumnHeader.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+import { TableCell, Typography, type SxProps } from '@mui/material';
+
+interface ColumnHeaderProps {
+    width?: string;
+    sx?: SxProps;
+    children?: ReactNode;
+}
+
+export default function ColumnHeader({ width, sx, children }: ColumnHeaderProps): JSX.Element {
+    return (
+        <TableCell sx={{ width, ...sx }}>
+            {children ? <Typography variant="columnHeader">{children}</Typography> : null}
+        </TableCell>
+    );
+}

--- a/frontend/src/PageTitle.tsx
+++ b/frontend/src/PageTitle.tsx
@@ -2,9 +2,13 @@ import type { ReactNode } from 'react';
 import { Typography } from '@mui/material';
 
 interface PageTitleProps {
-	children: ReactNode;
+        children: ReactNode;
 }
 
 export default function PageTitle({ children }: PageTitleProps): JSX.Element {
-	return <Typography variant="pageTitle">{children}</Typography>;
+        return (
+                <Typography variant="pageTitle" align="right">
+                        {children}
+                </Typography>
+        );
 }

--- a/frontend/src/SystemConfigPage.tsx
+++ b/frontend/src/SystemConfigPage.tsx
@@ -12,16 +12,17 @@ import {
 import { Delete, Add } from "@mui/icons-material";
 import EditBox from "./EditBox";
 import type {
-	SystemConfigConfigItem1,
-	SystemConfigList1,
+        SystemConfigConfigItem1,
+        SystemConfigList1,
 } from "./shared/RpcModels";
 import {
-	fetchConfigs,
-	fetchUpsertConfig,
-	fetchDeleteConfig,
+        fetchConfigs,
+        fetchUpsertConfig,
+        fetchDeleteConfig,
 } from "./rpc/system/config";
 import Notification from "./Notification";
 import PageTitle from "./PageTitle";
+import ColumnHeader from "./ColumnHeader";
 
 const SystemConfigPage = (): JSX.Element => {
 	const [items, setItems] = useState<SystemConfigConfigItem1[]>([]);
@@ -88,16 +89,16 @@ const SystemConfigPage = (): JSX.Element => {
 
 	return (
 		<Box sx={{ p: 2 }}>
-			<PageTitle>System Configuration</PageTitle>
-			<Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
-			<TableHead>
-				<TableRow>
-					<TableCell sx={{ width: "30%" }}>Key</TableCell>
-					<TableCell sx={{ width: "60%" }}>Value</TableCell>
-                                        <TableCell sx={{ width: "10%" }} />
-                                </TableRow>
-                        </TableHead>
-				<TableBody>
+                        <PageTitle>System Configuration</PageTitle>
+                        <Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
+                                <TableHead>
+                                        <TableRow>
+                                                <ColumnHeader sx={{ width: "30%" }}>Key</ColumnHeader>
+                                                <ColumnHeader sx={{ width: "60%" }}>Value</ColumnHeader>
+                                                <ColumnHeader sx={{ width: "10%" }} />
+                                        </TableRow>
+                                </TableHead>
+                                <TableBody>
                                         {items.map((i, idx) => (
                                                 <TableRow key={i.key}>
                                                         <TableCell sx={{ width: "30%" }}>

--- a/frontend/src/SystemRolesPage.tsx
+++ b/frontend/src/SystemRolesPage.tsx
@@ -13,6 +13,7 @@ import TextField from "@mui/material/TextField";
 import { Delete, Add, ArrowUpward, ArrowDownward } from "@mui/icons-material";
 import EditBox from "./EditBox";
 import PageTitle from "./PageTitle";
+import ColumnHeader from "./ColumnHeader";
 import type {
 SystemRolesRoleItem1,
 SystemRolesList1,
@@ -138,19 +139,19 @@ setNotification(true);
 
 	return (
 		<Box sx={{ p: 2 }}>
-			<PageTitle>System Roles</PageTitle>
-			<Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
-	<TableHead>
-	<TableRow>
-	<TableCell sx={{ width: '20%' }}>Mask</TableCell>
-	<TableCell sx={{ width: '25%' }}>Name</TableCell>
-	<TableCell sx={{ width: '25%' }}>Display</TableCell>
-	<TableCell sx={{ width: '10%' }} />
-	<TableCell sx={{ width: '10%' }} />
-	<TableCell sx={{ width: '10%' }} />
-	</TableRow>
-	</TableHead>
-	<TableBody>
+                        <PageTitle>System Roles</PageTitle>
+                        <Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
+        <TableHead>
+        <TableRow>
+        <ColumnHeader sx={{ width: '20%' }}>Mask</ColumnHeader>
+        <ColumnHeader sx={{ width: '25%' }}>Name</ColumnHeader>
+        <ColumnHeader sx={{ width: '25%' }}>Display</ColumnHeader>
+        <ColumnHeader sx={{ width: '10%' }} />
+        <ColumnHeader sx={{ width: '10%' }} />
+        <ColumnHeader sx={{ width: '10%' }} />
+        </TableRow>
+        </TableHead>
+        <TableBody>
 	{items.map((i, idx) => {
 	const bit = maskToBit(BigInt(i.mask));
 	return (

--- a/frontend/src/SystemRoutesPage.tsx
+++ b/frontend/src/SystemRoutesPage.tsx
@@ -15,6 +15,7 @@ import PageTitle from "./PageTitle";
 import { Delete, Add } from "@mui/icons-material";
 import RolesSelector from "./RolesSelector";
 import EditBox from "./EditBox";
+import ColumnHeader from "./ColumnHeader";
 import type {
 	SystemRoutesRouteItem1,
 	SystemRoutesList1,
@@ -112,19 +113,19 @@ const SystemRoutesPage = (): JSX.Element => {
 
 	return (
 		<Box sx={{ p: 2 }}>
-			<PageTitle>System Routes</PageTitle>
-			<Divider sx={{ mb: 2 }} />
-						<Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
-								<TableHead>
-										<TableRow>
-												<TableCell sx={{ width: '30%' }}>Path</TableCell>
-												<TableCell sx={{ width: '30%' }}>Name</TableCell>
-												<TableCell sx={{ width: '20%' }}>Icon</TableCell>
-												<TableCell sx={{ width: '15%' }}>Sequence</TableCell>
-												<TableCell sx={{ width: '5%' }} />
-										</TableRow>
-								</TableHead>
-								<TableBody>
+                        <PageTitle>System Routes</PageTitle>
+                        <Divider sx={{ mb: 2 }} />
+                        <Table size="small" sx={{ "& td, & th": { py: 0.5 } }}>
+                                <TableHead>
+                                        <TableRow>
+                                                <ColumnHeader sx={{ width: '30%' }}>Path</ColumnHeader>
+                                                <ColumnHeader sx={{ width: '30%' }}>Name</ColumnHeader>
+                                                <ColumnHeader sx={{ width: '20%' }}>Icon</ColumnHeader>
+                                                <ColumnHeader sx={{ width: '15%' }}>Sequence</ColumnHeader>
+                                                <ColumnHeader sx={{ width: '5%' }} />
+                                        </TableRow>
+                                </TableHead>
+                                <TableBody>
 										{routes.map((r, idx) => (
 												<Fragment key={r.path}>
 														<TableRow sx={{ "& > *": { borderBottom: 'none' } }}>


### PR DESCRIPTION
## Summary
- create ColumnHeader component to consolidate table header styling
- align PageTitle component to the right
- use ColumnHeader across system pages

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68ad03faa3108325b36c623647c858cc