### PR TITLE
Set rotation token cookie during OAuth login

### DIFF
--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -1,6 +1,7 @@
 import sys, types, pytest, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
+import json
 from fastapi import HTTPException
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 
@@ -212,6 +213,7 @@ def test_email_exists_confirm_links(monkeypatch):
 
   req = DummyRequest()
   res = asyncio.run(auth_google_oauth_login_v1(req))
-  assert res.payload["display_name"] == "User"
+  data = json.loads(res.body)
+  assert data["payload"]["display_name"] == "User"
   assert any(op == "urn:users:providers:link_provider:1" for op, _ in req.app.state.db.calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -134,6 +134,6 @@ def test_lookup_existing_user(monkeypatch):
 
   req = DummyRequest()
   resp = asyncio.run(auth_google_oauth_login_v1(req))
-  assert isinstance(resp, RPCResponse)
+  assert "rotation_token=" in resp.headers.get("set-cookie", "")
   assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -144,7 +144,7 @@ def test_fetch_user_after_create(monkeypatch):
 
   req = DummyRequest()
   resp = asyncio.run(auth_google_oauth_login_v1(req))
-  assert isinstance(resp, RPCResponse)
+  assert "rotation_token=" in resp.headers.get("set-cookie", "")
   calls = [op for op, _ in req.app.state.db.calls if op == "urn:users:providers:get_by_provider_identifier:1"]
   assert len(calls) == 2
   assert any(

--- a/tests/test_auth_google_profile_refresh.py
+++ b/tests/test_auth_google_profile_refresh.py
@@ -1,6 +1,7 @@
 import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
+import json
 
 class DummyAuth:
   def __init__(self, profile):
@@ -126,7 +127,8 @@ def test_updates_profile_if_unedited():
   req = DummyRequest(state)
   resp = asyncio.run(auth_google_oauth_login_v1(req))
   assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in db.calls)
-  assert resp.payload["display_name"] == "New"
+  data = json.loads(resp.body)
+  assert data["payload"]["display_name"] == "New"
 
 
 def test_leaves_profile_if_edited():
@@ -136,5 +138,6 @@ def test_leaves_profile_if_edited():
   req = DummyRequest(state)
   resp = asyncio.run(auth_google_oauth_login_v1(req))
   assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in db.calls)
-  assert resp.payload["display_name"] == "User"
+  data = json.loads(resp.body)
+  assert data["payload"]["display_name"] == "User"
 

--- a/tests/test_auth_microsoft_email_exists.py
+++ b/tests/test_auth_microsoft_email_exists.py
@@ -1,6 +1,7 @@
 import sys, types, pytest, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
+import json
 from fastapi import HTTPException
 
 class DummyAuth:
@@ -160,5 +161,6 @@ def test_email_exists_confirm_links(monkeypatch):
 
   req = DummyRequest()
   res = asyncio.run(auth_microsoft_oauth_login_v1(req))
-  assert res.payload["display_name"] == "User"
+  data = json.loads(res.body)
+  assert data["payload"]["display_name"] == "User"
   assert any(op == "urn:users:providers:link_provider:1" for op, _ in req.app.state.db.calls)

--- a/tests/test_auth_microsoft_home_account_lookup.py
+++ b/tests/test_auth_microsoft_home_account_lookup.py
@@ -94,5 +94,5 @@ def test_lookup_with_home_account_id(monkeypatch):
 
   req = DummyRequest()
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
-  assert isinstance(resp, RPCResponse)
+  assert "rotation_token=" in resp.headers.get("set-cookie", "")
   assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)

--- a/tests/test_auth_microsoft_oauth_login_creation.py
+++ b/tests/test_auth_microsoft_oauth_login_creation.py
@@ -102,7 +102,7 @@ def test_fetch_user_after_create(monkeypatch):
 
   req = DummyRequest()
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
-  assert isinstance(resp, RPCResponse)
+  assert "rotation_token=" in resp.headers.get("set-cookie", "")
   calls = [op for op, _ in req.app.state.db.calls if op == "urn:users:providers:get_by_provider_identifier:1"]
   assert len(calls) == 2
   assert any(

--- a/tests/test_auth_microsoft_profile_refresh.py
+++ b/tests/test_auth_microsoft_profile_refresh.py
@@ -1,6 +1,7 @@
 import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
+import json
 
 
 class DummyAuth:
@@ -110,7 +111,8 @@ def test_updates_profile_if_unedited():
   req = DummyRequest(state)
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
   assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in db.calls)
-  assert resp.payload["display_name"] == "New"
+  data = json.loads(resp.body)
+  assert data["payload"]["display_name"] == "New"
 
 
 def test_leaves_profile_if_edited():
@@ -120,5 +122,6 @@ def test_leaves_profile_if_edited():
   req = DummyRequest(state)
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
   assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in db.calls)
-  assert resp.payload["display_name"] == "User"
+  data = json.loads(resp.body)
+  assert data["payload"]["display_name"] == "User"
 

--- a/tests/test_google_services_helpers.py
+++ b/tests/test_google_services_helpers.py
@@ -111,10 +111,11 @@ class DummyAuth:
 def test_create_session_handles_missing_roles():
   db = DummyDb()
   auth = DummyAuth()
-  token, exp = asyncio.run(
+  token, exp, rot, rot_exp = asyncio.run(
     create_session(auth, db, str(uuid.uuid4()), "google", None, None, None)
   )
   assert token == "sess"
+  assert rot == "rot"
   ops = [op for op, _ in db.calls]
   assert "db:auth:session:create_session:1" in ops
   args = [a for op, a in db.calls if op == "db:auth:session:create_session:1"][0]

--- a/tests/test_microsoft_services_helpers.py
+++ b/tests/test_microsoft_services_helpers.py
@@ -100,10 +100,11 @@ class DummyAuth:
 def test_create_session_handles_missing_roles():
   db = DummyDb()
   auth = DummyAuth()
-  token, exp = asyncio.run(
+  token, exp, rot, rot_exp = asyncio.run(
     create_session(auth, db, str(uuid.uuid4()), "microsoft", None, None, None)
   )
   assert token == "sess"
+  assert rot == "rot"
   ops = [op for op, _ in db.calls]
   assert "db:auth:session:create_session:1" in ops
   args = [a for op, a in db.calls if op == "db:auth:session:create_session:1"][0]


### PR DESCRIPTION
## Summary
- set rotation token cookie when creating OAuth sessions
- expose rotation token from session helpers
- adjust tests for new response structure

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4bae7e8d08325bc281ecadfcc1707