### PR TITLE
Refresh Google profile details if unedited

### DIFF
--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -287,6 +287,21 @@ async def auth_google_oauth_login_v1(request: Request):
     user["profile_image"] = new_img
 
   user_guid = user["guid"]
+  if user.get("provider_name") == "google":
+    res_prof = await db.run(
+      "urn:users:profile:update_if_unedited:1",
+      {
+        "guid": user_guid,
+        "email": profile["email"],
+        "display_name": profile["username"],
+      },
+    )
+    if res_prof.rows:
+      updated = res_prof.rows[0]
+      if updated.get("display_name"):
+        user["display_name"] = updated["display_name"]
+      if updated.get("email"):
+        user["email"] = updated["email"]
   fingerprint = req_payload.fingerprint
   user_agent = request.headers.get("user-agent")
   ip_address = request.client.host if request.client else None

--- a/tests/test_auth_google_profile_refresh.py
+++ b/tests/test_auth_google_profile_refresh.py
@@ -1,0 +1,141 @@
+import sys, types, importlib.util, asyncio
+from types import SimpleNamespace
+from datetime import datetime, timezone, timedelta
+
+class DummyAuth:
+  def __init__(self, profile):
+    self.profile = profile
+    self.providers = {"google": SimpleNamespace(audience="gid")}
+  async def handle_auth_login(self, provider, id_token, access_token):
+    return "google-id", self.profile, {}
+  def make_rotation_token(self, user_guid):
+    return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, roles, provider):
+    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  async def get_user_roles(self, guid, refresh=False):
+    return [], 0
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+class DummyDb:
+  def __init__(self, allow_update):
+    self.calls = []
+    self.allow_update = allow_update
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    if op == "urn:users:providers:get_by_provider_identifier:1":
+      return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "provider_name": "google" }], 1)
+    if op == "urn:users:profile:update_if_unedited:1":
+      if self.allow_update:
+        return DBRes([{ "display_name": args["display_name"], "email": args["email"] }], 1)
+      return DBRes([], 0)
+    if op in ("db:users:session:set_rotkey:1", "db:auth:session:create_session:1"):
+      return DBRes([], 1)
+    if op == "urn:system:config:get_config:1":
+      if args.get("key") == "Hostname":
+        return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
+    return DBRes()
+
+class DummyEnv:
+  async def on_ready(self):
+    return None
+  def get(self, k):
+    assert k == "GOOGLE_AUTH_SECRET"
+    return "gsecret"
+
+class DummyState:
+  def __init__(self, auth, db):
+    self.auth = auth
+    self.db = db
+    self.env = DummyEnv()
+
+class DummyApp:
+  def __init__(self, state):
+    self.state = state
+
+class DummyRequest:
+  def __init__(self, state):
+    self.app = DummyApp(state)
+    self.headers = {"user-agent": "tester"}
+    self.client = SimpleNamespace(host="127.0.0.1")
+
+def setup_module(mod):
+  spec = importlib.util.spec_from_file_location("rpc.models", "rpc/models.py")
+  models = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(models)
+  sys.modules["rpc.models"] = models
+  RPCRequest = models.RPCRequest
+
+  helpers = types.ModuleType("rpc.helpers")
+  async def fake_unbox_request(_):
+    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code"}, version=1)
+    return rpc, None, None
+  helpers.unbox_request = fake_unbox_request
+  sys.modules["rpc.helpers"] = helpers
+
+  sys.modules.setdefault("rpc", types.ModuleType("rpc"))
+  sys.modules.setdefault("rpc.auth", types.ModuleType("rpc.auth"))
+  rpc_auth_google = types.ModuleType("rpc.auth.google")
+  rpc_auth_google.__path__ = []
+  sys.modules.setdefault("rpc.auth.google", rpc_auth_google)
+  from pydantic import BaseModel
+  models_mod = types.ModuleType("rpc.auth.google.models")
+  class AuthGoogleOauthLoginPayload1(BaseModel):
+    provider: str = "google"
+    code: str
+    confirm: bool | None = None
+    reauthToken: str | None = None
+    fingerprint: str | None = None
+  class AuthGoogleOauthLogin1(BaseModel):
+    sessionToken: str
+    display_name: str
+    credits: int
+    profile_image: str | None = None
+  models_mod.AuthGoogleOauthLoginPayload1 = AuthGoogleOauthLoginPayload1
+  models_mod.AuthGoogleOauthLogin1 = AuthGoogleOauthLogin1
+  sys.modules["rpc.auth.google.models"] = models_mod
+
+  sys.modules["server"] = types.ModuleType("server")
+  sys.modules["server.models"] = types.ModuleType("server.models")
+  sys.modules["server.modules"] = types.ModuleType("server.modules")
+  auth_mod = types.ModuleType("server.modules.auth_module")
+  class AuthModule: ...
+  auth_mod.AuthModule = AuthModule
+  sys.modules["server.modules.auth_module"] = auth_mod
+  db_mod = types.ModuleType("server.modules.db_module")
+  class DbModule: ...
+  db_mod.DbModule = DbModule
+  sys.modules["server.modules.db_module"] = db_mod
+
+  svc_spec = importlib.util.spec_from_file_location("rpc.auth.google.services", "rpc/auth/google/services.py")
+  svc_mod = importlib.util.module_from_spec(svc_spec)
+  svc_spec.loader.exec_module(svc_mod)
+  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+    assert code == "auth-code"
+    assert redirect_uri == "http://localhost:8000/userpage"
+    return "id", "acc"
+  svc_mod.exchange_code_for_tokens = fake_exchange
+  mod.auth_google_oauth_login_v1 = svc_mod.auth_google_oauth_login_v1
+
+def test_updates_profile_if_unedited():
+  auth = DummyAuth({"email": "new@example.com", "username": "New"})
+  db = DummyDb(True)
+  state = DummyState(auth, db)
+  req = DummyRequest(state)
+  resp = asyncio.run(auth_google_oauth_login_v1(req))
+  assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in db.calls)
+  assert resp.payload["display_name"] == "New"
+
+
+def test_leaves_profile_if_edited():
+  auth = DummyAuth({"email": "new@example.com", "username": "New"})
+  db = DummyDb(False)
+  state = DummyState(auth, db)
+  req = DummyRequest(state)
+  resp = asyncio.run(auth_google_oauth_login_v1(req))
+  assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in db.calls)
+  assert resp.payload["display_name"] == "User"
+


### PR DESCRIPTION
## Summary
- refresh Google user profile fields when unchanged by user
- add tests for profile refresh during Google login

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68b3b8c181908325873c0f70e5ed5e8b