### PR TITLE
Refactor scripting utilities into shared scriptlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Several helper scripts in the `scripts` directory manage the project database an
     - Requires `DATABASE_PROVIDER` and the `AZURE_SQL_CONNECTION_STRING` environment variable for MSSQL.
 - `generate_rpc_client.py` generates function accessors for the RPC namespace, parsing dispatcher mappings and payload models via the Python AST.
 - `generate_rpc_library.py` generates a data entity library for use in the front end.
-- `genlib.py` handles common RPC namespace generation functions.
+- `scriptlib.py` handles common RPC namespace generation functions and version helpers.
 - `msdblib.py` handles most of the mssql querying operations.
   Schema dumps now record NVARCHAR field lengths for accurate
   recreation across environments.

--- a/scripts/generate_rpc_client.py
+++ b/scripts/generate_rpc_client.py
@@ -7,7 +7,7 @@ This version uses the Python AST to read DISPATCHERS mappings and payload
 models rather than brittle regular expressions.
 """
 
-from genlib import REPO_ROOT, HEADER_COMMENT, camel_case
+from scriptlib import REPO_ROOT, HEADER_COMMENT, camel_case
 
 RPC_ROOT = os.path.join(REPO_ROOT, 'rpc')
 FRONTEND_RPC = os.path.join(REPO_ROOT, 'frontend', 'src', 'rpc')

--- a/scripts/generate_rpc_library.py
+++ b/scripts/generate_rpc_library.py
@@ -5,7 +5,7 @@ import sys
 import inspect
 from typing import List
 from pydantic import BaseModel
-from genlib import REPO_ROOT, HEADER_COMMENT, load_module, model_to_ts
+from scriptlib import REPO_ROOT, HEADER_COMMENT, load_module, model_to_ts
 
 # Ensure repo root is on sys.path so RPC modules can be imported with package names
 sys.path.insert(0, REPO_ROOT)

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,23 +1,7 @@
 from __future__ import annotations
 import subprocess, os, sys, importlib.util, asyncio, aioodbc, argparse
 from pathlib import Path
-
-def _unpack_version(ver: str) -> tuple[int, int, int, int]:
-  ver = ver.lstrip('v')
-  major, minor, patch, build = [int(p) for p in ver.split('.')]
-  return major, minor, patch, build
-
-def _next_build(current_version: str, last_version: str) -> int:
-  """Return the next build number for the given versions.
-
-  The build number is reset only when the major or minor version changes.
-  Patch version bumps continue the build count within the same minor version.
-  """
-  current_major, current_minor, _, current_build = _unpack_version(current_version)
-  last_major, last_minor, _, _ = _unpack_version(last_version)
-  if (current_major, current_minor) != (last_major, last_minor):
-    return 1
-  return current_build + 1
+from scriptlib import parse_version, next_build
 
 def _parse_args() -> argparse.Namespace:
   parser = argparse.ArgumentParser()
@@ -60,8 +44,8 @@ async def update_build_version() -> None:
         if not last_version:
           last_version = current_version
 
-        current_major, current_minor, current_patch, _ = _unpack_version(current_version)
-        build = _next_build(current_version, last_version)
+        current_major, current_minor, current_patch, _ = parse_version(current_version)
+        build = next_build(current_version, last_version)
 
         new_version = f"v{current_major}.{current_minor}.{current_patch}.{build}"
         print(f'Updating build version: {current_version} -> {new_version}')

--- a/tests/test_run_tests_build.py
+++ b/tests/test_run_tests_build.py
@@ -1,10 +1,10 @@
-from scripts.run_tests import _next_build
+from scriptlib import next_build
 
 def test_patch_version_does_not_reset_build():
-  assert _next_build('v0.5.2.20', 'v0.5.1.20') == 21
+  assert next_build('v0.5.2.20', 'v0.5.1.20') == 21
 
 def test_minor_version_resets_build():
-  assert _next_build('v0.6.0.5', 'v0.5.9.100') == 1
+  assert next_build('v0.6.0.5', 'v0.5.9.100') == 1
 
 def test_major_version_resets_build():
-  assert _next_build('v1.0.0.7', 'v0.9.9.3') == 1
+  assert next_build('v1.0.0.7', 'v0.9.9.3') == 1


### PR DESCRIPTION
## Summary
- add new `scriptlib` library with RPC generation and version helpers
- have `run_tests` and `mssql_cli` share version bump logic from `scriptlib`
- update RPC generation scripts, tests, and docs to reference `scriptlib`

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a39dcc0c8325bc796b1dbbd8798e