### PR TITLE
Restore soft deleted Microsoft accounts

### DIFF
--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -171,6 +171,13 @@ async def auth_microsoft_oauth_login_v1(request: Request):
     logging.debug("[auth_microsoft_oauth_login_v1] failed to create user")
     raise HTTPException(status_code=500, detail="Unable to create user")
 
+  if user.get("element_soft_deleted_at"):
+    await db.run(
+      "urn:users:providers:undelete_account:1",
+      {"provider": provider, "provider_identifier": provider_uid},
+    )
+    user["element_soft_deleted_at"] = None
+
   new_img = profile.get("profilePicture")
   if new_img != user.get("profile_image"):
     await db.run(

--- a/tests/test_auth_microsoft_soft_undelete.py
+++ b/tests/test_auth_microsoft_soft_undelete.py
@@ -1,0 +1,104 @@
+import sys, types, importlib.util, asyncio
+from types import SimpleNamespace
+from datetime import datetime, timezone, timedelta
+
+class DummyAuth:
+  async def handle_auth_login(self, provider, id_token, access_token):
+    profile = {"email": "user@example.com", "username": "User"}
+    return "00000000-0000-0000-0000-000000000001", profile, {}
+  def make_rotation_token(self, user_guid):
+    return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, roles, provider):
+    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  async def get_user_roles(self, guid, refresh=False):
+    return [], 0
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+class DummyDb:
+  def __init__(self):
+    self.calls = []
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    if op == "urn:users:providers:get_by_provider_identifier:1":
+      return DBRes([
+        {"guid": "user-guid", "display_name": "User", "credits": 0, "element_soft_deleted_at": "2024-01-01T00:00:00Z"}
+      ], 1)
+    if op in (
+      "urn:users:providers:undelete_account:1",
+      "db:users:session:set_rotkey:1",
+      "db:auth:session:create_session:1",
+    ):
+      return DBRes([], 1)
+    return DBRes()
+
+class DummyState:
+  def __init__(self):
+    self.auth = DummyAuth()
+    self.db = DummyDb()
+
+class DummyApp:
+  def __init__(self):
+    self.state = DummyState()
+
+class DummyRequest:
+  def __init__(self):
+    self.app = DummyApp()
+    self.headers = {"user-agent": "tester"}
+    self.client = SimpleNamespace(host="127.0.0.1")
+
+def test_undeletes_soft_deleted_account(monkeypatch):
+  spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
+  models = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(models)
+  sys.modules["rpc.models"] = models
+  RPCRequest = models.RPCRequest
+
+  helpers = types.ModuleType("rpc.helpers")
+  async def fake_unbox_request(_):
+    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
+    return rpc, None, None
+  helpers.unbox_request = fake_unbox_request
+  sys.modules["rpc.helpers"] = helpers
+
+  sys.modules.setdefault("rpc", types.ModuleType("rpc"))
+  sys.modules.setdefault("rpc.auth", types.ModuleType("rpc.auth"))
+  rpc_auth_ms = types.ModuleType("rpc.auth.microsoft")
+  rpc_auth_ms.__path__ = []
+  sys.modules.setdefault("rpc.auth.microsoft", rpc_auth_ms)
+  from pydantic import BaseModel
+  models_mod = types.ModuleType("rpc.auth.microsoft.models")
+  class AuthMicrosoftOauthLogin1(BaseModel):
+    sessionToken: str
+    display_name: str
+    credits: int
+    profile_image: str | None = None
+  models_mod.AuthMicrosoftOauthLogin1 = AuthMicrosoftOauthLogin1
+  sys.modules["rpc.auth.microsoft.models"] = models_mod
+
+  sys.modules["server"] = types.ModuleType("server")
+  sys.modules["server.modules"] = types.ModuleType("server.modules")
+  auth_mod = types.ModuleType("server.modules.auth_module")
+  class AuthModule: ...
+  auth_mod.AuthModule = AuthModule
+  sys.modules["server.modules.auth_module"] = auth_mod
+  db_mod = types.ModuleType("server.modules.db_module")
+  class DbModule: ...
+  db_mod.DbModule = DbModule
+  sys.modules["server.modules.db_module"] = db_mod
+
+  svc_spec = importlib.util.spec_from_file_location("rpc.auth.microsoft.services", "rpc/auth/microsoft/services.py")
+  svc_mod = importlib.util.module_from_spec(svc_spec)
+  svc_spec.loader.exec_module(svc_mod)
+  auth_microsoft_oauth_login_v1 = svc_mod.auth_microsoft_oauth_login_v1
+
+  req = DummyRequest()
+  asyncio.run(auth_microsoft_oauth_login_v1(req))
+  calls = req.app.state.db.calls
+  assert any(op == "urn:users:providers:undelete_account:1" for op, _ in calls)
+  undelete_idx = next(i for i, (op, _) in enumerate(calls) if op == "urn:users:providers:undelete_account:1")
+  create_idx = next(i for i, (op, _) in enumerate(calls) if op == "db:auth:session:create_session:1")
+  assert undelete_idx < create_idx


### PR DESCRIPTION
## Summary
- detect and restore soft-deleted Microsoft user records before session creation
- add unit test verifying undelete behavior

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68b3a0cb1eb08325afa567579ba02a78