### PR TITLE
style(account-roles): compact list styling

### DIFF
--- a/frontend/src/pages/AccountRolesPage.tsx
+++ b/frontend/src/pages/AccountRolesPage.tsx
@@ -83,15 +83,30 @@ const AccountRolesPage = (): JSX.Element => {
                 {roles.map((role) => (
                     <Stack key={role} spacing={2} direction="column" alignItems="center">
                         <Typography variant="h6">{role}</Typography>
-                        <Stack direction="row" spacing={2}>
-                            <List sx={{ width: 200, border: 1 }}>
+                        <Stack direction="row" spacing={1}>
+                            <List
+                                sx={{
+                                    width: 200,
+                                    maxHeight: 120,
+                                    overflow: "auto",
+                                    border: 1,
+                                    p: 0.25,
+                                }}
+                            >
                                 {(nonMembers[role] || []).map((u) => (
                                     <ListItemButton
                                         key={u.guid}
                                         selected={selectedLeft[role] === u.guid}
                                         onClick={() => setSelectedLeft({ ...selectedLeft, [role]: u.guid })}
+                                        sx={{ py: 0.25, px: 0.5, minHeight: 0 }}
                                     >
-                                        <ListItemText primary={u.displayName} />
+                                        <ListItemText
+                                            primary={u.displayName}
+                                            primaryTypographyProps={{
+                                                fontFamily: "monospace",
+                                                variant: "body2",
+                                            }}
+                                        />
                                     </ListItemButton>
                                 ))}
                             </List>
@@ -103,14 +118,29 @@ const AccountRolesPage = (): JSX.Element => {
                                     <ArrowBackIos />
                                 </IconButton>
                             </Stack>
-                            <List sx={{ width: 200, border: 1 }}>
+                            <List
+                                sx={{
+                                    width: 200,
+                                    maxHeight: 120,
+                                    overflow: "auto",
+                                    border: 1,
+                                    p: 0.25,
+                                }}
+                            >
                                 {(members[role] || []).map((u) => (
                                     <ListItemButton
                                         key={u.guid}
                                         selected={selectedRight[role] === u.guid}
                                         onClick={() => setSelectedRight({ ...selectedRight, [role]: u.guid })}
+                                        sx={{ py: 0.25, px: 0.5, minHeight: 0 }}
                                     >
-                                        <ListItemText primary={u.displayName} />
+                                        <ListItemText
+                                            primary={u.displayName}
+                                            primaryTypographyProps={{
+                                                fontFamily: "monospace",
+                                                variant: "body2",
+                                            }}
+                                        />
                                     </ListItemButton>
                                 ))}
                             </List>


### PR DESCRIPTION
## Summary
- use compact monospace list styling for user role assignments

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68b761ea07288325bf4ac91b8bee4731