### PR TITLE
feat(frontend): add account roles page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ const SystemRoutesPage = lazy(() => import("./pages/system/SystemRoutesPage"));
 const SystemRolesPage = lazy(() => import("./pages/system/SystemRolesPage"));
 const FileManager = lazy(() => import("./pages/FileManager"));
 const SystemConfigPage = lazy(() => import("./pages/system/SystemConfigPage"));
+const AccountRolesPage = lazy(() => import("./pages/AccountRolesPage"));
 
 function App(): JSX.Element {
 	return (
@@ -40,11 +41,12 @@ function App(): JSX.Element {
                                                                 <Route path="/system-routes" element={<SystemRoutesPage />} />
                                                                 <Route path="/system-config" element={<SystemConfigPage />} />
                                                                 <Route path="/system-roles" element={<SystemRolesPage />} />
+                                                                <Route path="/account-roles" element={<AccountRolesPage />} />
                                                                 <Route path="/file-manager" element={<FileManager />} />
                                                         </Routes>
                                                 </Suspense>
                                         </Container>
-				</Router>
+                                </Router>
 			</UserContextProvider>
 		</ThemeProvider>
 	);

--- a/frontend/src/pages/AccountRolesPage.tsx
+++ b/frontend/src/pages/AccountRolesPage.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+import {
+    Box,
+    Stack,
+    List,
+    ListItemButton,
+    ListItemText,
+    IconButton,
+    Typography,
+} from "@mui/material";
+import { ArrowForwardIos, ArrowBackIos } from "@mui/icons-material";
+import PageTitle from "../components/PageTitle";
+import type {
+    ServiceRolesUserItem1,
+    ServiceRolesRoleMembers1,
+    ServiceRolesRoles1,
+} from "../shared/RpcModels";
+import {
+    fetchRoles,
+    fetchRoleMembers,
+    fetchAddRoleMember,
+    fetchRemoveRoleMember,
+} from "../rpc/service/roles";
+
+const AccountRolesPage = (): JSX.Element => {
+    const [roles, setRoles] = useState<string[]>([]);
+    const [members, setMembers] = useState<Record<string, ServiceRolesUserItem1[]>>({});
+    const [nonMembers, setNonMembers] = useState<Record<string, ServiceRolesUserItem1[]>>({});
+    const [selectedLeft, setSelectedLeft] = useState<Record<string, string>>({});
+    const [selectedRight, setSelectedRight] = useState<Record<string, string>>({});
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                const res: ServiceRolesRoles1 = await fetchRoles();
+                setRoles(res.roles.sort());
+            } catch {
+                setRoles([]);
+            }
+        })();
+    }, []);
+
+    useEffect(() => {
+        roles.forEach((r) => {
+            if (members[r]) return;
+            void (async () => {
+                try {
+                    const res: ServiceRolesRoleMembers1 = await fetchRoleMembers({ role: r });
+                    setMembers((m) => ({ ...m, [r]: res.members }));
+                    setNonMembers((n) => ({ ...n, [r]: res.nonMembers }));
+                } catch {
+                    setMembers((m) => ({ ...m, [r]: [] }));
+                    setNonMembers((n) => ({ ...n, [r]: [] }));
+                }
+            })();
+        });
+    }, [roles, members]);
+
+    const moveRight = async (role: string): Promise<void> => {
+        const id = selectedLeft[role];
+        if (!id) return;
+        await fetchAddRoleMember({ role, userGuid: id });
+        const res: ServiceRolesRoleMembers1 = await fetchRoleMembers({ role });
+        setMembers((m) => ({ ...m, [role]: res.members }));
+        setNonMembers((n) => ({ ...n, [role]: res.nonMembers }));
+        setSelectedLeft((s) => ({ ...s, [role]: "" }));
+    };
+
+    const moveLeft = async (role: string): Promise<void> => {
+        const id = selectedRight[role];
+        if (!id) return;
+        await fetchRemoveRoleMember({ role, userGuid: id });
+        const res: ServiceRolesRoleMembers1 = await fetchRoleMembers({ role });
+        setMembers((m) => ({ ...m, [role]: res.members }));
+        setNonMembers((n) => ({ ...n, [role]: res.nonMembers }));
+        setSelectedRight((s) => ({ ...s, [role]: "" }));
+    };
+
+    return (
+        <Box sx={{ p: 2 }}>
+            <PageTitle>Account Roles</PageTitle>
+            <Stack spacing={2}>
+                {roles.map((role) => (
+                    <Stack key={role} spacing={2} direction="column" alignItems="center">
+                        <Typography variant="h6">{role}</Typography>
+                        <Stack direction="row" spacing={2}>
+                            <List sx={{ width: 200, border: 1 }}>
+                                {(nonMembers[role] || []).map((u) => (
+                                    <ListItemButton
+                                        key={u.guid}
+                                        selected={selectedLeft[role] === u.guid}
+                                        onClick={() => setSelectedLeft({ ...selectedLeft, [role]: u.guid })}
+                                    >
+                                        <ListItemText primary={u.displayName} />
+                                    </ListItemButton>
+                                ))}
+                            </List>
+                            <Stack spacing={1} justifyContent="center">
+                                <IconButton onClick={() => void moveRight(role)}>
+                                    <ArrowForwardIos />
+                                </IconButton>
+                                <IconButton onClick={() => void moveLeft(role)}>
+                                    <ArrowBackIos />
+                                </IconButton>
+                            </Stack>
+                            <List sx={{ width: 200, border: 1 }}>
+                                {(members[role] || []).map((u) => (
+                                    <ListItemButton
+                                        key={u.guid}
+                                        selected={selectedRight[role] === u.guid}
+                                        onClick={() => setSelectedRight({ ...selectedRight, [role]: u.guid })}
+                                    >
+                                        <ListItemText primary={u.displayName} />
+                                    </ListItemButton>
+                                ))}
+                            </List>
+                        </Stack>
+                    </Stack>
+                ))}
+            </Stack>
+        </Box>
+    );
+};
+
+export default AccountRolesPage;
+

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -21,104 +21,6 @@ export interface RPCResponse {
 	version: number;
 	timestamp: string | null;
 }
