### PR TITLE
Require credential when setting default provider

### DIFF
--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -21,93 +21,35 @@ export interface RPCResponse {
 	version: number;
 	timestamp: string | null;
 }
-export interface SystemConfigConfigItem1 {
-	key: string;
-	value: string;
+export interface PublicLinksHomeLinks1 {
+	links: PublicLinksLinkItem1[];
 }
-export interface SystemConfigDeleteConfig1 {
-	key: string;
+export interface PublicLinksLinkItem1 {
+	title: string;
+	url: string;
 }
-export interface SystemConfigList1 {
-	items: SystemConfigConfigItem1[];
-}
-export interface SystemRolesDeleteRole1 {
-	name: string;
-}
-export interface SystemRolesList1 {
-	roles: SystemRolesRoleItem1[];
-}
-export interface SystemRolesRoleItem1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface SystemRolesUpsertRole1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface SystemRoutesDeleteRoute1 {
-	path: string;
-}
-export interface SystemRoutesList1 {
-	routes: SystemRoutesRouteItem1[];
-}
-export interface SystemRoutesRouteItem1 {
+export interface PublicLinksNavBarRoute1 {
 	path: string;
 	name: string;
 	icon: string | null;
-	sequence: number;
-	required_roles: string[];
 }
-export interface UsersProfileAuthProvider1 {
-	name: string;
-	display: string;
+export interface PublicLinksNavBarRoutes1 {
+	routes: PublicLinksNavBarRoute1[];
 }
-export interface UsersProfileProfile1 {
-	guid: string;
-	display_name: string;
-	email: string;
-	display_email: boolean;
-	credits: number;
-	profile_image: string | null;
-	default_provider: string;
-	auth_providers: UsersProfileAuthProvider1[];
+export interface PublicVarsFfmpegVersion1 {
+	ffmpeg_version: string;
 }
-export interface UsersProfileRoles1 {
-	roles: number;
+export interface PublicVarsHostname1 {
+	hostname: string;
 }
-export interface UsersProfileSetDisplay1 {
-	display_name: string;
+export interface PublicVarsOdbcVersion1 {
+	odbc_version: string;
 }
-export interface UsersProfileSetOptin1 {
-	display_email: boolean;
+export interface PublicVarsRepo1 {
+	repo: string;
 }
-export interface UsersProfileSetProfileImage1 {
-	image_b64: string;
-	provider: string;
-}
-export interface UsersProvidersCreateFromProvider1 {
-	provider: string;
-	provider_identifier: string;
-	provider_email: string;
-	provider_displayname: string;
-	provider_profile_image: any;
-}
-export interface UsersProvidersGetByProviderIdentifier1 {
-	provider: string;
-	provider_identifier: string;
-}
-export interface UsersProvidersLinkProvider1 {
-	provider: string;
-	code: string;
-}
-export interface UsersProvidersSetProvider1 {
-	provider: string;
-}
-export interface UsersProvidersUnlinkProvider1 {
-	provider: string;
-	new_default: string | null;
+export interface PublicVarsVersion1 {
+	version: string;
 }
 export interface StorageFilesDeleteFiles1 {
 	files: string[];
@@ -148,72 +90,6 @@ export interface ServiceRolesUpsertRole1 {
 	mask: string;
 	display: any;
 }
-export interface SupportRolesMembers1 {
-	members: SupportRolesUserItem1[];
-	nonMembers: SupportRolesUserItem1[];
-}
-export interface SupportRolesRoleMemberUpdate1 {
-	role: string;
-	userGuid: string;
-}
-export interface SupportRolesUserItem1 {
-	guid: string;
-	displayName: string;
-}
-export interface SupportUsersGuid1 {
-	userGuid: string;
-}
-export interface SupportUsersSetCredits1 {
-	userGuid: string;
-	credits: number;
-}
-export interface PublicLinksHomeLinks1 {
-	links: PublicLinksLinkItem1[];
-}
-export interface PublicLinksLinkItem1 {
-	title: string;
-	url: string;
-}
-export interface PublicLinksNavBarRoute1 {
-	path: string;
-	name: string;
-	icon: string | null;
-}
-export interface PublicLinksNavBarRoutes1 {
-	routes: PublicLinksNavBarRoute1[];
-}
-export interface PublicVarsFfmpegVersion1 {
-	ffmpeg_version: string;
-}
-export interface PublicVarsHostname1 {
-	hostname: string;
-}
-export interface PublicVarsOdbcVersion1 {
-	odbc_version: string;
-}
-export interface PublicVarsRepo1 {
-	repo: string;
-}
-export interface PublicVarsVersion1 {
-	version: string;
-}
-export interface AuthGoogleOauthLogin1 {
-	sessionToken: string;
-	display_name: string;
-	credits: number;
-	profile_image: string | null;
-}
-export interface AuthGoogleOauthLoginPayload1 {
-	provider: string;
-	code: string;
-	fingerprint: any;
-}
-export interface AuthMicrosoftOauthLogin1 {
-	sessionToken: string;
-	display_name: string;
-	credits: number;
-	profile_image: string | null;
-}
 export interface AccountRoleList1 {
 	roles: AccountRoleRoleItem1[];
 }
@@ -233,6 +109,134 @@ export interface AccountRoleRoleItem1 {
 export interface AccountRoleUserItem1 {
 	guid: string;
 	displayName: string;
+}
+export interface UsersProvidersCreateFromProvider1 {
+	provider: string;
+	provider_identifier: string;
+	provider_email: string;
+	provider_displayname: string;
+	provider_profile_image: any;
+}
+export interface UsersProvidersGetByProviderIdentifier1 {
+	provider: string;
+	provider_identifier: string;
+}
+export interface UsersProvidersLinkProvider1 {
+	provider: string;
+	code: string;
+}
+export interface UsersProvidersSetProvider1 {
+	provider: string;
+	code: any;
+	access_token: any;
+}
+export interface UsersProvidersUnlinkProvider1 {
+	provider: string;
+	new_default: any;
+}
+export interface UsersProfileAuthProvider1 {
+	name: string;
+	display: string;
+}
+export interface UsersProfileProfile1 {
+	guid: string;
+	display_name: string;
+	email: string;
+	display_email: boolean;
+	credits: number;
+	profile_image: string | null;
+	default_provider: string;
+	auth_providers: UsersProfileAuthProvider1[];
+}
+export interface UsersProfileRoles1 {
+	roles: number;
+}
+export interface UsersProfileSetDisplay1 {
+	display_name: string;
+}
+export interface UsersProfileSetOptin1 {
+	display_email: boolean;
+}
+export interface UsersProfileSetProfileImage1 {
+	image_b64: string;
+	provider: string;
+}
+export interface SystemRolesDeleteRole1 {
+	name: string;
+}
+export interface SystemRolesList1 {
+	roles: SystemRolesRoleItem1[];
+}
+export interface SystemRolesRoleItem1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface SystemRolesUpsertRole1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface SystemRoutesDeleteRoute1 {
+	path: string;
+}
+export interface SystemRoutesList1 {
+	routes: SystemRoutesRouteItem1[];
+}
+export interface SystemRoutesRouteItem1 {
+	path: string;
+	name: string;
+	icon: string | null;
+	sequence: number;
+	required_roles: string[];
+}
+export interface SystemConfigConfigItem1 {
+	key: string;
+	value: string;
+}
+export interface SystemConfigDeleteConfig1 {
+	key: string;
+}
+export interface SystemConfigList1 {
+	items: SystemConfigConfigItem1[];
+}
+export interface AuthMicrosoftOauthLogin1 {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
+}
+export interface AuthGoogleOauthLogin1 {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
+}
+export interface AuthGoogleOauthLoginPayload1 {
+	provider: string;
+	code: string;
+	confirm: any;
+	reauthToken: any;
+	fingerprint: any;
+}
+export interface SupportRolesMembers1 {
+	members: SupportRolesUserItem1[];
+	nonMembers: SupportRolesUserItem1[];
+}
+export interface SupportRolesRoleMemberUpdate1 {
+	role: string;
+	userGuid: string;
+}
+export interface SupportRolesUserItem1 {
+	guid: string;
+	displayName: string;
+}
+export interface SupportUsersGuid1 {
+	userGuid: string;
+}
+export interface SupportUsersSetCredits1 {
+	userGuid: string;
+	credits: number;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/users/providers/models.py
+++ b/rpc/users/providers/models.py
@@ -3,6 +3,8 @@ from pydantic import BaseModel
 
 class UsersProvidersSetProvider1(BaseModel):
   provider: str
+  code: str | None = None
+  access_token: str | None = None
 
 
 class UsersProvidersLinkProvider1(BaseModel):

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -100,7 +100,7 @@ class DummyRequest:
 
 def test_set_provider_calls_db():
   async def fake_get(request):
-    rpc = RPCRequest(op="urn:users:providers:set_provider:1", payload={"provider": "microsoft"}, version=1)
+    rpc = RPCRequest(op="urn:users:providers:set_provider:1", payload={"provider": "microsoft", "access_token": "acc"}, version=1)
     return rpc, SimpleNamespace(user_guid="u1"), None
   svc_mod.unbox_request = fake_get
   db = DummyDb()
@@ -115,12 +115,14 @@ def test_set_provider_refreshes_profile():
   class DummyProvider:
     def __init__(self):
       self.calls = 0
+      self.token = None
     async def fetch_user_profile(self, token):
       self.calls += 1
+      self.token = token
       return {"email": "e@example.com", "username": "User"}
 
   async def fake_get(request):
-    rpc = RPCRequest(op="urn:users:providers:set_provider:1", payload={"provider": "microsoft"}, version=1)
+    rpc = RPCRequest(op="urn:users:providers:set_provider:1", payload={"provider": "microsoft", "access_token": "acc"}, version=1)
     return rpc, SimpleNamespace(user_guid="u1"), None
 
   provider = DummyProvider()
@@ -130,6 +132,7 @@ def test_set_provider_refreshes_profile():
   req = DummyRequest(DummyState(db, auth))
   asyncio.run(users_providers_set_provider_v1(req))
   assert provider.calls == 1
+  assert provider.token == "acc"
   assert (
     "urn:users:profile:update_if_unedited:1",
     {"guid": "u1", "email": "e@example.com", "display_name": "User"},
@@ -138,7 +141,19 @@ def test_set_provider_refreshes_profile():
 
 def test_set_provider_missing_provider_raises():
   async def fake_get(request):
-    rpc = RPCRequest(op="urn:users:providers:set_provider:1", payload={}, version=1)
+    rpc = RPCRequest(op="urn:users:providers:set_provider:1", payload={"access_token": "acc"}, version=1)
+    return rpc, SimpleNamespace(user_guid="u1"), None
+  svc_mod.unbox_request = fake_get
+  db = DummyDb()
+  req = DummyRequest(DummyState(db))
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(users_providers_set_provider_v1(req))
+  assert exc.value.status_code == 400
+
+
+def test_set_provider_missing_credential_raises():
+  async def fake_get(request):
+    rpc = RPCRequest(op="urn:users:providers:set_provider:1", payload={"provider": "microsoft"}, version=1)
     return rpc, SimpleNamespace(user_guid="u1"), None
   svc_mod.unbox_request = fake_get
   db = DummyDb()


### PR DESCRIPTION
## Summary
- require OAuth code or access token when changing default provider
- refresh profile after exchanging credential for tokens
- update generated RPC models and tests

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68b3cc6ea2fc83258ee0678a9087411a