### PR TITLE
Limit account role assignment by bit mask

### DIFF
--- a/rpc/account/role/services.py
+++ b/rpc/account/role/services.py
@@ -1,8 +1,9 @@
 from fastapi import HTTPException, Request
 
-from rpc.helpers import unbox_request
+from rpc.helpers import unbox_request, mask_to_bit, bit_to_mask
 from server.models import RPCResponse
 from server.modules.role_admin_module import RoleAdminModule
+from server.modules.auth_module import AuthModule
 from .models import (
   AccountRoleRoleItem1,
   AccountRoleList1,
@@ -15,10 +16,17 @@ from .models import (
 
 
 async def account_role_get_roles_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
+  rpc_request, auth_ctx, _ = await unbox_request(request)
   role_admin: RoleAdminModule = request.app.state.role_admin
   roles_raw = await role_admin.list_roles()
-  roles = [AccountRoleRoleItem1(**r) for r in roles_raw]
+  max_bit = mask_to_bit(auth_ctx.role_mask)
+  max_mask = bit_to_mask(max_bit)
+  roles = [
+    AccountRoleRoleItem1(**r)
+    for r in roles_raw
+    if int(r.get("mask", "0")) <= max_mask
+  ]
+  roles.sort(key=lambda r: int(r.mask))
   payload = AccountRoleList1(roles=roles)
   return RPCResponse(
     op=rpc_request.op,
@@ -46,8 +54,13 @@ async def account_role_get_role_members_v1(request: Request):
 
 
 async def account_role_add_role_member_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
+  rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleMemberUpdate1(**(rpc_request.payload or {}))
+  auth: AuthModule = request.app.state.auth
+  role_mask = auth.roles.get(data.role, 0)
+  max_mask = bit_to_mask(mask_to_bit(auth_ctx.role_mask))
+  if role_mask > max_mask:
+    raise HTTPException(status_code=403, detail="Forbidden")
   role_admin: RoleAdminModule = request.app.state.role_admin
   members_raw, non_raw = await role_admin.add_role_member(data.role, data.userGuid)
   members = [AccountRoleUserItem1(**m) for m in members_raw]
@@ -61,8 +74,13 @@ async def account_role_add_role_member_v1(request: Request):
 
 
 async def account_role_remove_role_member_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
+  rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleMemberUpdate1(**(rpc_request.payload or {}))
+  auth: AuthModule = request.app.state.auth
+  role_mask = auth.roles.get(data.role, 0)
+  max_mask = bit_to_mask(mask_to_bit(auth_ctx.role_mask))
+  if role_mask > max_mask:
+    raise HTTPException(status_code=403, detail="Forbidden")
   role_admin: RoleAdminModule = request.app.state.role_admin
   members_raw, non_raw = await role_admin.remove_role_member(data.role, data.userGuid)
   members = [AccountRoleUserItem1(**m) for m in members_raw]
@@ -76,8 +94,11 @@ async def account_role_remove_role_member_v1(request: Request):
 
 
 async def account_role_upsert_role_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
+  rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleUpsertRole1(**(rpc_request.payload or {}))
+  max_mask = bit_to_mask(mask_to_bit(auth_ctx.role_mask))
+  if int(data.mask) > max_mask:
+    raise HTTPException(status_code=403, detail="Forbidden")
   role_admin: RoleAdminModule = request.app.state.role_admin
   await role_admin.upsert_role(data.name, int(data.mask), data.display)
   return RPCResponse(
@@ -88,8 +109,13 @@ async def account_role_upsert_role_v1(request: Request):
 
 
 async def account_role_delete_role_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
+  rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleDeleteRole1(**(rpc_request.payload or {}))
+  auth: AuthModule = request.app.state.auth
+  role_mask = auth.roles.get(data.name, 0)
+  max_mask = bit_to_mask(mask_to_bit(auth_ctx.role_mask))
+  if role_mask > max_mask:
+    raise HTTPException(status_code=403, detail="Forbidden")
   role_admin: RoleAdminModule = request.app.state.role_admin
   await role_admin.delete_role(data.name)
   return RPCResponse(


### PR DESCRIPTION
## Summary
- hide roles above the current user's bit and enforce bit bounds on role management RPCs
- sort account roles by bit mask and track role metadata for display
- cover account role bit filtering and permissions with unit tests
- apply bit-based filtering and sorting to the account user panel

## Testing
- `npm run lint --prefix frontend`
- `npm run type-check --prefix frontend`
- `npm test --prefix frontend`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8877f43e08325bce70c117514fa91