### PR TITLE
document architecture and update db tooling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,22 @@
+# Architecture Overview
+
+This document describes the high level layering of the application and the security boundaries between them.
+
+```mermaid
+flowchart TD
+  Client --> RPC
+  RPC --> Services
+  Services --> Modules
+  Modules --> Providers
+  Security --> RPC
+  Security --> Services
+```
+
+* **Client** – User owned frontend or external application.
+* **RPC** – Typed boundary that exposes the public namespace. Only bearer tokens are accepted.
+* **Services** – Business logic invoked by RPC handlers.
+* **Modules** – Internal runtime modules loaded by the server. Modules communicate only through their contracts.
+* **Providers** – External systems such as databases and identity services.
+* **Security** – Cross cutting layer enforcing authentication, authorization, and privacy rules. Data marked internal never leaves the server.
+
+Internal details (modules, services, providers) are considered **server only** and are never exposed directly to clients. The client interacts solely through the RPC layer with validated tokens.

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1,5 +1,9 @@
 # Database Overview
 
+## Schema Management
+
+Database maintenance is performed with `scripts/mssql_cli.py`. Use the `schema dump` command to emit a `.sql` file containing `CREATE TABLE` statements along with indexes, constraints, and references. The companion `schema apply <file>` command executes such a script against a target server. Interactive commands for listing tables and columns have been removed now that SQL Server tooling provides this functionality.
+
 ## Simple User Schema
 
 The below statement illustrates a simple JOIN statement to get the entire view of a standard user, this will incude

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,8 +56,34 @@ The authentication provider is a client-side domain, this is the data that the c
  This is the back end server which handles all requests. The server domain includes the database and the information that is retained in the database is as follows:
 
  1) User's unique account identifier
- 2) User's email address*
- 3) User's unique session and device identifier
- 4) User's profile image (if available)
+  2) User's email address*
+  3) User's unique session and device identifier
+  4) User's profile image (if available)
 
- Email Opt-Out: If the user opt out of email, they will not be sent any e-mail based communication and their email address will not be shown to other users in their public profile.
+  Email Visibility: Email addresses are required for purchase receipts and cannot be removed. Users may hide their address from public profiles, and the service sends no other email communications.
+
+### Account Provisioning
+
+Accounts can only be created through trusted identity providers. Supported providers are **Microsoft**, **Google**, **Discord**, and **Apple**. No local credentials are ever issued or stored. When a user signs in for the first time, the provider identifier becomes the primary key used by the server to link all subsequent logins.
+
+### Authentication Workflow
+
+1. Client obtains an ID token from an identity provider.
+2. The token is sent to the server and validated against the provider's JWKS.
+3. For new accounts a GUID is generated and the provider becomes the user's primary provider.
+4. Existing accounts are looked up by GUID and their session/device records are refreshed.
+5. A server signed bearer token is returned to the client and used for all RPC calls.
+
+### Personal Data and Privacy
+
+The server stores only minimal personal information:
+
+* GUID (internal identifier)
+* Email address *(required; used only for purchase receipts)*
+* Profile image *(optional)*
+
+Email addresses are required for receipt delivery and cannot be changed or removed. Users may choose to hide their address from public profiles, and the service does not send other email communications.
+
+### Provider Association
+
+Each account is linked to a single primary provider for lookup and auditing. Identity provider data is not used in any internal cryptographic operations; it is only used to validate the provider's identity token during authentication. All encryption and signing routines rely solely on internal keys.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "modules": {
+    "db": "server.modules.db_module.DbModule",
+    "auth": "server.modules.auth_module.AuthModule",
+    "storage": "server.modules.storage_module.StorageModule",
+    "env": "server.modules.env_module.EnvModule",
+    "discord": "server.modules.discord_module.DiscordModule"
+  },
+  "providers": {
+    "MicrosoftAuthProvider": "server.modules.providers.auth.microsoft_provider.MicrosoftAuthProvider",
+    "GoogleAuthProvider": "server.modules.providers.auth.google_provider.GoogleAuthProvider",
+    "MssqlProvider": "server.modules.providers.database.mssql_provider.MssqlProvider"
+  }
+}

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+import inspect, json
+from importlib import import_module
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from server.modules import BaseModule
+from server.modules.providers import (
+  AuthProvider,
+  AuthProviderBase,
+  BaseProvider,
+  DbProviderBase,
+  LifecycleProvider,
+)
+
+
+def _collect_modules() -> dict[str, str]:
+  modules: dict[str, str] = {}
+  for path in Path('server/modules').glob('*_module.py'):
+    name = path.stem[:-7]
+    mod = import_module(f'server.modules.{path.stem}')
+    for attr in mod.__dict__.values():
+      if inspect.isclass(attr) and issubclass(attr, BaseModule) and attr is not BaseModule:
+        modules[name] = f'{mod.__name__}.{attr.__name__}'
+  return modules
+
+
+def _collect_providers() -> dict[str, str]:
+  providers: dict[str, str] = {}
+  base = Path('server/modules/providers')
+  for path in base.rglob('*.py'):
+    if path.name == '__init__.py' and path.parent == base:
+      continue
+    pkg = '.'.join((path.parent if path.name == '__init__.py' else path.with_suffix('')).parts)
+    mod = import_module(pkg)
+    for attr in mod.__dict__.values():
+      if inspect.isclass(attr) and attr not in {
+        AuthProviderBase,
+        DbProviderBase,
+        AuthProvider,
+        BaseProvider,
+        LifecycleProvider,
+      }:
+        if issubclass(attr, AuthProviderBase) or issubclass(attr, DbProviderBase):
+          providers[attr.__name__] = f'{mod.__name__}.{attr.__name__}'
+  return providers
+
+
+def main() -> None:
+  manifest = {
+    'modules': _collect_modules(),
+    'providers': _collect_providers(),
+  }
+  with open('manifest.json', 'w') as f:
+    json.dump(manifest, f, indent=2)
+  print(json.dumps(manifest, indent=2))
+
+
+if __name__ == '__main__':
+  main()

