### PR TITLE
feat: add filter tabs to gallery

### DIFF
--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -1,12 +1,27 @@
-import type { JSX } from 'react';
+import { useState, type JSX } from 'react';
+import { Tabs, Tab, Typography } from '@mui/material';
 import PageTitle from '../components/PageTitle';
 
-// TODO: Implement gallery component
-export default function Gallery(): JSX.Element {
-	return (
-		<div>
-			<PageTitle>Gallery</PageTitle>
-			Gallery placeholder
-		</div>
-	);
-}
+const Gallery = (): JSX.Element => {
+        const [value, setValue] = useState(0);
+
+        return (
+                <div>
+                        <PageTitle>Gallery</PageTitle>
+                        <Tabs
+                                value={value}
+                                onChange={(_e, newValue) => setValue(newValue)}
+                                aria-label="gallery filters"
+                        >
+                                <Tab label="Image" />
+                                <Tab label="Video" />
+                                <Tab label="Audio" />
+                                <Tab label="Document" />
+                                <Tab label="Misc" />
+                        </Tabs>
+                        <Typography>Coming soon...</Typography>
+                </div>
+        );
+};
+
+export default Gallery;


### PR DESCRIPTION
## Summary
- add tab row for future media type filters on gallery page
- display "Coming soon..." placeholder under filters

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68b905a27a088325b7b610addf45fb3b