### PR TITLE
feat: add public modules

### DIFF
--- a/rpc/public/links/services.py
+++ b/rpc/public/links/services.py
@@ -1,25 +1,9 @@
 from fastapi import Request
-import importlib.util
-import pathlib
-import sys
-
-# The admin service tests monkeypatch ``rpc.helpers`` with a stub module and do
-# not restore it afterwards.  Subsequent tests that import helper functions (the
-# public link and vars services as well as ``tests/test_rpc_helpers.py``) expect
-# the real implementation.  To ensure the helpers are available we reload the
-# helper module directly from the source file and replace the entry in
-# ``sys.modules``.  This makes the import resilient to earlier stubs while still
-# allowing tests to monkeypatch the function attribute as needed.
-_helpers_spec = importlib.util.spec_from_file_location(
-  "rpc.helpers", pathlib.Path(__file__).resolve().parents[2] / "helpers.py"
-)
-_helpers_mod = importlib.util.module_from_spec(_helpers_spec)
-_helpers_spec.loader.exec_module(_helpers_mod)
-sys.modules["rpc.helpers"] = _helpers_mod
-unbox_request = _helpers_mod.unbox_request
-
+from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.db_module import DbModule
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+  from server.modules.public_links_module import PublicLinksModule
 from .models import (
   PublicLinksHomeLinks1,
   PublicLinksLinkItem1,
@@ -30,9 +14,9 @@ from .models import (
 
 async def public_links_get_home_links_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
-  db: DbModule = request.app.state.db
-  res = await db.run(rpc_request.op, rpc_request.payload or {})
-  links = [PublicLinksLinkItem1(**row) for row in res.rows]
+  links_mod: PublicLinksModule = request.app.state.public_links
+  rows = await links_mod.get_home_links()
+  links = [PublicLinksLinkItem1(**row) for row in rows]
   payload = PublicLinksHomeLinks1(links=links)
   return RPCResponse(
     op=rpc_request.op,
@@ -42,9 +26,9 @@ async def public_links_get_home_links_v1(request: Request):
 
 async def public_links_get_navbar_routes_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
-  db: DbModule = request.app.state.db
-  res = await db.run("urn:public:links:get_navbar_routes:1", {"role_mask": auth_ctx.role_mask})
-  routes = [PublicLinksNavBarRoute1(**row) for row in res.rows]
+  links_mod: PublicLinksModule = request.app.state.public_links
+  rows = await links_mod.get_navbar_routes(auth_ctx.role_mask)
+  routes = [PublicLinksNavBarRoute1(**row) for row in rows]
   payload = PublicLinksNavBarRoutes1(routes=routes)
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/public_links_module.py
+++ b/server/modules/public_links_module.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from fastapi import FastAPI
+from . import BaseModule
+from .db_module import DbModule
+
+class PublicLinksModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    self.db = None
+
+  async def get_home_links(self):
+    res = await self.db.run("urn:public:links:get_home_links:1", {})
+    return res.rows
+
+  async def get_navbar_routes(self, role_mask: int):
+    res = await self.db.run("urn:public:links:get_navbar_routes:1", {"role_mask": role_mask})
+    return res.rows

--- a/server/modules/public_vars_module.py
+++ b/server/modules/public_vars_module.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+import asyncio, subprocess
+from fastapi import FastAPI
+from . import BaseModule
+from .db_module import DbModule
+
+class PublicVarsModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    self.db = None
+
+  async def _run_command(self, *cmd: str):
+    try:
+      process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+      )
+      return await process.communicate()
+    except NotImplementedError:
+      result = await asyncio.to_thread(subprocess.run, cmd, capture_output=True)
+      return result.stdout, result.stderr
+
+  async def get_version(self) -> str:
+    res = await self.db.run("urn:public:vars:get_version:1", {})
+    return res.rows[0].get("version") if res.rows else ""
+
+  async def get_hostname(self) -> str:
+    res = await self.db.run("urn:public:vars:get_hostname:1", {})
+    return res.rows[0].get("hostname") if res.rows else ""
+
+  async def get_repo(self) -> str:
+    res = await self.db.run("urn:public:vars:get_repo:1", {})
+    return res.rows[0].get("repo") if res.rows else ""
+
+  async def get_ffmpeg_version(self) -> str:
+    try:
+      stdout, stderr = await self._run_command("ffmpeg", "-version")
+      if stdout:
+        return stdout.decode().splitlines()[0]
+      return stderr.decode().splitlines()[0]
+    except FileNotFoundError:
+      return "ffmpeg library not found (Windows)"
+    except Exception as e:
+      raise RuntimeError(f"Error checking ffmpeg: {e}")
+
+  async def get_odbc_version(self) -> str:
+    system = __import__("platform").system()
+    try:
+      if system == "Windows":
+        stdout, stderr = await self._run_command(
+          "cmd",
+          "/c",
+          "reg query \"HKLM\\SOFTWARE\\ODBC\\ODBCINST.INI\\ODBC Driver 18 for SQL Server\" /v Version",
+        )
+        output = stdout.decode() or stderr.decode()
+        version_line = ""
+        for line in output.splitlines():
+          if line.strip().startswith("Version"):
+            parts = line.split()
+            version_line = f"ODBC Driver 18 for SQL Server {parts[-1]}"
+            break
+        if not version_line:
+          version_line = "odbc library not found (Windows)"
+      else:
+        packages = ["msodbcsql18", "unixodbc", "libodbc2"]
+        stdout, stderr = await self._run_command(
+          "dpkg-query",
+          "-W",
+          "-f",
+          "${Package} ${Version}\\n",
+          *packages,
+        )
+        if stdout:
+          version_line = stdout.decode().strip().replace("\n", "; ")
+        else:
+          version_line = stderr.decode().strip() or "odbc library not found"
+    except FileNotFoundError:
+      version_line = "odbc library not found" if system != "Windows" else "odbc library not found (Windows)"
+    except Exception as e:
+      raise RuntimeError(f"Error checking odbc: {e}")
+    return version_line

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import sys, importlib.util, pathlib, types, pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+@pytest.fixture(autouse=True)
+def restore_rpc_helpers():
+  spec = importlib.util.spec_from_file_location('rpc.helpers', ROOT / 'rpc/helpers.py')
+  real = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(real)
+  sys.modules.setdefault('rpc', types.ModuleType('rpc'))
+  yield
+  sys.modules['rpc.helpers'] = real

--- a/tests/test_google_services_helpers.py
+++ b/tests/test_google_services_helpers.py
@@ -60,6 +60,14 @@ services_mod = importlib.util.module_from_spec(spec_services)
 sys.modules["rpc.auth.google.services"] = services_mod
 spec_services.loader.exec_module(services_mod)
 
+# restore real helpers for subsequent tests
+real_helpers_spec = importlib.util.spec_from_file_location(
+  "rpc.helpers", root_path / "rpc/helpers.py"
+)
+real_helpers = importlib.util.module_from_spec(real_helpers_spec)
+real_helpers_spec.loader.exec_module(real_helpers)
+sys.modules["rpc.helpers"] = real_helpers
+
 extract_identifiers = services_mod.extract_identifiers
 lookup_user = services_mod.lookup_user
 create_session = services_mod.create_session

--- a/tests/test_microsoft_services_helpers.py
+++ b/tests/test_microsoft_services_helpers.py
@@ -60,6 +60,14 @@ services_mod = importlib.util.module_from_spec(spec_services)
 sys.modules["rpc.auth.microsoft.services"] = services_mod
 spec_services.loader.exec_module(services_mod)
 
+# restore real helpers for subsequent tests
+real_helpers_spec = importlib.util.spec_from_file_location(
+  "rpc.helpers", root_path / "rpc/helpers.py"
+)
+real_helpers = importlib.util.module_from_spec(real_helpers_spec)
+real_helpers_spec.loader.exec_module(real_helpers)
+sys.modules["rpc.helpers"] = real_helpers
+
 extract_identifiers = services_mod.extract_identifiers
 lookup_user = services_mod.lookup_user
 create_session = services_mod.create_session


### PR DESCRIPTION
## Summary
- introduce PublicVarsModule and PublicLinksModule to handle database queries and subprocess calls
- delegate public RPC services to these modules, removing dynamic helper imports
- add test fixtures restoring `rpc.helpers` and update helper tests

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68ba57d3916c8325a40813f429f3c410