### PR TITLE
Retain provider identifiers with link state flag

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -12,7 +12,7 @@ provider, their credits, security roles, and session/device details and tokens.
 
 SELECT * FROM account_users au
 JOIN users_sessions us ON au.element_guid = us.users_guid
-JOIN users_auth ua ON au.element_guid = ua.users_guid
+JOIN users_auth ua ON au.element_guid = ua.users_guid AND ua.element_linked = 1
 JOIN users_credits uc ON au.element_guid = uc.users_guid
 JOIN users_roles ur ON au.element_guid = ur.users_guid
 JOIN users_profileimg up ON au.element_guid = up.users_guid
@@ -22,7 +22,7 @@ JOIN auth_providers ap2 ON sd.providers_recid = ap2.recid
 
 `users_sessions` records only map a user to a session identifier and creation time. Token data, device metadata, and the issuing provider live in `sessions_devices`, which references the session via `sessions_guid`.
 
-Note: `users_auth.element_identifier` is a `UNIQUEIDENTIFIER` and must be unique across all providers.
+Note: `users_auth.element_identifier` is a `UNIQUEIDENTIFIER` and must be unique across all providers. `users_auth.element_linked` indicates whether a provider is currently linked. Records are never deleted; unlinking sets this flag to `0`.
 
 The above materialized view would result in a row that looks like this:
 

--- a/scripts/MSSQL_schema.sql
+++ b/scripts/MSSQL_schema.sql
@@ -87,6 +87,7 @@ CREATE TABLE users_auth (
     users_guid UNIQUEIDENTIFIER NOT NULL,
     providers_recid INT NOT NULL,
     element_identifier UNIQUEIDENTIFIER NOT NULL UNIQUE,
+    element_linked BIT NOT NULL,
     FOREIGN KEY (providers_recid) REFERENCES auth_providers(recid),
     FOREIGN KEY (users_guid) REFERENCES account_users(element_guid)
 );

--- a/scripts/MSSQL_scripts.sql
+++ b/scripts/MSSQL_scripts.sql
@@ -1,7 +1,7 @@
 -- SEE MATERIALIZED VIEW --
 SELECT * FROM account_users au
 JOIN users_sessions us ON au.element_guid = us.users_guid
-JOIN users_auth ua ON au.element_guid = ua.users_guid
+JOIN users_auth ua ON au.element_guid = ua.users_guid AND ua.element_linked = 1
 JOIN users_credits uc ON au.element_guid = uc.users_guid
 JOIN users_roles ur ON au.element_guid = ur.users_guid
 JOIN users_profileimg up ON au.element_guid = up.users_guid
@@ -13,7 +13,7 @@ JOIN auth_providers apd ON sd.providers_recid = apd.recid
 -- DELETE JOINED RECORD --
 DELETE FROM sessions_devices WHERE sessions_guid = ''
 GO
-DELETE FROM users_auth WHERE users_guid = ''
+UPDATE users_auth SET element_linked = 0 WHERE users_guid = ''
 DELETE FROM users_credits WHERE users_guid = ''
 DELETE FROM users_roles WHERE users_guid = ''
 DELETE FROM users_sessions WHERE users_guid = ''
@@ -32,8 +32,8 @@ SELECT * FROM users_sessions
 SELECT * FROM sessions_devices
 
 
--- FAST  CLEANUP--
-TRUNCATE TABLE users_auth
+-- mark all auth records unlinked instead of deleting
+UPDATE users_auth SET element_linked = 0
 TRUNCATE TABLE users_credits
 TRUNCATE TABLE users_roles
 TRUNCATE TABLE users_sessions

