### PR TITLE
refactor: unify module lifecycle

### DIFF
--- a/server/modules/__init__.py
+++ b/server/modules/__init__.py
@@ -1,6 +1,17 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 from fastapi import FastAPI
 
-class BaseModule(ABC):
+
+class BaseProvider(ABC):
   def __init__(self, app: FastAPI):
     self.app = app
+
+
+class LifecycleProvider(BaseProvider):
+  @abstractmethod
+  async def startup(self):
+    pass
+
+  @abstractmethod
+  async def shutdown(self):
+    pass

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI, HTTPException, Request, status, Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import jwt, JWTError
 from typing import Dict, Optional
-from . import BaseModule
+from . import LifecycleProvider
 from .env_module import EnvironmentModule
 from .discord_module import DiscordModule
 from .database_provider import DatabaseProvider
@@ -24,7 +24,7 @@ async def fetch_ms_jwks(jwks_uri: str) -> Dict:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Failed to fetch JWKS.")
       return await response.json()
 
-class AuthModule(BaseModule):
+class AuthModule(LifecycleProvider):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.ms_jwks: Optional[Dict] = None

--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -4,8 +4,9 @@ from server.modules.database_provider import DatabaseProvider
 from fastapi import FastAPI, Request
 from discord.ext import commands
 from server.helpers.logging import configure_discord_logging #, remove_discord_logging
+from . import LifecycleProvider
 
-class DiscordModule():
+class DiscordModule(LifecycleProvider):
   def __init__(self, app: FastAPI):
     self.app: FastAPI = app
     try:
@@ -94,9 +95,9 @@ class DiscordModule():
       except Exception as e:
         await ctx.send(f"Error: {e}")
 
-  # async def shutdown(self):
-  #   await self.bot.close()
-  #   if self.task:
-  #     self.task.cancel()
-  #   remove_discord_logging(self)
+  async def shutdown(self):
+    await self.bot.close()
+    if self.task:
+      self.task.cancel()
+    logging.info("Discord module shutdown")
 

--- a/server/modules/mssql_provider.py
+++ b/server/modules/mssql_provider.py
@@ -2,7 +2,7 @@ import json, aioodbc, logging
 from uuid import uuid4
 from datetime import datetime
 from fastapi import FastAPI
-from . import BaseModule
+from . import LifecycleProvider
 from .env_module import EnvironmentModule
 from .database_provider import DatabaseProvider, _utos
 
@@ -18,7 +18,7 @@ def _maybe_loads_json(data):
     return [_maybe_loads_json(v) for v in data]
   return data
 
-class MSSQLProvider(BaseModule, DatabaseProvider):
+class MSSQLProvider(LifecycleProvider, DatabaseProvider):
   def __init__(self, app: FastAPI, dsn: str | None = None):
     super().__init__(app)
     self.pool: aioodbc.pool.Pool | None = None

--- a/server/modules/permcap_module.py
+++ b/server/modules/permcap_module.py
@@ -1,9 +1,9 @@
 import json, os
 from pathlib import Path
 from fastapi import FastAPI
-from . import BaseModule
+from . import LifecycleProvider
 
-class PermCapModule(BaseModule):
+class PermCapModule(LifecycleProvider):
   def __init__(self, app: FastAPI, metadata_file: str | None = None):
     super().__init__(app)
     root = Path(__file__).resolve().parents[1]

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -1,12 +1,12 @@
 from azure.storage.blob.aio import BlobServiceClient
 from azure.core.exceptions import ResourceExistsError
 from fastapi import FastAPI
-from . import BaseModule
+from . import LifecycleProvider
 from .env_module import EnvironmentModule
 from .database_provider import DatabaseProvider
 import io, logging
 
-class StorageModule(BaseModule):
+class StorageModule(LifecycleProvider):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     try:


### PR DESCRIPTION
## Summary
- add `BaseProvider` and `LifecycleProvider` abstractions
- migrate server modules to `LifecycleProvider`
- iterate lifecycle providers uniformly during app lifespan

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7314ffc083258b34493f399a01a2