### PR TITLE
Handle duplicate provider identifiers

### DIFF
--- a/tests/test_user_creation_profile_img.py
+++ b/tests/test_user_creation_profile_img.py
@@ -21,6 +21,8 @@ def test_create_from_provider_inserts_profile_image(monkeypatch):
     q = query.strip().lower()
     if q.startswith("select recid from auth_providers"):
       return DBResult(rows=[{"recid": 1}], rowcount=1)
+    if q.startswith("select users_guid from users_auth"):
+      return DBResult(rows=[], rowcount=0)
     return DBResult(rows=[{"guid": "gid", "profile_image": args["provider_profile_image"]}], rowcount=1)
 
   async def fake_fetch_rows(query, params, one=False, stream=False):


### PR DESCRIPTION
## Summary
- avoid unique constraint errors when creating users by checking for existing provider identifiers and linking to existing account
- adapt tests for new duplicate identifier check

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6a74f9dcc8325953d503051a3f176