### PR TITLE
Use session view and fingerprint

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -8,6 +8,7 @@ import UserContext from '../shared/UserContext';
 import Notification from '../components/Notification';
 import { fetchOauthLogin as fetchMicrosoftOauthLogin } from '../rpc/auth/microsoft';
 import { fetchOauthLogin as fetchGoogleOauthLogin } from '../rpc/auth/google';
+import { getFingerprint } from '../shared/fingerprint';
 import type { AuthMicrosoftOauthLogin1, AuthGoogleOauthLogin1 } from '../shared/RpcModels';
 
 declare global {
@@ -41,6 +42,7 @@ const data = await fetchMicrosoftOauthLogin({
 idToken,
 accessToken,
 provider: 'microsoft',
+fingerprint: getFingerprint(),
 }) as AuthMicrosoftOauthLogin1;
 setUserData({ provider: 'microsoft', ...data });
 setNotification({ open: true, severity: 'success', message: 'Login successful!' });
@@ -68,6 +70,7 @@ console.debug('[LoginPage] authorization code received', code);
 const data = await fetchGoogleOauthLogin({
 code,
 provider: 'google',
+fingerprint: getFingerprint(),
 }) as AuthGoogleOauthLogin1;
 setUserData({ provider: 'google', ...data });
 setNotification({ open: true, severity: 'success', message: 'Login successful!' });

--- a/frontend/src/shared/UserContextProvider.tsx
+++ b/frontend/src/shared/UserContextProvider.tsx
@@ -4,6 +4,7 @@ import UserContext, { AuthTokens } from './UserContext';
 import { msalConfig, loginRequest } from '../config/msal';
 import { fetchOauthLogin as fetchMicrosoftOauthLogin } from '../rpc/auth/microsoft';
 import type { AuthMicrosoftOauthLogin1 } from './RpcModels';
+import { getFingerprint } from './fingerprint';
 
 interface UserContextProviderProps {
 	children: ReactNode;
@@ -55,15 +56,16 @@ const setUserData = useCallback((data: AuthTokens) => {
                                                                 await msal.initialize();
                                                                 const account = msal.getActiveAccount() || msal.getAllAccounts()[0];
                                                                 if (!account) return;
-                                                                const result = await msal.acquireTokenSilent({
-                                                                                ...loginRequest,
-                                                                                account
-                                                                });
-                                                                const data = await fetchMicrosoftOauthLogin({
-                                                                                idToken: result.idToken,
-                                                                                accessToken: result.accessToken,
-                                                                                provider: 'microsoft'
-                                                                }) as AuthMicrosoftOauthLogin1;
+const result = await msal.acquireTokenSilent({
+...loginRequest,
+account
+});
+const data = await fetchMicrosoftOauthLogin({
+idToken: result.idToken,
+accessToken: result.accessToken,
+provider: 'microsoft',
+fingerprint: getFingerprint(),
+}) as AuthMicrosoftOauthLogin1;
                                                                 setUserData({ provider: 'microsoft', ...data });
                                                 } catch {
                                                                 /* silent token acquisition failed */

--- a/frontend/src/shared/fingerprint.ts
+++ b/frontend/src/shared/fingerprint.ts
@@ -1,0 +1,8 @@
+export const getFingerprint = (): string => {
+	let fp = localStorage.getItem('deviceFingerprint');
+	if (!fp) {
+		fp = crypto.randomUUID();
+		localStorage.setItem('deviceFingerprint', fp);
+	}
+	return fp;
+};

--- a/rpc/auth/google/models.py
+++ b/rpc/auth/google/models.py
@@ -8,7 +8,7 @@ class AuthGoogleOauthLoginPayload1(BaseModel):
   code: str
   confirm: bool | None = None
   reauthToken: str | None = None
-  fingerprint: str | None = None
+  fingerprint: str
 
 
 class AuthGoogleOauthLogin1(BaseModel):

--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -130,7 +130,7 @@ async def create_session(
   db: DbModule,
   user_guid: str,
   provider: str,
-  fingerprint: str | None,
+  fingerprint: str,
   user_agent: str | None,
   ip_address: str | None,
 ):

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -133,7 +133,7 @@ async def create_session(
   db: DbModule,
   user_guid: str,
   provider: str,
-  fingerprint: str | None,
+  fingerprint: str,
   user_agent: str | None,
   ip_address: str | None,
 ):
@@ -266,6 +266,8 @@ async def auth_microsoft_oauth_login_v1(request: Request):
       if updated.get("email"):
         user["email"] = updated["email"]
   fingerprint = req_payload.get("fingerprint")
+  if not fingerprint:
+    raise HTTPException(status_code=400, detail="Missing fingerprint")
   user_agent = request.headers.get("user-agent")
   ip_address = request.client.host if request.client else None
   session_token, session_exp, rotation_token, rot_exp = await create_session(

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -97,7 +97,7 @@ def test_email_exists_prompt(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(request):
-    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code"}, version=1)
+    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers
@@ -114,7 +114,7 @@ def test_email_exists_prompt(monkeypatch):
     code: str
     confirm: bool | None = None
     reauthToken: str | None = None
-    fingerprint: str | None = None
+    fingerprint: str
   class AuthGoogleOauthLogin1(BaseModel):
     sessionToken: str
     display_name: str
@@ -166,7 +166,7 @@ def test_email_exists_confirm_links(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(request):
-    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code", "confirm": True}, version=1)
+    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code", "confirm": True, "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers
@@ -183,7 +183,7 @@ def test_email_exists_confirm_links(monkeypatch):
     code: str
     confirm: bool | None = None
     reauthToken: str | None = None
-    fingerprint: str | None = None
+    fingerprint: str
   class AuthGoogleOauthLogin1(BaseModel):
     sessionToken: str
     display_name: str

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -88,7 +88,7 @@ def test_lookup_existing_user(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(request):
-    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code"}, version=1)
+    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers
@@ -105,7 +105,7 @@ def test_lookup_existing_user(monkeypatch):
     code: str
     confirm: bool | None = None
     reauthToken: str | None = None
-    fingerprint: str | None = None
+    fingerprint: str
   class AuthGoogleOauthLogin1(BaseModel):
     sessionToken: str
     display_name: str

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -94,7 +94,7 @@ def test_fetch_user_after_create(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(request):
-    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code"}, version=1)
+    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers
@@ -111,7 +111,7 @@ def test_fetch_user_after_create(monkeypatch):
     code: str
     confirm: bool | None = None
     reauthToken: str | None = None
-    fingerprint: str | None = None
+    fingerprint: str
   class AuthGoogleOauthLogin1(BaseModel):
     sessionToken: str
     display_name: str

--- a/tests/test_auth_google_profile_image_update.py
+++ b/tests/test_auth_google_profile_image_update.py
@@ -91,7 +91,7 @@ def test_updates_profile_image(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(_):
-    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code"}, version=1)
+    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers
@@ -108,7 +108,7 @@ def test_updates_profile_image(monkeypatch):
     code: str
     confirm: bool | None = None
     reauthToken: str | None = None
-    fingerprint: str | None = None
+    fingerprint: str
   class AuthGoogleOauthLogin1(BaseModel):
     sessionToken: str
     display_name: str

--- a/tests/test_auth_google_profile_refresh.py
+++ b/tests/test_auth_google_profile_refresh.py
@@ -76,7 +76,7 @@ def setup_module(mod):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(_):
-    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code"}, version=1)
+    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers
@@ -93,7 +93,7 @@ def setup_module(mod):
     code: str
     confirm: bool | None = None
     reauthToken: str | None = None
-    fingerprint: str | None = None
+    fingerprint: str
   class AuthGoogleOauthLogin1(BaseModel):
     sessionToken: str
     display_name: str

--- a/tests/test_auth_google_relink_unlinked.py
+++ b/tests/test_auth_google_relink_unlinked.py
@@ -86,7 +86,7 @@ def test_relinks_unlinked_account(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(_):
-    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code"}, version=1)
+    rpc = RPCRequest(op="urn:auth:google:oauth_login:1", payload={"code": "auth-code", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers
@@ -103,7 +103,7 @@ def test_relinks_unlinked_account(monkeypatch):
     code: str
     confirm: bool | None = None
     reauthToken: str | None = None
-    fingerprint: str | None = None
+    fingerprint: str
   class AuthGoogleOauthLogin1(BaseModel):
     sessionToken: str
     display_name: str

--- a/tests/test_auth_google_soft_undelete.py
+++ b/tests/test_auth_google_soft_undelete.py
@@ -107,7 +107,7 @@ def test_undeletes_soft_deleted_account(monkeypatch):
   async def fake_unbox_request(_):
     rpc = RPCRequest(
       op="urn:auth:google:oauth_login:1",
-      payload={"code": "auth-code"},
+      payload={"code": "auth-code", "fingerprint": "fp"},
       version=1,
     )
     return rpc, None, None
@@ -128,7 +128,7 @@ def test_undeletes_soft_deleted_account(monkeypatch):
     code: str
     confirm: bool | None = None
     reauthToken: str | None = None
-    fingerprint: str | None = None
+    fingerprint: str
 
   class AuthGoogleOauthLogin1(BaseModel):
     sessionToken: str

--- a/tests/test_auth_microsoft_email_exists.py
+++ b/tests/test_auth_microsoft_email_exists.py
@@ -71,7 +71,7 @@ def test_email_exists_prompt(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(request):
-    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
+    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers
@@ -126,7 +126,7 @@ def test_email_exists_confirm_links(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(request):
-    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc", "confirm": True}, version=1)
+    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc", "confirm": True, "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers

--- a/tests/test_auth_microsoft_home_account_lookup.py
+++ b/tests/test_auth_microsoft_home_account_lookup.py
@@ -60,7 +60,7 @@ def test_lookup_with_home_account_id(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(request):
-    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
+    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers

--- a/tests/test_auth_microsoft_oauth_login_creation.py
+++ b/tests/test_auth_microsoft_oauth_login_creation.py
@@ -64,7 +64,7 @@ def test_fetch_user_after_create(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(request):
-    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
+    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers

--- a/tests/test_auth_microsoft_profile_image_clear.py
+++ b/tests/test_auth_microsoft_profile_image_clear.py
@@ -57,7 +57,7 @@ def test_clears_profile_image(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(_):
-    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
+    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers

--- a/tests/test_auth_microsoft_profile_image_update.py
+++ b/tests/test_auth_microsoft_profile_image_update.py
@@ -57,7 +57,7 @@ def test_updates_profile_image(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(_):
-    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
+    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers

--- a/tests/test_auth_microsoft_profile_refresh.py
+++ b/tests/test_auth_microsoft_profile_refresh.py
@@ -71,7 +71,7 @@ def setup_module(mod):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(_):
-    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
+    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers

--- a/tests/test_auth_microsoft_relink_unlinked.py
+++ b/tests/test_auth_microsoft_relink_unlinked.py
@@ -65,7 +65,7 @@ def test_relinks_unlinked_account(monkeypatch):
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox_request(_):
-    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc"}, version=1)
+    rpc = RPCRequest(op="urn:auth:microsoft:oauth_login:1", payload={"idToken": "id", "accessToken": "acc", "fingerprint": "fp"}, version=1)
     return rpc, None, None
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers

--- a/tests/test_auth_session_db_profile.py
+++ b/tests/test_auth_session_db_profile.py
@@ -72,7 +72,7 @@ def test_auth_session_returns_db_profile(monkeypatch):
       self.headers = {"user-agent": "tester"}
       self.client = SimpleNamespace(host="127.0.0.1")
     async def json(self):
-      return {"provider": "google", "id_token": "id", "access_token": "acc"}
+      return {"provider": "google", "id_token": "id", "access_token": "acc", "fingerprint": "fp"}
 
   req = DummyRequest()
   resp = asyncio.run(auth_session_get_token_v1(req))

--- a/tests/test_auth_session_logout_device.py
+++ b/tests/test_auth_session_logout_device.py
@@ -57,6 +57,8 @@ class DummyRequest:
     self.client = SimpleNamespace(host="127.0.0.1")
     self.cookies = {"rotation_token": "rot-token"}
     self.op = ""
+  async def json(self):
+    return {"fingerprint": "fp"}
 
 
 def _setup(monkeypatch):

--- a/tests/test_auth_session_refresh_provider.py
+++ b/tests/test_auth_session_refresh_provider.py
@@ -45,6 +45,8 @@ class DummyRequest:
     self.headers = {}
     self.cookies = {"rotation_token": "rot-token"}
     self.client = SimpleNamespace(host="127.0.0.1")
+  async def json(self):
+    return {"fingerprint": "fp"}
 
 
 def _setup():

--- a/tests/test_google_services_helpers.py
+++ b/tests/test_google_services_helpers.py
@@ -116,7 +116,7 @@ def test_create_session_handles_missing_roles():
   db = DummyDb()
   auth = DummyAuth()
   token, exp, rot, rot_exp = asyncio.run(
-    create_session(auth, db, str(uuid.uuid4()), "google", None, None, None)
+    create_session(auth, db, str(uuid.uuid4()), "google", "fp", None, None)
   )
   assert token == "sess"
   assert rot == "rot"

--- a/tests/test_microsoft_services_helpers.py
+++ b/tests/test_microsoft_services_helpers.py
@@ -105,7 +105,7 @@ def test_create_session_handles_missing_roles():
   db = DummyDb()
   auth = DummyAuth()
   token, exp, rot, rot_exp = asyncio.run(
-    create_session(auth, db, str(uuid.uuid4()), "microsoft", None, None, None)
+    create_session(auth, db, str(uuid.uuid4()), "microsoft", "fp", None, None)
   )
   assert token == "sess"
   assert rot == "rot"

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -77,8 +77,8 @@ def test_mssql_get_by_access_token_uses_security_view():
   handler = get_mssql_handler("db:auth:session:get_by_access_token:1")
   _, sql, _ = handler({"access_token": "tok"})
   sql = sql.lower()
-  assert "vw_account_user_security" in sql
-  assert "providers_recid" in sql
+  assert "vw_user_session_security" in sql
+  assert "user_roles" in sql
 
 
 def test_mssql_support_users_set_credits_updates_table():

--- a/tests/test_users_session_upsert.py
+++ b/tests/test_users_session_upsert.py
@@ -58,7 +58,10 @@ def test_create_session_updates_existing(monkeypatch):
       if not fetch_calls:
         fetch_calls.append(1)
         return (1,)
-      return ("sess",)
+      if len(fetch_calls) == 1:
+        fetch_calls.append(1)
+        return ("sess",)
+      return ("dev",)
 
   @asynccontextmanager
   async def fake_tx():
@@ -69,7 +72,7 @@ def test_create_session_updates_existing(monkeypatch):
   args = {
     "access_token": "tok",
     "expires": datetime.now(timezone.utc),
-    "fingerprint": None,
+    "fingerprint": "fp",
     "user_agent": None,
     "ip_address": None,
     "user_guid": "user",
@@ -78,3 +81,5 @@ def test_create_session_updates_existing(monkeypatch):
   asyncio.run(handler(args))
   assert any("update users_sessions" in q for q in executed)
   assert not any("insert into users_sessions" in q for q in executed)
+  assert any("update sessions_devices" in q for q in executed)
+  assert not any("insert into sessions_devices" in q for q in executed)


### PR DESCRIPTION
## Summary
- ensure sessions upsert devices by fingerprint and read tokens from vw_user_session_security
- require fingerprint in auth flows and expose helper to generate client fingerprint
- update tests and RPC bindings for fingerprint-aware sessions

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba06e0d5708325bf11e43e925bea0e