### PR TITLE
Add device logout RPC without rotkey rotation

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -74,6 +74,7 @@ Authentication and session management calls.
 | `urn:auth:session:get_token:1`        | Get a bearer token for a new device session.           |
 | `urn:auth:session:refresh_token:1`    | Get a new bearer token for an existing device session. |
 | `urn:auth:session:invalidate_token:1` | Invalidate an existing device session token.           |
+| `urn:auth:session:logout_device:1`    | Revoke the current device's session token.             |
 | `urn:auth:session:get_session:1`      | Map a bearer token to its session and device details.  |
 
 ## Public (React/Frontend) Domain

--- a/frontend/src/rpc/auth/session/index.ts
+++ b/frontend/src/rpc/auth/session/index.ts
@@ -9,4 +9,5 @@ import { rpcCall } from '../../../shared/RpcModels';
 export const fetchToken = (payload: any = null): Promise<any> => rpcCall('urn:auth:session:get_token:1', payload);
 export const fetchRefreshToken = (payload: any = null): Promise<any> => rpcCall('urn:auth:session:refresh_token:1', payload);
 export const fetchInvalidateToken = (payload: any = null): Promise<any> => rpcCall('urn:auth:session:invalidate_token:1', payload);
+export const fetchLogoutDevice = (payload: any = null): Promise<any> => rpcCall('urn:auth:session:logout_device:1', payload);
 export const fetchSession = (payload: any = null): Promise<any> => rpcCall('urn:auth:session:get_session:1', payload);

--- a/rpc/auth/session/__init__.py
+++ b/rpc/auth/session/__init__.py
@@ -2,7 +2,8 @@ from .services import (
   auth_session_get_token_v1,
   auth_session_refresh_token_v1,
   auth_session_invalidate_token_v1,
-  auth_session_get_session_v1
+  auth_session_get_session_v1,
+  auth_session_logout_device_v1
 )
 
 
@@ -10,6 +11,7 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("get_token", "1"): auth_session_get_token_v1,
   ("refresh_token", "1"): auth_session_refresh_token_v1,
   ("invalidate_token", "1"): auth_session_invalidate_token_v1,
+  ("logout_device", "1"): auth_session_logout_device_v1,
   ("get_session", "1"): auth_session_get_session_v1,
 }
 

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -184,6 +184,18 @@ async def auth_session_invalidate_token_v1(request: Request):
   return RPCResponse(op=rpc_request.op, payload={"ok": True}, version=rpc_request.version)
 
 