--- a/scripts/v0.2.3.3_20250818.json
+++ b/scripts/v0.2.3.3_20250818.json
@@ -1,0 +1,1143 @@
+{
+  "tables": [
+    {
+      "name": "auth_providers",
+      "columns": [
+        {
+          "name": "recid",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_name",
+          "type": "nvarchar",
+          "length": 1024,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_display",
+          "type": "nvarchar",
+          "length": 1024,
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "recid"
+      ],
+      "foreign_keys": [],
+      "indexes": [
+        {
+          "indexname": "PK__auth_pro__1B427A0A2309032F",
+          "indexdef": "CLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "PK__auth_pro__1B427A0A2309032F",
+          "column_name": "recid",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__auth_pro__1B427A0A2309032F",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ]
+    },
+    {
+      "name": "account_users",
+      "columns": [
+        {
+          "name": "recid",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_guid",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_rotkey",
+          "type": "nvarchar",
+          "length": -1,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_rotkey_iat",
+          "type": "datetimeoffset",
+          "length": null,
+          "nullable": false,
+          "default": "(sysdatetimeoffset())"
+        },
+        {
+          "name": "element_rotkey_exp",
+          "type": "datetimeoffset",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_email",
+          "type": "nvarchar",
+          "length": 1024,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_display",
+          "type": "nvarchar",
+          "length": 1024,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "providers_recid",
+          "type": "int",
+          "length": null,
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "element_optin",
+          "type": "bit",
+          "length": null,
+          "nullable": true,
+          "default": "((0))"
+        }
+      ],
+      "primary_key": [
+        "recid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "providers_recid",
+          "ref_table": "auth_providers",
+          "ref_column": "recid"
+        }
+      ],
+      "indexes": [
+        {
+          "indexname": "PK__account___1B427A0AF59F6F64",
+          "indexdef": "CLUSTERED"
+        },
+        {
+          "indexname": "UQ__account___D23E50605BA10A17",
+          "indexdef": "NONCLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "FK__account_u__eleme__37703C52",
+          "column_name": "providers_recid",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "PK__account___1B427A0AF59F6F64",
+          "column_name": "recid",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "UQ__account___D23E50605BA10A17",
+          "column_name": "element_guid",
+          "constraint_type": "UNIQUE"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__account___1B427A0AF59F6F64",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "UQ__account___D23E50605BA10A17",
+          "constraint_type": "UNIQUE"
+        },
+        {
+          "constraint_name": "FK__account_u__eleme__37703C52",
+          "constraint_type": "FOREIGN KEY"
+        }
+      ]
+    },
+    {
+      "name": "users_sessions",
+      "columns": [
+        {
+          "name": "element_guid",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "users_guid",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_created_at",
+          "type": "datetimeoffset",
+          "length": null,
+          "nullable": false,
+          "default": "(sysdatetimeoffset())"
+        }
+      ],
+      "primary_key": [
+        "element_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "users_guid",
+          "ref_table": "account_users",
+          "ref_column": "element_guid"
+        }
+      ],
+      "indexes": [
+        {
+          "indexname": "PK__users_se__D23E506157A24F28",
+          "indexdef": "CLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "FK__users_ses__users__09746778",
+          "column_name": "users_guid",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "PK__users_se__D23E506157A24F28",
+          "column_name": "element_guid",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__users_se__D23E506157A24F28",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "FK__users_ses__users__09746778",
+          "constraint_type": "FOREIGN KEY"
+        }
+      ]
+    },
+    {
+      "name": "sessions_devices",
+      "columns": [
+        {
+          "name": "element_guid",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "sessions_guid",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_token",
+          "type": "nvarchar",
+          "length": -1,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_token_iat",
+          "type": "datetimeoffset",
+          "length": null,
+          "nullable": false,
+          "default": "(sysdatetimeoffset())"
+        },
+        {
+          "name": "element_token_exp",
+          "type": "datetimeoffset",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_device_fingerprint",
+          "type": "nvarchar",
+          "length": 512,
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "element_user_agent",
+          "type": "nvarchar",
+          "length": 1024,
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "element_ip_last_seen",
+          "type": "nvarchar",
+          "length": 64,
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "element_revoked_at",
+          "type": "datetimeoffset",
+          "length": null,
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "element_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "sessions_guid",
+          "ref_table": "users_sessions",
+          "ref_column": "element_guid"
+        }
+      ],
+      "indexes": [
+        {
+          "indexname": "PK__sessions__D23E5061D8205B3C",
+          "indexdef": "CLUSTERED"
+        },
+        {
+          "indexname": "UQ__sessions__56462BBD91641381",
+          "indexdef": "NONCLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "FK__sessions___sessi__0E391C95",
+          "column_name": "sessions_guid",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "PK__sessions__D23E5061D8205B3C",
+          "column_name": "element_guid",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "UQ__sessions__56462BBD91641381",
+          "column_name": "element_guid",
+          "constraint_type": "UNIQUE"
+        },
+        {
+          "constraint_name": "UQ__sessions__56462BBD91641381",
+          "column_name": "sessions_guid",
+          "constraint_type": "UNIQUE"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__sessions__D23E5061D8205B3C",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "UQ__sessions__56462BBD91641381",
+          "constraint_type": "UNIQUE"
+        },
+        {
+          "constraint_name": "FK__sessions___sessi__0E391C95",
+          "constraint_type": "FOREIGN KEY"
+        }
+      ]
+    },
+    {
+      "name": "frontend_links",
+      "columns": [
+        {
+          "name": "recid",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_sequence",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": "((0))"
+        },
+        {
+          "name": "element_title",
+          "type": "nvarchar",
+          "length": -1,
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "element_url",
+          "type": "nvarchar",
+          "length": -1,
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "recid"
+      ],
+      "foreign_keys": [],
+      "indexes": [
+        {
+          "indexname": "PK__frontend__1B427A0AF0BF8488",
+          "indexdef": "CLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "PK__frontend__1B427A0AF0BF8488",
+          "column_name": "recid",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__frontend__1B427A0AF0BF8488",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ]
+    },
+    {
+      "name": "frontend_routes",
+      "columns": [
+        {
+          "name": "recid",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_enablement",
+          "type": "nvarchar",
+          "length": 1,
+          "nullable": false,
+          "default": "('0')"
+        },
+        {
+          "name": "element_roles",
+          "type": "bigint",
+          "length": null,
+          "nullable": false,
+          "default": "((0))"
+        },
+        {
+          "name": "element_sequence",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": "((0))"
+        },
+        {
+          "name": "element_path",
+          "type": "nvarchar",
+          "length": 512,
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "element_name",
+          "type": "nvarchar",
+          "length": 256,
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "element_icon",
+          "type": "nvarchar",
+          "length": 256,
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "recid"
+      ],
+      "foreign_keys": [],
+      "indexes": [
+        {
+          "indexname": "PK__frontend__1B427A0A651E506F",
+          "indexdef": "CLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "PK__frontend__1B427A0A651E506F",
+          "column_name": "recid",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__frontend__1B427A0A651E506F",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ]
+    },
+    {
+      "name": "system_config",
+      "columns": [
+        {
+          "name": "recid",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_key",
+          "type": "nvarchar",
+          "length": 1024,
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "element_value",
+          "type": "nvarchar",
+          "length": -1,
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "recid"
+      ],
+      "foreign_keys": [],
+      "indexes": [
+        {
+          "indexname": "PK__system_c__1B427A0A7AC49C1A",
+          "indexdef": "CLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "PK__system_c__1B427A0A7AC49C1A",
+          "column_name": "recid",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__system_c__1B427A0A7AC49C1A",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ]
+    },
+    {
+      "name": "system_roles",
+      "columns": [
+        {
+          "name": "recid",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_mask",
+          "type": "bigint",
+          "length": null,
+          "nullable": false,
+          "default": "((0))"
+        },
+        {
+          "name": "element_enablement",
+          "type": "nvarchar",
+          "length": 1,
+          "nullable": false,
+          "default": "('0')"
+        },
+        {
+          "name": "element_name",
+          "type": "nvarchar",
+          "length": 1024,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_display",
+          "type": "nvarchar",
+          "length": 1024,
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "recid"
+      ],
+      "foreign_keys": [],
+      "indexes": [
+        {
+          "indexname": "PK__system_r__1B427A0AEEF1A435",
+          "indexdef": "CLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "PK__system_r__1B427A0AEEF1A435",
+          "column_name": "recid",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__system_r__1B427A0AEEF1A435",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ]
+    },
+    {
+      "name": "users_credits",
+      "columns": [
+        {
+          "name": "users_guid",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_credits",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_reserve",
+          "type": "int",
+          "length": null,
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "users_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "users_guid",
+          "ref_table": "account_users",
+          "ref_column": "element_guid"
+        }
+      ],
+      "indexes": [
+        {
+          "indexname": "PK__users_cr__323291AE45C17175",
+          "indexdef": "CLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "FK__users_cre__users__41EDCAC5",
+          "column_name": "users_guid",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "PK__users_cr__323291AE45C17175",
+          "column_name": "users_guid",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__users_cr__323291AE45C17175",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "FK__users_cre__users__41EDCAC5",
+          "constraint_type": "FOREIGN KEY"
+        }
+      ]
+    },
+    {
+      "name": "users_roles",
+      "columns": [
+        {
+          "name": "users_guid",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_roles",
+          "type": "bigint",
+          "length": null,
+          "nullable": false,
+          "default": "((0))"
+        }
+      ],
+      "primary_key": [
+        "users_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "users_guid",
+          "ref_table": "account_users",
+          "ref_column": "element_guid"
+        }
+      ],
+      "indexes": [
+        {
+          "indexname": "PK__users_ro__323291AEB6D74289",
+          "indexdef": "CLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "FK__users_rol__users__45BE5BA9",
+          "column_name": "users_guid",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "PK__users_ro__323291AEB6D74289",
+          "column_name": "users_guid",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__users_ro__323291AEB6D74289",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "FK__users_rol__users__45BE5BA9",
+          "constraint_type": "FOREIGN KEY"
+        }
+      ]
+    },
+    {
+      "name": "users_enablements",
+      "columns": [
+        {
+          "name": "users_guid",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_enablements",
+          "type": "nvarchar",
+          "length": -1,
+          "nullable": false,
+          "default": "('0')"
+        }
+      ],
+      "primary_key": [
+        "users_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "users_guid",
+          "ref_table": "account_users",
+          "ref_column": "element_guid"
+        }
+      ],
+      "indexes": [
+        {
+          "indexname": "PK__users_en__323291AE416CA5CE",
+          "indexdef": "CLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "FK__users_ena__users__498EEC8D",
+          "column_name": "users_guid",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "PK__users_en__323291AE416CA5CE",
+          "column_name": "users_guid",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__users_en__323291AE416CA5CE",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "FK__users_ena__users__498EEC8D",
+          "constraint_type": "FOREIGN KEY"
+        }
+      ]
+    },
+    {
+      "name": "users_profileimg",
+      "columns": [
+        {
+          "name": "users_guid",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_base64",
+          "type": "nvarchar",
+          "length": -1,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "providers_recid",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "users_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "providers_recid",
+          "ref_table": "auth_providers",
+          "ref_column": "recid"
+        },
+        {
+          "column": "users_guid",
+          "ref_table": "account_users",
+          "ref_column": "element_guid"
+        }
+      ],
+      "indexes": [
+        {
+          "indexname": "PK__users_pr__323291AE7EECDE71",
+          "indexdef": "CLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "FK__users_pro__provi__5F7E2DAC",
+          "column_name": "providers_recid",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "FK__users_pro__users__5E8A0973",
+          "column_name": "users_guid",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "PK__users_pr__323291AE7EECDE71",
+          "column_name": "users_guid",
+          "constraint_type": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__users_pr__323291AE7EECDE71",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "FK__users_pro__users__5E8A0973",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "FK__users_pro__provi__5F7E2DAC",
+          "constraint_type": "FOREIGN KEY"
+        }
+      ]
+    },
+    {
+      "name": "sysdiagrams",
+      "columns": [
+        {
+          "name": "name",
+          "type": "nvarchar",
+          "length": 128,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "principal_id",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "diagram_id",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "version",
+          "type": "int",
+          "length": null,
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "definition",
+          "type": "varbinary",
+          "length": -1,
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "diagram_id"
+      ],
+      "foreign_keys": [],
+      "indexes": [
+        {
+          "indexname": "PK__sysdiagr__C2B05B6144C6318B",
+          "indexdef": "CLUSTERED"
+        },
+        {
+          "indexname": "UK_principal_name",
+          "indexdef": "NONCLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "PK__sysdiagr__C2B05B6144C6318B",
+          "column_name": "diagram_id",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "UK_principal_name",
+          "column_name": "name",
+          "constraint_type": "UNIQUE"
+        },
+        {
+          "constraint_name": "UK_principal_name",
+          "column_name": "principal_id",
+          "constraint_type": "UNIQUE"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__sysdiagr__C2B05B6144C6318B",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "UK_principal_name",
+          "constraint_type": "UNIQUE"
+        }
+      ]
+    },
+    {
+      "name": "users_auth",
+      "columns": [
+        {
+          "name": "recid",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "users_guid",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "providers_recid",
+          "type": "int",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_identifier",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_linked",
+          "type": "bit",
+          "length": null,
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "recid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "providers_recid",
+          "ref_table": "auth_providers",
+          "ref_column": "recid"
+        },
+        {
+          "column": "users_guid",
+          "ref_table": "account_users",
+          "ref_column": "element_guid"
+        }
+      ],
+      "indexes": [
+        {
+          "indexname": "PK__users_au__1B427A0A12BB7F8F",
+          "indexdef": "CLUSTERED"
+        },
+        {
+          "indexname": "UQ__users_au__element_identifier",
+          "indexdef": "NONCLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "FK__users_aut__provi__76619304",
+          "column_name": "providers_recid",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "FK__users_aut__users__7755B73D",
+          "column_name": "users_guid",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "PK__users_au__1B427A0A12BB7F8F",
+          "column_name": "recid",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "UQ__users_au__element_identifier",
+          "column_name": "element_identifier",
+          "constraint_type": "UNIQUE"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__users_au__1B427A0A12BB7F8F",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "FK__users_aut__provi__76619304",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "FK__users_aut__users__7755B73D",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "UQ__users_au__element_identifier",
+          "constraint_type": "UNIQUE"
+        }
+      ]
+    },
+    {
+      "name": "users_apitokens",
+      "columns": [
+        {
+          "name": "element_guid",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "users_guid",
+          "type": "uniqueidentifier",
+          "length": null,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_token",
+          "type": "nvarchar",
+          "length": -1,
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "element_token_iat",
+          "type": "datetimeoffset",
+          "length": null,
+          "nullable": false,
+          "default": "(sysdatetimeoffset())"
+        },
+        {
+          "name": "element_token_exp",
+          "type": "datetimeoffset",
+          "length": null,
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primary_key": [
+        "element_guid"
+      ],
+      "foreign_keys": [
+        {
+          "column": "users_guid",
+          "ref_table": "account_users",
+          "ref_column": "element_guid"
+        }
+      ],
+      "indexes": [
+        {
+          "indexname": "PK__users_ap__D23E5061137C4EF8",
+          "indexdef": "CLUSTERED"
+        },
+        {
+          "indexname": "UQ__users_ap__3F1174A9E2939F72",
+          "indexdef": "NONCLUSTERED"
+        }
+      ],
+      "keys": [
+        {
+          "constraint_name": "FK__users_api__users__7C1A6C5A",
+          "column_name": "users_guid",
+          "constraint_type": "FOREIGN KEY"
+        },
+        {
+          "constraint_name": "PK__users_ap__D23E5061137C4EF8",
+          "column_name": "element_guid",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "UQ__users_ap__3F1174A9E2939F72",
+          "column_name": "element_guid",
+          "constraint_type": "UNIQUE"
+        },
+        {
+          "constraint_name": "UQ__users_ap__3F1174A9E2939F72",
+          "column_name": "users_guid",
+          "constraint_type": "UNIQUE"
+        }
+      ],
+      "constraints": [
+        {
+          "constraint_name": "PK__users_ap__D23E5061137C4EF8",
+          "constraint_type": "PRIMARY KEY"
+        },
+        {
+          "constraint_name": "UQ__users_ap__3F1174A9E2939F72",
+          "constraint_type": "UNIQUE"
+        },
+        {
+          "constraint_name": "FK__users_api__users__7C1A6C5A",
+          "constraint_type": "FOREIGN KEY"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- track provider link status with new `element_linked` column in `users_auth`
- toggle link state instead of deleting during link/unlink workflows
- document and script updates for provider link tracking

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68b646a9b82c83258f43b9db1213becd