### PR TITLE
feat: add auth relink and provider unlink operations

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -61,12 +61,20 @@ Authentication and session management calls.
 | Operation                          | Description                                                                                                              |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `urn:auth:microsoft:oauth_login:1` | Validate Microsoft tokens, create a user record if necessary, and start a user session. Returns bearer and profile data. |
+| `urn:auth:microsoft:oauth_relink:1` | Reactivate or relink an existing Microsoft account and refresh user data. |
 
 ### `google`
 
 | Operation                       | Description                                                                  |
 | ------------------------------ | ---------------------------------------------------------------------------- |
 | `urn:auth:google:oauth_login:1` | Exchange a Google OAuth authorization code for tokens, validate them, create a user record if necessary, and start a user session. Returns bearer and profile data. |
+| `urn:auth:google:oauth_relink:1` | Reactivate or relink an existing Google account and refresh user data. |
+
+### `providers`
+
+| Operation                           | Description                                                       |
+| ----------------------------------- | ----------------------------------------------------------------- |
+| `urn:auth:unlink_last_provider:1`   | Unlink the final auth provider for a user and revoke all tokens. |
 
 ### `session`
 

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -192,7 +192,6 @@ async def auth_microsoft_oauth_login_v1(request: Request):
 
   auth: AuthModule = request.app.state.auth
   db: DbModule = request.app.state.db