-export interface SystemRolesDeleteRole1 {
-	name: string;
-}
-export interface SystemRolesList1 {
-	roles: SystemRolesRoleItem1[];
-}
-export interface SystemRolesRoleItem1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface SystemRolesUpsertRole1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface SystemConfigConfigItem1 {
-	key: string;
-	value: string;
-}
-export interface SystemConfigDeleteConfig1 {
-	key: string;
-}
-export interface SystemConfigList1 {
-	items: SystemConfigConfigItem1[];
-}
-export interface SystemRoutesDeleteRoute1 {
-	path: string;
-}
-export interface SystemRoutesList1 {
-	routes: SystemRoutesRouteItem1[];
-}
-export interface SystemRoutesRouteItem1 {
-	path: string;
-	name: string;
-	icon: string | null;
-	sequence: number;
-	required_roles: string[];
-}
-export interface AuthMicrosoftOauthLogin1 {
-	sessionToken: string;
-	display_name: string;
-	credits: number;
-	profile_image: string | null;
-}
-export interface AuthGoogleOauthLogin1 {
-	sessionToken: string;
-	display_name: string;
-	credits: number;
-	profile_image: string | null;
-}
-export interface AuthGoogleOauthLoginPayload1 {
-	provider: string;
-	code: string;
-	fingerprint: any;
-}
-export interface SupportRolesMembers1 {
-	members: SupportRolesUserItem1[];
-	nonMembers: SupportRolesUserItem1[];
-}
-export interface SupportRolesRoleMemberUpdate1 {
-	role: string;
-	userGuid: string;
-}
-export interface SupportRolesUserItem1 {
-	guid: string;
-	displayName: string;
-}
-export interface SupportUsersGuid1 {
-	userGuid: string;
-}
-export interface SupportUsersSetCredits1 {
-	userGuid: string;
-	credits: number;
-}
-export interface ServiceRolesDeleteRole1 {
-	name: string;
-}
-export interface ServiceRolesRoleMemberUpdate1 {
-	role: string;
-	userGuid: string;
-}
-export interface ServiceRolesRoleMembers1 {
-	members: ServiceRolesUserItem1[];
-	nonMembers: ServiceRolesUserItem1[];
-}
-export interface ServiceRolesRoles1 {
-	roles: string[];
-}
-export interface ServiceRolesUpsertRole1 {
-	name: string;
-	bit: number;
-	display: any;
-}
-export interface ServiceRolesUserItem1 {
-	guid: string;
-	displayName: string;
-}
 export interface StorageFilesDeleteFiles1 {
 	files: string[];
 }
