### PR TITLE
Refresh SPA on logout or provider unlink

### DIFF
--- a/frontend/src/shared/UserContextProvider.tsx
+++ b/frontend/src/shared/UserContextProvider.tsx
@@ -36,6 +36,9 @@ const setUserData = useCallback((data: AuthTokens) => {
                                 if (typeof localStorage !== 'undefined') {
                                                 localStorage.removeItem('authTokens');
                                 }
+                                if (typeof window !== 'undefined') {
+                                                window.location.replace('/');
+                                }
                 }, []);
 
                 const refreshed = useRef(false);


### PR DESCRIPTION
## Summary
- refresh user session context to redirect to home whenever authentication is cleared

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68b7adeffcf08325be1ac6aed6e29dc5