### PR TITLE
Refactor role management into shared module and update account admin bindings

### DIFF
--- a/frontend/src/pages/AccountUsersPage.tsx
+++ b/frontend/src/pages/AccountUsersPage.tsx
@@ -3,16 +3,16 @@ import { Box, Table, TableHead, TableRow, TableCell, TableBody, Button } from '@
 import ColumnHeader from '../components/ColumnHeader';
 import PageTitle from '../components/PageTitle';
 import { Link as RouterLink } from 'react-router-dom';
-import type { SupportRolesUserItem1, SupportRolesMembers1 } from '../shared/RpcModels';
-import { fetchMembers } from '../rpc/support/roles';
+import type { AccountRoleUserItem1, AccountRoleMembers1 } from '../shared/RpcModels';
+import { fetchRoleMembers } from '../rpc/account/role';
 
 const AccountUsersPage = (): JSX.Element => {
-        const [users, setUsers] = useState<SupportRolesUserItem1[]>([]);
+        const [users, setUsers] = useState<AccountRoleUserItem1[]>([]);
 
 	useEffect(() => {
 		void (async () => {
 			try {
-                                const res: SupportRolesMembers1 = await fetchMembers({ role: 'ROLE_REGISTERED' });
+                                const res: AccountRoleMembers1 = await fetchRoleMembers({ role: 'ROLE_REGISTERED' });
                                 setUsers(res.members);
 			} catch {
 				setUsers([]);

--- a/rpc/account/role/services.py
+++ b/rpc/account/role/services.py
@@ -2,8 +2,7 @@ from fastapi import HTTPException, Request
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.db_module import DbModule
-from server.modules.auth_module import AuthModule
+from server.modules.role_admin_module import RoleAdminModule
 from .models import (
   AccountRoleRoleItem1,
   AccountRoleList1,
@@ -17,17 +16,9 @@ from .models import (
 
 async def account_role_get_roles_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
-  db: DbModule = request.app.state.db
-  res = await db.run("db:system:roles:list:1", {})
-  roles = [
-    AccountRoleRoleItem1(
-      name=r.get("name", ""),
-      mask=str(r.get("mask", "")),
-      display=r.get("display"),
-    )
-    for r in res.rows
-    if r.get("name") != "ROLE_REGISTERED"
-  ]
+  role_admin: RoleAdminModule = request.app.state.role_admin
+  roles_raw = await role_admin.list_roles()
+  roles = [AccountRoleRoleItem1(**r) for r in roles_raw]
   payload = AccountRoleList1(roles=roles)
   return RPCResponse(
     op=rpc_request.op,
@@ -36,37 +27,20 @@ async def account_role_get_roles_v1(request: Request):
   )
 
 
-async def _fetch_role_members(db: DbModule, role: str) -> AccountRoleMembers1:
-  mem_res = await db.run("db:security:roles:get_role_members:1", {"role": role})
-  non_res = await db.run("db:security:roles:get_role_non_members:1", {"role": role})
-  members = [
-    AccountRoleUserItem1(
-      guid=r.get("guid", ""),
-      displayName=r.get("display_name", ""),
-    )
-    for r in mem_res.rows
-  ]
-  non_members = [
-    AccountRoleUserItem1(
-      guid=r.get("guid", ""),
-      displayName=r.get("display_name", ""),
-    )
-    for r in non_res.rows
-  ]
-  return AccountRoleMembers1(members=members, nonMembers=non_members)
-
-
 async def account_role_get_role_members_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   payload = rpc_request.payload or {}
   role = payload.get("role")
   if not role:
     raise HTTPException(status_code=400, detail="Missing role")
-  db: DbModule = request.app.state.db
-  members = await _fetch_role_members(db, role)
+  role_admin: RoleAdminModule = request.app.state.role_admin
+  members_raw, non_raw = await role_admin.get_role_members(role)
+  members = [AccountRoleUserItem1(**m) for m in members_raw]
+  non_members = [AccountRoleUserItem1(**m) for m in non_raw]
+  res = AccountRoleMembers1(members=members, nonMembers=non_members)
   return RPCResponse(
     op=rpc_request.op,
-    payload=members.model_dump(),
+    payload=res.model_dump(),
     version=rpc_request.version,
   )
 
@@ -74,15 +48,14 @@ async def account_role_get_role_members_v1(request: Request):
 async def account_role_add_role_member_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountRoleMemberUpdate1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  await db.run("db:security:roles:add_role_member:1", {
-    "role": data.role,
-    "user_guid": data.userGuid,
-  })
-  members = await _fetch_role_members(db, data.role)
+  role_admin: RoleAdminModule = request.app.state.role_admin
+  members_raw, non_raw = await role_admin.add_role_member(data.role, data.userGuid)
+  members = [AccountRoleUserItem1(**m) for m in members_raw]
+  non_members = [AccountRoleUserItem1(**m) for m in non_raw]
+  res = AccountRoleMembers1(members=members, nonMembers=non_members)
   return RPCResponse(
     op=rpc_request.op,
-    payload=members.model_dump(),
+    payload=res.model_dump(),
     version=rpc_request.version,
   )
 
@@ -90,15 +63,14 @@ async def account_role_add_role_member_v1(request: Request):
 async def account_role_remove_role_member_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountRoleMemberUpdate1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  await db.run("db:security:roles:remove_role_member:1", {
-    "role": data.role,
-    "user_guid": data.userGuid,
-  })
-  members = await _fetch_role_members(db, data.role)
+  role_admin: RoleAdminModule = request.app.state.role_admin
+  members_raw, non_raw = await role_admin.remove_role_member(data.role, data.userGuid)
+  members = [AccountRoleUserItem1(**m) for m in members_raw]
+  non_members = [AccountRoleUserItem1(**m) for m in non_raw]
+  res = AccountRoleMembers1(members=members, nonMembers=non_members)
   return RPCResponse(
     op=rpc_request.op,
-    payload=members.model_dump(),
+    payload=res.model_dump(),
     version=rpc_request.version,
   )
 
@@ -106,8 +78,8 @@ async def account_role_remove_role_member_v1(request: Request):
 async def account_role_upsert_role_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountRoleUpsertRole1(**(rpc_request.payload or {}))
-  auth: AuthModule = request.app.state.auth
-  await auth.upsert_role(data.name, int(data.mask), data.display)
+  role_admin: RoleAdminModule = request.app.state.role_admin
+  await role_admin.upsert_role(data.name, int(data.mask), data.display)
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),
@@ -118,8 +90,8 @@ async def account_role_upsert_role_v1(request: Request):
 async def account_role_delete_role_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountRoleDeleteRole1(**(rpc_request.payload or {}))
-  auth: AuthModule = request.app.state.auth
-  await auth.delete_role(data.name)
+  role_admin: RoleAdminModule = request.app.state.role_admin
+  await role_admin.delete_role(data.name)
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),

--- a/rpc/support/roles/services.py
+++ b/rpc/support/roles/services.py
@@ -2,32 +2,12 @@ from fastapi import HTTPException, Request
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.db_module import DbModule
+from server.modules.role_admin_module import RoleAdminModule
 from .models import (
   SupportRolesMembers1,
   SupportRolesRoleMemberUpdate1,
   SupportRolesUserItem1,
 )
-
-
-async def fetch_role_members(db: DbModule, role: str) -> SupportRolesMembers1:
-  mem_res = await db.run("db:security:roles:get_role_members:1", {"role": role})
-  non_res = await db.run("db:security:roles:get_role_non_members:1", {"role": role})
-  members = [
-    SupportRolesUserItem1(
-      guid=r.get("guid", ""),
-      displayName=r.get("display_name", ""),
-    )
-    for r in mem_res.rows
-  ]
-  non_members = [
-    SupportRolesUserItem1(
-      guid=r.get("guid", ""),
-      displayName=r.get("display_name", ""),
-    )
-    for r in non_res.rows
-  ]
-  return SupportRolesMembers1(members=members, nonMembers=non_members)
 
 
 async def support_roles_get_members_v1(request: Request):
@@ -36,51 +16,43 @@ async def support_roles_get_members_v1(request: Request):
   role = payload.get("role")
   if not role:
     raise HTTPException(status_code=400, detail="Missing role")
-  db: DbModule = request.app.state.db
-  members = await fetch_role_members(db, role)
+  role_admin: RoleAdminModule = request.app.state.role_admin
+  members_raw, non_raw = await role_admin.get_role_members(role)
+  members = [SupportRolesUserItem1(**m) for m in members_raw]
+  non_members = [SupportRolesUserItem1(**m) for m in non_raw]
+  res = SupportRolesMembers1(members=members, nonMembers=non_members)
   return RPCResponse(
     op=rpc_request.op,
-    payload=members.model_dump(),
+    payload=res.model_dump(),
     version=rpc_request.version,
   )
-
-
-async def add_role_member(db: DbModule, role: str, user_guid: str) -> SupportRolesMembers1:
-  await db.run(
-    "db:security:roles:add_role_member:1",
-    {"role": role, "user_guid": user_guid},
-  )
-  return await fetch_role_members(db, role)
 
 
 async def support_roles_add_member_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = SupportRolesRoleMemberUpdate1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  members = await add_role_member(db, data.role, data.userGuid)
+  role_admin: RoleAdminModule = request.app.state.role_admin
+  members_raw, non_raw = await role_admin.add_role_member(data.role, data.userGuid)
+  members = [SupportRolesUserItem1(**m) for m in members_raw]
+  non_members = [SupportRolesUserItem1(**m) for m in non_raw]
+  res = SupportRolesMembers1(members=members, nonMembers=non_members)
   return RPCResponse(
     op=rpc_request.op,
-    payload=members.model_dump(),
+    payload=res.model_dump(),
     version=rpc_request.version,
   )
-
-
-async def remove_role_member(db: DbModule, role: str, user_guid: str) -> SupportRolesMembers1:
-  await db.run(
-    "db:security:roles:remove_role_member:1",
-    {"role": role, "user_guid": user_guid},
-  )
-  return await fetch_role_members(db, role)
 
 
 async def support_roles_remove_member_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = SupportRolesRoleMemberUpdate1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  members = await remove_role_member(db, data.role, data.userGuid)
+  role_admin: RoleAdminModule = request.app.state.role_admin
+  members_raw, non_raw = await role_admin.remove_role_member(data.role, data.userGuid)
+  members = [SupportRolesUserItem1(**m) for m in members_raw]
+  non_members = [SupportRolesUserItem1(**m) for m in non_raw]
+  res = SupportRolesMembers1(members=members, nonMembers=non_members)
   return RPCResponse(
     op=rpc_request.op,
-    payload=members.model_dump(),
+    payload=res.model_dump(),
     version=rpc_request.version,
   )
-

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -1,0 +1,64 @@
+from fastapi import FastAPI
+from server.modules import BaseModule
+from server.modules.db_module import DbModule
+from server.modules.auth_module import AuthModule
+
+
+class RoleAdminModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+
+  async def startup(self):
+    self.db: DbModule = self.app.state.db
+    await self.db.on_ready()
+    self.auth: AuthModule = self.app.state.auth
+    await self.auth.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    pass
+
+  async def list_roles(self) -> list[dict]:
+    res = await self.db.run("db:system:roles:list:1", {})
+    return [
+      {
+        "name": r.get("name", ""),
+        "mask": str(r.get("mask", "")),
+        "display": r.get("display"),
+      }
+      for r in res.rows
+      if r.get("name") != "ROLE_REGISTERED"
+    ]
+
+  async def get_role_members(self, role: str) -> tuple[list[dict], list[dict]]:
+    mem_res = await self.db.run("db:security:roles:get_role_members:1", {"role": role})
+    non_res = await self.db.run("db:security:roles:get_role_non_members:1", {"role": role})
+    members = [
+      {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
+      for r in mem_res.rows
+    ]
+    non_members = [
+      {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
+      for r in non_res.rows
+    ]
+    return members, non_members
+
+  async def add_role_member(self, role: str, user_guid: str) -> tuple[list[dict], list[dict]]:
+    await self.db.run(
+      "db:security:roles:add_role_member:1",
+      {"role": role, "user_guid": user_guid},
+    )
+    return await self.get_role_members(role)
+
+  async def remove_role_member(self, role: str, user_guid: str) -> tuple[list[dict], list[dict]]:
+    await self.db.run(
+      "db:security:roles:remove_role_member:1",
+      {"role": role, "user_guid": user_guid},
+    )
+    return await self.get_role_members(role)
+
+  async def upsert_role(self, name: str, mask: int, display: str | None) -> None:
+    await self.auth.upsert_role(name, mask, display)
+
+  async def delete_role(self, name: str) -> None:
+    await self.auth.delete_role(name)

--- a/tests/test_service_roles_services.py
+++ b/tests/test_service_roles_services.py
@@ -129,10 +129,35 @@ class DummyAuth:
     return bool(self.user_roles.get(guid, 0) & mask)
 
 
+class DummyRoleAdmin:
+  def __init__(self, db, auth):
+    self.db = db
+    self.auth = auth
+
+  async def list_roles(self):
+    res = await self.db.run("db:system:roles:list:1", {})
+    return [
+      {
+        "name": r.get("name", ""),
+        "mask": str(r.get("mask", "")),
+        "display": r.get("display"),
+      }
+      for r in res.rows
+      if r.get("name") != "ROLE_REGISTERED"
+    ]
+
+  async def upsert_role(self, name, mask, display):
+    await self.auth.upsert_role(name, mask, display)
+
+  async def delete_role(self, name):
+    await self.auth.delete_role(name)
+
+
 class DummyState:
   def __init__(self, db, auth):
     self.db = db
     self.auth = auth
+    self.role_admin = DummyRoleAdmin(db, auth)
 
 
 class DummyApp:


### PR DESCRIPTION
## Summary
- centralize role business logic in new `RoleAdminModule`
- route account/service/system/support role RPCs through the shared module
- update account admin frontend to use account namespace RPC bindings

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68b85893b50483259f6bd603eb4e84a0