### PR TITLE
Fix system routes page role access

### DIFF
--- a/frontend/src/pages/system/SystemRoutesPage.tsx
+++ b/frontend/src/pages/system/SystemRoutesPage.tsx
@@ -19,14 +19,14 @@ import ColumnHeader from "../../components/ColumnHeader";
 import type {
         SystemRoutesRouteItem1,
         SystemRoutesList1,
-                ServiceRolesList1,
+                SystemRolesList1,
                                 } from "../../shared/RpcModels";
 import {
         fetchRoutes,
         fetchUpsertRoute,
         fetchDeleteRoute,
                                 } from "../../rpc/system/routes";
-import { fetchRoles } from "../../rpc/service/roles";
+import { fetchRoles } from "../../rpc/system/roles";
 
 const SystemRoutesPage = (): JSX.Element => {
 	const [routes, setRoutes] = useState<SystemRoutesRouteItem1[]>([]);
@@ -52,19 +52,19 @@ const SystemRoutesPage = (): JSX.Element => {
 								setRoutes([]);
 						}
 				}
-				try {
-                                        const roles: ServiceRolesList1 = await fetchRoles();
+                                try {
+                                        const roles: SystemRolesList1 = await fetchRoles();
                                                 setRoleNames(roles.roles.map((r) => r.name));
-						console.debug("[SystemRoutesPage] loaded roles");
-				} catch (e: any) {
-						console.debug("[SystemRoutesPage] failed to load roles", e);
-						if (e?.response?.status === 403) {
-								setForbidden(true);
-						} else {
-								setRoleNames([]);
-						}
-				}
-		};
+                                                console.debug("[SystemRoutesPage] loaded roles");
+                                } catch (e: any) {
+                                                console.debug("[SystemRoutesPage] failed to load roles", e);
+                                                if (e?.response?.status === 403) {
+                                                                setForbidden(true);
+                                                } else {
+                                                                setRoleNames([]);
+                                                }
+                                }
+                };
 
 		useEffect(() => {
 				void load();

--- a/tests/test_system_routes_services.py
+++ b/tests/test_system_routes_services.py
@@ -1,0 +1,175 @@
+import types, sys, pathlib
+from types import SimpleNamespace
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+# Stub rpc packages
+pkg = types.ModuleType('rpc')
+pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc')]
+sys.modules.setdefault('rpc', pkg)
+
+rpc_system_pkg = types.ModuleType('rpc.system')
+rpc_system_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc/system')]
+sys.modules.setdefault('rpc.system', rpc_system_pkg)
+
+rpc_system_routes_pkg = types.ModuleType('rpc.system.routes')
+rpc_system_routes_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc/system/routes')]
+sys.modules.setdefault('rpc.system.routes', rpc_system_routes_pkg)
+
+# Stub server modules
+server_pkg = types.ModuleType('server')
+modules_pkg = types.ModuleType('server.modules')
+db_module_pkg = types.ModuleType('server.modules.db_module')
+auth_module_pkg = types.ModuleType('server.modules.auth_module')
+models_pkg = types.ModuleType('server.models')
+
+
+class DbModule:
+  pass
+
+
+db_module_pkg.DbModule = DbModule
+modules_pkg.db_module = db_module_pkg
+
+
+class AuthModule:
+  def __init__(self):
+    self.roles = {'ROLE_SYSTEM_ADMIN': 1}
+
+  def mask_to_names(self, mask):
+    return [name for name, bit in self.roles.items() if mask & bit]
+
+  def names_to_mask(self, names):
+    mask = 0
+    for n in names:
+      mask |= self.roles.get(n, 0)
+    return mask
+
+
+auth_module_pkg.AuthModule = AuthModule
+modules_pkg.auth_module = auth_module_pkg
+
+
+class RPCResponse:
+  def __init__(self, **data):
+    self.__dict__.update(data)
+
+
+models_pkg.RPCResponse = RPCResponse
+server_pkg.modules = modules_pkg
+server_pkg.models = models_pkg
+
+sys.modules.setdefault('server', server_pkg)
+sys.modules.setdefault('server.modules', modules_pkg)
+sys.modules.setdefault('server.modules.db_module', db_module_pkg)
+sys.modules.setdefault('server.modules.auth_module', auth_module_pkg)
+sys.modules.setdefault('server.models', models_pkg)
+
+import importlib.util
+
+svc_spec = importlib.util.spec_from_file_location(
+  'rpc.system.routes.services',
+  pathlib.Path(__file__).resolve().parent.parent / 'rpc/system/routes/services.py',
+)
+svc = importlib.util.module_from_spec(svc_spec)
+sys.modules['rpc.system.routes.services'] = svc
+svc_spec.loader.exec_module(svc)
+
+system_routes_get_routes_v1 = svc.system_routes_get_routes_v1
+system_routes_upsert_route_v1 = svc.system_routes_upsert_route_v1
+system_routes_delete_route_v1 = svc.system_routes_delete_route_v1
+
+
+async def fake_unbox(request: Request):
+  body = await request.json()
+  op = body.get('op')
+  payload = body.get('payload')
+  rpc_req = SimpleNamespace(op=op, payload=payload, version=1)
+  auth_ctx = SimpleNamespace(user_guid='u1', roles=['ROLE_SYSTEM_ADMIN'])
+  return rpc_req, auth_ctx, None
+
+
+svc.unbox_request = fake_unbox
+
+
+class DummyDb:
+  def __init__(self):
+    self.calls = []
+
+  async def run(self, op: str, args: dict):
+    self.calls.append((op, args))
+    if op == 'urn:system:routes:get_routes:1':
+      rows = [{
+        'element_path': '/a',
+        'element_name': 'A',
+        'element_icon': 'home',
+        'element_sequence': 1,
+        'element_roles': 1,
+      }]
+      return SimpleNamespace(rows=rows, rowcount=1)
+    if op in ('urn:system:routes:upsert_route:1', 'urn:system:routes:delete_route:1'):
+      return SimpleNamespace(rows=[], rowcount=1)
+    raise AssertionError(f'unexpected op {op}')
+
+
+db = DummyDb()
+auth = AuthModule()
+
+app = FastAPI()
+app.state.db = db
+app.state.auth = auth
+
+
+@app.post('/rpc')
+async def rpc_endpoint(request: Request):
+  body = await request.json()
+  op = body['op']
+  if op == 'urn:system:routes:get_routes:1':
+    return await system_routes_get_routes_v1(request)
+  if op == 'urn:system:routes:upsert_route:1':
+    return await system_routes_upsert_route_v1(request)
+  if op == 'urn:system:routes:delete_route:1':
+    return await system_routes_delete_route_v1(request)
+  raise AssertionError('unexpected op')
+
+
+client = TestClient(app)
+
+
+def test_get_routes_service():
+  resp = client.post('/rpc', json={'op': 'urn:system:routes:get_routes:1'})
+  assert resp.status_code == 200
+  data = resp.json()
+  assert data['payload'] == {
+    'routes': [{
+      'path': '/a',
+      'name': 'A',
+      'icon': 'home',
+      'sequence': 1,
+      'required_roles': ['ROLE_SYSTEM_ADMIN'],
+    }]
+  }
+  assert ('urn:system:routes:get_routes:1', {}) in db.calls
+
+
+def test_upsert_and_delete_route_service():
+  upsert_payload = {
+    'path': '/a',
+    'name': 'A',
+    'icon': 'home',
+    'sequence': 1,
+    'required_roles': ['ROLE_SYSTEM_ADMIN'],
+  }
+  resp = client.post('/rpc', json={'op': 'urn:system:routes:upsert_route:1', 'payload': upsert_payload})
+  assert resp.status_code == 200
+  resp = client.post('/rpc', json={'op': 'urn:system:routes:delete_route:1', 'payload': {'path': '/a'}})
+  assert resp.status_code == 200
+  assert ('urn:system:routes:upsert_route:1', {
+    'path': '/a',
+    'name': 'A',
+    'icon': 'home',
+    'sequence': 1,
+    'roles': 1,
+  }) in db.calls
+  assert ('urn:system:routes:delete_route:1', {'path': '/a'}) in db.calls


### PR DESCRIPTION
## Summary
- use system role RPC calls on SystemRoutesPage so ROLE_SYSTEM_ADMIN can load roles
- cover system routes RPC operations with tests

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68b8f2d75d348325bb4f919bdf9b80ad