### PR TITLE
Refactor session tokens to include session/device identifiers

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -551,15 +551,27 @@ def _auth_session_get_by_access_token(args: Dict[str, Any]):
 
 @register("db:auth:session:update_session:1")
 def _auth_session_update_session(args: Dict[str, Any]):
-    token = args["access_token"]
-    ip_address = args.get("ip_address")
-    user_agent = args.get("user_agent")
-    sql = """
+  token = args["access_token"]
+  ip_address = args.get("ip_address")
+  user_agent = args.get("user_agent")
+  sql = """
       UPDATE sessions_devices
       SET element_ip_last_seen = ?, element_user_agent = ?
       WHERE element_token = ?;
     """
-    return ("exec", sql, (ip_address, user_agent, token))
+  return ("exec", sql, (ip_address, user_agent, token))
+
+@register("db:auth:session:update_device_token:1")
+def _auth_session_update_device_token(args: Dict[str, Any]):
+  from uuid import UUID
+  device_guid = str(UUID(args["device_guid"]))
+  token = args["access_token"]
+  sql = """
+    UPDATE sessions_devices
+    SET element_token = ?
+    WHERE element_guid = ?;
+  """
+  return ("exec", sql, (token, device_guid))
 
 @register("db:auth:session:revoke_device_token:1")
 def _auth_session_revoke_device_token(args: Dict[str, Any]):

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -11,8 +11,8 @@ class DummyAuth:
     return "00000000-0000-0000-0000-000000000001", profile, {}
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
   def __init__(self):
@@ -50,7 +50,11 @@ class DummyDb:
     if op == "urn:users:providers:link_provider:1":
       self.linked = True
       return DBRes(rowcount=1)
-    if op in ("db:users:session:set_rotkey:1", "db:auth:session:create_session:1"):
+    if op == "db:users:session:set_rotkey:1":
+      return DBRes(rowcount=1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
       return DBRes(rowcount=1)
     if op == "urn:system:config:get_config:1":
       key = args.get("key")

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -13,8 +13,8 @@ class DummyAuth:
     return str(uuid.uuid4()), profile, {}
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
   def __init__(self):
@@ -44,6 +44,12 @@ class DummyDb:
       key = args.get("key")
       if key == "Hostname":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
+    if op == "db:users:session:set_rotkey:1":
+      return DBRes([], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
+      return DBRes([], 1)
     return DBRes()
 
   async def get_google_api_secret(self):

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -13,8 +13,8 @@ class DummyAuth:
     return "google-id", profile, {}
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
   def __init__(self):
@@ -53,6 +53,8 @@ class DummyDb:
     if op == "urn:users:profile:get_roles:1":
       return DBRes([{ "element_roles": 0 }], 1)
     if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 

--- a/tests/test_auth_google_profile_image_update.py
+++ b/tests/test_auth_google_profile_image_update.py
@@ -11,8 +11,8 @@ class DummyAuth:
     return "google-id", profile, {}
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
   def __init__(self):
@@ -40,7 +40,11 @@ class DummyDb:
     self.calls.append((op, args))
     if op == "urn:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
-    if op in ("db:users:session:set_rotkey:1", "db:auth:session:create_session:1", "urn:users:profile:set_profile_image:1"):
+    if op == "db:users:session:set_rotkey:1" or op == "urn:users:profile:set_profile_image:1":
+      return DBRes([], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
     if op == "urn:system:config:get_config:1":
       key = args.get("key")

--- a/tests/test_auth_google_profile_refresh.py
+++ b/tests/test_auth_google_profile_refresh.py
@@ -11,8 +11,8 @@ class DummyAuth:
     return "google-id", self.profile, {}
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
 
@@ -33,7 +33,11 @@ class DummyDb:
       if self.allow_update:
         return DBRes([{ "display_name": args["display_name"], "email": args["email"] }], 1)
       return DBRes([], 0)
-    if op in ("db:users:session:set_rotkey:1", "db:auth:session:create_session:1"):
+    if op == "db:users:session:set_rotkey:1":
+      return DBRes([], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
     if op == "urn:system:config:get_config:1":
       if args.get("key") == "Hostname":

--- a/tests/test_auth_google_soft_undelete.py
+++ b/tests/test_auth_google_soft_undelete.py
@@ -13,8 +13,8 @@ class DummyAuth:
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
 
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
 
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
@@ -52,11 +52,11 @@ class DummyDb:
           "element_soft_deleted_at": "2024-01-01T00:00:00Z",
         }
       ], 1)
-    if op in (
-      "urn:users:providers:undelete_account:1",
-      "db:users:session:set_rotkey:1",
-      "db:auth:session:create_session:1",
-    ):
+    if op == "urn:users:providers:undelete_account:1" or op == "db:users:session:set_rotkey:1":
+      return DBRes([], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
     if op == "urn:system:config:get_config:1":
       key = args.get("key")

--- a/tests/test_auth_microsoft_email_exists.py
+++ b/tests/test_auth_microsoft_email_exists.py
@@ -10,8 +10,8 @@ class DummyAuth:
     return "00000000-0000-0000-0000-000000000001", profile, {}
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
 
@@ -39,7 +39,11 @@ class DummyDb:
     if op == "urn:users:providers:link_provider:1":
       self.linked = True
       return DBRes(rowcount=1)
-    if op in ("db:users:session:set_rotkey:1", "db:auth:session:create_session:1"):
+    if op == "db:users:session:set_rotkey:1":
+      return DBRes(rowcount=1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
       return DBRes(rowcount=1)
     return DBRes()
 

--- a/tests/test_auth_microsoft_home_account_lookup.py
+++ b/tests/test_auth_microsoft_home_account_lookup.py
@@ -10,8 +10,8 @@ class DummyAuth:
     return home_account_id, profile, {}
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
 
@@ -27,6 +27,12 @@ class DummyDb:
     self.calls.append((op, args))
     if op == "urn:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
+    if op == "db:users:session:set_rotkey:1":
+      return DBRes([], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
+      return DBRes([], 1)
     return DBRes()
 
 class DummyState:

--- a/tests/test_auth_microsoft_oauth_login_creation.py
+++ b/tests/test_auth_microsoft_oauth_login_creation.py
@@ -8,8 +8,8 @@ class DummyAuth:
     return "00000000-0000-0000-0000-000000000001", profile, {}
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
 
@@ -34,6 +34,8 @@ class DummyDb:
     if op == "urn:users:profile:get_roles:1":
       return DBRes([{ "element_roles": 0 }], 1)
     if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 

--- a/tests/test_auth_microsoft_profile_image_clear.py
+++ b/tests/test_auth_microsoft_profile_image_clear.py
@@ -8,8 +8,8 @@ class DummyAuth:
     return "00000000-0000-0000-0000-000000000001", profile, {}
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
 
@@ -25,7 +25,11 @@ class DummyDb:
     self.calls.append((op, args))
     if op == "urn:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
-    if op in ("db:users:session:set_rotkey:1", "db:auth:session:create_session:1", "urn:users:profile:set_profile_image:1"):
+    if op == "db:users:session:set_rotkey:1" or op == "urn:users:profile:set_profile_image:1":
+      return DBRes([], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 

--- a/tests/test_auth_microsoft_profile_image_update.py
+++ b/tests/test_auth_microsoft_profile_image_update.py
@@ -8,8 +8,8 @@ class DummyAuth:
     return "00000000-0000-0000-0000-000000000001", profile, {}
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
 
@@ -25,7 +25,11 @@ class DummyDb:
     self.calls.append((op, args))
     if op == "urn:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
-    if op in ("db:users:session:set_rotkey:1", "db:auth:session:create_session:1", "urn:users:profile:set_profile_image:1"):
+    if op == "db:users:session:set_rotkey:1" or op == "urn:users:profile:set_profile_image:1":
+      return DBRes([], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 

--- a/tests/test_auth_microsoft_profile_refresh.py
+++ b/tests/test_auth_microsoft_profile_refresh.py
@@ -11,8 +11,8 @@ class DummyAuth:
     return "00000000-0000-0000-0000-000000000001", self.profile, {}
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
 
@@ -35,7 +35,11 @@ class DummyDb:
       if self.allow_update:
         return DBRes([{ "display_name": args["display_name"], "email": args["email"] }], 1)
       return DBRes([], 0)
-    if op in ("db:users:session:set_rotkey:1", "db:auth:session:create_session:1"):
+    if op == "db:users:session:set_rotkey:1":
+      return DBRes([], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 

--- a/tests/test_auth_microsoft_soft_undelete.py
+++ b/tests/test_auth_microsoft_soft_undelete.py
@@ -8,8 +8,8 @@ class DummyAuth:
     return "00000000-0000-0000-0000-000000000001", profile, {}
   def make_rotation_token(self, user_guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
 
@@ -27,11 +27,11 @@ class DummyDb:
       return DBRes([
         {"guid": "user-guid", "display_name": "User", "credits": 0, "element_soft_deleted_at": "2024-01-01T00:00:00Z"}
       ], 1)
-    if op in (
-      "urn:users:providers:undelete_account:1",
-      "db:users:session:set_rotkey:1",
-      "db:auth:session:create_session:1",
-    ):
+    if op == "urn:users:providers:undelete_account:1" or op == "db:users:session:set_rotkey:1":
+      return DBRes([], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 

--- a/tests/test_auth_session_db_profile.py
+++ b/tests/test_auth_session_db_profile.py
@@ -43,6 +43,12 @@ def test_auth_session_returns_db_profile(monkeypatch):
       self.calls.append((op, args))
       if op == "urn:users:providers:get_by_provider_identifier:1":
         return DBRes([{ "guid": "u1", "display_name": "DB", "email": "db@example.com", "credits": 5, "profile_image": "img" }], 1)
+      if op == "db:users:session:set_rotkey:1":
+        return DBRes(rowcount=1)
+      if op == "db:auth:session:create_session:1":
+        return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+      if op == "db:auth:session:update_device_token:1":
+        return DBRes(rowcount=1)
       return DBRes()
 
   class DummyAuth:
@@ -50,8 +56,8 @@ def test_auth_session_returns_db_profile(monkeypatch):
       return "0a1b2c3d-4e5f-6789-aaaa-bbbbccccdddd", {"email": "prov@example.com", "username": "Prov"}, {}
     def make_rotation_token(self, user_guid):
       return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-    def make_session_token(self, user_guid, rot, roles, provider):
-      return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+    def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+      return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
     async def get_user_roles(self, guid, refresh=False):
       return [], 0
 

--- a/tests/test_auth_session_logout_device.py
+++ b/tests/test_auth_session_logout_device.py
@@ -27,6 +27,10 @@ class DummyDb:
       return DBRes([{"revoked_at": None}], 1)
     if op == "db:users:session:get_rotkey:1":
       return DBRes([{"rotkey": "rot-token", "provider_name": "microsoft"}], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess-guid", "device_guid": "dev-guid" }], 1)
+    if op == "db:auth:session:update_device_token:1":
+      return DBRes(rowcount=1)
     return DBRes()
 
 class DummyAuth:
@@ -34,8 +38,8 @@ class DummyAuth:
     return {"guid": "user-guid"}
   async def get_user_roles(self, _guid):
     return (["user"], 0)
-  def make_session_token(self, user_guid, rot, roles, provider):
-    return ("new-token", None)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return ("new-token", exp)
 
 class DummyState:
   def __init__(self):

--- a/tests/test_google_services_helpers.py
+++ b/tests/test_google_services_helpers.py
@@ -89,6 +89,10 @@ class DummyDb:
     self.calls = []
   async def run(self, op, args):
     self.calls.append((op, args))
+    if op == "db:auth:session:create_session:1":
+      return SimpleNamespace(rows=[{"session_guid": "sess", "device_guid": "dev"}])
+    if op == "db:auth:session:update_device_token:1":
+      return SimpleNamespace(rows=[], rowcount=1)
     return SimpleNamespace(rows=[])
 
 
@@ -102,8 +106,8 @@ def test_lookup_user_skips_invalid_identifier():
 class DummyAuth:
   def make_rotation_token(self, guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
 

--- a/tests/test_microsoft_services_helpers.py
+++ b/tests/test_microsoft_services_helpers.py
@@ -78,6 +78,10 @@ class DummyDb:
     self.calls = []
   async def run(self, op, args):
     self.calls.append((op, args))
+    if op == "db:auth:session:create_session:1":
+      return SimpleNamespace(rows=[{"session_guid": "sess", "device_guid": "dev"}])
+    if op == "db:auth:session:update_device_token:1":
+      return SimpleNamespace(rows=[], rowcount=1)
     return SimpleNamespace(rows=[])
 
 
@@ -91,8 +95,8 @@ def test_lookup_user_skips_invalid_identifier():
 class DummyAuth:
   def make_rotation_token(self, guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-  def make_session_token(self, guid, rot, roles, provider):
-    return "sess", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
 


### PR DESCRIPTION
## Summary
- derive session JWTs using user, session, device, and rotation keys
- persist session and device GUIDs then update device with finalized token
- add helper to update device tokens in database

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5154a2e9883258ce711e669199ef4