### PR TITLE
fix: add auth providers subdomain

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -74,7 +74,7 @@ Authentication and session management calls.
 
 | Operation                           | Description                                                       |
 | ----------------------------------- | ----------------------------------------------------------------- |
-| `urn:auth:unlink_last_provider:1`   | Unlink the final auth provider for a user and revoke all tokens. |
+| `urn:auth:providers:unlink_last_provider:1`   | Unlink the final auth provider for a user and revoke all tokens. |
 
 ### `session`
 

--- a/rpc/auth/__init__.py
+++ b/rpc/auth/__init__.py
@@ -1,11 +1,13 @@
 from .microsoft.handler import handle_microsoft_request
 from .session.handler import handle_session_request
 from .google.handler import handle_google_request
+from .providers.handler import handle_providers_request
 
 
 HANDLERS: dict[str, callable] = {
   "microsoft": handle_microsoft_request,
   "session": handle_session_request,
   "google": handle_google_request,
+  "providers": handle_providers_request,
 }
 

--- a/rpc/auth/providers/__init__.py
+++ b/rpc/auth/providers/__init__.py
@@ -1,0 +1,5 @@
+from .services import auth_providers_unlink_last_provider_v1
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("unlink_last_provider", "1"): auth_providers_unlink_last_provider_v1,
+}

--- a/rpc/auth/providers/handler.py
+++ b/rpc/auth/providers/handler.py
@@ -1,0 +1,16 @@
+import logging
+
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_providers_request(parts: list[str], request: Request) -> RPCResponse:
+  logging.debug("handle_providers_request parts=%s", parts)
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail="Unknown RPC operation")
+  return await handler(request)

--- a/rpc/auth/providers/models.py
+++ b/rpc/auth/providers/models.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class AuthProvidersUnlinkLastProvider1(BaseModel):
+  guid: str
+  provider: str

--- a/rpc/auth/providers/services.py
+++ b/rpc/auth/providers/services.py
@@ -1,0 +1,22 @@
+from fastapi import HTTPException, Request
+from pydantic import ValidationError
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.db_module import DbModule
+
+from .models import AuthProvidersUnlinkLastProvider1
+
+
+async def auth_providers_unlink_last_provider_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  try:
+    payload = AuthProvidersUnlinkLastProvider1(**(rpc_request.payload or {}))
+  except ValidationError as e:
+    raise HTTPException(status_code=400, detail=str(e))
+  db: DbModule = request.app.state.db
+  await db.run(
+    rpc_request.op,
+    {"guid": payload.guid, "provider": payload.provider},
+  )
+  return RPCResponse(op=rpc_request.op, payload={"ok": True}, version=rpc_request.version)

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -137,7 +137,7 @@ async def users_providers_unlink_provider_v1(request: Request):
   remaining = res.rows[0].get("providers_remaining") if res.rows else 0
   if remaining == 0:
     await db.run(
-      "urn:auth:unlink_last_provider:1",
+      "urn:auth:providers:unlink_last_provider:1",
       {"guid": auth_ctx.user_guid, "provider": payload.provider},
     )
   elif payload.provider == default_provider:

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -257,7 +257,7 @@ def _users_profile(args: Dict[str, Any]):
     """
     return ("row_one", sql, (guid,))
 
-@register("urn:auth:unlink_last_provider:1")
+@register("urn:auth:providers:unlink_last_provider:1")
 def _auth_unlink_last_provider(args: Dict[str, Any]):
     guid = str(UUID(args["guid"]))
     provider = args["provider"]

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -308,13 +308,13 @@ def test_unlink_last_provider_soft_deletes_and_revokes():
         return DBRes(rows=[{"default_provider": "google"}])
       if op == "urn:users:providers:unlink_provider:1":
         return DBRes(rows=[{"providers_remaining": 0}], rowcount=1)
-      if op == "urn:auth:unlink_last_provider:1":
+      if op == "urn:auth:providers:unlink_last_provider:1":
         return DBRes([], 1)
       return DBRes()
 
   db = LocalDb()
   req = DummyRequest(DummyState(db))
   asyncio.run(users_providers_unlink_provider_v1(req))
-  assert ("urn:auth:unlink_last_provider:1", {"guid": "u1", "provider": "google"}) in db.calls
+  assert ("urn:auth:providers:unlink_last_provider:1", {"guid": "u1", "provider": "google"}) in db.calls
   assert not any(op == "db:auth:session:revoke_provider_tokens:1" for op, _ in db.calls)
 


### PR DESCRIPTION
## Summary
- add auth providers subdomain and handler
- correct unlink_last_provider URN to `urn:auth:providers:unlink_last_provider:1`

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68b7047b672c83259c71d0cfe75f8d0b