### PR TITLE
feat(db): add handler for support user credits

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -239,6 +239,23 @@ def _db_users_set_display(args: Dict[str, Any]):
   return _users_set_display(args)
 
 
+@register("urn:support:users:set_credits:1")
+def _support_users_set_credits(args: Dict[str, Any]):
+  guid = args["guid"]
+  credits = args["credits"]
+  sql = """
+    UPDATE users_credits
+    SET element_credits = ?
+    WHERE users_guid = ?;
+  """
+  return ("exec", sql, (credits, guid))
+
+
+@register("db:support:users:set_credits:1")
+def _db_support_users_set_credits(args: Dict[str, Any]):
+  return _support_users_set_credits(args)
+
+
 @register("urn:support:users:enable_storage:1")
 def _support_users_enable_storage(args: Dict[str, Any]):
   guid = args["guid"]

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -81,6 +81,14 @@ def test_mssql_get_by_access_token_uses_security_view():
   assert "providers_recid" in sql
 
 
+def test_mssql_support_users_set_credits_updates_table():
+  handler = get_mssql_handler("db:support:users:set_credits:1")
+  mode, sql, params = handler({"guid": "gid", "credits": 10})
+  assert mode == "exec"
+  assert "update users_credits" in sql.lower()
+  assert params == (10, "gid")
+
+
 def test_fetch_rows_returns_empty_on_error(monkeypatch):
   class Cur:
     async def execute(self, q, p):


### PR DESCRIPTION
## Summary
- add MSSQL handler to update user credits via support API
- cover support credit handler in provider query tests

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68b6012f75f083259b323dcc1f4967a6