### PR TITLE
Prefetch JWKS during auth provider startup

### DIFF
--- a/server/modules/providers/__init__.py
+++ b/server/modules/providers/__init__.py
@@ -36,7 +36,8 @@ class AuthProvider(AuthProviderBase):
     self._jwks_fetched_at: datetime | None = None
 
   async def startup(self) -> None:
-    pass
+    logging.debug("[AuthProvider] Startup initiating JWKS fetch")
+    await self._get_jwks()
 
   async def shutdown(self) -> None:
     pass

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -16,6 +16,12 @@ class DummyAuth:
     return [], 0
   def __init__(self):
     provider = GoogleAuthProvider(api_id="gid", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
+
+    async def fake_fetch_jwks():
+      provider._jwks = {"keys": []}
+      provider._jwks_fetched_at = datetime.now(timezone.utc)
+
+    provider.fetch_jwks = fake_fetch_jwks
     asyncio.run(provider.startup())
     self.providers = {"google": provider}
 

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -19,6 +19,12 @@ class DummyAuth:
     return [], 0
   def __init__(self):
     provider = GoogleAuthProvider(api_id="gid", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
+
+    async def fake_fetch_jwks():
+      provider._jwks = {"keys": []}
+      provider._jwks_fetched_at = datetime.now(timezone.utc)
+
+    provider.fetch_jwks = fake_fetch_jwks
     asyncio.run(provider.startup())
     self.providers = {"google": provider}
 

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -19,6 +19,12 @@ class DummyAuth:
     return [], 0
   def __init__(self):
     provider = GoogleAuthProvider(api_id="gid", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
+
+    async def fake_fetch_jwks():
+      provider._jwks = {"keys": []}
+      provider._jwks_fetched_at = datetime.now(timezone.utc)
+
+    provider.fetch_jwks = fake_fetch_jwks
     asyncio.run(provider.startup())
     self.providers = {"google": provider}
 

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -5,7 +5,7 @@ import sys
 import types
 from types import SimpleNamespace
 import uuid
-from datetime import timedelta
+from datetime import datetime, timezone, timedelta
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 
 import pytest
@@ -136,8 +136,15 @@ def test_link_provider_google_normalizes_identifier():
   class DummyAuth:
     def __init__(self):
       provider = GoogleAuthProvider(api_id="client-id", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
+
+      async def fake_fetch_jwks():
+        provider._jwks = {"keys": []}
+        provider._jwks_fetched_at = datetime.now(timezone.utc)
+
+      provider.fetch_jwks = fake_fetch_jwks
       asyncio.run(provider.startup())
       self.providers = {"google": provider}
+
     async def handle_auth_login(self, provider, id_token, access_token):
       return "google-id", {}, {}
 


### PR DESCRIPTION
## Summary
- ensure `AuthProvider.startup()` fetches JWKS so providers pre-load their signing keys
- adjust auth tests to stub JWKS retrieval and rely on provider `startup()` initialization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af5e24ac208325aba50c7d95fe21da