### PR TITLE
Assign default role on provider relink

### DIFF
--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -335,6 +335,10 @@ async def auth_google_oauth_login_v1(request: Request):
 
   user_guid = user["guid"]
   if reactivated:
+    await db.run(
+      "urn:users:profile:set_roles:1",
+      {"guid": user_guid, "roles": 1},
+    )
     res_prof = await db.run(
       "urn:users:profile:get_profile:1",
       {"guid": user_guid},

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -314,6 +314,10 @@ async def auth_microsoft_oauth_login_v1(request: Request):
 
   user_guid = user["guid"]
   if reactivated:
+    await db.run(
+      "urn:users:profile:set_roles:1",
+      {"guid": user_guid, "roles": 1},
+    )
     res_prof = await db.run(
       "urn:users:profile:get_profile:1",
       {"guid": user_guid},

--- a/tests/test_auth_google_relink_unlinked.py
+++ b/tests/test_auth_google_relink_unlinked.py
@@ -46,6 +46,8 @@ class DummyDb:
       return DBRes([], 1)
     if op == "urn:users:profile:get_profile:1":
       return DBRes([{ "default_provider": 0 }], 1)
+    if op == "urn:users:profile:set_roles:1":
+      return DBRes([], 1)
     if op == "urn:users:providers:set_provider:1":
       return DBRes([], 1)
     if op == "urn:users:profile:update_if_unedited:1":
@@ -146,6 +148,10 @@ def test_relinks_unlinked_account(monkeypatch):
     for op, args in calls
   )
   assert any(op == "urn:users:providers:undelete_account:1" for op, _ in calls)
+  assert any(
+    op == "urn:users:profile:set_roles:1" and args["guid"] == "user-guid" and args["roles"] == 1
+    for op, args in calls
+  )
   assert any(op == "urn:users:providers:set_provider:1" for op, _ in calls)
   assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in calls)
   assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in calls)

--- a/tests/test_auth_microsoft_relink_unlinked.py
+++ b/tests/test_auth_microsoft_relink_unlinked.py
@@ -35,6 +35,8 @@ class DummyDb:
       return DBRes([], 1)
     if op == "urn:users:profile:get_profile:1":
       return DBRes([{ "default_provider": 0 }], 1)
+    if op == "urn:users:profile:set_roles:1":
+      return DBRes([], 1)
     if op == "urn:users:providers:set_provider:1":
       return DBRes([], 1)
     if op == "urn:users:profile:update_if_unedited:1":
@@ -110,6 +112,10 @@ def test_relinks_unlinked_account(monkeypatch):
   calls = req.app.state.db.calls
   assert ("urn:users:providers:link_provider:1", {"guid": "user-guid", "provider": "microsoft", "provider_identifier": "00000000-0000-0000-0000-000000000001"}) in calls
   assert any(op == "urn:users:providers:undelete_account:1" for op, _ in calls)
+  assert any(
+    op == "urn:users:profile:set_roles:1" and args["guid"] == "user-guid" and args["roles"] == 1
+    for op, args in calls
+  )
   assert any(op == "urn:users:providers:set_provider:1" for op, _ in calls)
   assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in calls)
   assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in calls)


### PR DESCRIPTION
## Summary
- ensure relinked accounts regain the default registered role
- test relink flows for google and microsoft providers

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68b6b0c1e7a08325a5ce0bd36c62ee62