--- a/scripts/mssql_cli.py
+++ b/scripts/mssql_cli.py
@@ -39,14 +39,9 @@ Available commands:
   help                               Show this help message
   exit, quit                         Exit the console
   reconnect <db>                     Connect to a different database
-  list tables                        List all tables
-  list columns <table>               List columns of a table
-  list indexes <table>               List indexes on a table
-  list keys <table>                  List key columns and constraint types
-  list constraints <table>           List constraints on a table
   index all                          Reindex the current database
-  schema dump [name]                 Dump DB schema to <name>_YYYYMMDD.json
-  schema apply <file>                Apply schema JSON to the database
+  schema dump [name]                 Dump DB schema to <name>_YYYYMMDD.sql
+  schema apply <file>                Execute schema SQL on the database
   dump data [name]                   Dump DB schema and rows to <name>_YYYYMMDD.json
   update version major               Increment the major version
   update version minor               Increment the minor version
@@ -71,36 +66,6 @@ async def interactive_console(conn):
           conn = await db.connect(dbname)
         except Exception as e:
           print(f'Error reconnecting: {e}')
-      case ['list', 'tables']:
-        rows = await db.list_tables(conn)
-        for r in rows:
-          print(r['table_name'])
-      case ['list', 'columns', table]:
-        rows = await db.list_columns(conn, table)
-        for r in rows:
-          length = r.get('max_length')
-          if length is not None and r['data_type'].lower() in {
-            'varchar', 'nvarchar', 'char', 'nchar', 'varbinary'
-          }:
-            if length == -1:
-              t = f"{r['data_type']}(MAX)"
-            else:
-              t = f"{r['data_type']}({length})"
-          else:
-            t = r['data_type']
-          print(f"{r['column_name']} ({t})")
-      case ['list', 'indexes', table]:
-        rows = await db.list_indexes(conn, table)
-        for r in rows:
-          print(f"{r['indexname']} ({r['indexdef']})")
-      case ['list', 'keys', table]:
-        rows = await db.list_keys(conn, table)
-        for r in rows:
-          print(f"{r['column_name']} -> {r['constraint_name']} ({r['constraint_type']})")
-      case ['list', 'constraints', table]:
-        rows = await db.list_constraints(conn, table)
-        for r in rows:
-          print(f"{r['constraint_name']} ({r['constraint_type']})")
       case ['index', 'all']:
         try:
           async with conn.cursor() as cur:

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -1,3 +1,5 @@
+"""Authentication module handling login and token workflows."""
+
 import base64, logging, uuid
 from datetime import datetime, timedelta, timezone
 from fastapi import FastAPI, HTTPException, status

--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -1,3 +1,5 @@
+"""Discord integration module."""
+
 import logging, discord, json, asyncio
 from fastapi import FastAPI, Request
 from discord.ext import commands

--- a/server/modules/env_module.py
+++ b/server/modules/env_module.py
@@ -1,3 +1,5 @@
+"""Environment variable loader module."""
+
 import os, dotenv, logging
 from fastapi import FastAPI
 from . import BaseModule

--- a/server/modules/providers/__init__.py
+++ b/server/modules/providers/__init__.py
@@ -1,3 +1,5 @@
+"""Provider contract definitions for authentication and database layers."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -1,3 +1,5 @@
+"""Blob storage access module."""
+
 from azure.storage.blob.aio import BlobServiceClient, ContainerClient
 from azure.core.exceptions import ResourceExistsError
 from fastapi import FastAPI


### PR DESCRIPTION
## Summary
- add architecture overview and manifest metadata for modules
- expand security doc with account provisioning and privacy workflow
- simplify MSSQL CLI and dump schema as SQL
- clarify provider token verification and email retention in security doc
- fix manifest generation to enumerate auth and database providers

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/run_tests.py` *(fails: ODBC Driver 18 for SQL Server not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e0a4126c832586d11ee6c47b9626