### PR TITLE
Cache Google OAuth profile images locally

### DIFF
--- a/server/modules/providers/auth/google_provider/__init__.py
+++ b/server/modules/providers/auth/google_provider/__init__.py
@@ -1,4 +1,5 @@
 import aiohttp
+import base64
 from datetime import timedelta
 from typing import Dict, Any
 
@@ -55,8 +56,18 @@ class GoogleAuthProvider(AuthProvider):
           error_message = await response.text()
           raise HTTPException(status_code=500, detail=f"Failed to fetch user profile. Status: {response.status}, Error: {error_message}")
         user = await response.json()
+      profile_picture_base64 = None
+      picture_url = user.get("picture")
+      if picture_url:
+        try:
+          async with session.get(picture_url) as img_resp:
+            if img_resp.status == 200:
+              picture_bytes = await img_resp.read()
+              profile_picture_base64 = base64.b64encode(picture_bytes).decode("utf-8")
+        except Exception as e:
+          logging.exception("[GoogleAuthProvider] failed to fetch profile image: %s", e)
     return {
       "email": user.get("email"),
       "username": user.get("name"),
-      "profilePicture": user.get("picture"),
+      "profilePicture": profile_picture_base64,
     }

--- a/tests/test_auth_google_profile_image_update.py
+++ b/tests/test_auth_google_profile_image_update.py
@@ -1,0 +1,134 @@
+import sys, types, importlib.util, asyncio
+from types import SimpleNamespace
+from datetime import datetime, timezone, timedelta
+
+from server.modules.providers.auth.google_provider import GoogleAuthProvider
+
+
+class DummyAuth:
+  async def handle_auth_login(self, provider, id_token, access_token):
+    profile = {"email": "user@example.com", "username": "User", "profilePicture": "new"}
+    return "google-id", profile, {}
+  def make_rotation_token(self, user_guid):
+    return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, roles, provider):
+    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  async def get_user_roles(self, guid, refresh=False):
+    return [], 0
+  def __init__(self):
+    provider = GoogleAuthProvider(api_id="gid", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
+
+    async def fake_fetch_jwks():
+      provider._jwks = {"keys": []}
+      provider._jwks_fetched_at = datetime.now(timezone.utc)
+
+    provider.fetch_jwks = fake_fetch_jwks
+    asyncio.run(provider.startup())
+    self.providers = {"google": provider}
+
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+
+class DummyDb:
+  def __init__(self):
+    self.calls = []
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    if op == "urn:users:providers:get_by_provider_identifier:1":
+      return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
+    if op in ("db:users:session:set_rotkey:1", "db:auth:session:create_session:1", "urn:users:profile:set_profile_image:1"):
+      return DBRes([], 1)
+    if op == "urn:system:config:get_config:1":
+      key = args.get("key")
+      if key == "GoogleApiId":
+        return DBRes([{ "value": "gid" }], 1)
+      if key == "GoogleAuthRedirectLocalhost":
+        return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
+    return DBRes()
+
+  async def get_google_api_secret(self):
+    return "gsecret"
+
+
+class DummyState:
+  def __init__(self):
+    self.auth = DummyAuth()
+    self.db = DummyDb()
+
+
+class DummyApp:
+  def __init__(self):
+    self.state = DummyState()
+
+
+class DummyRequest:
+  def __init__(self):
+    self.app = DummyApp()
+    self.headers = {"user-agent": "tester"}
+    self.client = SimpleNamespace(host="127.0.0.1")
+
+
+def test_updates_profile_image(monkeypatch):
+  spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
+  models = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(models)
+  sys.modules["rpc.models"] = models
+  RPCRequest = models.RPCRequest
+
+  helpers = types.ModuleType("rpc.helpers")
+  async def fake_unbox_request(_):
+    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code"}, version=1)
+    return rpc, None, None
+  helpers.unbox_request = fake_unbox_request
+  sys.modules["rpc.helpers"] = helpers
+
+  sys.modules.setdefault("rpc", types.ModuleType("rpc"))
+  sys.modules.setdefault("rpc.auth", types.ModuleType("rpc.auth"))
+  rpc_auth_google = types.ModuleType("rpc.auth.google")
+  rpc_auth_google.__path__ = []
+  sys.modules.setdefault("rpc.auth.google", rpc_auth_google)
+  from pydantic import BaseModel
+  models_mod = types.ModuleType("rpc.auth.google.models")
+  class AuthGoogleOauthLoginPayload1(BaseModel):
+    provider: str = "google"
+    code: str
+    fingerprint: str | None = None
+  class AuthGoogleOauthLogin1(BaseModel):
+    sessionToken: str
+    display_name: str
+    credits: int
+    profile_image: str | None = None
+  models_mod.AuthGoogleOauthLoginPayload1 = AuthGoogleOauthLoginPayload1
+  models_mod.AuthGoogleOauthLogin1 = AuthGoogleOauthLogin1
+  sys.modules["rpc.auth.google.models"] = models_mod
+
+  sys.modules["server"] = types.ModuleType("server")
+  sys.modules["server.models"] = types.ModuleType("server.models")
+  sys.modules["server.modules"] = types.ModuleType("server.modules")
+  auth_mod = types.ModuleType("server.modules.auth_module")
+  class AuthModule: ...
+  auth_mod.AuthModule = AuthModule
+  sys.modules["server.modules.auth_module"] = auth_mod
+  db_mod = types.ModuleType("server.modules.db_module")
+  class DbModule: ...
+  db_mod.DbModule = DbModule
+  sys.modules["server.modules.db_module"] = db_mod
+
+  svc_spec = importlib.util.spec_from_file_location("rpc.auth.google.services", "rpc/auth/google/services.py")
+  svc_mod = importlib.util.module_from_spec(svc_spec)
+  svc_spec.loader.exec_module(svc_mod)
+  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+    assert code == "auth-code"
+    assert redirect_uri == "http://localhost:8000/userpage"
+    return "id", "acc"
+  svc_mod.exchange_code_for_tokens = fake_exchange
+  auth_google_oauth_login_v1 = svc_mod.auth_google_oauth_login_v1
+
+  req = DummyRequest()
+  asyncio.run(auth_google_oauth_login_v1(req))
+  assert any(op == "urn:users:profile:set_profile_image:1" for op, _ in req.app.state.db.calls)
+  asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_google_provider_profile_image.py
+++ b/tests/test_google_provider_profile_image.py
@@ -1,0 +1,57 @@
+import asyncio
+import base64
+import types
+from datetime import timedelta
+
+from server.modules.providers.auth import google_provider
+
+
+def test_fetch_user_profile_downloads_image(monkeypatch):
+  provider = google_provider.GoogleAuthProvider(
+    api_id="gid", jwks_uri="uri", jwks_expiry=timedelta(minutes=1)
+  )
+  provider.userinfo_endpoint = "userinfo"
+
+  class DummyResp:
+    def __init__(self, status, data, is_json=False):
+      self.status = status
+      self.data = data
+      self.is_json = is_json
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, *args):
+      pass
+    async def json(self):
+      return self.data
+    async def text(self):
+      if isinstance(self.data, bytes):
+        return self.data.decode()
+      return self.data
+    async def read(self):
+      if isinstance(self.data, str):
+        return self.data.encode()
+      return self.data
+
+  class DummySession:
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, *args):
+      pass
+    def get(self, url, headers=None):
+      if url == "userinfo":
+        return DummyResp(
+          200,
+          {"email": "user@example.com", "name": "User", "picture": "pic"},
+          True,
+        )
+      if url == "pic":
+        return DummyResp(200, b"imgbytes")
+      return DummyResp(404, "", True)
+
+  monkeypatch.setattr(
+    google_provider, "aiohttp", types.SimpleNamespace(ClientSession=lambda: DummySession())
+  )
+
+  profile = asyncio.run(provider.fetch_user_profile("token"))
+  expected = base64.b64encode(b"imgbytes").decode("utf-8")
+  assert profile["profilePicture"] == expected


### PR DESCRIPTION
## Summary
- fetch Google user profile pictures and store as base64
- test Google profile image download and caching logic

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68b26404bf7083259f55f3a804d72554