### PR TITLE
refactor: resolve role masks dynamically

### DIFF
--- a/rpc/account/handler.py
+++ b/rpc/account/handler.py
@@ -10,13 +10,12 @@ from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 from . import HANDLERS
 
-REQUIRED_ROLE_MASK = 0x1000000000000000  # ROLE_ACCOUNT_ADMIN
-
 
 async def handle_account_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+  required_mask = auth.roles.get("ROLE_ACCOUNT_ADMIN", 0)
+  if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail="Forbidden")
 
   subdomain = parts[0]

--- a/rpc/auth/handler.py
+++ b/rpc/auth/handler.py
@@ -10,8 +10,6 @@ from server.models import RPCResponse
 
 from . import HANDLERS
 
-REQUIRED_ROLE_MASK = 0
-
 
 async def handle_auth_request(parts: list[str], request: Request) -> RPCResponse:
   subdomain = parts[0]

--- a/rpc/discord/handler.py
+++ b/rpc/discord/handler.py
@@ -11,13 +11,12 @@ from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
-REQUIRED_ROLE_MASK = 0x0000000000000040  # ROLE_DISCORD_BOT
-
 
 async def handle_discord_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+  required_mask = auth.roles.get("ROLE_DISCORD_BOT", 0)
+  if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')
 
   subdomain = parts[0]

--- a/rpc/moderation/handler.py
+++ b/rpc/moderation/handler.py
@@ -12,13 +12,12 @@ from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
-REQUIRED_ROLE_MASK = 0x0800000000000000  # ROLE_MODERATOR
-
 
 async def handle_moderation_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+  required_mask = auth.roles.get("ROLE_MODERATOR", 0)
+  if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')
 
   subdomain = parts[0]

--- a/rpc/public/handler.py
+++ b/rpc/public/handler.py
@@ -10,8 +10,6 @@ from server.models import RPCResponse
 
 from . import HANDLERS
 
-REQUIRED_ROLE_MASK = 0
-
 
 async def handle_public_request(parts: list[str], request: Request) -> RPCResponse:
   subdomain = parts[0]

--- a/rpc/service/handler.py
+++ b/rpc/service/handler.py
@@ -12,13 +12,12 @@ from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
-REQUIRED_ROLE_MASK = 0x4000000000000000  # ROLE_SERVICE_ADMIN
-
 
 async def handle_service_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+  required_mask = auth.roles.get("ROLE_SERVICE_ADMIN", 0)
+  if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail="Forbidden")
 
   subdomain = parts[0]

--- a/rpc/storage/handler.py
+++ b/rpc/storage/handler.py
@@ -12,13 +12,12 @@ from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
-REQUIRED_ROLE_MASK = 0x0000000000000002  # ROLE_STORAGE
-
 
 async def handle_storage_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+  required_mask = auth.roles.get("ROLE_STORAGE", 0)
+  if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')
 
   subdomain = parts[0]

--- a/rpc/support/handler.py
+++ b/rpc/support/handler.py
@@ -12,13 +12,12 @@ from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
-REQUIRED_ROLE_MASK = 0x0400000000000000  # ROLE_SUPPORT
-
 
 async def handle_support_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+  required_mask = auth.roles.get("ROLE_SUPPORT", 0)
+  if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')
 
   subdomain = parts[0]

--- a/rpc/system/handler.py
+++ b/rpc/system/handler.py
@@ -12,13 +12,12 @@ from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
-REQUIRED_ROLE_MASK = 0x2000000000000000  # ROLE_SYSTEM_ADMIN
-
 
 async def handle_system_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+  required_mask = auth.roles.get("ROLE_SYSTEM_ADMIN", 0)
+  if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail="Forbidden")
 
   subdomain = parts[0]

--- a/rpc/users/handler.py
+++ b/rpc/users/handler.py
@@ -12,13 +12,12 @@ from server.modules.auth_module import AuthModule
 
 from . import HANDLERS
 
-REQUIRED_ROLE_MASK = 0x0000000000000001  # ROLE_REGISTERED
-
 
 async def handle_users_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  if not await auth.user_has_role(auth_ctx.user_guid, REQUIRED_ROLE_MASK):
+  required_mask = auth.roles.get("ROLE_REGISTERED", 0)
+  if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')
 
   subdomain = parts[0]

--- a/tests/test_discord_handler.py
+++ b/tests/test_discord_handler.py
@@ -47,6 +47,7 @@ async def dummy_handler(parts, request):
 class DummyAuth:
   def __init__(self, allowed: bool):
     self.allowed = allowed
+    self.roles = {"ROLE_DISCORD_BOT": 0x40}
 
   async def user_has_role(self, guid: str, mask: int) -> bool:
     return self.allowed

--- a/tests/test_service_roles_services.py
+++ b/tests/test_service_roles_services.py
@@ -88,7 +88,11 @@ class DummyDb:
 class DummyAuth:
   def __init__(self, db=None):
     self.loaded = False
-    self.roles = {"ROLE_ACCOUNT_ADMIN": 1, "ROLE_SYSTEM_ADMIN": 2}
+    self.roles = {
+      "ROLE_ACCOUNT_ADMIN": 1,
+      "ROLE_SYSTEM_ADMIN": 2,
+      "ROLE_SERVICE_ADMIN": 0x4000000000000000,
+    }
     self.user_roles: dict[str, int] = {}
     self.db = db
     self.upsert_args = None


### PR DESCRIPTION
## Summary
- fetch role masks from AuthModule for all RPC handlers instead of hard-coded constants
- adjust tests for Discord and service roles to reflect dynamic masks

## Testing
- `python scripts/generate_rpc_library.py`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b85017b6a08325910df21f41bac610