### PR TITLE
feat: add image thumbnails in file manager

### DIFF
--- a/frontend/src/components/ImagePreview.tsx
+++ b/frontend/src/components/ImagePreview.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Box, IconButton } from '@mui/material';
+
+interface ImagePreviewProps {
+    url: string;
+}
+
+const ImagePreview = ({ url }: ImagePreviewProps): JSX.Element => (
+    <IconButton size="small" onClick={() => window.open(url, '_blank')} sx={{ p: 0 }}>
+        <Box
+            component="img"
+            src={url}
+            alt=""
+            sx={{ width: 120, height: 20, objectFit: 'cover' }}
+        />
+    </IconButton>
+);
+
+export default ImagePreview;

--- a/frontend/src/pages/FileManager.tsx
+++ b/frontend/src/pages/FileManager.tsx
@@ -32,6 +32,7 @@ import UserContext from '../shared/UserContext';
 import FileUpload from '../components/FileUpload';
 import FolderManager from '../components/FolderManager';
 import AudioPreview from '../components/AudioPreview';
+import ImagePreview from '../components/ImagePreview';
 
 interface StorageFile {
     name: string;
@@ -110,6 +111,9 @@ const FileManager = (): JSX.Element => {
         const type = getType(file);
         if (type === 'audio') {
             return <AudioPreview url={file.url} />;
+        }
+        if (type === 'image') {
+            return <ImagePreview url={file.url} />;
         }
         return (
             <IconButton size="small" onClick={() => window.open(file.url, '_blank')}>


### PR DESCRIPTION
## Summary
- show clickable thumbnail for images in file manager
- support small image preview in files list
- widen image thumbnail to 120x20 for better alignment with audio preview

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68b52028d26c83258204e8e94c4bd4d5