### PR TITLE
Add privacy policy page and route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ const SystemConfigPage = lazy(() => import("./pages/system/SystemConfigPage"));
 const AccountRolesPage = lazy(() => import("./pages/AccountRolesPage"));
 const AccountUsersPage = lazy(() => import("./pages/AccountUsersPage"));
 const AccountUserPanel = lazy(() => import("./pages/AccountUserPanel"));
+const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
 
 function App(): JSX.Element {
 	return (
@@ -47,6 +48,7 @@ function App(): JSX.Element {
 								<Route path="/account-users" element={<AccountUsersPage />} />
 								<Route path="/account-users/:guid" element={<AccountUserPanel />} />
 								<Route path="/file-manager" element={<FileManager />} />
+								<Route path="/privacy-policy" element={<PrivacyPolicy />} />
 							</Routes>
 						</Suspense>
 					</Container>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -138,6 +138,9 @@ const Home = (): JSX.Element => {
 					contact@elideusgroup.com
 				</Link>
 			</Typography>
+			<Typography variant="body1" sx={{ marginTop: '4px' }}>
+				<Link href="/privacy-policy" underline="none">Privacy Policy</Link>
+			</Typography>
 		</Box>
 	);
 };

--- a/frontend/src/pages/PrivacyPolicy.tsx
+++ b/frontend/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,43 @@
+import { Box, Typography } from '@mui/material';
+import PageTitle from '../components/PageTitle';
+
+const PrivacyPolicy = (): JSX.Element => {
+	return (
+		<Box sx={{ p: 2 }}>
+			<PageTitle>Privacy Policy</PageTitle>
+			<Typography variant="h6" sx={{ mt: 2 }}>
+				Data We Collect
+			</Typography>
+			<Typography variant="body1" component="div">
+				<ul>
+					<li>Username from your identity provider</li>
+					<li>Email address from your identity provider</li>
+					<li>Profile image from your identity provider</li>
+				</ul>
+			</Typography>
+			<Typography variant="h6" sx={{ mt: 2 }}>
+				Your Control
+			</Typography>
+			<Typography variant="body1" component="div">
+				<ul>
+					<li>You may set your display name to anything you prefer. Changing providers refreshes the name from the provider but it remains editable.</li>
+					<li>Your email address is hidden by default. You may choose to display it, but it is sourced from the provider and not editable.</li>
+				</ul>
+			</Typography>
+			<Typography variant="body1" sx={{ mt: 2 }}>
+				We keep no other information about users, payment providers or personal details. Our objective is to comply with modern EU privacy standards.
+			</Typography>
+			<Typography variant="body1" sx={{ mt: 2 }}>
+				Moderators cannot set your name but may reset it to the provider default if reported or offensive.
+			</Typography>
+			<Typography variant="body1" sx={{ mt: 2 }}>
+				Unlinking your account from all providers will soft-delete your account; we retain unique identifiers to match you to previously generated content.
+			</Typography>
+			<Typography variant="body1" sx={{ mt: 2 }}>
+				Your content is private by default. You may flag content to be shared publicly if you desire.
+			</Typography>
+		</Box>
+	);
+};
+
+export default PrivacyPolicy;


### PR DESCRIPTION
## Summary
- create PrivacyPolicy page with details on collected data and user controls
- add /privacy-policy route and link from home page

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b39d1c5aec832590d98b5f95d77594