### PR TITLE
feat: consolidate rpc generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN python3 -m venv $VIRTUAL_ENV \
 
 COPY . .
 
-RUN python3 scripts/generate_rpc_library.py && python3 scripts/generate_rpc_client.py
+RUN python3 scripts/generate_rpc_bindings.py
 
 WORKDIR /app/frontend
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ Several helper scripts in the `scripts` directory manage the project database an
 - `mssql_cli.py` provides similar features for Azure SQL using the `AZURE_SQL_CONNECTION_STRING` environment variable.
 - `run_tests.py` executes various test, generate, and update operations for build automation. It increments the build version directly in the Azure SQL database.
     - Requires `DATABASE_PROVIDER` and the `AZURE_SQL_CONNECTION_STRING` environment variable for MSSQL.
-- `generate_rpc_client.py` generates function accessors for the RPC namespace, parsing dispatcher mappings and payload models via the Python AST.
-- `generate_rpc_library.py` generates a data entity library for use in the front end.
+- `generate_rpc_bindings.py` generates RPC TypeScript models and client accessors.
 - `scriptlib.py` handles common RPC namespace generation functions and version helpers.
 - `msdblib.py` handles most of the mssql querying operations.
   Schema dumps now record NVARCHAR field lengths for accurate

--- a/dev.cmd
+++ b/dev.cmd
@@ -35,9 +35,7 @@ IF ERRORLEVEL 1 EXIT /b 1
 EXIT /b 0
 
 :GENERATE_LIBS
-  python scripts\generate_rpc_library.py
-  IF ERRORLEVEL 1 EXIT /b 1
-  python scripts\generate_rpc_client.py
+  python scripts\generate_rpc_bindings.py
   IF ERRORLEVEL 1 EXIT /b 1
   EXIT /b 0
 

--- a/scripts/generate_rpc_bindings.py
+++ b/scripts/generate_rpc_bindings.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""Run both RPC generation steps for library models and client functions."""
+
+from generate_rpc_library import main as gen_library
+from generate_rpc_client import main as gen_client
+
+
+def main() -> None:
+  gen_library()
+  gen_client()
+
+
+if __name__ == '__main__':
+  main()

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -96,8 +96,7 @@ def main() -> None:
   if not args.test:
     asyncio.run(update_build_version())
 
-  subprocess.check_call([sys.executable, 'scripts/generate_rpc_library.py'], cwd=ROOT)
-  subprocess.check_call([sys.executable, 'scripts/generate_rpc_client.py'], cwd=ROOT)
+  subprocess.check_call([sys.executable, 'scripts/generate_rpc_bindings.py'], cwd=ROOT)
   
   subprocess.check_call(['npm', 'run', 'lint'], cwd=ROOT / 'frontend')
   subprocess.check_call(['npm', 'run', 'type-check'], cwd=ROOT / 'frontend')

--- a/scripts/scriptlib.py
+++ b/scripts/scriptlib.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import os, importlib.util, types, json, aioodbc, dotenv, re
+import os, importlib.util, types, json, dotenv, re
 from typing import Any, Union, get_origin, get_args
 from pydantic import BaseModel
 from pathlib import Path
@@ -414,6 +414,10 @@ async def apply_schema(conn, path: str):
   print('Schema applied.')
 
 async def connect(dbname=None):
+  try:
+    import aioodbc  # type: ignore
+  except Exception as e:
+    raise ImportError('aioodbc is required for database operations') from e
   dsn = os.getenv('AZURE_SQL_CONNECTION_STRING')
   if not dsn:
     raise RuntimeError('AZURE_SQL_CONNECTION_STRING not set')


### PR DESCRIPTION
## Summary
- combine rpc generation scripts into unified `generate_rpc_bindings.py`
- avoid unconditional `aioodbc` import in scriptlib
- update tooling, docs and Dockerfile for new script

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68ba4e8470088325b1ecc008df94d596