### PR TITLE
test: update tests for provider classes

### DIFF
--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -5,6 +5,7 @@ import importlib.util
 import sys
 import types
 import uuid
+from server.modules.providers.auth.google_provider import GoogleAuthProvider
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -17,7 +18,9 @@ class DummyAuth:
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
   def __init__(self):
-    self.providers = {"google": SimpleNamespace(audience="gid")}
+    provider = GoogleAuthProvider(api_id="gid", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
+    asyncio.run(provider.startup())
+    self.providers = {"google": provider}
 
 class DBRes:
   def __init__(self, rows=None, rowcount=0):
@@ -120,3 +123,4 @@ def test_lookup_existing_user(monkeypatch):
   resp = asyncio.run(auth_google_oauth_login_v1(req))
   assert isinstance(resp, RPCResponse)
   assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)
+  asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -5,6 +5,7 @@ import importlib.util
 import sys
 import types
 import uuid
+from server.modules.providers.auth.google_provider import GoogleAuthProvider
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -17,7 +18,9 @@ class DummyAuth:
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
   def __init__(self):
-    self.providers = {"google": SimpleNamespace(audience="gid")}
+    provider = GoogleAuthProvider(api_id="gid", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
+    asyncio.run(provider.startup())
+    self.providers = {"google": provider}
 
 class DBRes:
   def __init__(self, rows=None, rowcount=0):
@@ -140,3 +143,4 @@ def test_fetch_user_after_create(monkeypatch):
     op == "urn:users:providers:create_from_provider:1" and args["provider_identifier"] == expected
     for op, args in req.app.state.db.calls
   )
+  asyncio.run(req.app.state.auth.providers["google"].shutdown())


### PR DESCRIPTION
## Summary
- update Google auth tests to use class-based provider and lifecycle
- ensure Microsoft auth tests invoke provider startup/shutdown
- align users/providers service tests with new GoogleAuthProvider

## Testing
- `python run_tests.py` *(fails: file not found)*
- `pytest tests/test_auth_google_existing_user_lookup.py tests/test_auth_google_oauth_login_creation.py tests/test_auth_google_email_exists.py tests/test_users_providers_services.py tests/test_auth_module.py`

------
https://chatgpt.com/codex/tasks/task_e_68af5c4c2dec8325968015494e35ec00