### PR TITLE
feat(db): add set display and enable storage handlers

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -234,6 +234,31 @@ def _users_set_display(args: Dict[str, Any]):
     return ("exec", sql, (display_name, guid))
 
 
+@register("db:users:profile:set_display:1")
+def _db_users_set_display(args: Dict[str, Any]):
+  return _users_set_display(args)
+
+
+@register("urn:support:users:enable_storage:1")
+def _support_users_enable_storage(args: Dict[str, Any]):
+  guid = args["guid"]
+  sql = """
+    MERGE users_enablements AS ue
+    USING (SELECT ? AS users_guid) AS src
+    ON ue.users_guid = src.users_guid
+    WHEN MATCHED THEN UPDATE SET element_enablements =
+      CONVERT(NVARCHAR(MAX), CONVERT(BIGINT, ue.element_enablements) | 1)
+    WHEN NOT MATCHED THEN INSERT (users_guid, element_enablements)
+      VALUES (src.users_guid, '1');
+  """
+  return ("exec", sql, (guid,))
+
+
+@register("db:support:users:enable_storage:1")
+def _db_support_users_enable_storage(args: Dict[str, Any]):
+  return _support_users_enable_storage(args)
+
+
 @register("urn:users:profile:set_optin:1")
 def _users_set_optin(args: Dict[str, Any]):
     guid = args["guid"]


### PR DESCRIPTION
## Summary
- add MSSQL handler for db:users:profile:set_display:1
- add MSSQL handler for db:support:users:enable_storage:1

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68b5facb4a548325a63eefee9217fafe