### PR TITLE
fix: set default provider on account reactivation

### DIFF
--- a/tests/test_auth_google_relink_unlinked.py
+++ b/tests/test_auth_google_relink_unlinked.py
@@ -44,6 +44,10 @@ class DummyDb:
       return DBRes([{"guid": "user-guid", "element_soft_deleted_at": "2024-01-01T00:00:00Z"}], 1)
     if op in ("urn:users:providers:link_provider:1", "urn:users:providers:undelete_account:1", "db:users:session:set_rotkey:1"):
       return DBRes([], 1)
+    if op == "urn:users:profile:get_profile:1":
+      return DBRes([{ "default_provider": 0 }], 1)
+    if op == "urn:users:providers:set_provider:1":
+      return DBRes([], 1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":
@@ -140,7 +144,9 @@ def test_relinks_unlinked_account(monkeypatch):
     for op, args in calls
   )
   assert any(op == "urn:users:providers:undelete_account:1" for op, _ in calls)
+  assert any(op == "urn:users:providers:set_provider:1" for op, _ in calls)
   link_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:providers:link_provider:1")
+  set_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:providers:set_provider:1")
   create_idx = next(i for i,(op,_) in enumerate(calls) if op == "db:auth:session:create_session:1")
-  assert link_idx < create_idx
+  assert link_idx < set_idx < create_idx
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_microsoft_relink_unlinked.py
+++ b/tests/test_auth_microsoft_relink_unlinked.py
@@ -33,6 +33,10 @@ class DummyDb:
       return DBRes([{"guid": "user-guid", "element_soft_deleted_at": "2024-01-01T00:00:00Z"}], 1)
     if op == "urn:users:providers:link_provider:1" or op == "urn:users:providers:undelete_account:1" or op == "db:users:session:set_rotkey:1":
       return DBRes([], 1)
+    if op == "urn:users:profile:get_profile:1":
+      return DBRes([{ "default_provider": 0 }], 1)
+    if op == "urn:users:providers:set_provider:1":
+      return DBRes([], 1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":
@@ -104,6 +108,8 @@ def test_relinks_unlinked_account(monkeypatch):
   calls = req.app.state.db.calls
   assert ("urn:users:providers:link_provider:1", {"guid": "user-guid", "provider": "microsoft", "provider_identifier": "00000000-0000-0000-0000-000000000001"}) in calls
   assert any(op == "urn:users:providers:undelete_account:1" for op, _ in calls)
+  assert any(op == "urn:users:providers:set_provider:1" for op, _ in calls)
   link_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:providers:link_provider:1")
+  set_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:providers:set_provider:1")
   create_idx = next(i for i,(op,_) in enumerate(calls) if op == "db:auth:session:create_session:1")
-  assert link_idx < create_idx
+  assert link_idx < set_idx < create_idx

--- a/tests/test_auth_microsoft_soft_undelete.py
+++ b/tests/test_auth_microsoft_soft_undelete.py
@@ -29,6 +29,10 @@ class DummyDb:
       ], 1)
     if op == "urn:users:providers:undelete_account:1" or op == "db:users:session:set_rotkey:1":
       return DBRes([], 1)
+    if op == "urn:users:profile:get_profile:1":
+      return DBRes([{ "default_provider": 0 }], 1)
+    if op == "urn:users:providers:set_provider:1":
+      return DBRes([], 1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":
@@ -99,6 +103,8 @@ def test_undeletes_soft_deleted_account(monkeypatch):
   asyncio.run(auth_microsoft_oauth_login_v1(req))
   calls = req.app.state.db.calls
   assert any(op == "urn:users:providers:undelete_account:1" for op, _ in calls)
+  assert any(op == "urn:users:providers:set_provider:1" for op, _ in calls)
   undelete_idx = next(i for i, (op, _) in enumerate(calls) if op == "urn:users:providers:undelete_account:1")
+  set_idx = next(i for i, (op, _) in enumerate(calls) if op == "urn:users:providers:set_provider:1")
   create_idx = next(i for i, (op, _) in enumerate(calls) if op == "db:auth:session:create_session:1")
-  assert undelete_idx < create_idx
+  assert undelete_idx < set_idx < create_idx


### PR DESCRIPTION
## Summary
- ensure microsoft and google reactivations set default provider when missing
- test that reactivated accounts persist provider choice

## Testing
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68b65b7da76c832581c44782b4f2351f