### PR TITLE
Refresh user role cache on membership updates

### DIFF
--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -48,6 +48,7 @@ class RoleAdminModule(BaseModule):
       "db:security:roles:add_role_member:1",
       {"role": role, "user_guid": user_guid},
     )
+    await self.auth.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 
   async def remove_role_member(self, role: str, user_guid: str) -> tuple[list[dict], list[dict]]:
@@ -55,6 +56,7 @@ class RoleAdminModule(BaseModule):
       "db:security:roles:remove_role_member:1",
       {"role": role, "user_guid": user_guid},
     )
+    await self.auth.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 
   async def upsert_role(self, name: str, mask: int, display: str | None) -> None:


### PR DESCRIPTION
## Summary
- ensure RoleAdminModule refreshes user roles after adding or removing a role membership

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68b8ecc3c99483259ad2777036d6dd6f