@@ -219,6 +121,104 @@ export interface PublicVarsRepo1 {
 }
 export interface PublicVarsVersion1 {
 	version: string;
+}
+export interface ServiceRolesDeleteRole1 {
+	name: string;
+}
+export interface ServiceRolesRoleMemberUpdate1 {
+	role: string;
+	userGuid: string;
+}
+export interface ServiceRolesRoleMembers1 {
+	members: ServiceRolesUserItem1[];
+	nonMembers: ServiceRolesUserItem1[];
+}
+export interface ServiceRolesRoles1 {
+	roles: string[];
+}
+export interface ServiceRolesUpsertRole1 {
+	name: string;
+	bit: number;
+	display: any;
+}
+export interface ServiceRolesUserItem1 {
+	guid: string;
+	displayName: string;
+}
+export interface SupportUsersGuid1 {
+	userGuid: string;
+}
+export interface SupportUsersSetCredits1 {
+	userGuid: string;
+	credits: number;
+}
+export interface SupportRolesMembers1 {
+	members: SupportRolesUserItem1[];
+	nonMembers: SupportRolesUserItem1[];
+}
+export interface SupportRolesRoleMemberUpdate1 {
+	role: string;
+	userGuid: string;
+}
+export interface SupportRolesUserItem1 {
+	guid: string;
+	displayName: string;
+}
+export interface SystemConfigConfigItem1 {
+	key: string;
+	value: string;
+}
+export interface SystemConfigDeleteConfig1 {
+	key: string;
+}
+export interface SystemConfigList1 {
+	items: SystemConfigConfigItem1[];
+}
+export interface SystemRolesDeleteRole1 {
+	name: string;
+}
+export interface SystemRolesList1 {
+	roles: SystemRolesRoleItem1[];
+}
+export interface SystemRolesRoleItem1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface SystemRolesUpsertRole1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface SystemRoutesDeleteRoute1 {
+	path: string;
+}
+export interface SystemRoutesList1 {
+	routes: SystemRoutesRouteItem1[];
+}
+export interface SystemRoutesRouteItem1 {
+	path: string;
+	name: string;
+	icon: string | null;
+	sequence: number;
+	required_roles: string[];
+}
+export interface AuthGoogleOauthLogin1 {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
+}
+export interface AuthGoogleOauthLoginPayload1 {
+	provider: string;
+	code: string;
+	fingerprint: any;
+}
+export interface AuthMicrosoftOauthLogin1 {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/frontend/tests/account-roles.test.tsx
+++ b/frontend/tests/account-roles.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import AccountRolesPage from '../src/pages/AccountRolesPage';
+
+describe('AccountRolesPage component', () => {
+    it('should render title', () => {
+        const html = renderToString(<AccountRolesPage />);
+        expect(html).toContain('Account Roles');
+    });
+});
+


### PR DESCRIPTION
## Summary
- implement account roles management UI using service roles RPC calls
- add route and basic test for account roles page

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b11278a254832585a355b4c0adba43