### PR TITLE
Fix DB module provider selection to skip abstract classes

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -36,7 +36,12 @@ class DbModule(BaseModule):
 
     provider_cls = None
     for attr in module.__dict__.values():
-      if inspect.isclass(attr) and issubclass(attr, DbProviderBase):
+      if (
+        inspect.isclass(attr)
+        and issubclass(attr, DbProviderBase)
+        and attr is not DbProviderBase
+        and not inspect.isabstract(attr)
+      ):
         provider_cls = attr
         break
     if not provider_cls:

--- a/tests/test_db_module_init.py
+++ b/tests/test_db_module_init.py
@@ -1,0 +1,12 @@
+import asyncio
+from fastapi import FastAPI
+
+from server.modules.db_module import DbModule
+from server.modules.providers.mssql_provider import MssqlProvider
+
+
+def test_init_uses_concrete_provider():
+  app = FastAPI()
+  db = DbModule(app)
+  asyncio.run(db.init(provider="mssql"))
+  assert isinstance(db._provider, MssqlProvider)


### PR DESCRIPTION
## Summary
- avoid instantiating abstract DbProviderBase when loading database providers
- add regression test ensuring DbModule uses concrete MssqlProvider

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run type-check`
- `npm --prefix frontend test`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68af650b25f48325aa33b93e8ddb140f