+async def auth_session_logout_device_v1(request: Request):
+  rpc_request, _auth_ctx, _ = await unbox_request(request)
+  header = request.headers.get("authorization")
+  if not header or not header.lower().startswith("bearer "):
+    raise HTTPException(status_code=401, detail="Missing or invalid authorization header")
+  token = header.split(" ", 1)[1].strip()
+
+  db: DbModule = request.app.state.db
+  await db.run("db:auth:session:revoke_device_token:1", {"access_token": token})
+  return RPCResponse(op=rpc_request.op, payload={"ok": True}, version=rpc_request.version)
+
+
 async def auth_session_get_session_v1(request: Request):
   rpc_request, _auth_ctx, _ = await unbox_request(request)
   header = request.headers.get("authorization")

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -497,6 +497,16 @@ def _auth_session_update_session(args: Dict[str, Any]):
     """
     return ("exec", sql, (ip_address, user_agent, token))
 
+@register("db:auth:session:revoke_device_token:1")
+def _auth_session_revoke_device_token(args: Dict[str, Any]):
+  token = args["access_token"]
+  sql = """
+    UPDATE sessions_devices
+    SET element_revoked_at = SYSDATETIMEOFFSET()
+    WHERE element_token = ?;
+  """
+  return ("exec", sql, (token,))
+
 # -------------------- SYSTEM CONFIG --------------------
 
 @register("db:system:config:get_config:1")

--- a/tests/test_auth_session_logout_device.py
+++ b/tests/test_auth_session_logout_device.py
@@ -1,0 +1,111 @@
+import importlib.util
+import types
+import sys
+import asyncio
+import pytest
+from types import SimpleNamespace
+from fastapi import HTTPException
+
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+class DummyDb:
+  def __init__(self):
+    self.calls = []
+    self.revoked = False
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    if op == "db:auth:session:revoke_device_token:1":
+      self.revoked = True
+      return DBRes(rowcount=1)
+    if op == "db:auth:session:get_by_access_token:1":
+      if self.revoked:
+        return DBRes([{"revoked_at": "2024-01-01T00:00:00Z"}], 1)
+      return DBRes([{"revoked_at": None}], 1)
+    if op == "db:users:session:get_rotkey:1":
+      return DBRes([{"rotkey": "rot-token"}], 1)
+    return DBRes()
+
+class DummyAuth:
+  def decode_rotation_token(self, token):
+    return {"guid": "user-guid"}
+  async def get_user_roles(self, _guid):
+    return (["user"], 0)
+  def make_session_token(self, user_guid, rot, roles, provider):
+    return ("new-token", None)
+
+class DummyState:
+  def __init__(self):
+    self.db = DummyDb()
+    self.auth = DummyAuth()
+
+class DummyApp:
+  def __init__(self):
+    self.state = DummyState()
+
+class DummyRequest:
+  def __init__(self):
+    self.app = DummyApp()
+    self.headers = {"authorization": "Bearer tok", "user-agent": "ua"}
+    self.client = SimpleNamespace(host="127.0.0.1")
+    self.cookies = {"rotation_token": "rot-token"}
+    self.op = ""
+
+
+def _setup(monkeypatch):
+  spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
+  models = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(models)
+  sys.modules["rpc.models"] = models
+  RPCRequest = models.RPCRequest
+  RPCResponse = models.RPCResponse
+
+  helpers = types.ModuleType("rpc.helpers")
+  async def fake_unbox(req):
+    rpc = RPCRequest(op=req.op, payload=None, version=1)
+    return rpc, SimpleNamespace(user_guid="user-guid", claims={}), None
+  helpers.unbox_request = fake_unbox
+  sys.modules["rpc.helpers"] = helpers
+
+  sys.modules.setdefault("server", types.ModuleType("server"))
+  sys.modules.setdefault("server.modules", types.ModuleType("server.modules"))
+  db_mod = types.ModuleType("server.modules.db_module")
+  class DbModule: ...
+  db_mod.DbModule = DbModule
+  sys.modules["server.modules.db_module"] = db_mod
+
+  auth_mod = types.ModuleType("server.modules.auth_module")
+  class AuthModule: ...
+  auth_mod.AuthModule = AuthModule
+  sys.modules["server.modules.auth_module"] = auth_mod
+
+  svc_spec = importlib.util.spec_from_file_location("rpc.auth.session.services", "rpc/auth/session/services.py")
+  svc_mod = importlib.util.module_from_spec(svc_spec)
+  svc_spec.loader.exec_module(svc_mod)
+  return svc_mod, RPCResponse
+
+
+def test_logout_device_revokes_token(monkeypatch):
+  svc_mod, RPCResponse = _setup(monkeypatch)
+  req = DummyRequest()
+  req.op = "urn:auth:session:logout_device:1"
+  resp = asyncio.run(svc_mod.auth_session_logout_device_v1(req))
+  assert isinstance(resp, RPCResponse)
+  assert ("db:auth:session:revoke_device_token:1", {"access_token": "tok"}) in req.app.state.db.calls
+  req.op = "urn:auth:session:get_session:1"
+  with pytest.raises(HTTPException):
+    asyncio.run(svc_mod.auth_session_get_session_v1(req))
+
+
+def test_logout_device_allows_refresh(monkeypatch):
+  svc_mod, RPCResponse = _setup(monkeypatch)
+  req = DummyRequest()
+  req.op = "urn:auth:session:logout_device:1"
+  asyncio.run(svc_mod.auth_session_logout_device_v1(req))
+  req.op = "urn:auth:session:refresh_token:1"
+  resp = asyncio.run(svc_mod.auth_session_refresh_token_v1(req))
+  assert isinstance(resp, RPCResponse)
+  assert resp.payload["token"] == "new-token"


### PR DESCRIPTION
## Summary
- add auth_session_logout_device_v1 RPC to revoke current device token
- update database provider to mark device tokens revoked
- add tests ensuring device logout doesn't rotate rotkey and refresh still works

## Testing
- `python scripts/run_tests.py`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run type-check`
- `npm --prefix frontend run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b3aad44270832590f832936e5cd0cd