### PR TITLE
Restrict schema dump to dbo views and compact view statements

### DIFF
--- a/scripts/msdblib.py
+++ b/scripts/msdblib.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import os, json, aioodbc, dotenv
+import os, json, aioodbc, dotenv, re
 from datetime import datetime, timezone
 
 dotenv.load_dotenv()
@@ -26,6 +26,7 @@ async def list_views(conn):
       """SELECT v.name AS view_name, m.definition AS view_definition
            FROM sys.views v
            JOIN sys.sql_modules m ON v.object_id = m.object_id
+          WHERE SCHEMA_NAME(v.schema_id)='dbo'
            FOR JSON PATH"""
     )
     return await _fetch_json(cur)
@@ -36,8 +37,10 @@ async def list_view_dependencies(conn):
       """SELECT OBJECT_NAME(d.referencing_id) AS view_name,
                 OBJECT_NAME(d.referenced_id) AS ref_name
            FROM sys.sql_expression_dependencies d
-          WHERE d.referencing_id IN (SELECT object_id FROM sys.views)
-            AND d.referenced_id IN (SELECT object_id FROM sys.views)
+           JOIN sys.views v ON d.referencing_id = v.object_id
+           JOIN sys.views r ON d.referenced_id = r.object_id
+          WHERE SCHEMA_NAME(v.schema_id)='dbo'
+            AND SCHEMA_NAME(r.schema_id)='dbo'
            FOR JSON PATH"""
     )
     return await _fetch_json(cur)
@@ -240,10 +243,11 @@ async def dump_schema(conn, prefix: str = 'schema') -> str:
     for idx in table.get('indexes', []):
       lines.append(f"CREATE INDEX {idx['index_name']} ON {table['name']} ({idx['columns']});")
   for view in schema.get('views', []):
-    definition = view['definition'].strip()
+    raw_def = re.sub(r'--.*?(\r?\n|$)', ' ', view['definition'])
+    definition = ' '.join(raw_def.split())
     if not definition.lower().startswith('create'):
       definition = f"CREATE VIEW {view['name']} AS {definition}"
-    if not definition.rstrip().endswith(';'):
+    if not definition.endswith(';'):
       definition += ';'
     lines.append(definition)
   with open(filename, 'w') as f:


### PR DESCRIPTION
## Summary
- Dump only dbo views, excluding system views from schema scripts
- Write view definitions as single-line statements for consistency with table and index output
- Strip inline comments from view definitions to avoid invalid SQL when compacted

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/generate_rpc_client.py`
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68b9bdfef86083258eb47318442dd90a