### PR TITLE
Refresh provider profile when default changes

### DIFF
--- a/rpc/users/providers/models.py
+++ b/rpc/users/providers/models.py
@@ -3,6 +3,9 @@ from pydantic import BaseModel
 
 class UsersProvidersSetProvider1(BaseModel):
   provider: str
+  code: str | None = None
+  id_token: str | None = None
+  access_token: str | None = None
 
 
 class UsersProvidersLinkProvider1(BaseModel):

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -31,6 +31,58 @@ async def users_providers_set_provider_v1(request: Request):
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
   db: DbModule = request.app.state.db
+  auth: AuthModule = request.app.state.auth
+  profile = None
+  if payload.code or (payload.id_token and payload.access_token):
+    if payload.provider == "google":
+      if payload.code:
+        google_provider = getattr(auth, "providers", {}).get("google")
+        if not google_provider or not google_provider.audience:
+          raise HTTPException(status_code=500, detail="Google OAuth client_id not configured")
+        client_id = google_provider.audience
+        env = request.app.state.env
+        client_secret = env.get("GOOGLE_AUTH_SECRET")
+        if not client_secret:
+          raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
+        res_redirect = await db.run("urn:system:config:get_config:1", {"key": "Hostname"})
+        if not res_redirect.rows:
+          raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
+        redirect_uri = res_redirect.rows[0]["value"]
+        id_token, access_token = await exchange_code_for_tokens(
+          payload.code,
+          client_id,
+          client_secret,
+          redirect_uri,
+        )
+      else:
+        id_token, access_token = payload.id_token, payload.access_token
+    elif payload.provider == "microsoft":
+      ms_provider = getattr(auth, "providers", {}).get("microsoft")
+      if not ms_provider or not ms_provider.audience:
+        raise HTTPException(status_code=500, detail="Microsoft OAuth client_id not configured")
+      if payload.code:
+        client_id = ms_provider.audience
+        env = request.app.state.env
+        client_secret = env.get("MICROSOFT_AUTH_SECRET")
+        if not client_secret:
+          raise HTTPException(status_code=500, detail="Microsoft OAuth client_secret not configured")
+        res_redirect = await db.run("urn:system:config:get_config:1", {"key": "Hostname"})
+        if not res_redirect.rows:
+          raise HTTPException(status_code=500, detail="Microsoft OAuth redirect URI not configured")
+        redirect_uri = res_redirect.rows[0]["value"]
+        id_token, access_token = await ms_exchange_code_for_tokens(
+          payload.code,
+          client_id,
+          client_secret,
+          redirect_uri,
+        )
+      else:
+        if not payload.id_token or not payload.access_token:
+          raise HTTPException(status_code=400, detail="id_token and access_token required")
+        id_token, access_token = payload.id_token, payload.access_token
+    else:
+      raise HTTPException(status_code=400, detail="Unsupported auth provider")
+    _, profile, _ = await auth.handle_auth_login(payload.provider, id_token, access_token)
   await db.run(
     rpc_request.op,
     {
@@ -38,6 +90,15 @@ async def users_providers_set_provider_v1(request: Request):
       "provider": payload.provider,
     },
   )
+  if profile:
+    await db.run(
+      "urn:users:profile:update_if_unedited:1",
+      {
+        "guid": auth_ctx.user_guid,
+        "email": profile.get("email"),
+        "display_name": profile.get("username"),
+      },
+    )
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),


### PR DESCRIPTION
## Summary
- refresh account details from identity provider when switching default provider
- simplify user profile page: immediate saves and re-auth on provider change

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b75858c39083258f30bda101d2a5cc