### PR TITLE
Use tab indentation in RPC model generation

### DIFF
--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -7,254 +7,254 @@
 import axios from "axios";
 
 export interface RPCRequest {
-  op: string;
-  payload: any | null;
-  version: number;
-  timestamp: string | null;
-  user_guid: string | null;
-  roles: string[];
-  role_mask: number;
+	op: string;
+	payload: any | null;
+	version: number;
+	timestamp: string | null;
+	user_guid: string | null;
+	roles: string[];
+	role_mask: number;
 }
 export interface RPCResponse {
-  op: string;
-  payload: any;
-  version: number;
-  timestamp: string | null;
-}
-export interface AuthGoogleOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
-  credits: number;
-  profile_image: string | null;
-}
-export interface AuthGoogleOauthLoginPayload1 {
-  provider: string;
-  code: string;
-  fingerprint: any;
-}
-export interface AuthMicrosoftOauthLogin1 {
-  sessionToken: string;
-  display_name: string;
-  credits: number;
-  profile_image: string | null;
-}
-export interface SupportUsersGuid1 {
-  userGuid: string;
-}
-export interface SupportUsersSetCredits1 {
-  userGuid: string;
-  credits: number;
-}
-export interface SupportRolesMembers1 {
-  members: SupportRolesUserItem1[];
-  nonMembers: SupportRolesUserItem1[];
-}
-export interface SupportRolesRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface SupportRolesUserItem1 {
-  guid: string;
-  displayName: string;
-}
-export interface ServiceRolesDeleteRole1 {
-  name: string;
-}
-export interface ServiceRolesRoleMemberUpdate1 {
-  role: string;
-  userGuid: string;
-}
-export interface ServiceRolesRoleMembers1 {
-  members: ServiceRolesUserItem1[];
-  nonMembers: ServiceRolesUserItem1[];
-}
-export interface ServiceRolesRoles1 {
-  roles: string[];
-}
-export interface ServiceRolesUpsertRole1 {
-  name: string;
-  bit: number;
-  display: any;
-}
-export interface ServiceRolesUserItem1 {
-  guid: string;
-  displayName: string;
-}
-export interface StorageFilesDeleteFiles1 {
-  files: string[];
-}
-export interface StorageFilesFileItem1 {
-  name: string;
-  url: string;
-  content_type: string | null;
-}
-export interface StorageFilesFiles1 {
-  files: StorageFilesFileItem1[];
-}
-export interface StorageFilesSetGallery1 {
-  name: string;
-  gallery: boolean;
-}
-export interface StorageFilesUploadFile1 {
-  name: string;
-  content_b64: string;
-  content_type: string | null;
-}
-export interface StorageFilesUploadFiles1 {
-  files: StorageFilesUploadFile1[];
-}
-export interface SystemRoutesDeleteRoute1 {
-  path: string;
-}
-export interface SystemRoutesList1 {
-  routes: SystemRoutesRouteItem1[];
-}
-export interface SystemRoutesRouteItem1 {
-  path: string;
-  name: string;
-  icon: string | null;
-  sequence: number;
-  required_roles: string[];
-}
-export interface SystemConfigConfigItem1 {
-  key: string;
-  value: string;
-}
-export interface SystemConfigDeleteConfig1 {
-  key: string;
-}
-export interface SystemConfigList1 {
-  items: SystemConfigConfigItem1[];
+	op: string;
+	payload: any;
+	version: number;
+	timestamp: string | null;
 }
 export interface SystemRolesDeleteRole1 {
-  name: string;
+	name: string;
 }
 export interface SystemRolesList1 {
-  roles: SystemRolesRoleItem1[];
+	roles: SystemRolesRoleItem1[];
 }
 export interface SystemRolesRoleItem1 {
-  name: string;
-  mask: string;
-  display: any;
+	name: string;
+	mask: string;
+	display: any;
 }
 export interface SystemRolesUpsertRole1 {
-  name: string;
-  mask: string;
-  display: any;
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface SystemConfigConfigItem1 {
+	key: string;
+	value: string;
+}
+export interface SystemConfigDeleteConfig1 {
+	key: string;
+}
+export interface SystemConfigList1 {
+	items: SystemConfigConfigItem1[];
+}
+export interface SystemRoutesDeleteRoute1 {
+	path: string;
+}
+export interface SystemRoutesList1 {
+	routes: SystemRoutesRouteItem1[];
+}
+export interface SystemRoutesRouteItem1 {
+	path: string;
+	name: string;
+	icon: string | null;
+	sequence: number;
+	required_roles: string[];
+}
+export interface AuthMicrosoftOauthLogin1 {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
+}
+export interface AuthGoogleOauthLogin1 {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
+}
+export interface AuthGoogleOauthLoginPayload1 {
+	provider: string;
+	code: string;
+	fingerprint: any;
+}
+export interface SupportRolesMembers1 {
+	members: SupportRolesUserItem1[];
+	nonMembers: SupportRolesUserItem1[];
+}
+export interface SupportRolesRoleMemberUpdate1 {
+	role: string;
+	userGuid: string;
+}
+export interface SupportRolesUserItem1 {
+	guid: string;
+	displayName: string;
+}
+export interface SupportUsersGuid1 {
+	userGuid: string;
+}
+export interface SupportUsersSetCredits1 {
+	userGuid: string;
+	credits: number;
+}
+export interface ServiceRolesDeleteRole1 {
+	name: string;
+}
+export interface ServiceRolesRoleMemberUpdate1 {
+	role: string;
+	userGuid: string;
+}
+export interface ServiceRolesRoleMembers1 {
+	members: ServiceRolesUserItem1[];
+	nonMembers: ServiceRolesUserItem1[];
+}
+export interface ServiceRolesRoles1 {
+	roles: string[];
+}
+export interface ServiceRolesUpsertRole1 {
+	name: string;
+	bit: number;
+	display: any;
+}
+export interface ServiceRolesUserItem1 {
+	guid: string;
+	displayName: string;
+}
+export interface StorageFilesDeleteFiles1 {
+	files: string[];
+}
+export interface StorageFilesFileItem1 {
+	name: string;
+	url: string;
+	content_type: string | null;
+}
+export interface StorageFilesFiles1 {
+	files: StorageFilesFileItem1[];
+}
+export interface StorageFilesSetGallery1 {
+	name: string;
+	gallery: boolean;
+}
+export interface StorageFilesUploadFile1 {
+	name: string;
+	content_b64: string;
+	content_type: string | null;
+}
+export interface StorageFilesUploadFiles1 {
+	files: StorageFilesUploadFile1[];
 }
 export interface UsersProvidersCreateFromProvider1 {
-  provider: string;
-  provider_identifier: string;
-  provider_email: string;
-  provider_displayname: string;
-  provider_profile_image: any;
+	provider: string;
+	provider_identifier: string;
+	provider_email: string;
+	provider_displayname: string;
+	provider_profile_image: any;
 }
 export interface UsersProvidersGetByProviderIdentifier1 {
-  provider: string;
-  provider_identifier: string;
+	provider: string;
+	provider_identifier: string;
 }
 export interface UsersProvidersLinkProvider1 {
-  provider: string;
-  code: string;
+	provider: string;
+	code: string;
 }
 export interface UsersProvidersSetProvider1 {
-  provider: string;
+	provider: string;
 }
 export interface UsersProvidersUnlinkProvider1 {
-  provider: string;
+	provider: string;
 }
 export interface UsersProfileAuthProvider1 {
-  name: string;
-  display: string;
+	name: string;
+	display: string;
 }
 export interface UsersProfileProfile1 {
-  guid: string;
-  display_name: string;
-  email: string;
-  display_email: boolean;
-  credits: number;
-  profile_image: string | null;
-  default_provider: string;
-  auth_providers: UsersProfileAuthProvider1[];
+	guid: string;
+	display_name: string;
+	email: string;
+	display_email: boolean;
+	credits: number;
+	profile_image: string | null;
+	default_provider: string;
+	auth_providers: UsersProfileAuthProvider1[];
 }
 export interface UsersProfileRoles1 {
-  roles: number;
+	roles: number;
 }
 export interface UsersProfileSetDisplay1 {
-  display_name: string;
+	display_name: string;
 }
 export interface UsersProfileSetOptin1 {
-  display_email: boolean;
+	display_email: boolean;
 }
 export interface UsersProfileSetProfileImage1 {
-  image_b64: string;
-  provider: string;
-}
-export interface PublicVarsFfmpegVersion1 {
-  ffmpeg_version: string;
-}
-export interface PublicVarsHostname1 {
-  hostname: string;
-}
-export interface PublicVarsOdbcVersion1 {
-  odbc_version: string;
-}
-export interface PublicVarsRepo1 {
-  repo: string;
-}
-export interface PublicVarsVersion1 {
-  version: string;
+	image_b64: string;
+	provider: string;
 }
 export interface PublicLinksHomeLinks1 {
-  links: PublicLinksLinkItem1[];
+	links: PublicLinksLinkItem1[];
 }
 export interface PublicLinksLinkItem1 {
-  title: string;
-  url: string;
+	title: string;
+	url: string;
 }
 export interface PublicLinksNavBarRoute1 {
-  path: string;
-  name: string;
-  icon: string | null;
+	path: string;
+	name: string;
+	icon: string | null;
 }
 export interface PublicLinksNavBarRoutes1 {
-  routes: PublicLinksNavBarRoute1[];
+	routes: PublicLinksNavBarRoute1[];
+}
+export interface PublicVarsFfmpegVersion1 {
+	ffmpeg_version: string;
+}
+export interface PublicVarsHostname1 {
+	hostname: string;
+}
+export interface PublicVarsOdbcVersion1 {
+	odbc_version: string;
+}
+export interface PublicVarsRepo1 {
+	repo: string;
+}
+export interface PublicVarsVersion1 {
+	version: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {
-    const request: RPCRequest = {
-        op,
-        payload,
-        version: 1,
-        timestamp: new Date().toISOString(),
-        user_guid: null,
-        roles: [],
-        role_mask: 0
-    };
-    const headers: Record<string, string> = {};
-    if (typeof localStorage !== 'undefined') {
-        try {
-            const raw = localStorage.getItem('authTokens');
-            if (raw) {
-                const { sessionToken } = JSON.parse(raw);
-                if (sessionToken) headers.Authorization = `Bearer ${sessionToken}`;
-            }
-        } catch {
-            /* ignore token parsing errors */
-        }
-    }
-    try {
-        const response = await axios.post<RPCResponse>('/rpc', request, { headers });
-        return response.data.payload as T;
-    } catch (err: any) {
-        if (axios.isAxiosError(err) && err.response?.status === 401) {
-            if (typeof localStorage !== 'undefined') {
-                localStorage.removeItem('authTokens');
-            }
-            if (typeof window !== 'undefined') {
-                window.dispatchEvent(new Event('sessionExpired'));
-            }
-        }
-        throw err;
-    }
+	const request: RPCRequest = {
+	op,
+	payload,
+	version: 1,
+	timestamp: new Date().toISOString(),
+	user_guid: null,
+	roles: [],
+	role_mask: 0
+	};
+	const headers: Record<string, string> = {};
+	if (typeof localStorage !== 'undefined') {
+		try {
+			const raw = localStorage.getItem('authTokens');
+			if (raw) {
+				const { sessionToken } = JSON.parse(raw);
+				if (sessionToken) headers.Authorization = `Bearer ${sessionToken}`;
+			}
+		} catch {
+			/* ignore token parsing errors */
+		}
+	}
+	try {
+		const response = await axios.post<RPCResponse>('/rpc', request, { headers });
+		return response.data.payload as T;
+	} catch (err: any) {
+		if (axios.isAxiosError(err) && err.response?.status === 401) {
+			if (typeof localStorage !== 'undefined') {
+				localStorage.removeItem('authTokens');
+			}
+			if (typeof window !== 'undefined') {
+				window.dispatchEvent(new Event('sessionExpired'));
+			}
+		}
+		throw err;
+	}
 }

--- a/scripts/generate_rpc_library.py
+++ b/scripts/generate_rpc_library.py
@@ -12,43 +12,52 @@ sys.path.insert(0, REPO_ROOT)
 
 RPC_CALL_FUNC = [
   "export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {",
-  "    const request: RPCRequest = {",
-  "        op,",
-  "        payload,",
-  "        version: 1,",
-  "        timestamp: new Date().toISOString(),",
-  "        user_guid: null,",
-  "        roles: [],",
-  "        role_mask: 0",
-  "    };",
-  "    const headers: Record<string, string> = {};",
-  "    if (typeof localStorage !== 'undefined') {",
-  "        try {",
-  "            const raw = localStorage.getItem('authTokens');",
-  "            if (raw) {",
-  "                const { sessionToken } = JSON.parse(raw);",
-  "                if (sessionToken) headers.Authorization = `Bearer ${sessionToken}`;",
-  "            }",
-  "        } catch {",
-  "            /* ignore token parsing errors */",
-  "        }",
-  "    }",
-  "    try {",
-  "        const response = await axios.post<RPCResponse>('/rpc', request, { headers });",
-  "        return response.data.payload as T;",
-  "    } catch (err: any) {",
-  "        if (axios.isAxiosError(err) && err.response?.status === 401) {",
-  "            if (typeof localStorage !== 'undefined') {",
-  "                localStorage.removeItem('authTokens');",
-  "            }",
-  "            if (typeof window !== 'undefined') {",
-  "                window.dispatchEvent(new Event('sessionExpired'));",
-  "            }",
-  "        }",
-  "        throw err;",
-  "    }",
+  "\tconst request: RPCRequest = {",
+  "\top,",
+  "\tpayload,",
+  "\tversion: 1,",
+  "\ttimestamp: new Date().toISOString(),",
+  "\tuser_guid: null,",
+  "\troles: [],",
+  "\trole_mask: 0",
+  "\t};",
+  "\tconst headers: Record<string, string> = {};",
+  "\tif (typeof localStorage !== 'undefined') {",
+  "\t\ttry {",
+  "\t\t\tconst raw = localStorage.getItem('authTokens');",
+  "\t\t\tif (raw) {",
+  "\t\t\t\tconst { sessionToken } = JSON.parse(raw);",
+  "\t\t\t\tif (sessionToken) headers.Authorization = `Bearer ${sessionToken}`;",
+  "\t\t\t}",
+  "\t\t} catch {",
+  "\t\t\t/* ignore token parsing errors */",
+  "\t\t}",
+  "\t}",
+  "\ttry {",
+  "\t\tconst response = await axios.post<RPCResponse>('/rpc', request, { headers });",
+  "\t\treturn response.data.payload as T;",
+  "\t} catch (err: any) {",
+  "\t\tif (axios.isAxiosError(err) && err.response?.status === 401) {",
+  "\t\t\tif (typeof localStorage !== 'undefined') {",
+  "\t\t\t\tlocalStorage.removeItem('authTokens');",
+  "\t\t\t}",
+  "\t\t\tif (typeof window !== 'undefined') {",
+  "\t\t\t\twindow.dispatchEvent(new Event('sessionExpired'));",
+  "\t\t\t}",
+  "\t\t}",
+  "\t\tthrow err;",
+  "\t}",
   "}",
 ]
+
+
+def to_tabs(text: str) -> str:
+  lines = []
+  for line in text.splitlines():
+    leading = len(line) - len(line.lstrip(' '))
+    tabs = "\t" * (leading // 2)
+    lines.append(tabs + line.lstrip(' '))
+  return "\n".join(lines)
 
 ROOT = os.path.join(REPO_ROOT, 'rpc')
 FRONTEND_SRC = os.path.join(REPO_ROOT, 'frontend', 'src', 'shared')
@@ -68,7 +77,7 @@ def extract_interfaces_from_models_py(path: str, seen: set[str]) -> List[str]:
         continue
       print(f"🧩 Found model: {obj.__name__}")
       seen.add(obj.__name__)
-      interfaces.append(model_to_ts(obj))
+      interfaces.append(to_tabs(model_to_ts(obj)))
 
   return interfaces
 


### PR DESCRIPTION
## Summary
- ensure `generate_rpc_library.py` emits tab-indented TypeScript
- regenerate `RpcModels.tsx` with tab style and verify generated files contain no leading spaces

## Testing
- `npm run lint`
- `npm run type-check`
- `npx vitest run`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae749a29088325aa98430980fc8901