### PR TITLE
feat: centralize storage file operations

### DIFF
--- a/rpc/storage/files/services.py
+++ b/rpc/storage/files/services.py
@@ -1,6 +1,3 @@
-import base64
-import io
-
 from fastapi import HTTPException, Request
 
 from rpc.helpers import unbox_request
@@ -34,10 +31,7 @@ async def storage_files_upload_files_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = StorageFilesUploadFiles1(**(rpc_request.payload or {}))
   storage: StorageModule = request.app.state.storage
-  await storage.ensure_user_folder(auth_ctx.user_guid)
-  for item in data.files:
-    buffer = io.BytesIO(base64.b64decode(item.content_b64))
-    await storage.write_buffer(buffer, auth_ctx.user_guid, item.name, item.content_type)
+  await storage.upload_files(auth_ctx.user_guid, data.files)
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),
@@ -49,8 +43,7 @@ async def storage_files_delete_files_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = StorageFilesDeleteFiles1(**(rpc_request.payload or {}))
   storage: StorageModule = request.app.state.storage
-  for name in data.files:
-    await storage.delete_user_file(auth_ctx.user_guid, name)
+  await storage.delete_files(auth_ctx.user_guid, data.files)
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),
@@ -62,8 +55,9 @@ async def storage_files_set_gallery_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = StorageFilesSetGallery1(**(rpc_request.payload or {}))
   storage: StorageModule = request.app.state.storage
-  files = await storage.list_user_files(auth_ctx.user_guid)
-  if not any(f.get("name") == data.name for f in files):
+  try:
+    await storage.ensure_user_file(auth_ctx.user_guid, data.name)
+  except FileNotFoundError:
     raise HTTPException(status_code=404, detail="File not found")
   return RPCResponse(
     op=rpc_request.op,


### PR DESCRIPTION
## Summary
- extend StorageModule with upload, delete, move, and file validation helpers
- refactor storage file services to use StorageModule APIs
- update storage service tests for new module delegation

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba6e22a8b8832590840b98ff4b2985