### PR TITLE
Send Discord online status message directly

### DIFF
--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -82,7 +82,9 @@ class DiscordModule(BaseModule):
       if channel:
         res = await self.db.run("db:system:config:get_config:1", {"key": "Version"})
         version = res.rows[0]["value"] if res.rows else None
-        logging.info(f"TheOracleGPT-Dev Online. Version: {version or 'unknown'}")
+        msg = f"TheOracleGPT-Dev Online. Version: {version or 'unknown'}"
+        await channel.send(msg)
+        logging.info(msg)
       else:
         logging.warning("[DiscordProvider] System channel not found on ready.")
 


### PR DESCRIPTION
## Summary
- Send Discord module startup message straight to system channel and log separately so it always appears regardless of logging level

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68b640cd67f48325a1737cf8f35558be