### PR TITLE
Undelete Google account on login

### DIFF
--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -240,6 +240,13 @@ async def auth_google_oauth_login_v1(request: Request):
     logging.debug("[auth_google_oauth_login_v1] failed to create user")
     raise HTTPException(status_code=500, detail="Unable to create user")
 
+  if user.get("element_soft_deleted_at"):
+    await db.run(
+      "urn:users:providers:undelete_account:1",
+      {"provider": provider, "provider_identifier": provider_uid},
+    )
+    user["element_soft_deleted_at"] = None
+
   new_img = profile.get("profilePicture")
   if new_img and new_img != user.get("profile_image"):
     await db.run(

--- a/tests/test_auth_google_soft_undelete.py
+++ b/tests/test_auth_google_soft_undelete.py
@@ -1,0 +1,177 @@
+import sys, types, importlib.util, asyncio
+from types import SimpleNamespace
+from datetime import datetime, timezone, timedelta
+
+from server.modules.providers.auth.google_provider import GoogleAuthProvider
+
+
+class DummyAuth:
+  async def handle_auth_login(self, provider, id_token, access_token):
+    profile = {"email": "user@example.com", "username": "User"}
+    return "google-id", profile, {}
+
+  def make_rotation_token(self, user_guid):
+    return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
+
+  def make_session_token(self, user_guid, rot, roles, provider):
+    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+
+  async def get_user_roles(self, guid, refresh=False):
+    return [], 0
+
+  def __init__(self):
+    provider = GoogleAuthProvider(api_id="gid", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
+
+    async def fake_fetch_jwks():
+      provider._jwks = {"keys": []}
+      provider._jwks_fetched_at = datetime.now(timezone.utc)
+
+    provider.fetch_jwks = fake_fetch_jwks
+    asyncio.run(provider.startup())
+    self.providers = {"google": provider}
+
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+
+class DummyDb:
+  def __init__(self):
+    self.calls = []
+
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    if op == "urn:users:providers:get_by_provider_identifier:1":
+      return DBRes([
+        {
+          "guid": "user-guid",
+          "display_name": "User",
+          "credits": 0,
+          "element_soft_deleted_at": "2024-01-01T00:00:00Z",
+        }
+      ], 1)
+    if op in (
+      "urn:users:providers:undelete_account:1",
+      "db:users:session:set_rotkey:1",
+      "db:auth:session:create_session:1",
+    ):
+      return DBRes([], 1)
+    if op == "urn:system:config:get_config:1":
+      key = args.get("key")
+      if key == "Hostname":
+        return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
+    return DBRes()
+
+
+class DummyEnv:
+  async def on_ready(self):
+    return None
+
+  def get(self, k):
+    assert k == "GOOGLE_AUTH_SECRET"
+    return "gsecret"
+
+
+class DummyState:
+  def __init__(self):
+    self.auth = DummyAuth()
+    self.db = DummyDb()
+    self.env = DummyEnv()
+
+
+class DummyApp:
+  def __init__(self):
+    self.state = DummyState()
+
+
+class DummyRequest:
+  def __init__(self):
+    self.app = DummyApp()
+    self.headers = {"user-agent": "tester"}
+    self.client = SimpleNamespace(host="127.0.0.1")
+
+
+def test_undeletes_soft_deleted_account(monkeypatch):
+  spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
+  models = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(models)
+  sys.modules["rpc.models"] = models
+  RPCRequest = models.RPCRequest
+
+  helpers = types.ModuleType("rpc.helpers")
+
+  async def fake_unbox_request(_):
+    rpc = RPCRequest(
+      op="urn:auth:google:oauth_login:1",
+      payload={"code": "auth-code"},
+      version=1,
+    )
+    return rpc, None, None
+
+  helpers.unbox_request = fake_unbox_request
+  sys.modules["rpc.helpers"] = helpers
+
+  sys.modules.setdefault("rpc", types.ModuleType("rpc"))
+  sys.modules.setdefault("rpc.auth", types.ModuleType("rpc.auth"))
+  rpc_auth_google = types.ModuleType("rpc.auth.google")
+  rpc_auth_google.__path__ = []
+  sys.modules.setdefault("rpc.auth.google", rpc_auth_google)
+  from pydantic import BaseModel
+  models_mod = types.ModuleType("rpc.auth.google.models")
+
+  class AuthGoogleOauthLoginPayload1(BaseModel):
+    provider: str = "google"
+    code: str
+    fingerprint: str | None = None
+
+  class AuthGoogleOauthLogin1(BaseModel):
+    sessionToken: str
+    display_name: str
+    credits: int
+    profile_image: str | None = None
+
+  models_mod.AuthGoogleOauthLoginPayload1 = AuthGoogleOauthLoginPayload1
+  models_mod.AuthGoogleOauthLogin1 = AuthGoogleOauthLogin1
+  sys.modules["rpc.auth.google.models"] = models_mod
+
+  sys.modules["server"] = types.ModuleType("server")
+  sys.modules["server.models"] = types.ModuleType("server.models")
+  sys.modules["server.modules"] = types.ModuleType("server.modules")
+  auth_mod = types.ModuleType("server.modules.auth_module")
+
+  class AuthModule: ...
+
+  auth_mod.AuthModule = AuthModule
+  sys.modules["server.modules.auth_module"] = auth_mod
+  db_mod = types.ModuleType("server.modules.db_module")
+
+  class DbModule: ...
+
+  db_mod.DbModule = DbModule
+  sys.modules["server.modules.db_module"] = db_mod
+
+  svc_spec = importlib.util.spec_from_file_location(
+    "rpc.auth.google.services", "rpc/auth/google/services.py"
+  )
+  svc_mod = importlib.util.module_from_spec(svc_spec)
+  svc_spec.loader.exec_module(svc_mod)
+
+  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+    assert code == "auth-code"
+    assert redirect_uri == "http://localhost:8000/userpage"
+    return "id", "acc"
+
+  svc_mod.exchange_code_for_tokens = fake_exchange
+  auth_google_oauth_login_v1 = svc_mod.auth_google_oauth_login_v1
+
+  req = DummyRequest()
+  asyncio.run(auth_google_oauth_login_v1(req))
+  calls = req.app.state.db.calls
+  assert any(op == "urn:users:providers:undelete_account:1" for op, _ in calls)
+  undelete_idx = next(i for i, (op, _) in enumerate(calls) if op == "urn:users:providers:undelete_account:1")
+  create_idx = next(i for i, (op, _) in enumerate(calls) if op == "db:auth:session:create_session:1")
+  assert undelete_idx < create_idx
+  asyncio.run(req.app.state.auth.providers["google"].shutdown())
+


### PR DESCRIPTION
## Summary
- restore soft-deleted Google accounts before creating a session
- add unit test ensuring undelete occurs before session creation

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68b3b4dd82748325a2bc8cdafc815800