### PR TITLE
feat: add MSSQL database provider implementation

### DIFF
--- a/server/modules/providers/mssql_provider/__init__.py
+++ b/server/modules/providers/mssql_provider/__init__.py
@@ -1,27 +1,33 @@
 # providers/mssql_provider/__init__.py
 from typing import Any, Dict
+
+from .. import DbProviderBase
+from ..models import DBResult
 from .logic import init_pool, close_pool
 from .db_helpers import fetch_rows, fetch_json, exec_query
 from .registry import get_handler
 
-async def init(**cfg):
-  # pass: dsn="...", etc.
-  await init_pool(**cfg)
 
-async def dispatch(op: str, args: Dict[str, Any]):
-  handler = get_handler(op)
-  spec = handler(args)
-  # async handler path
-  if hasattr(spec, "__await__"):
-    return await spec
-  # tuple path: (mode, sql, params)
-  mode, sql, params = spec
-  if mode == "json_one":
-    return await fetch_json(sql, params)
-  if mode == "row_one":
-    return await fetch_rows(sql, params, one=True)
-  if mode == "json_many":
-    return await fetch_json(sql, params, many=True)
-  if mode == "exec":
-    return await exec_query(sql, params)
-  raise ValueError(f"Unknown mode: {mode}")
+class MssqlProvider(DbProviderBase):
+  async def startup(self) -> None:
+    await init_pool(**self.config)
+
+  async def shutdown(self) -> None:
+    await close_pool()
+
+  async def run(self, op: str, args: Dict[str, Any]) -> DBResult:
+    handler = get_handler(op)
+    spec = handler(args)
+    if hasattr(spec, "__await__"):
+      return await spec
+    mode, sql, params = spec
+    if mode == "json_one":
+      return await fetch_json(sql, params)
+    if mode == "row_one":
+      return await fetch_rows(sql, params, one=True)
+    if mode == "json_many":
+      return await fetch_json(sql, params, many=True)
+    if mode == "exec":
+      return await exec_query(sql, params)
+    raise ValueError(f"Unknown mode: {mode}")
+


### PR DESCRIPTION
## Summary
- implement MSSQL DbProvider to support modular startup
- connect startup, shutdown, and query dispatch to existing helpers

## Testing
- `python scripts/generate_rpc_client.py`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68af60f485f883259dc54ae1cad26235