### PR TITLE
Add profile refresh support and improve auth providers

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -58,7 +58,7 @@ class AuthModule(BaseModule):
       logging.info("Auth module loaded")
       self.mark_ready()
     except Exception as e:
-      logging.error(f"[AuthModule] Failed to load providers: {e}")
+      logging.exception("[AuthModule] Failed to load providers: %s", e)
 
   async def shutdown(self):
     for provider in self.providers.values():

--- a/server/modules/providers/auth/google_provider/__init__.py
+++ b/server/modules/providers/auth/google_provider/__init__.py
@@ -60,6 +60,7 @@ class GoogleAuthProvider(AuthProvider):
       profile_picture_base64 = None
       picture_url = user.get("picture")
       if picture_url:
+        logging.debug("[GoogleAuthProvider] Fetching profile image from %s", picture_url)
         try:
           async with session.get(picture_url) as img_resp:
             if img_resp.status == 200:

--- a/server/modules/providers/auth/microsoft_provider/__init__.py
+++ b/server/modules/providers/auth/microsoft_provider/__init__.py
@@ -1,4 +1,4 @@
-import base64
+import base64, logging
 from datetime import timedelta
 from typing import Dict, Any
 
@@ -13,11 +13,14 @@ MICROSOFT_GRAPH_PHOTO = "https://graph.microsoft.com/v1.0/me/photo/$value"
 MICROSOFT_ISSUER = "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"
 
 async def _fetch_openid_config() -> Dict[str, Any]:
+  logging.debug("[MicrosoftAuthProvider] Fetching OpenID configuration from %s", MICROSOFT_OPENID_CONFIG)
   async with aiohttp.ClientSession() as session:
     async with session.get(MICROSOFT_OPENID_CONFIG) as response:
       if response.status != 200:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Failed to fetch OpenID configuration.")
-      return await response.json()
+      config = await response.json()
+      logging.debug("[MicrosoftAuthProvider] OpenID configuration fetched")
+      return config
 
 class MicrosoftAuthProvider(AuthProvider):
   def __init__(self, *, api_id: str, jwks_uri: str, jwks_expiry: timedelta):
@@ -25,23 +28,34 @@ class MicrosoftAuthProvider(AuthProvider):
 
   @classmethod
   async def create(cls, *, api_id: str, jwks_expiry: timedelta):
+    logging.debug("[MicrosoftAuthProvider] Creating provider with api_id=%s", api_id)
     config = await _fetch_openid_config()
     jwks_uri = config["jwks_uri"]
+    logging.debug(
+      "[MicrosoftAuthProvider] jwks_uri=%s jwks_expiry=%s",
+      jwks_uri,
+      jwks_expiry,
+    )
     return cls(api_id=api_id, jwks_uri=jwks_uri, jwks_expiry=jwks_expiry)
 
   async def fetch_user_profile(self, access_token: str) -> Dict[str, Any]:
     async with aiohttp.ClientSession() as session:
       headers = {"Authorization": f"Bearer {access_token}"}
+      logging.debug("[MicrosoftAuthProvider] Fetching user profile from %s", MICROSOFT_GRAPH_USER)
+      logging.debug("[MicrosoftAuthProvider] access_token=%s", access_token[:40])
       async with session.get(MICROSOFT_GRAPH_USER, headers=headers) as response:
         if response.status != 200:
           error_message = await response.text()
           raise HTTPException(status_code=500, detail=f"Failed to fetch user profile. Status: {response.status}, Error: {error_message}")
         user = await response.json()
       profile_picture_base64 = None
-      async with session.get(MICROSOFT_GRAPH_PHOTO, headers=headers) as response:
-        if response.status == 200:
-          picture_bytes = await response.read()
-          profile_picture_base64 = base64.b64encode(picture_bytes).decode("utf-8")
+      try:
+        async with session.get(MICROSOFT_GRAPH_PHOTO, headers=headers) as response:
+          if response.status == 200:
+            picture_bytes = await response.read()
+            profile_picture_base64 = base64.b64encode(picture_bytes).decode("utf-8")
+      except Exception as e:
+        logging.exception("[MicrosoftAuthProvider] failed to fetch profile image: %s", e)
       return {
         "email": user.get("mail") or user.get("userPrincipalName"),
         "username": user.get("displayName"),


### PR DESCRIPTION
## Summary
- add MSSQL handler to refresh user profile fields when logging in
- improve Microsoft auth provider with detailed logging and resilient image fetch
- log provider load failures and align Google provider logging

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run type-check`
- `npm --prefix frontend test`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4b61a8ec883258f7303f3fad66899