### PR TITLE
Include views in MSSQL schema export

### DIFF
--- a/tests/test_msdblib_views.py
+++ b/tests/test_msdblib_views.py
@@ -1,0 +1,27 @@
+import asyncio
+from pathlib import Path
+import scripts.msdblib as mlib
+
+async def fake_get_schema(conn):
+  return {
+    'tables': [{
+      'name': 't1',
+      'columns': [{
+        'name': 'id', 'type': 'int', 'length': None,
+        'nullable': False, 'default': None
+      }],
+      'primary_key': [],
+      'foreign_keys': [],
+      'indexes': []
+    }],
+    'views': [{
+      'name': 'v_t1',
+      'definition': 'CREATE VIEW v_t1 AS SELECT id FROM t1'
+    }]
+  }
+
+def test_dump_schema_includes_views(tmp_path, monkeypatch):
+  monkeypatch.setattr(mlib, 'get_schema', fake_get_schema)
+  filename = asyncio.run(mlib.dump_schema(None, prefix=str(tmp_path / 'schema')))
+  text = Path(filename).read_text()
+  assert 'CREATE VIEW v_t1 AS SELECT id FROM t1;' in text


### PR DESCRIPTION
## Summary
- export MSSQL views with schema dump, ordering by dependencies
- write CREATE VIEW statements to schema file
- add regression test for view export

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a12de8a8832598c999aeba9fc254