-  reactivated = False
 
   provider_uid, profile, payload = await auth.handle_auth_login(
     provider, id_token, access_token
@@ -205,132 +204,52 @@ async def auth_microsoft_oauth_login_v1(request: Request):
   identifiers = extract_identifiers(provider_uid, payload)
   user = await lookup_user(db, provider, identifiers)
 
-  if not user:
+  if not user or user.get("element_soft_deleted_at"):
     res = await db.run(
-      "urn:users:providers:get_any_by_provider_identifier:1",
-      {"provider": provider, "provider_identifier": provider_uid},
+      f"urn:auth:{provider}:oauth_relink:1",
+      {
+        "provider_identifier": provider_uid,
+        "email": profile["email"],
+        "display_name": profile["username"],
+        "profile_image": profile.get("profilePicture"),
+        "confirm": req_payload.get("confirm"),
+        "reauth_token": req_payload.get("reauthToken") or req_payload.get("reAuthToken"),
+      },
     )
-    if res.rows:
-      relink = res.rows[0]
-      await db.run(
-        "urn:users:providers:link_provider:1",
-        {
-          "guid": relink["guid"],
-          "provider": provider,
-          "provider_identifier": provider_uid,
-        },
-      )
-      reactivated = True
-      res2 = await db.run(
-        "urn:users:providers:get_by_provider_identifier:1",
-        {"provider": provider, "provider_identifier": provider_uid},
-      )
-      user = res2.rows[0] if res2.rows else None
-      if user and relink.get("element_soft_deleted_at"):
-        await db.run(
-          "urn:users:providers:undelete_account:1",
-          {"provider": provider, "provider_identifier": provider_uid},
-        )
-        user["element_soft_deleted_at"] = None
-        reactivated = True
+    user = res.rows[0] if res.rows else None
 
   if not user:
     logging.debug("[auth_microsoft_oauth_login_v1] user not found, creating new user")
     res = await db.run(
-      "urn:users:providers:get_user_by_email:1",
-      {"email": profile["email"]},
+      "urn:users:providers:create_from_provider:1",
+      {
+        "provider": provider,
+        "provider_identifier": provider_uid,
+        "provider_email": profile["email"],
+        "provider_displayname": profile["username"],
+        "provider_profile_image": profile.get("profilePicture"),
+      },
     )
-    if res.rows:
-      logging.debug("[auth_microsoft_oauth_login_v1] email already registered")
-      existing_guid = res.rows[0]["guid"]
-      confirm = req_payload.get("confirm")
-      reauth_token = req_payload.get("reauthToken") or req_payload.get("reAuthToken")
-      if reauth_token:
-        decoded = auth.decode_rotation_token(reauth_token)
-        if decoded.get("guid") != existing_guid:
-          raise HTTPException(status_code=401, detail="Re-auth token mismatch")
-        confirm = True
-      if confirm:
-        await db.run(
-          "urn:users:providers:link_provider:1",
-          {
-            "guid": existing_guid,
-            "provider": provider,
-            "provider_identifier": provider_uid,
-          },
-        )
-        res = await db.run(
-          "urn:users:providers:get_by_provider_identifier:1",
-          {"provider": provider, "provider_identifier": provider_uid},
-        )
-        user = res.rows[0] if res.rows else None
-      else:
-        res_prof = await db.run(
-          "urn:users:profile:get_profile:1",
-          {"guid": existing_guid},
-        )
-        default_provider = None
-        if res_prof.rows:
-          default_provider = res_prof.rows[0].get("default_provider")
-        raise HTTPException(status_code=409, detail={"default_provider": default_provider})
-    else:
+    user = res.rows[0] if res.rows else None
+    if not user:
+      logging.debug("[auth_microsoft_oauth_login_v1] fetching user after creation")
       res = await db.run(
-        "urn:users:providers:create_from_provider:1",
-        {
-          "provider": provider,
-          "provider_identifier": provider_uid,
-          "provider_email": profile["email"],
-          "provider_displayname": profile["username"],
-          "provider_profile_image": profile.get("profilePicture"),
-        },
+        "urn:users:providers:get_by_provider_identifier:1",
+        {"provider": provider, "provider_identifier": provider_uid},
       )
       user = res.rows[0] if res.rows else None
-      if not user:
-        logging.debug("[auth_microsoft_oauth_login_v1] fetching user after creation")
-        res = await db.run(
-          "urn:users:providers:get_by_provider_identifier:1",
-          {"provider": provider, "provider_identifier": provider_uid},
-        )
-        user = res.rows[0] if res.rows else None
-  if not user:
-    logging.debug("[auth_microsoft_oauth_login_v1] failed to create user")
-    raise HTTPException(status_code=500, detail="Unable to create user")
+    if not user:
+      logging.debug("[auth_microsoft_oauth_login_v1] failed to create user")
+      raise HTTPException(status_code=500, detail="Unable to create user")
 
-  if user.get("element_soft_deleted_at"):
-    await db.run(
-      "urn:users:providers:undelete_account:1",
-      {"provider": provider, "provider_identifier": provider_uid},
-    )
-    user["element_soft_deleted_at"] = None
-    reactivated = True
-
+  user_guid = user["guid"]
   new_img = profile.get("profilePicture")
   if new_img != user.get("profile_image"):
     await db.run(
       "urn:users:profile:set_profile_image:1",
-      {"guid": user["guid"], "image_b64": new_img, "provider": provider},
+      {"guid": user_guid, "image_b64": new_img, "provider": provider},
     )
     user["profile_image"] = new_img
-
-  user_guid = user["guid"]
-  if reactivated:
-    await db.run(
-      "urn:users:profile:set_roles:1",
-      {"guid": user_guid, "roles": 1},
-    )
-    res_prof = await db.run(
-      "urn:users:profile:get_profile:1",
-      {"guid": user_guid},
-    )
-    default_provider = None
-    if res_prof.rows:
-      default_provider = res_prof.rows[0].get("default_provider")
-    if default_provider != provider:
-      await db.run(
-        "urn:users:providers:set_provider:1",
-        {"guid": user_guid, "provider": provider},
-      )
-      user["provider_name"] = provider
   if user.get("provider_name") == "microsoft":
     res_prof = await db.run(
       "urn:users:profile:update_if_unedited:1",

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -137,17 +137,8 @@ async def users_providers_unlink_provider_v1(request: Request):
   remaining = res.rows[0].get("providers_remaining") if res.rows else 0
   if remaining == 0:
     await db.run(
-      "urn:users:providers:soft_delete_account:1",
-      {"guid": auth_ctx.user_guid},
-    )
-    await db.run(
-      "db:auth:session:revoke_all_device_tokens:1",
-      {"guid": auth_ctx.user_guid},
-    )
-    now = datetime.now(timezone.utc)
-    await db.run(
-      "db:users:session:set_rotkey:1",
-      {"guid": auth_ctx.user_guid, "rotkey": "", "iat": now, "exp": now},
+      "urn:auth:unlink_last_provider:1",
+      {"guid": auth_ctx.user_guid, "provider": payload.provider},
     )
   elif payload.provider == default_provider:
     if not payload.new_default:

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -257,6 +257,31 @@ def _users_profile(args: Dict[str, Any]):
     """
     return ("row_one", sql, (guid,))
 
+@register("urn:auth:unlink_last_provider:1")
+def _auth_unlink_last_provider(args: Dict[str, Any]):
+    guid = str(UUID(args["guid"]))
+    provider = args["provider"]
+    sql = "EXEC auth_unlink_last_provider @guid=?, @provider=?;"
+    return ("exec", sql, (guid, provider))
+
+@register("urn:auth:microsoft:oauth_relink:1")
+def _auth_ms_oauth_relink(args: Dict[str, Any]):
+    identifier = str(UUID(args["provider_identifier"]))
+    email = args.get("email")
+    display = args.get("display_name")
+    img = args.get("profile_image", "")
+    sql = "EXEC auth_oauth_relink @provider='microsoft', @identifier=?, @email=?, @display=?, @image=?;"
+    return ("row_one", sql, (identifier, email, display, img))
+
+@register("urn:auth:google:oauth_relink:1")
+def _auth_google_oauth_relink(args: Dict[str, Any]):
+    identifier = str(UUID(args["provider_identifier"]))
+    email = args.get("email")
+    display = args.get("display_name")
+    img = args.get("profile_image", "")
+    sql = "EXEC auth_oauth_relink @provider='google', @identifier=?, @email=?, @display=?, @image=?;"
+    return ("row_one", sql, (identifier, email, display, img))
+
 
 @register("db:users:profile:get_profile:1")
 def _db_users_profile(args: Dict[str, Any]):

--- a/tests/test_auth_google_relink_unlinked.py
+++ b/tests/test_auth_google_relink_unlinked.py
@@ -41,17 +41,11 @@ class DummyDb:
         return DBRes([], 0)
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
     if op == "urn:users:providers:get_any_by_provider_identifier:1":
-      return DBRes([{"guid": "user-guid", "element_soft_deleted_at": "2024-01-01T00:00:00Z"}], 1)
-    if op in ("urn:users:providers:link_provider:1", "urn:users:providers:undelete_account:1", "db:users:session:set_rotkey:1"):
+      return DBRes([{"guid": "user-guid"}], 1)
+    if op == "urn:auth:google:oauth_relink:1":
+      return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
+    if op == "db:users:session:set_rotkey:1":
       return DBRes([], 1)
-    if op == "urn:users:profile:get_profile:1":
-      return DBRes([{ "default_provider": 0 }], 1)
-    if op == "urn:users:profile:set_roles:1":
-      return DBRes([], 1)
-    if op == "urn:users:providers:set_provider:1":
-      return DBRes([], 1)
-    if op == "urn:users:profile:update_if_unedited:1":
-      return DBRes(rows=[{"display_name": "User", "email": "user@example.com"}], rowcount=1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":
@@ -143,21 +137,6 @@ def test_relinks_unlinked_account(monkeypatch):
   req = DummyRequest()
   asyncio.run(auth_google_oauth_login_v1(req))
   calls = req.app.state.db.calls
-  assert any(
-    op == "urn:users:providers:link_provider:1" and args["guid"] == "user-guid" and args["provider"] == "google"
-    for op, args in calls
-  )
-  assert any(op == "urn:users:providers:undelete_account:1" for op, _ in calls)
-  assert any(
-    op == "urn:users:profile:set_roles:1" and args["guid"] == "user-guid" and args["roles"] == 1
-    for op, args in calls
-  )
-  assert any(op == "urn:users:providers:set_provider:1" for op, _ in calls)
-  assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in calls)
+  assert any(op == "urn:auth:google:oauth_relink:1" for op, _ in calls)
   assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in calls)
-  link_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:providers:link_provider:1")
-  set_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:providers:set_provider:1")
-  update_idx = next(i for i,(op,_) in enumerate(calls) if op == "urn:users:profile:update_if_unedited:1")
-  create_idx = next(i for i,(op,_) in enumerate(calls) if op == "db:auth:session:create_session:1")
-  assert link_idx < set_idx < update_idx < create_idx
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_microsoft_email_exists.py
+++ b/tests/test_auth_microsoft_email_exists.py
@@ -32,13 +32,13 @@ class DummyDb:
           {"guid": "existing-guid", "display_name": "User", "credits": 0, "profile_image": None}
         ], 1)
       return DBRes([], 0)
-    if op == "urn:users:providers:get_user_by_email:1":
-      return DBRes([{ "guid": "existing-guid" }], 1)
-    if op == "urn:users:profile:get_profile:1":
-      return DBRes([{ "default_provider": "google" }], 1)
-    if op == "urn:users:providers:link_provider:1":
-      self.linked = True
-      return DBRes(rowcount=1)
+    if op == "urn:auth:microsoft:oauth_relink:1":
+      if args.get("confirm"):
+        self.linked = True
+        return DBRes([
+          {"guid": "existing-guid", "display_name": "User", "credits": 0, "profile_image": None}
+        ], 1)
+      raise HTTPException(status_code=409, detail={"default_provider": "google"})
     if op == "db:users:session:set_rotkey:1":
       return DBRes(rowcount=1)
     if op == "db:auth:session:create_session:1":
@@ -114,6 +114,7 @@ def test_email_exists_prompt(monkeypatch):
     asyncio.run(auth_microsoft_oauth_login_v1(req))
   assert exc.value.status_code == 409
   assert exc.value.detail == {"default_provider": "google"}
+  assert any(op == "urn:auth:microsoft:oauth_relink:1" for op, _ in req.app.state.db.calls)
   assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)
 
 def test_email_exists_confirm_links(monkeypatch):
@@ -167,4 +168,4 @@ def test_email_exists_confirm_links(monkeypatch):
   res = asyncio.run(auth_microsoft_oauth_login_v1(req))
   data = json.loads(res.body)
   assert data["payload"]["display_name"] == "User"
-  assert any(op == "urn:users:providers:link_provider:1" for op, _ in req.app.state.db.calls)
+  assert any(op == "urn:auth:microsoft:oauth_relink:1" for op, _ in req.app.state.db.calls)


### PR DESCRIPTION
## Summary
- add oauth_relink RPC paths for Microsoft and Google providers
- support unlink_last_provider with single backend call
- document new auth operations and update tests
- handle default provider when unlinking in user profile UI

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `python scripts/run_tests.py`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6b90d997483259f38ac47c043702c