### PR TITLE
Add storage provisioning check and default name reset

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -29,6 +29,7 @@ All Support domain calls require `ROLE_SUPPORT`.
 | `urn:support:users:get_profile:1`      | Get a user's profile details.                    |
 | `urn:support:users:set_credits:1`      | Moderator can set user credit amount.            |
 | `urn:support:users:enable_storage:1`   | Moderator can enable user storage.               |
+| `urn:support:users:check_storage:1`    | Check if user storage folder exists.             |
 | `urn:support:users:reset_display:1`    | Moderator reset of user display name to default. |
 
 ## Users Domain

--- a/rpc/support/users/__init__.py
+++ b/rpc/support/users/__init__.py
@@ -2,7 +2,8 @@ from .services import (
   support_users_get_profile_v1,
   support_users_reset_display_v1,
   support_users_set_credits_v1,
-  support_users_enable_storage_v1
+  support_users_enable_storage_v1,
+  support_users_check_storage_v1
 )
 
 
@@ -12,6 +13,7 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("get_profile", "1"): support_users_get_profile_v1,
   ("set_credits", "1"): support_users_set_credits_v1,
   ("reset_display", "1"): support_users_reset_display_v1,
-  ("enable_storage", "1"): support_users_enable_storage_v1
+  ("enable_storage", "1"): support_users_enable_storage_v1,
+  ("check_storage", "1"): support_users_check_storage_v1
 }
 

--- a/rpc/support/users/models.py
+++ b/rpc/support/users/models.py
@@ -8,3 +8,7 @@ class SupportUsersGuid1(BaseModel):
 class SupportUsersSetCredits1(SupportUsersGuid1):
   credits: int
 
+
+class SupportUsersStorageStatus1(SupportUsersGuid1):
+  exists: bool
+


### PR DESCRIPTION
## Summary
- add RPC to check if a user's storage folder exists
- reset offensive display names to literal "Default User"
- gate Account Users panel storage provisioning button on role and folder state

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5efffa3d88325b12fff437c0c3400