### PR TITLE
feat(frontend): add tooltips for file actions

### DIFF
--- a/frontend/src/pages/FileManager.tsx
+++ b/frontend/src/pages/FileManager.tsx
@@ -10,6 +10,7 @@ IconButton,
 Stack,
 Checkbox,
 FormControlLabel,
+Tooltip,
 } from '@mui/material';
 import {
 OpenInNew,
@@ -225,22 +226,30 @@ return (
 							<TableCell sx={{ width: '60%' }}>{file.name}</TableCell>
 							<TableCell sx={{ width: '20%' }}>
 								<Stack direction="row" spacing={1}>
-									<IconButton size="small" onClick={() => void handleCopy(file.url)}>
-										<LinkIcon />
-									</IconButton>
-									<IconButton size="small" onClick={() => void handleDelete(file.name)}>
-										<Delete />
-									</IconButton>
-									<IconButton size="small" onClick={() => void handleSetGallery(file.name)}>
-										<Publish />
-									</IconButton>
-									<IconButton
-										size="small"
-										disabled={moveTarget === null}
-										onClick={() => void handleMove(file.name)}
-									>
-										<DriveFileMove />
-									</IconButton>
+									<Tooltip title="Get link">
+										<IconButton size="small" onClick={() => void handleCopy(file.url)}>
+											<LinkIcon />
+										</IconButton>
+									</Tooltip>
+									<Tooltip title="Delete">
+										<IconButton size="small" onClick={() => void handleDelete(file.name)}>
+											<Delete />
+										</IconButton>
+									</Tooltip>
+									<Tooltip title="Publish">
+										<IconButton size="small" onClick={() => void handleSetGallery(file.name)}>
+											<Publish />
+										</IconButton>
+									</Tooltip>
+									<Tooltip title="Move">
+										<IconButton
+											size="small"
+											disabled={moveTarget === null}
+											onClick={() => void handleMove(file.name)}
+										>
+											<DriveFileMove />
+										</IconButton>
+									</Tooltip>
 								</Stack>
 							</TableCell>
 						</TableRow>


### PR DESCRIPTION
## Summary
- add Material UI tooltips for file manager actions (Get link, Delete, Publish, Move)

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5c43135ac8325a38182081d774544