### PR TITLE
feat(frontend): add styled file upload with progress

### DIFF
--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -1,0 +1,118 @@
+import React, { useRef, useState } from 'react';
+import { Box, Button, LinearProgress, TextField, Typography } from '@mui/material';
+import { Cancel } from '@mui/icons-material';
+import axios from 'axios';
+
+interface FileUploadProps {
+    onComplete?: () => Promise<void> | void;
+}
+
+const FileUpload = ({ onComplete }: FileUploadProps): JSX.Element => {
+    const [fileName, setFileName] = useState('');
+    const [uploading, setUploading] = useState(false);
+    const [uploaded, setUploaded] = useState(0);
+    const [total, setTotal] = useState(0);
+    const [bps, setBps] = useState(0);
+    const controllerRef = useRef<AbortController | null>(null);
+
+    const handleFile = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        setFileName(file.name);
+        controllerRef.current = new AbortController();
+        setUploading(true);
+        const start = Date.now();
+        try {
+            await uploadWithProgress(file, controllerRef.current.signal, (loaded, totalBytes) => {
+                const elapsed = (Date.now() - start) / 1000;
+                setUploaded(loaded);
+                setTotal(totalBytes);
+                setBps(loaded / Math.max(elapsed, 0.001));
+            });
+            if (onComplete) await onComplete();
+        } finally {
+            setUploading(false);
+            setUploaded(0);
+            setTotal(0);
+            setBps(0);
+            setFileName('');
+            if (e.target) e.target.value = '';
+        }
+    };
+
+    const handleCancel = (): void => {
+        controllerRef.current?.abort();
+    };
+
+    const percent = total ? (uploaded / total) * 100 : 0;
+
+    return (
+        <Box sx={{ border: '1px solid', borderColor: 'grey.500', p: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Button variant="contained" component="label">
+                Select File
+                <input type="file" hidden onChange={handleFile} />
+            </Button>
+            <TextField value={fileName} InputProps={{ readOnly: true }} sx={{ flexGrow: 1 }} />
+            {uploading && (
+                <>
+                    <Box sx={{ flexGrow: 1, position: 'relative' }}>
+                        <LinearProgress variant="determinate" value={percent} />
+                        <Typography variant="caption" sx={{ position: 'absolute', left: '50%', top: 0, bottom: 0, display: 'flex', alignItems: 'center', transform: 'translateX(-50%)' }}>
+                            {`${uploaded} / ${total} (${Math.round(bps)} B/s)`}
+                        </Typography>
+                    </Box>
+                    <Button onClick={handleCancel} startIcon={<Cancel />}>Cancel</Button>
+                </>
+            )}
+        </Box>
+    );
+};
+
+const uploadWithProgress = async (
+    file: File,
+    signal: AbortSignal,
+    onProgress: (loaded: number, total: number) => void,
+): Promise<void> => {
+    const toUpload = await fileToUpload(file);
+    const request = {
+        op: 'urn:storage:files:upload_files:1',
+        payload: { files: [toUpload] },
+        version: 1,
+        timestamp: new Date().toISOString(),
+    };
+    const headers: Record<string, string> = {};
+    if (typeof localStorage !== 'undefined') {
+        try {
+            const raw = localStorage.getItem('authTokens');
+            if (raw) {
+                const { sessionToken } = JSON.parse(raw);
+                if (sessionToken) headers.Authorization = `Bearer ${sessionToken}`;
+            }
+        } catch {
+            /* ignore token parsing errors */
+        }
+    }
+    await axios.post('/rpc', request, {
+        headers,
+        signal,
+        onUploadProgress: (e) => {
+            if (e.total) onProgress(e.loaded, e.total);
+        },
+    });
+};
+
+const fileToUpload = (file: File): Promise<{ name: string; content_b64: string; content_type?: string }> => {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            const result = reader.result as string;
+            const content_b64 = result.split(',')[1] ?? '';
+            resolve({ name: file.name, content_b64, content_type: file.type || undefined });
+        };
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+    });
+};
+
+export default FileUpload;
+

--- a/frontend/src/pages/FileManager.tsx
+++ b/frontend/src/pages/FileManager.tsx
@@ -19,7 +19,6 @@ import {
 } from '@mui/icons-material';
 import {
     fetchFiles,
-    fetchUploadFiles,
     fetchDeleteFiles,
     fetchSetGallery,
 } from '../rpc/storage/files';
@@ -27,6 +26,7 @@ import PageTitle from '../components/PageTitle';
 import ColumnHeader from '../components/ColumnHeader';
 import Notification from '../components/Notification';
 import UserContext from '../shared/UserContext';
+import FileUpload from '../components/FileUpload';
 
 interface StorageFile {
     name: string;
@@ -57,27 +57,6 @@ const FileManager = (): JSX.Element => {
         void load();
     }, [userData]);
 
-    const fileToUpload = (file: File): Promise<{ name: string; content_b64: string; content_type?: string }> => {
-        return new Promise((resolve, reject) => {
-            const reader = new FileReader();
-            reader.onload = () => {
-                const result = reader.result as string;
-                const content_b64 = result.split(',')[1] ?? '';
-                resolve({ name: file.name, content_b64, content_type: file.type || undefined });
-            };
-            reader.onerror = reject;
-            reader.readAsDataURL(file);
-        });
-    };
-
-    const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
-        const selected = e.target.files;
-        if (!selected || selected.length === 0) return;
-        const uploads = await Promise.all(Array.from(selected).map(fileToUpload));
-        await fetchUploadFiles({ files: uploads });
-        e.target.value = '';
-        await load();
-    };
 
     const handleDelete = async (name: string): Promise<void> => {
         await fetchDeleteFiles({ files: [name] });
@@ -139,7 +118,7 @@ const FileManager = (): JSX.Element => {
         <Box sx={{ p: 2 }}>
             <Stack spacing={2}>
                 <PageTitle>File Manager</PageTitle>
-                <input type="file" multiple onChange={handleUpload} />
+                <FileUpload onComplete={() => load()} />
                 <Table size="small" sx={{ '& td, & th': { py: 0.5 } }}>
                     <TableHead>
                         <TableRow>


### PR DESCRIPTION
## Summary
- style file upload control with ElideusTheme and progress bar
- support upload progress with cancel capability
- integrate new upload component into file manager

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4f1a997f48325a447216aa013622e