### PR TITLE
Handle returning users by relinking auth providers

### DIFF
--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -228,6 +228,33 @@ async def auth_google_oauth_login_v1(request: Request):
   user = await lookup_user(db, provider, identifiers)
 
   if not user:
+    res = await db.run(
+      "urn:users:providers:get_any_by_provider_identifier:1",
+      {"provider": provider, "provider_identifier": provider_uid},
+    )
+    if res.rows:
+      relink = res.rows[0]
+      await db.run(
+        "urn:users:providers:link_provider:1",
+        {
+          "guid": relink["guid"],
+          "provider": provider,
+          "provider_identifier": provider_uid,
+        },
+      )
+      res2 = await db.run(
+        "urn:users:providers:get_by_provider_identifier:1",
+        {"provider": provider, "provider_identifier": provider_uid},
+      )
+      user = res2.rows[0] if res2.rows else None
+      if user and relink.get("element_soft_deleted_at"):
+        await db.run(
+          "urn:users:providers:undelete_account:1",
+          {"provider": provider, "provider_identifier": provider_uid},
+        )
+        user["element_soft_deleted_at"] = None
+
+  if not user:
     logging.debug("[auth_google_oauth_login_v1] user not found, creating new user")
     res = await db.run(
       "urn:users:providers:get_user_by_email:1",

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -45,6 +45,21 @@ def _users_select(provider_args: Dict[str, Any]):
     """
     return ("row_one", sql, (provider, identifier))
 
+@register("urn:users:providers:get_any_by_provider_identifier:1")
+def _users_select_any(provider_args: Dict[str, Any]):
+    provider = provider_args["provider"]
+    identifier = str(UUID(provider_args["provider_identifier"]))
+    sql = """
+      SELECT TOP 1
+        au.element_guid AS guid,
+        au.element_soft_deleted_at
+      FROM users_auth ua
+      JOIN auth_providers ap ON ap.recid = ua.providers_recid
+      JOIN account_users au ON au.element_guid = ua.users_guid
+      WHERE ap.element_name = ? AND ua.element_identifier = ?;
+    """
+    return ("row_one", sql, (provider, identifier))
+
 @register("urn:users:providers:create_from_provider:1")
 async def _users_insert(args: Dict[str, Any]):
     # mirrors your insert_user() logic, including provider recid lookup + 3 inserts

--- a/tests/test_auth_google_relink_unlinked.py
+++ b/tests/test_auth_google_relink_unlinked.py
@@ -1,0 +1,146 @@
+import sys, types, importlib.util, asyncio
+from types import SimpleNamespace
+from datetime import datetime, timezone, timedelta
+
+from server.modules.providers.auth.google_provider import GoogleAuthProvider
+
+class DummyAuth:
+  def __init__(self):
+    provider = GoogleAuthProvider(api_id="gid", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
+    async def fake_fetch_jwks():
+      provider._jwks = {"keys": []}
+      provider._jwks_fetched_at = datetime.now(timezone.utc)
+    provider.fetch_jwks = fake_fetch_jwks
+    asyncio.run(provider.startup())
+    self.providers = {"google": provider}
+
+  async def handle_auth_login(self, provider, id_token, access_token):
+    profile = {"email": "user@example.com", "username": "User"}
+    return "google-id", profile, {}
+  def make_rotation_token(self, user_guid):
+    return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
+  async def get_user_roles(self, guid, refresh=False):
+    return [], 0
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+class DummyDb:
+  def __init__(self):
+    self.calls = []
+    self._get_by_count = 0
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    if op == "urn:users:providers:get_by_provider_identifier:1":
+      self._get_by_count += 1
+      if self._get_by_count == 1:
+        return DBRes([], 0)
+      return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
+    if op == "urn:users:providers:get_any_by_provider_identifier:1":
+      return DBRes([{"guid": "user-guid", "element_soft_deleted_at": "2024-01-01T00:00:00Z"}], 1)
+    if op in ("urn:users:providers:link_provider:1", "urn:users:providers:undelete_account:1", "db:users:session:set_rotkey:1"):
+      return DBRes([], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
+      return DBRes([], 1)
+    if op == "urn:system:config:get_config:1":
+      return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
+    return DBRes()
+
+class DummyEnv:
+  async def on_ready(self):
+    return None
+  def get(self, k):
+    assert k == "GOOGLE_AUTH_SECRET"
+    return "gsecret"
+
+class DummyState:
+  def __init__(self):
+    self.auth = DummyAuth()
+    self.db = DummyDb()
+    self.env = DummyEnv()
+
+class DummyApp:
+  def __init__(self):
+    self.state = DummyState()
+
+class DummyRequest:
+  def __init__(self):
+    self.app = DummyApp()
+    self.headers = {"user-agent": "tester"}
+    self.client = SimpleNamespace(host="127.0.0.1")
+
+def test_relinks_unlinked_account(monkeypatch):
+  spec = importlib.util.spec_from_file_location("server.models", "server/models.py")
+  models = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(models)
+  sys.modules["server.models"] = models
+  RPCRequest = models.RPCRequest
+
+  helpers = types.ModuleType("rpc.helpers")
+  async def fake_unbox_request(_):
+    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code"}, version=1)
+    return rpc, None, None
+  helpers.unbox_request = fake_unbox_request
+  sys.modules["rpc.helpers"] = helpers
+
+  sys.modules.setdefault("rpc", types.ModuleType("rpc"))
+  sys.modules.setdefault("rpc.auth", types.ModuleType("rpc.auth"))
+  rpc_auth_google = types.ModuleType("rpc.auth.google")
+  rpc_auth_google.__path__ = []
+  sys.modules.setdefault("rpc.auth.google", rpc_auth_google)
+  from pydantic import BaseModel
+  models_mod = types.ModuleType("rpc.auth.google.models")
+  class AuthGoogleOauthLoginPayload1(BaseModel):
+    provider: str = "google"
+    code: str
+    confirm: bool | None = None
+    reauthToken: str | None = None
+    fingerprint: str | None = None
+  class AuthGoogleOauthLogin1(BaseModel):
+    sessionToken: str
+    display_name: str
+    credits: int
+    profile_image: str | None = None
+  models_mod.AuthGoogleOauthLoginPayload1 = AuthGoogleOauthLoginPayload1
+  models_mod.AuthGoogleOauthLogin1 = AuthGoogleOauthLogin1
+  sys.modules["rpc.auth.google.models"] = models_mod
+
+  sys.modules["server"] = types.ModuleType("server")
+  sys.modules["server.modules"] = types.ModuleType("server.modules")
+  auth_mod = types.ModuleType("server.modules.auth_module")
+  class AuthModule: ...
+  auth_mod.AuthModule = AuthModule
+  sys.modules["server.modules.auth_module"] = auth_mod
+  db_mod = types.ModuleType("server.modules.db_module")
+  class DbModule: ...
+  db_mod.DbModule = DbModule
+  sys.modules["server.modules.db_module"] = db_mod
+
+  svc_spec = importlib.util.spec_from_file_location("rpc.auth.google.services", "rpc/auth/google/services.py")
+  svc_mod = importlib.util.module_from_spec(svc_spec)
+  svc_spec.loader.exec_module(svc_mod)
+  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+    assert code == "auth-code"
+    assert redirect_uri == "http://localhost:8000/userpage"
+    return "id", "acc"
+  svc_mod.exchange_code_for_tokens = fake_exchange
+  auth_google_oauth_login_v1 = svc_mod.auth_google_oauth_login_v1
+
+  req = DummyRequest()
+  asyncio.run(auth_google_oauth_login_v1(req))
+  calls = req.app.state.db.calls
+  assert any(
+    op == "urn:users:providers:link_provider:1" and args["guid"] == "user-guid" and args["provider"] == "google"
+    for op, args in calls
+  )
+  assert any(op == "urn:users:providers:undelete_account:1" for op, _ in calls)
+  link_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:providers:link_provider:1")
+  create_idx = next(i for i,(op,_) in enumerate(calls) if op == "db:auth:session:create_session:1")
+  assert link_idx < create_idx
+  asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_microsoft_relink_unlinked.py
+++ b/tests/test_auth_microsoft_relink_unlinked.py
@@ -1,0 +1,109 @@
+import sys, types, importlib.util, asyncio
+from types import SimpleNamespace
+from datetime import datetime, timezone, timedelta
+
+class DummyAuth:
+  async def handle_auth_login(self, provider, id_token, access_token):
+    profile = {"email": "user@example.com", "username": "User"}
+    return "00000000-0000-0000-0000-000000000001", profile, {}
+  def make_rotation_token(self, user_guid):
+    return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
+  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
+    return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
+  async def get_user_roles(self, guid, refresh=False):
+    return [], 0
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+class DummyDb:
+  def __init__(self):
+    self.calls = []
+    self._get_by_count = 0
+  async def run(self, op, args):
+    self.calls.append((op, args))
+    if op == "urn:users:providers:get_by_provider_identifier:1":
+      self._get_by_count += 1
+      if self._get_by_count == 1:
+        return DBRes([], 0)
+      return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
+    if op == "urn:users:providers:get_any_by_provider_identifier:1":
+      return DBRes([{"guid": "user-guid", "element_soft_deleted_at": "2024-01-01T00:00:00Z"}], 1)
+    if op == "urn:users:providers:link_provider:1" or op == "urn:users:providers:undelete_account:1" or op == "db:users:session:set_rotkey:1":
+      return DBRes([], 1)
+    if op == "db:auth:session:create_session:1":
+      return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
+    if op == "db:auth:session:update_device_token:1":
+      return DBRes([], 1)
+    return DBRes()
+
+class DummyState:
+  def __init__(self):
+    self.auth = DummyAuth()
+    self.db = DummyDb()
+
+class DummyApp:
+  def __init__(self):
+    self.state = DummyState()
+
+class DummyRequest:
+  def __init__(self):
+    self.app = DummyApp()
+    self.headers = {"user-agent": "tester"}
+    self.client = SimpleNamespace(host="127.0.0.1")
+
+def test_relinks_unlinked_account(monkeypatch):
+  spec = importlib.util.spec_from_file_location("server.models", "server/models.py")
+  models = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(models)
+  sys.modules["server.models"] = models
+  RPCRequest = models.RPCRequest
+
+  helpers = types.ModuleType("rpc.helpers")
+  async def fake_unbox_request(_):
+    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
+    return rpc, None, None
+  helpers.unbox_request = fake_unbox_request
+  sys.modules["rpc.helpers"] = helpers
+
+  sys.modules.setdefault("rpc", types.ModuleType("rpc"))
+  sys.modules.setdefault("rpc.auth", types.ModuleType("rpc.auth"))
+  rpc_auth_ms = types.ModuleType("rpc.auth.microsoft")
+  rpc_auth_ms.__path__ = []
+  sys.modules.setdefault("rpc.auth.microsoft", rpc_auth_ms)
+  from pydantic import BaseModel
+  models_mod = types.ModuleType("rpc.auth.microsoft.models")
+  class AuthMicrosoftOauthLogin1(BaseModel):
+    sessionToken: str
+    display_name: str
+    credits: int
+    profile_image: str | None = None
+  models_mod.AuthMicrosoftOauthLogin1 = AuthMicrosoftOauthLogin1
+  sys.modules["rpc.auth.microsoft.models"] = models_mod
+
+  sys.modules["server"] = types.ModuleType("server")
+  sys.modules["server.modules"] = types.ModuleType("server.modules")
+  auth_mod = types.ModuleType("server.modules.auth_module")
+  class AuthModule: ...
+  auth_mod.AuthModule = AuthModule
+  sys.modules["server.modules.auth_module"] = auth_mod
+  db_mod = types.ModuleType("server.modules.db_module")
+  class DbModule: ...
+  db_mod.DbModule = DbModule
+  sys.modules["server.modules.db_module"] = db_mod
+
+  svc_spec = importlib.util.spec_from_file_location("rpc.auth.microsoft.services", "rpc/auth/microsoft/services.py")
+  svc_mod = importlib.util.module_from_spec(svc_spec)
+  svc_spec.loader.exec_module(svc_mod)
+  auth_microsoft_oauth_login_v1 = svc_mod.auth_microsoft_oauth_login_v1
+
+  req = DummyRequest()
+  asyncio.run(auth_microsoft_oauth_login_v1(req))
+  calls = req.app.state.db.calls
+  assert ("urn:users:providers:link_provider:1", {"guid": "user-guid", "provider": "microsoft", "provider_identifier": "00000000-0000-0000-0000-000000000001"}) in calls
+  assert any(op == "urn:users:providers:undelete_account:1" for op, _ in calls)
+  link_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:providers:link_provider:1")
+  create_idx = next(i for i,(op,_) in enumerate(calls) if op == "db:auth:session:create_session:1")
+  assert link_idx < create_idx


### PR DESCRIPTION
## Summary
- add DB query to find users by provider identifier regardless of link state
- relink and undelete accounts on Microsoft/Google login when identifiers already exist
- test relinking flows for both Microsoft and Google providers

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68b653ab57d08325868b844f5dba57f5