### PR TITLE
Prevent patch version bump from resetting build counter

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -7,6 +7,18 @@ def _unpack_version(ver: str) -> tuple[int, int, int, int]:
   major, minor, patch, build = [int(p) for p in ver.split('.')]
   return major, minor, patch, build
 
+def _next_build(current_version: str, last_version: str) -> int:
+  """Return the next build number for the given versions.
+
+  The build number is reset only when the major or minor version changes.
+  Patch version bumps continue the build count within the same minor version.
+  """
+  current_major, current_minor, _, current_build = _unpack_version(current_version)
+  last_major, last_minor, _, _ = _unpack_version(last_version)
+  if (current_major, current_minor) != (last_major, last_minor):
+    return 1
+  return current_build + 1
+
 def _parse_args() -> argparse.Namespace:
   parser = argparse.ArgumentParser()
   parser.add_argument(
@@ -48,13 +60,8 @@ async def update_build_version() -> None:
         if not last_version:
           last_version = current_version
 
-        current_major, current_minor, current_patch, current_build = _unpack_version(current_version)
-        last_major, last_minor, last_patch, _ = _unpack_version(last_version)
-
-        if (current_major, current_minor, current_patch) != (last_major, last_minor, last_patch):
-          build = 1
-        else:
-          build = current_build + 1
+        current_major, current_minor, current_patch, _ = _unpack_version(current_version)
+        build = _next_build(current_version, last_version)
 
         new_version = f"v{current_major}.{current_minor}.{current_patch}.{build}"
         print(f'Updating build version: {current_version} -> {new_version}')

--- a/tests/test_run_tests_build.py
+++ b/tests/test_run_tests_build.py
@@ -1,0 +1,10 @@
+from scripts.run_tests import _next_build
+
+def test_patch_version_does_not_reset_build():
+  assert _next_build('v0.5.2.20', 'v0.5.1.20') == 21
+
+def test_minor_version_resets_build():
+  assert _next_build('v0.6.0.5', 'v0.5.9.100') == 1
+
+def test_major_version_resets_build():
+  assert _next_build('v1.0.0.7', 'v0.9.9.3') == 1


### PR DESCRIPTION
## Summary
- add `_next_build` helper to compute next build number without resetting on patch-only updates
- adjust build version update script to use new logic
- add tests for build number behavior

## Testing
- `python scripts/run_tests.py --test` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'npm')*
- `apt-get update` *(fails: 403 Forbidden for all sources)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99de3e28483259d19c474b46ea575