### PR TITLE
Add account user management pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,8 @@ const SystemRolesPage = lazy(() => import("./pages/system/SystemRolesPage"));
 const FileManager = lazy(() => import("./pages/FileManager"));
 const SystemConfigPage = lazy(() => import("./pages/system/SystemConfigPage"));
 const AccountRolesPage = lazy(() => import("./pages/AccountRolesPage"));
+const AccountUsersPage = lazy(() => import("./pages/AccountUsersPage"));
+const AccountUserPanel = lazy(() => import("./pages/AccountUserPanel"));
 
 function App(): JSX.Element {
 	return (
@@ -21,32 +23,34 @@ function App(): JSX.Element {
 			<CssBaseline />
 			<UserContextProvider>
 				<Router>
-                                        <NavBar />
-                                        <Container
-                                                maxWidth="lg"
-                                                disableGutters
-                                                sx={{
-                                                        bgcolor: "background.paper",
-                                                        color: "text.primary",
-                                                        minHeight: "100vh",
-                                                        py: 2,
-                                                }}
-                                        >
-                                                <Suspense fallback={<div>Loading...</div>}>
-                                                        <Routes>
-                                                                <Route path="/" element={<Home />} />
-                                                                <Route path="/gallery" element={<Gallery />} />
-                                                                <Route path="/loginpage" element={<LoginPage />} />
-                                                                <Route path="/userpage" element={<UserPage />} />
-                                                                <Route path="/system-routes" element={<SystemRoutesPage />} />
-                                                                <Route path="/system-config" element={<SystemConfigPage />} />
-                                                                <Route path="/system-roles" element={<SystemRolesPage />} />
-                                                                <Route path="/account-roles" element={<AccountRolesPage />} />
-                                                                <Route path="/file-manager" element={<FileManager />} />
-                                                        </Routes>
-                                                </Suspense>
-                                        </Container>
-                                </Router>
+					<NavBar />
+					<Container
+						maxWidth="lg"
+						disableGutters
+						sx={{
+							bgcolor: "background.paper",
+							color: "text.primary",
+							minHeight: "100vh",
+							py: 2,
+						}}
+					>
+						<Suspense fallback={<div>Loading...</div>}>
+							<Routes>
+								<Route path="/" element={<Home />} />
+								<Route path="/gallery" element={<Gallery />} />
+								<Route path="/loginpage" element={<LoginPage />} />
+								<Route path="/userpage" element={<UserPage />} />
+								<Route path="/system-routes" element={<SystemRoutesPage />} />
+								<Route path="/system-config" element={<SystemConfigPage />} />
+								<Route path="/system-roles" element={<SystemRolesPage />} />
+								<Route path="/account-roles" element={<AccountRolesPage />} />
+								<Route path="/account-users" element={<AccountUsersPage />} />
+								<Route path="/account-users/:guid" element={<AccountUserPanel />} />
+								<Route path="/file-manager" element={<FileManager />} />
+							</Routes>
+						</Suspense>
+					</Container>
+				</Router>
 			</UserContextProvider>
 		</ThemeProvider>
 	);

--- a/frontend/src/pages/AccountUserPanel.tsx
+++ b/frontend/src/pages/AccountUserPanel.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Box, Stack, Button, List, ListItemButton, ListItemText, IconButton, Typography } from '@mui/material';
+import { ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
+import PageTitle from '../components/PageTitle';
+import EditBox from '../components/EditBox';
+import Notification from '../components/Notification';
+import type { UsersProfileProfile1, SystemRolesRoleItem1, SupportRolesMembers1 } from '../shared/RpcModels';
+import { fetchProfile, fetchSetCredits, fetchEnableStorage, fetchResetDisplay } from '../rpc/support/users';
+import { fetchRoles as fetchSystemRoles } from '../rpc/system/roles';
+import { fetchMembers, fetchAddMember, fetchRemoveMember } from '../rpc/support/roles';
+
+const AccountUserPanel = (): JSX.Element => {
+	const { guid } = useParams();
+	const [profile, setProfile] = useState<UsersProfileProfile1 | null>(null);
+	const [roles, setRoles] = useState<SystemRolesRoleItem1[]>([]);
+	const [assigned, setAssigned] = useState<string[]>([]);
+	const [available, setAvailable] = useState<string[]>([]);
+	const [credits, setCredits] = useState<number>(0);
+	const [notification, setNotification] = useState(false);
+	const [initialAssigned, setInitialAssigned] = useState<string[]>([]);
+	const [selectedLeft, setSelectedLeft] = useState('');
+	const [selectedRight, setSelectedRight] = useState('');
+
+	useEffect(() => {
+		void (async () => {
+			if (!guid) return;
+			try {
+				const prof: UsersProfileProfile1 = await fetchProfile({ userGuid: guid });
+				setProfile(prof);
+				setCredits(prof.credits);
+				const roleRes = await fetchSystemRoles();
+				const roleItems: SystemRolesRoleItem1[] = roleRes.roles;
+				setRoles(roleItems);
+				const assignments: string[] = [];
+				const avail: string[] = [];
+				await Promise.all(
+					roleItems.map(async (r) => {
+						try {
+							const members: SupportRolesMembers1 = await fetchMembers({ role: r.name });
+							if (members.members.some((m) => m.guid === guid)) {
+								assignments.push(r.name);
+							} else {
+								avail.push(r.name);
+							}
+						} catch {
+							avail.push(r.name);
+						}
+					})
+				);
+				setAssigned(assignments);
+				setAvailable(avail);
+				setInitialAssigned(assignments);
+			} catch {
+				setProfile(null);
+				setRoles([]);
+				setAssigned([]);
+				setAvailable([]);
+				setInitialAssigned([]);
+			}
+		})();
+	}, [guid]);
+
+	const moveRight = (): void => {
+		if (!selectedLeft) return;
+		setAssigned([...assigned, selectedLeft]);
+		setAvailable(available.filter((r) => r !== selectedLeft));
+		setSelectedLeft('');
+	};
+
+	const moveLeft = (): void => {
+		if (!selectedRight) return;
+		setAvailable([...available, selectedRight]);
+		setAssigned(assigned.filter((r) => r !== selectedRight));
+		setSelectedRight('');
+	};
+
+	const handleResetDisplay = async (): Promise<void> => {
+		if (!guid) return;
+		await fetchResetDisplay({ userGuid: guid });
+		const prof: UsersProfileProfile1 = await fetchProfile({ userGuid: guid });
+		setProfile(prof);
+	};
+
+	const handleEnableStorage = async (): Promise<void> => {
+		if (!guid) return;
+		await fetchEnableStorage({ userGuid: guid });
+	};
+
+	const handleSave = async (): Promise<void> => {
+		if (!guid) return;
+		const toAdd = assigned.filter((r) => !initialAssigned.includes(r));
+		const toRemove = initialAssigned.filter((r) => !assigned.includes(r));
+		await Promise.all(toAdd.map((r) => fetchAddMember({ role: r, userGuid: guid })));
+		await Promise.all(toRemove.map((r) => fetchRemoveMember({ role: r, userGuid: guid })));
+		await fetchSetCredits({ userGuid: guid, credits });
+		setInitialAssigned(assigned);
+		setNotification(true);
+	};
+
+	return (
+		<Box sx={{ p: 2, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+			<PageTitle>User Management</PageTitle>
+			{profile && (
+				<Stack spacing={2} sx={{ mb: 4, alignItems: 'center' }}>
+					<Typography variant="h6">{profile.display_name}</Typography>
+					<Button variant="outlined" onClick={handleResetDisplay}>Reset Display Name</Button>
+					<Typography>Email: {profile.email}</Typography>
+					<EditBox value={credits} onCommit={(val) => setCredits(Number(val))} width={120} />
+					<Button variant="outlined" onClick={handleEnableStorage}>Enable Storage</Button>
+				</Stack>
+			)}
+			<Stack direction="row" spacing={2}>
+				<List sx={{ width: 200, border: 1 }}>
+					{available.map((r) => (
+						<ListItemButton key={r} selected={selectedLeft === r} onClick={() => setSelectedLeft(r)}>
+							<ListItemText primary={roles.find((ro) => ro.name === r)?.display ?? r} />
+						</ListItemButton>
+					))}
+				</List>
+				<Stack spacing={1} justifyContent="center">
+					<IconButton onClick={moveRight}>
+						<ArrowForwardIos />
+					</IconButton>
+					<IconButton onClick={moveLeft}>
+						<ArrowBackIos />
+					</IconButton>
+				</Stack>
+				<List sx={{ width: 200, border: 1 }}>
+					{assigned.map((r) => (
+						<ListItemButton key={r} selected={selectedRight === r} onClick={() => setSelectedRight(r)}>
+							<ListItemText primary={roles.find((ro) => ro.name === r)?.display ?? r} />
+						</ListItemButton>
+					))}
+				</List>
+			</Stack>
+			<Box sx={{ mt: 2 }}>
+				<Button variant="contained" onClick={handleSave}>Save</Button>
+			</Box>
+			<Notification open={notification} handleClose={() => setNotification(false)} severity="success" message="Saved" />
+		</Box>
+	);
+};
+
+export default AccountUserPanel;

--- a/frontend/src/pages/AccountUsersPage.tsx
+++ b/frontend/src/pages/AccountUsersPage.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { Box, Table, TableHead, TableRow, TableCell, TableBody, Button } from '@mui/material';
+import ColumnHeader from '../components/ColumnHeader';
+import PageTitle from '../components/PageTitle';
+import { Link as RouterLink } from 'react-router-dom';
+import type { SupportRolesUserItem1, SupportRolesMembers1 } from '../shared/RpcModels';
+import { fetchMembers } from '../rpc/support/roles';
+
+const AccountUsersPage = (): JSX.Element => {
+        const [users, setUsers] = useState<SupportRolesUserItem1[]>([]);
+
+	useEffect(() => {
+		void (async () => {
+			try {
+                                const res: SupportRolesMembers1 = await fetchMembers({ role: 'ROLE_REGISTERED' });
+                                setUsers(res.members);
+			} catch {
+				setUsers([]);
+			}
+		})();
+	}, []);
+
+	return (
+		<Box sx={{ p: 2 }}>
+			<PageTitle>Account Users</PageTitle>
+			<Table size="small" sx={{ '& td, & th': { py: 0.5 } }}>
+				<TableHead>
+					<TableRow>
+						<ColumnHeader>Display Name</ColumnHeader>
+						<ColumnHeader>Actions</ColumnHeader>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					{users.map((u) => (
+						<TableRow key={u.guid}>
+							<TableCell>{u.displayName}</TableCell>
+							<TableCell>
+								<Button component={RouterLink} to={`/account-users/${u.guid}`} variant="contained">Edit</Button>
+							</TableCell>
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
+		</Box>
+	);
+};
+
+export default AccountUsersPage;


### PR DESCRIPTION
## Summary
- Implement account user listing page that pulls registered users via support roles
- Add user management panel with profile, credits, storage, and role assignments using support RPCs
- Register new account user routes in the app router

## Testing
- `python scripts/generate_rpc_client.py`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b118b5f9e0832583f48897126f6935