### PR TITLE
Centralize role filtering and permission validation

### DIFF
--- a/rpc/account/role/services.py
+++ b/rpc/account/role/services.py
@@ -1,9 +1,8 @@
 from fastapi import HTTPException, Request
 
-from rpc.helpers import unbox_request, mask_to_bit, bit_to_mask
+from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.role_admin_module import RoleAdminModule
-from server.modules.auth_module import AuthModule
 from .models import (
   AccountRoleRoleItem1,
   AccountRoleList1,
@@ -18,15 +17,8 @@ from .models import (
 async def account_role_get_roles_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   role_admin: RoleAdminModule = request.app.state.role_admin
-  roles_raw = await role_admin.list_roles()
-  max_bit = mask_to_bit(auth_ctx.role_mask)
-  max_mask = bit_to_mask(max_bit)
-  roles = [
-    AccountRoleRoleItem1(**r)
-    for r in roles_raw
-    if int(r.get("mask", "0")) <= max_mask
-  ]
-  roles.sort(key=lambda r: int(r.mask))
+  roles_raw = await role_admin.list_roles(auth_ctx.role_mask)
+  roles = [AccountRoleRoleItem1(**r) for r in roles_raw]
   payload = AccountRoleList1(roles=roles)
   return RPCResponse(
     op=rpc_request.op,
@@ -56,13 +48,12 @@ async def account_role_get_role_members_v1(request: Request):
 async def account_role_add_role_member_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleMemberUpdate1(**(rpc_request.payload or {}))
-  auth: AuthModule = request.app.state.auth
-  role_mask = auth.roles.get(data.role, 0)
-  max_mask = bit_to_mask(mask_to_bit(auth_ctx.role_mask))
-  if role_mask > max_mask:
-    raise HTTPException(status_code=403, detail="Forbidden")
   role_admin: RoleAdminModule = request.app.state.role_admin
-  members_raw, non_raw = await role_admin.add_role_member(data.role, data.userGuid)
+  members_raw, non_raw = await role_admin.add_role_member(
+    data.role,
+    data.userGuid,
+    auth_ctx.role_mask,
+  )
   members = [AccountRoleUserItem1(**m) for m in members_raw]
   non_members = [AccountRoleUserItem1(**m) for m in non_raw]
   res = AccountRoleMembers1(members=members, nonMembers=non_members)
@@ -76,13 +67,12 @@ async def account_role_add_role_member_v1(request: Request):
 async def account_role_remove_role_member_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleMemberUpdate1(**(rpc_request.payload or {}))
-  auth: AuthModule = request.app.state.auth
-  role_mask = auth.roles.get(data.role, 0)
-  max_mask = bit_to_mask(mask_to_bit(auth_ctx.role_mask))
-  if role_mask > max_mask:
-    raise HTTPException(status_code=403, detail="Forbidden")
   role_admin: RoleAdminModule = request.app.state.role_admin
-  members_raw, non_raw = await role_admin.remove_role_member(data.role, data.userGuid)
+  members_raw, non_raw = await role_admin.remove_role_member(
+    data.role,
+    data.userGuid,
+    auth_ctx.role_mask,
+  )
   members = [AccountRoleUserItem1(**m) for m in members_raw]
   non_members = [AccountRoleUserItem1(**m) for m in non_raw]
   res = AccountRoleMembers1(members=members, nonMembers=non_members)
@@ -96,11 +86,13 @@ async def account_role_remove_role_member_v1(request: Request):
 async def account_role_upsert_role_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleUpsertRole1(**(rpc_request.payload or {}))
-  max_mask = bit_to_mask(mask_to_bit(auth_ctx.role_mask))
-  if int(data.mask) > max_mask:
-    raise HTTPException(status_code=403, detail="Forbidden")
   role_admin: RoleAdminModule = request.app.state.role_admin
-  await role_admin.upsert_role(data.name, int(data.mask), data.display)
+  await role_admin.upsert_role(
+    data.name,
+    int(data.mask),
+    data.display,
+    auth_ctx.role_mask,
+  )
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),
@@ -111,13 +103,8 @@ async def account_role_upsert_role_v1(request: Request):
 async def account_role_delete_role_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleDeleteRole1(**(rpc_request.payload or {}))
-  auth: AuthModule = request.app.state.auth
-  role_mask = auth.roles.get(data.name, 0)
-  max_mask = bit_to_mask(mask_to_bit(auth_ctx.role_mask))
-  if role_mask > max_mask:
-    raise HTTPException(status_code=403, detail="Forbidden")
   role_admin: RoleAdminModule = request.app.state.role_admin
-  await role_admin.delete_role(data.name)
+  await role_admin.delete_role(data.name, auth_ctx.role_mask)
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),

--- a/tests/test_role_admin_module.py
+++ b/tests/test_role_admin_module.py
@@ -1,0 +1,53 @@
+import types, asyncio
+from fastapi import HTTPException
+
+from server.modules.role_admin_module import RoleAdminModule
+
+
+class DummyDb:
+  def __init__(self, roles=None):
+    self.roles = roles or []
+  async def on_ready(self):
+    pass
+  async def run(self, op, args):
+    if op == "db:system:roles:list:1":
+      return types.SimpleNamespace(rows=self.roles)
+    return types.SimpleNamespace(rows=[])
+
+class DummyAuth:
+  def __init__(self, roles=None):
+    self.roles = roles or {}
+  async def on_ready(self):
+    pass
+  async def refresh_user_roles(self, guid):
+    pass
+  async def upsert_role(self, name, mask, display):
+    self.roles[name] = mask
+  async def delete_role(self, name):
+    self.roles.pop(name, None)
+
+async def make_module(roles, auth_roles):
+  db = DummyDb(roles)
+  auth = DummyAuth(auth_roles)
+  app = types.SimpleNamespace(state=types.SimpleNamespace(db=db, auth=auth))
+  mod = RoleAdminModule(app)
+  await mod.startup()
+  return mod
+
+def test_list_roles_filters_and_sorts():
+  roles = [
+    {"name": "ROLE_B", "mask": 4, "display": None},
+    {"name": "ROLE_REGISTERED", "mask": 1, "display": None},
+    {"name": "ROLE_A", "mask": 2, "display": None},
+  ]
+  mod = asyncio.run(make_module(roles, {}))
+  res = asyncio.run(mod.list_roles(4))
+  assert [r["name"] for r in res] == ["ROLE_A", "ROLE_B"]
+
+def test_permission_check_blocks_higher_mask():
+  mod = asyncio.run(make_module([], {}))
+  try:
+    asyncio.run(mod.upsert_role("ROLE_X", 8, None, 4))
+    assert False, "expected forbidden"
+  except HTTPException as e:
+    assert e.status_code == 403


### PR DESCRIPTION
## Summary
- Handle role filtering, sorting, and permission checks in `RoleAdminModule`
- Simplify account role services to use module-level validation
- Cover role admin logic with new tests

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68ba67b6567c8325a16af494297b6a76