### PR TITLE
Fix rotation token lookup for Microsoft login

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -330,16 +330,17 @@ def _users_session_set_rotkey(args: Dict[str, Any]):
 
 @register("db:users:session:get_rotkey:1")
 def _users_session_get_rotkey(args: Dict[str, Any]):
-    guid = args["guid"]
-    sql = """
-      SELECT TOP 1
-        element_rotkey AS rotkey,
-        provider_name
-      FROM vw_account_user_security
-      WHERE user_guid = ?
+  guid = args["guid"]
+  sql = """
+      SELECT
+        au.element_rotkey AS rotkey,
+        ap.element_name AS provider_name
+      FROM account_users AS au
+      JOIN auth_providers AS ap ON au.providers_recid = ap.recid
+      WHERE au.element_guid = ?
       FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
     """
-    return ("json_one", sql, (guid,))
+  return ("json_one", sql, (guid,))
 
 @register("urn:public:links:get_home_links:1")
 def _public_links_get_home_links(args: Dict[str, Any]):

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -65,10 +65,13 @@ def test_mssql_get_profile_uses_profile_view():
   assert "v.credits" in sql
   assert "users_credits" not in sql
 
-def test_mssql_get_rotkey_uses_security_view():
+def test_mssql_get_rotkey_queries_users_and_providers():
   handler = get_mssql_handler("db:users:session:get_rotkey:1")
   _, sql, _ = handler({"guid": "gid"})
-  assert "vw_account_user_security" in sql.lower()
+  sql = sql.lower()
+  assert "from account_users" in sql
+  assert "auth_providers" in sql
+  assert "vw_account_user_security" not in sql
 
 def test_mssql_get_by_access_token_uses_security_view():
   handler = get_mssql_handler("db:auth:session:get_by_access_token:1")


### PR DESCRIPTION
## Summary
- fetch rotation key from account_users and auth_providers instead of vw_account_user_security
- adjust provider query test for new lookup

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68b4c33fb08c8325b59cf0762d6976b6