### PR TITLE
Fix provider relink and unlink handling

### DIFF
--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -342,11 +342,12 @@ async def auth_google_oauth_login_v1(request: Request):
     default_provider = None
     if res_prof.rows:
       default_provider = res_prof.rows[0].get("default_provider")
-    if default_provider in (None, 0):
+    if default_provider != provider:
       await db.run(
         "urn:users:providers:set_provider:1",
         {"guid": user_guid, "provider": provider},
       )
+      user["provider_name"] = provider
   if user.get("provider_name") == "google":
     res_prof = await db.run(
       "urn:users:profile:update_if_unedited:1",

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -321,11 +321,12 @@ async def auth_microsoft_oauth_login_v1(request: Request):
     default_provider = None
     if res_prof.rows:
       default_provider = res_prof.rows[0].get("default_provider")
-    if default_provider in (None, 0):
+    if default_provider != provider:
       await db.run(
         "urn:users:providers:set_provider:1",
         {"guid": user_guid, "provider": provider},
       )
+      user["provider_name"] = provider
   if user.get("provider_name") == "microsoft":
     res_prof = await db.run(
       "urn:users:profile:update_if_unedited:1",

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -177,7 +177,7 @@ async def _users_unlink_provider(args: Dict[str, Any]):
           (guid,)
         )
         await cur.execute(
-          "UPDATE account_users SET providers_recid = NULL WHERE element_guid = ?;",
+          "UPDATE account_users SET providers_recid = NULL, element_display = '', element_email = '' WHERE element_guid = ?;",
           (guid,)
         )
       elif current_recid == provider_recid:

--- a/tests/test_auth_google_relink_unlinked.py
+++ b/tests/test_auth_google_relink_unlinked.py
@@ -48,6 +48,8 @@ class DummyDb:
       return DBRes([{ "default_provider": 0 }], 1)
     if op == "urn:users:providers:set_provider:1":
       return DBRes([], 1)
+    if op == "urn:users:profile:update_if_unedited:1":
+      return DBRes(rows=[{"display_name": "User", "email": "user@example.com"}], rowcount=1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":
@@ -145,9 +147,11 @@ def test_relinks_unlinked_account(monkeypatch):
   )
   assert any(op == "urn:users:providers:undelete_account:1" for op, _ in calls)
   assert any(op == "urn:users:providers:set_provider:1" for op, _ in calls)
+  assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in calls)
   assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in calls)
   link_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:providers:link_provider:1")
   set_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:providers:set_provider:1")
+  update_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:profile:update_if_unedited:1")
   create_idx = next(i for i,(op,_) in enumerate(calls) if op == "db:auth:session:create_session:1")
-  assert link_idx < set_idx < create_idx
+  assert link_idx < set_idx < update_idx < create_idx
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_microsoft_relink_unlinked.py
+++ b/tests/test_auth_microsoft_relink_unlinked.py
@@ -37,6 +37,8 @@ class DummyDb:
       return DBRes([{ "default_provider": 0 }], 1)
     if op == "urn:users:providers:set_provider:1":
       return DBRes([], 1)
+    if op == "urn:users:profile:update_if_unedited:1":
+      return DBRes(rows=[{"display_name": "User", "email": "user@example.com"}], rowcount=1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":
@@ -109,8 +111,10 @@ def test_relinks_unlinked_account(monkeypatch):
   assert ("urn:users:providers:link_provider:1", {"guid": "user-guid", "provider": "microsoft", "provider_identifier": "00000000-0000-0000-0000-000000000001"}) in calls
   assert any(op == "urn:users:providers:undelete_account:1" for op, _ in calls)
   assert any(op == "urn:users:providers:set_provider:1" for op, _ in calls)
+  assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in calls)
   assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in calls)
   link_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:providers:link_provider:1")
   set_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:providers:set_provider:1")
+  update_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:profile:update_if_unedited:1")
   create_idx = next(i for i,(op,_) in enumerate(calls) if op == "db:auth:session:create_session:1")
-  assert link_idx < set_idx < create_idx
+  assert link_idx < set_idx < update_idx < create_idx

--- a/tests/test_unlink_last_provider_clears_profile.py
+++ b/tests/test_unlink_last_provider_clears_profile.py
@@ -1,0 +1,43 @@
+import asyncio
+from contextlib import asynccontextmanager
+
+from server.modules.providers.database.mssql_provider import registry
+
+class FakeCursor:
+  def __init__(self, fetches, log):
+    self._fetches = fetches
+    self.log = log
+  async def execute(self, sql, params):
+    self.log.append((sql.strip(), params))
+  async def fetchone(self):
+    return self._fetches.pop(0)
+
+@asynccontextmanager
+async def fake_transaction(fetches, log):
+  cur = FakeCursor(fetches, log)
+  yield cur
+
+def test_unlink_last_provider_clears_profile(monkeypatch):
+  log = []
+  fetches = [
+    (1,),  # current providers_recid
+    (1,),  # provider recid lookup
+    (0,),  # remaining linked providers
+  ]
+  monkeypatch.setattr(
+    registry,
+    "transaction",
+    lambda: fake_transaction(fetches, log),
+  )
+  res = asyncio.run(
+    registry._users_unlink_provider({
+      "guid": "00000000-0000-0000-0000-000000000001",
+      "provider": "google",
+    })
+  )
+  assert res["rows"][0]["providers_remaining"] == 0
+  assert any(
+    "element_display = ''" in sql and "element_email = ''" in sql
+    for sql, _ in log
+  )
+


### PR DESCRIPTION
## Summary
- Clear account profile fields when last auth provider is unlinked
- Refresh default provider and profile data when relinking a disconnected account
- Add regression tests for provider relink and unlink flows

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68b66ea672b8832594c63c1af9aa90c8