### PR TITLE
Fix provider model imports in tests

### DIFF
--- a/tests/test_db_module_api_ids.py
+++ b/tests/test_db_module_api_ids.py
@@ -2,7 +2,7 @@ import asyncio
 from fastapi import FastAPI
 
 from server.modules.db_module import DbModule
-from server.modules.providers.models import DBResult
+from server.modules.providers import DBResult
 
 
 def test_get_google_client_id():

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -32,14 +32,6 @@ logic_mod = importlib.util.module_from_spec(spec_logic)
 sys.modules["server.modules.providers.database.mssql_provider.logic"] = logic_mod
 spec_logic.loader.exec_module(logic_mod)
 
-spec_models = importlib.util.spec_from_file_location(
-  "server.modules.providers.models",
-  root_path / "server/modules/providers/models.py",
-)
-models_mod = importlib.util.module_from_spec(spec_models)
-sys.modules["server.modules.providers.models"] = models_mod
-spec_models.loader.exec_module(models_mod)
-
 spec_db_helpers = importlib.util.spec_from_file_location(
   "server.modules.providers.database.mssql_provider.db_helpers",
   root_path / "server/modules/providers/database/mssql_provider/db_helpers.py",

--- a/tests/test_user_creation_profile_img.py
+++ b/tests/test_user_creation_profile_img.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from uuid import uuid4
 
 from server.modules.providers.database.mssql_provider import registry
-from server.modules.providers.models import DBResult
+from server.modules.providers import DBResult
 
 
 def test_create_from_provider_inserts_profile_image(monkeypatch):


### PR DESCRIPTION
## Summary
- update tests to import `DBResult` from `server.modules.providers`
- remove stale models reference in provider queries test

## Testing
- `python scripts/run_tests.py --test`
- `pytest tests/test_db_module_api_ids.py tests/test_user_creation_profile_img.py tests/test_provider_queries.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b10de0eb7c8325ba6dc00eef91b41a