### PR TITLE
Refactor session services into dedicated module

### DIFF
--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -1,159 +1,35 @@
-from datetime import datetime, timezone, timedelta
-import logging
-
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
-import uuid
-
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.auth_module import AuthModule
-try:
-  from server.modules.auth_module import DEFAULT_SESSION_TOKEN_EXPIRY
-except Exception:
-  DEFAULT_SESSION_TOKEN_EXPIRY = 15
-from server.modules.db_module import DbModule
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+  from server.modules.session_module import SessionModule
+
+
+def _get_session_module(request: Request) -> 'SessionModule':
+  return request.app.state.session
 
 async def auth_session_get_token_v1(request: Request):
   body = await request.json()
   provider = body.get("provider")
   id_token = body.get("id_token")
   access_token = body.get("access_token")
-  if not provider or not id_token or not access_token:
-    raise HTTPException(status_code=400, detail="Missing credentials")
-
-  auth: AuthModule = request.app.state.auth
-  db: DbModule = request.app.state.db
-
-  provider_uid, provider_profile, payload = await auth.handle_auth_login(provider, id_token, access_token)
-
-  identifiers = []
-  if provider_uid:
-    identifiers.append(provider_uid)
-  oid = payload.get("oid")
-  sub = payload.get("sub")
-  if oid and oid not in identifiers:
-    identifiers.append(oid)
-  if sub and sub not in identifiers:
-    identifiers.append(sub)
-  base_id = oid or sub or provider_uid
-  if base_id:
-    try:
-      import base64
-      home_account_id = base64.urlsafe_b64encode(b"\x00" * 16 + uuid.UUID(base_id).bytes).decode("utf-8").rstrip("=")
-      if home_account_id not in identifiers:
-        identifiers.append(home_account_id)
-    except Exception:
-      pass
-
-  def _norm(pid: str) -> str | None:
-    try:
-      return str(uuid.UUID(pid))
-    except ValueError:
-      try:
-        import base64
-        pad = pid + "=" * (-len(pid) % 4)
-        raw = base64.urlsafe_b64decode(pad)
-        if len(raw) >= 16:
-          return str(uuid.UUID(bytes=raw[-16:]))
-      except Exception:
-        return None
-    return None
-
-  user = None
-  checked = set()
-  for pid in identifiers:
-    uid = _norm(pid)
-    if not uid or uid in checked:
-      continue
-    checked.add(uid)
-    res = await db.run(
-      "urn:users:providers:get_by_provider_identifier:1",
-      {"provider": provider, "provider_identifier": uid},
-    )
-    if res.rows:
-      user = res.rows[0]
-      break
-
-  if not user:
-    try:
-      provider_uid = str(uuid.UUID(provider_uid))
-    except ValueError:
-      raise HTTPException(status_code=400, detail="Invalid provider identifier")
-    res = await db.run(
-      "urn:users:providers:create_from_provider:1",
-      {
-        "provider": provider,
-        "provider_identifier": provider_uid,
-        "provider_email": provider_profile["email"],
-        "provider_displayname": provider_profile["username"],
-        "provider_profile_image": provider_profile.get("profilePicture"),
-      },
-    )
-    user = res.rows[0] if res.rows else None
-    if not user:
-      res = await db.run(
-        "urn:users:providers:get_by_provider_identifier:1",
-        {"provider": provider, "provider_identifier": provider_uid},
-      )
-      user = res.rows[0] if res.rows else None
-  if not user:
-    raise HTTPException(status_code=500, detail="Unable to create user")
-
-  new_img = provider_profile.get("profilePicture")
-  if new_img and new_img != user.get("profile_image"):
-    await db.run(
-      "urn:users:profile:set_profile_image:1",
-      {"guid": user["guid"], "image_b64": new_img, "provider": provider},
-    )
-    user["profile_image"] = new_img
-
-  user_guid = user["guid"]
-  rotation_token, rot_exp = auth.make_rotation_token(user_guid)
-  now = datetime.now(timezone.utc)
-  await db.run(
-    "db:users:session:set_rotkey:1",
-    {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
-  )
-
-  roles, _ = await auth.get_user_roles(user_guid)
   fingerprint = body.get("fingerprint")
-  if not fingerprint:
-    raise HTTPException(status_code=400, detail="Missing fingerprint")
+  if not provider or not id_token or not access_token or not fingerprint:
+    raise HTTPException(status_code=400, detail="Missing credentials or fingerprint")
+  session_mod = _get_session_module(request)
   user_agent = request.headers.get("user-agent")
   ip_address = request.client.host if request.client else None
-  session_exp = datetime.now(timezone.utc) + timedelta(minutes=DEFAULT_SESSION_TOKEN_EXPIRY)
-  placeholder = uuid.uuid4().hex
-  res = await db.run(
-    "db:auth:session:create_session:1",
-    {
-      "access_token": placeholder,
-      "expires": session_exp,
-      "fingerprint": fingerprint,
-      "user_agent": user_agent,
-      "ip_address": ip_address,
-      "user_guid": user_guid,
-      "provider": provider,
-    },
+  session_token, rotation_token, rot_exp, profile = await session_mod.issue_token(
+    provider,
+    id_token,
+    access_token,
+    fingerprint,
+    user_agent,
+    ip_address,
   )
-  row = res.rows[0] if res.rows else {}
-  session_guid = row.get("session_guid")
-  device_guid = row.get("device_guid")
-  session_token, _ = auth.make_session_token(
-    user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp
-  )
-  await db.run(
-    "db:auth:session:update_device_token:1",
-    {"device_guid": device_guid, "access_token": session_token},
-  )
-
-  profile = {
-    "display_name": user["display_name"],
-    "email": user.get("email"),
-    "credits": user.get("credits"),
-    "profile_image": user.get("profile_image"),
-  }
   payload = {"token": session_token, "profile": profile}
   rpc_resp = RPCResponse(op="urn:auth:session:get_token:1", payload=payload, version=1)
   response = JSONResponse(content=jsonable_encoder(rpc_resp))
@@ -171,20 +47,6 @@ async def auth_session_refresh_token_v1(request: Request):
   rotation_token = request.cookies.get("rotation_token")
   if not rotation_token:
     raise HTTPException(status_code=401, detail="Missing rotation token")
-
-  auth: AuthModule = request.app.state.auth
-  db: DbModule = request.app.state.db
-
-  data = auth.decode_rotation_token(rotation_token)
-  user_guid = data["guid"]
-  stored = await db.run("db:users:session:get_rotkey:1", {"guid": user_guid})
-  row = stored.rows[0] if stored.rows else None
-  if not row or row.get("rotkey") != rotation_token:
-    raise HTTPException(status_code=401, detail="Invalid rotation token")
-  provider = row.get("provider_name") or "microsoft"
-  roles, _ = await auth.get_user_roles(user_guid)
-  session_exp = datetime.now(timezone.utc) + timedelta(minutes=DEFAULT_SESSION_TOKEN_EXPIRY)
-  placeholder = uuid.uuid4().hex
   try:
     body = await request.json()
   except Exception:
@@ -192,27 +54,14 @@ async def auth_session_refresh_token_v1(request: Request):
   fingerprint = body.get("fingerprint")
   if not fingerprint:
     raise HTTPException(status_code=400, detail="Missing fingerprint")
-  res = await db.run(
-    "db:auth:session:create_session:1",
-    {
-      "access_token": placeholder,
-      "expires": session_exp,
-      "fingerprint": fingerprint,
-      "user_agent": request.headers.get("user-agent"),
-      "ip_address": request.client.host if request.client else None,
-      "user_guid": user_guid,
-      "provider": provider,
-    },
-  )
-  row2 = res.rows[0] if res.rows else {}
-  session_guid = row2.get("session_guid")
-  device_guid = row2.get("device_guid")
-  session_token, _ = auth.make_session_token(
-    user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp
-  )
-  await db.run(
-    "db:auth:session:update_device_token:1",
-    {"device_guid": device_guid, "access_token": session_token},
+  session_mod = _get_session_module(request)
+  user_agent = request.headers.get("user-agent")
+  ip_address = request.client.host if request.client else None
+  session_token = await session_mod.refresh_token(
+    rotation_token,
+    fingerprint,
+    user_agent,
+    ip_address,
   )
   return RPCResponse(op="urn:auth:session:refresh_token:1", payload={"token": session_token}, version=1)
 
@@ -220,15 +69,9 @@ async def auth_session_invalidate_token_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   if not auth_ctx.user_guid:
     raise HTTPException(status_code=401, detail="Missing or invalid session token")
-
-  db: DbModule = request.app.state.db
-  now = datetime.now(timezone.utc)
-  await db.run(
-    "db:users:session:set_rotkey:1",
-    {"guid": auth_ctx.user_guid, "rotkey": "", "iat": now, "exp": now},
-  )
+  session_mod = _get_session_module(request)
+  await session_mod.invalidate_token(auth_ctx.user_guid)
   return RPCResponse(op=rpc_request.op, payload={"ok": True}, version=rpc_request.version)
-
 
 async def auth_session_logout_device_v1(request: Request):
   rpc_request, _auth_ctx, _ = await unbox_request(request)
@@ -236,11 +79,9 @@ async def auth_session_logout_device_v1(request: Request):
   if not header or not header.lower().startswith("bearer "):
     raise HTTPException(status_code=401, detail="Missing or invalid authorization header")
   token = header.split(" ", 1)[1].strip()
-
-  db: DbModule = request.app.state.db
-  await db.run("db:auth:session:revoke_device_token:1", {"access_token": token})
+  session_mod = _get_session_module(request)
+  await session_mod.logout_device(token)
   return RPCResponse(op=rpc_request.op, payload={"ok": True}, version=rpc_request.version)
-
 
 async def auth_session_get_session_v1(request: Request):
   rpc_request, _auth_ctx, _ = await unbox_request(request)
@@ -248,43 +89,8 @@ async def auth_session_get_session_v1(request: Request):
   if not header or not header.lower().startswith("bearer "):
     raise HTTPException(status_code=401, detail="Missing or invalid authorization header")
   token = header.split(" ", 1)[1].strip()
-
-  db: DbModule = request.app.state.db
-  res = await db.run("db:auth:session:get_by_access_token:1", {"access_token": token})
-  session = res.rows[0] if res.rows else None
-  if not session:
-    raise HTTPException(status_code=401, detail="Invalid session token")
-
-  if session.get("revoked_at"):
-    raise HTTPException(status_code=401, detail="Session revoked")
-
-  expires_at = session.get("expires_at")
-  if expires_at:
-    try:
-      exp_dt = datetime.fromisoformat(expires_at)
-    except ValueError:
-      exp_dt = None
-    if exp_dt and exp_dt.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
-      raise HTTPException(status_code=401, detail="Session expired")
+  session_mod = _get_session_module(request)
   ip_address = request.client.host if request.client else None
   user_agent = request.headers.get("user-agent")
-  try:
-    await db.run(
-      "db:auth:session:update_session:1",
-      {"access_token": token, "ip_address": ip_address, "user_agent": user_agent},
-    )
-  except Exception as e:
-    logging.error("[auth_session_get_session_v1] Failed to update session metadata: %s", e)
-
-  payload = {
-    "session_guid": session.get("session_guid"),
-    "device_guid": session.get("device_guid"),
-    "user_guid": session.get("user_guid"),
-    "issued_at": session.get("issued_at"),
-    "expires_at": session.get("expires_at"),
-    "device_fingerprint": session.get("device_fingerprint"),
-    "user_agent": session.get("user_agent"),
-    "ip_last_seen": session.get("ip_last_seen"),
-  }
+  payload = await session_mod.get_session(token, ip_address, user_agent)
   return RPCResponse(op=rpc_request.op, payload=payload, version=rpc_request.version)
-

--- a/server/modules/session_module.py
+++ b/server/modules/session_module.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+import base64, logging, uuid
+from datetime import datetime, timedelta, timezone
+from fastapi import FastAPI, HTTPException
+
+from server.modules import BaseModule
+from server.modules.auth_module import AuthModule, DEFAULT_SESSION_TOKEN_EXPIRY
+from server.modules.db_module import DbModule
+
+
+class SessionModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+
+  async def startup(self):
+    self.auth: AuthModule = self.app.state.auth
+    await self.auth.on_ready()
+    self.db: DbModule = self.app.state.db
+    await self.db.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    pass
+
+  async def issue_token(
+    self,
+    provider: str,
+    id_token: str,
+    access_token: str,
+    fingerprint: str,
+    user_agent: str | None,
+    ip_address: str | None,
+  ) -> tuple[str, str, datetime, dict]:
+    if not provider or not id_token or not access_token:
+      raise HTTPException(status_code=400, detail="Missing credentials")
+
+    provider_uid, provider_profile, payload = await self.auth.handle_auth_login(
+      provider, id_token, access_token
+    )
+
+    identifiers = []
+    if provider_uid:
+      identifiers.append(provider_uid)
+    oid = payload.get("oid")
+    sub = payload.get("sub")
+    if oid and oid not in identifiers:
+      identifiers.append(oid)
+    if sub and sub not in identifiers:
+      identifiers.append(sub)
+    base_id = oid or sub or provider_uid
+    if base_id:
+      try:
+        home_account_id = base64.urlsafe_b64encode(
+          b"\x00" * 16 + uuid.UUID(base_id).bytes
+        ).decode("utf-8").rstrip("=")
+        if home_account_id not in identifiers:
+          identifiers.append(home_account_id)
+      except Exception:
+        pass
+
+    def _norm(pid: str) -> str | None:
+      try:
+        return str(uuid.UUID(pid))
+      except ValueError:
+        try:
+          pad = pid + "=" * (-len(pid) % 4)
+          raw = base64.urlsafe_b64decode(pad)
+          if len(raw) >= 16:
+            return str(uuid.UUID(bytes=raw[-16:]))
+        except Exception:
+          return None
+      return None
+
+    user = None
+    checked = set()
+    for pid in identifiers:
+      uid = _norm(pid)
+      if not uid or uid in checked:
+        continue
+      checked.add(uid)
+      res = await self.db.run(
+        "urn:users:providers:get_by_provider_identifier:1",
+        {"provider": provider, "provider_identifier": uid},
+      )
+      if res.rows:
+        user = res.rows[0]
+        break
+
+    if not user:
+      try:
+        provider_uid = str(uuid.UUID(provider_uid))
+      except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid provider identifier")
+      res = await self.db.run(
+        "urn:users:providers:create_from_provider:1",
+        {
+          "provider": provider,
+          "provider_identifier": provider_uid,
+          "provider_email": provider_profile["email"],
+          "provider_displayname": provider_profile["username"],
+          "provider_profile_image": provider_profile.get("profilePicture"),
+        },
+      )
+      user = res.rows[0] if res.rows else None
+      if not user:
+        res = await self.db.run(
+          "urn:users:providers:get_by_provider_identifier:1",
+          {"provider": provider, "provider_identifier": provider_uid},
+        )
+        user = res.rows[0] if res.rows else None
+    if not user:
+      raise HTTPException(status_code=500, detail="Unable to create user")
+
+    new_img = provider_profile.get("profilePicture")
+    if new_img and new_img != user.get("profile_image"):
+      await self.db.run(
+        "urn:users:profile:set_profile_image:1",
+        {"guid": user["guid"], "image_b64": new_img, "provider": provider},
+      )
+      user["profile_image"] = new_img
+
+    user_guid = user["guid"]
+    rotation_token, rot_exp = self.auth.make_rotation_token(user_guid)
+    now = datetime.now(timezone.utc)
+    await self.db.run(
+      "db:users:session:set_rotkey:1",
+      {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
+    )
+
+    roles, _ = await self.auth.get_user_roles(user_guid)
+    session_exp = datetime.now(timezone.utc) + timedelta(
+      minutes=DEFAULT_SESSION_TOKEN_EXPIRY
+    )
+    placeholder = uuid.uuid4().hex
+    res = await self.db.run(
+      "db:auth:session:create_session:1",
+      {
+        "access_token": placeholder,
+        "expires": session_exp,
+        "fingerprint": fingerprint,
+        "user_agent": user_agent,
+        "ip_address": ip_address,
+        "user_guid": user_guid,
+        "provider": provider,
+      },
+    )
+    row = res.rows[0] if res.rows else {}
+    session_guid = row.get("session_guid")
+    device_guid = row.get("device_guid")
+    session_token, _ = self.auth.make_session_token(
+      user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp
+    )
+    await self.db.run(
+      "db:auth:session:update_device_token:1",
+      {"device_guid": device_guid, "access_token": session_token},
+    )
+
+    profile = {
+      "display_name": user["display_name"],
+      "email": user.get("email"),
+      "credits": user.get("credits"),
+      "profile_image": user.get("profile_image"),
+    }
+    return session_token, rotation_token, rot_exp, profile
+
+  async def refresh_token(
+    self,
+    rotation_token: str,
+    fingerprint: str,
+    user_agent: str | None,
+    ip_address: str | None,
+  ) -> str:
+    data = self.auth.decode_rotation_token(rotation_token)
+    user_guid = data["guid"]
+    stored = await self.db.run("db:users:session:get_rotkey:1", {"guid": user_guid})
+    row = stored.rows[0] if stored.rows else None
+    if not row or row.get("rotkey") != rotation_token:
+      raise HTTPException(status_code=401, detail="Invalid rotation token")
+    provider = row.get("provider_name") or "microsoft"
+    roles, _ = await self.auth.get_user_roles(user_guid)
+    session_exp = datetime.now(timezone.utc) + timedelta(
+      minutes=DEFAULT_SESSION_TOKEN_EXPIRY
+    )
+    placeholder = uuid.uuid4().hex
+    res = await self.db.run(
+      "db:auth:session:create_session:1",
+      {
+        "access_token": placeholder,
+        "expires": session_exp,
+        "fingerprint": fingerprint,
+        "user_agent": user_agent,
+        "ip_address": ip_address,
+        "user_guid": user_guid,
+        "provider": provider,
+      },
+    )
+    row2 = res.rows[0] if res.rows else {}
+    session_guid = row2.get("session_guid")
+    device_guid = row2.get("device_guid")
+    session_token, _ = self.auth.make_session_token(
+      user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp
+    )
+    await self.db.run(
+      "db:auth:session:update_device_token:1",
+      {"device_guid": device_guid, "access_token": session_token},
+    )
+    return session_token
+
+  async def invalidate_token(self, user_guid: str) -> None:
+    now = datetime.now(timezone.utc)
+    await self.db.run(
+      "db:users:session:set_rotkey:1",
+      {"guid": user_guid, "rotkey": "", "iat": now, "exp": now},
+    )
+
+  async def logout_device(self, token: str) -> None:
+    await self.db.run(
+      "db:auth:session:revoke_device_token:1",
+      {"access_token": token},
+    )
+
+  async def get_session(
+    self,
+    token: str,
+    ip_address: str | None,
+    user_agent: str | None,
+  ) -> dict:
+    res = await self.db.run(
+      "db:auth:session:get_by_access_token:1", {"access_token": token}
+    )
+    session = res.rows[0] if res.rows else None
+    if not session:
+      raise HTTPException(status_code=401, detail="Invalid session token")
+
+    if session.get("revoked_at"):
+      raise HTTPException(status_code=401, detail="Session revoked")
+
+    expires_at = session.get("expires_at")
+    if expires_at:
+      try:
+        exp_dt = datetime.fromisoformat(expires_at)
+      except ValueError:
+        exp_dt = None
+      if exp_dt and exp_dt.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
+        raise HTTPException(status_code=401, detail="Session expired")
+
+    try:
+      await self.db.run(
+        "db:auth:session:update_session:1",
+        {"access_token": token, "ip_address": ip_address, "user_agent": user_agent},
+      )
+    except Exception as e:
+      logging.error("[SessionModule.get_session] Failed to update session metadata: %s", e)
+
+    payload = {
+      "session_guid": session.get("session_guid"),
+      "device_guid": session.get("device_guid"),
+      "user_guid": session.get("user_guid"),
+      "issued_at": session.get("issued_at"),
+      "expires_at": session.get("expires_at"),
+      "device_fingerprint": session.get("device_fingerprint"),
+      "user_agent": session.get("user_agent"),
+      "ip_last_seen": session.get("ip_last_seen"),
+    }
+    return payload

--- a/tests/test_auth_session_db_profile.py
+++ b/tests/test_auth_session_db_profile.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+
 def test_auth_session_returns_db_profile(monkeypatch):
   spec = importlib.util.spec_from_file_location("server.models", "server/models.py")
   models = importlib.util.module_from_spec(spec)
@@ -15,56 +16,24 @@ def test_auth_session_returns_db_profile(monkeypatch):
     raise NotImplementedError
   helpers.unbox_request = _unbox_request
   monkeypatch.setitem(sys.modules, "rpc.helpers", helpers)
-  monkeypatch.setitem(sys.modules, "server", types.ModuleType("server"))
-  monkeypatch.setitem(sys.modules, "server.modules", types.ModuleType("server.modules"))
-  auth_mod = types.ModuleType("server.modules.auth_module")
-  class AuthModule: ...
-  auth_mod.AuthModule = AuthModule
-  monkeypatch.setitem(sys.modules, "server.modules.auth_module", auth_mod)
-  db_mod = types.ModuleType("server.modules.db_module")
-  class DbModule: ...
-  db_mod.DbModule = DbModule
-  monkeypatch.setitem(sys.modules, "server.modules.db_module", db_mod)
 
-  svc_spec = importlib.util.spec_from_file_location("rpc.auth.session.services", "rpc/auth/session/services.py")
-  svc_mod = importlib.util.module_from_spec(svc_spec)
-  svc_spec.loader.exec_module(svc_mod)
-  auth_session_get_token_v1 = svc_mod.auth_session_get_token_v1
-
-  class DBRes:
-    def __init__(self, rows=None, rowcount=0):
-      self.rows = rows or []
-      self.rowcount = rowcount
-
-  class DummyDb:
+  class DummySession:
     def __init__(self):
-      self.calls = []
-    async def run(self, op, args):
-      self.calls.append((op, args))
-      if op == "urn:users:providers:get_by_provider_identifier:1":
-        return DBRes([{ "guid": "u1", "display_name": "DB", "email": "db@example.com", "credits": 5, "profile_image": "img" }], 1)
-      if op == "db:users:session:set_rotkey:1":
-        return DBRes(rowcount=1)
-      if op == "db:auth:session:create_session:1":
-        return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-      if op == "db:auth:session:update_device_token:1":
-        return DBRes(rowcount=1)
-      return DBRes()
+      self.called = None
+    async def issue_token(self, provider, id_token, access_token, fingerprint, user_agent, ip_address):
+      self.called = (provider, id_token, access_token, fingerprint, user_agent, ip_address)
+      return "sess", "rot", datetime.now(timezone.utc) + timedelta(hours=1), {
+        "display_name": "DB",
+        "email": "db@example.com",
+        "credits": 5,
+        "profile_image": "img",
+      }
 
-  class DummyAuth:
-    async def handle_auth_login(self, provider, id_token, access_token):
-      return "0a1b2c3d-4e5f-6789-aaaa-bbbbccccdddd", {"email": "prov@example.com", "username": "Prov"}, {}
-    def make_rotation_token(self, user_guid):
-      return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
-    def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
-      return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
-    async def get_user_roles(self, guid, refresh=False):
-      return [], 0
+  session_mod = DummySession()
 
   class DummyState:
     def __init__(self):
-      self.db = DummyDb()
-      self.auth = DummyAuth()
+      self.session = session_mod
 
   class DummyRequest:
     def __init__(self):
@@ -74,13 +43,15 @@ def test_auth_session_returns_db_profile(monkeypatch):
     async def json(self):
       return {"provider": "google", "id_token": "id", "access_token": "acc", "fingerprint": "fp"}
 
+  svc_spec = importlib.util.spec_from_file_location("rpc.auth.session.services", "rpc/auth/session/services.py")
+  svc_mod = importlib.util.module_from_spec(svc_spec)
+  svc_spec.loader.exec_module(svc_mod)
+  auth_session_get_token_v1 = svc_mod.auth_session_get_token_v1
+
   req = DummyRequest()
   resp = asyncio.run(auth_session_get_token_v1(req))
   data = json.loads(resp.body)
   profile = data["payload"]["profile"]
   assert profile["display_name"] == "DB"
   assert profile["email"] == "db@example.com"
-  assert any(
-    op == "db:auth:session:create_session:1" and args.get("provider") == "google"
-    for op, args in req.app.state.db.calls
-  )
+  assert session_mod.called[0] == "google"

--- a/tests/test_auth_session_get_session.py
+++ b/tests/test_auth_session_get_session.py
@@ -1,45 +1,6 @@
 import sys, types, asyncio, importlib.util
 from types import SimpleNamespace
 
-class DBRes:
-  def __init__(self, rows=None, rowcount=0):
-    self.rows = rows or []
-    self.rowcount = rowcount
-
-class DummyDb:
-  def __init__(self):
-    self.calls = []
-  async def run(self, op, args):
-    self.calls.append((op, args))
-    if op == "db:auth:session:get_by_access_token:1":
-      return DBRes([
-        {
-          "session_guid": "sess-guid",
-          "device_guid": "dev-guid",
-          "user_guid": "user-guid",
-          "issued_at": "2099-01-01T00:00:00Z",
-          "expires_at": "2099-01-01T01:00:00Z",
-          "device_fingerprint": "fp",
-          "user_agent": "ua",
-          "ip_last_seen": "127.0.0.1",
-        }
-      ], 1)
-    return DBRes()
-
-class DummyState:
-  def __init__(self):
-    self.db = DummyDb()
-
-class DummyApp:
-  def __init__(self):
-    self.state = DummyState()
-
-class DummyRequest:
-  def __init__(self):
-    self.app = DummyApp()
-    self.headers = {"authorization": "Bearer tok", "user-agent": "ua"}
-    self.client = SimpleNamespace(host="127.0.0.1")
-
 
 def test_get_session(monkeypatch):
   spec = importlib.util.spec_from_file_location("server.models", "server/models.py")
@@ -56,12 +17,28 @@ def test_get_session(monkeypatch):
   helpers.unbox_request = fake_unbox_request
   sys.modules["rpc.helpers"] = helpers
 
-  sys.modules.setdefault("server", types.ModuleType("server"))
-  sys.modules.setdefault("server.modules", types.ModuleType("server.modules"))
-  db_mod = types.ModuleType("server.modules.db_module")
-  class DbModule: ...
-  db_mod.DbModule = DbModule
-  sys.modules["server.modules.db_module"] = db_mod
+  class DummySession:
+    def __init__(self):
+      self.calls = []
+    async def get_session(self, token, ip_address, user_agent):
+      self.calls.append((token, ip_address, user_agent))
+      return {"session_guid": "sess-guid"}
+
+  session_mod = DummySession()
+
+  class DummyState:
+    def __init__(self):
+      self.session = session_mod
+
+  class DummyApp:
+    def __init__(self):
+      self.state = DummyState()
+
+  class DummyRequest:
+    def __init__(self):
+      self.app = DummyApp()
+      self.headers = {"authorization": "Bearer tok", "user-agent": "ua"}
+      self.client = SimpleNamespace(host="127.0.0.1")
 
   svc_spec = importlib.util.spec_from_file_location(
     "rpc.auth.session.services", "rpc/auth/session/services.py"
@@ -73,6 +50,4 @@ def test_get_session(monkeypatch):
   req = DummyRequest()
   resp = asyncio.run(auth_session_get_session_v1(req))
   assert isinstance(resp, RPCResponse)
-  calls = [op for op, _ in req.app.state.db.calls]
-  assert "db:auth:session:get_by_access_token:1" in calls
-  assert "db:auth:session:update_session:1" in calls
+  assert session_mod.calls[0] == ("tok", "127.0.0.1", "ua")

--- a/tests/test_auth_session_logout_device.py
+++ b/tests/test_auth_session_logout_device.py
@@ -1,67 +1,10 @@
-import importlib.util
-import types
-import sys
-import asyncio
+import types, sys, importlib.util, asyncio
 import pytest
 from types import SimpleNamespace
 from fastapi import HTTPException
 
 
-class DBRes:
-  def __init__(self, rows=None, rowcount=0):
-    self.rows = rows or []
-    self.rowcount = rowcount
-
-class DummyDb:
-  def __init__(self):
-    self.calls = []
-    self.revoked = False
-  async def run(self, op, args):
-    self.calls.append((op, args))
-    if op == "db:auth:session:revoke_device_token:1":
-      self.revoked = True
-      return DBRes(rowcount=1)
-    if op == "db:auth:session:get_by_access_token:1":
-      if self.revoked:
-        return DBRes([{"revoked_at": "2024-01-01T00:00:00Z"}], 1)
-      return DBRes([{"revoked_at": None}], 1)
-    if op == "db:users:session:get_rotkey:1":
-      return DBRes([{"rotkey": "rot-token", "provider_name": "microsoft"}], 1)
-    if op == "db:auth:session:create_session:1":
-      return DBRes([{ "session_guid": "sess-guid", "device_guid": "dev-guid" }], 1)
-    if op == "db:auth:session:update_device_token:1":
-      return DBRes(rowcount=1)
-    return DBRes()
-
-class DummyAuth:
-  def decode_rotation_token(self, token):
-    return {"guid": "user-guid"}
-  async def get_user_roles(self, _guid):
-    return (["user"], 0)
-  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
-    return ("new-token", exp)
-
-class DummyState:
-  def __init__(self):
-    self.db = DummyDb()
-    self.auth = DummyAuth()
-
-class DummyApp:
-  def __init__(self):
-    self.state = DummyState()
-
-class DummyRequest:
-  def __init__(self):
-    self.app = DummyApp()
-    self.headers = {"authorization": "Bearer tok", "user-agent": "ua"}
-    self.client = SimpleNamespace(host="127.0.0.1")
-    self.cookies = {"rotation_token": "rot-token"}
-    self.op = ""
-  async def json(self):
-    return {"fingerprint": "fp"}
-
-
-def _setup(monkeypatch):
+def _setup():
   spec = importlib.util.spec_from_file_location("server.models", "server/models.py")
   models = importlib.util.module_from_spec(spec)
   spec.loader.exec_module(models)
@@ -76,38 +19,57 @@ def _setup(monkeypatch):
   helpers.unbox_request = fake_unbox
   sys.modules["rpc.helpers"] = helpers
 
-  sys.modules.setdefault("server", types.ModuleType("server"))
-  sys.modules.setdefault("server.modules", types.ModuleType("server.modules"))
-  db_mod = types.ModuleType("server.modules.db_module")
-  class DbModule: ...
-  db_mod.DbModule = DbModule
-  sys.modules["server.modules.db_module"] = db_mod
+  class DummySession:
+    def __init__(self):
+      self.revoked = False
+    async def logout_device(self, token):
+      self.revoked = True
+    async def get_session(self, token, ip_address, user_agent):
+      if self.revoked:
+        raise HTTPException(status_code=401, detail="Session revoked")
+      return {}
+    async def refresh_token(self, rotation_token, fingerprint, user_agent, ip_address):
+      return "new-token"
 
-  auth_mod = types.ModuleType("server.modules.auth_module")
-  class AuthModule: ...
-  auth_mod.AuthModule = AuthModule
-  sys.modules["server.modules.auth_module"] = auth_mod
+  session_mod = DummySession()
+
+  class DummyState:
+    def __init__(self):
+      self.session = session_mod
+
+  class DummyApp:
+    def __init__(self):
+      self.state = DummyState()
+
+  class DummyRequest:
+    def __init__(self):
+      self.app = DummyApp()
+      self.headers = {"authorization": "Bearer tok", "user-agent": "ua"}
+      self.client = SimpleNamespace(host="127.0.0.1")
+      self.cookies = {"rotation_token": "rot-token"}
+      self.op = ""
+    async def json(self):
+      return {"fingerprint": "fp"}
 
   svc_spec = importlib.util.spec_from_file_location("rpc.auth.session.services", "rpc/auth/session/services.py")
   svc_mod = importlib.util.module_from_spec(svc_spec)
   svc_spec.loader.exec_module(svc_mod)
-  return svc_mod, RPCResponse
+  return svc_mod, RPCResponse, DummyRequest
 
 
 def test_logout_device_revokes_token(monkeypatch):
-  svc_mod, RPCResponse = _setup(monkeypatch)
+  svc_mod, RPCResponse, DummyRequest = _setup()
   req = DummyRequest()
   req.op = "urn:auth:session:logout_device:1"
   resp = asyncio.run(svc_mod.auth_session_logout_device_v1(req))
   assert isinstance(resp, RPCResponse)
-  assert ("db:auth:session:revoke_device_token:1", {"access_token": "tok"}) in req.app.state.db.calls
   req.op = "urn:auth:session:get_session:1"
   with pytest.raises(HTTPException):
     asyncio.run(svc_mod.auth_session_get_session_v1(req))
 
 
 def test_logout_device_allows_refresh(monkeypatch):
-  svc_mod, RPCResponse = _setup(monkeypatch)
+  svc_mod, RPCResponse, DummyRequest = _setup()
   req = DummyRequest()
   req.op = "urn:auth:session:logout_device:1"
   asyncio.run(svc_mod.auth_session_logout_device_v1(req))

--- a/tests/test_auth_session_refresh_provider.py
+++ b/tests/test_auth_session_refresh_provider.py
@@ -1,86 +1,53 @@
-import importlib.util
-import types
-import sys
-import asyncio
+import sys, asyncio, importlib.util, types
 from types import SimpleNamespace
 
 
-class DBRes:
-  def __init__(self, rows=None, rowcount=0):
-    self.rows = rows or []
-    self.rowcount = rowcount
-
-class DummyDb:
-  async def run(self, op, args):
-    if op == "db:users:session:get_rotkey:1":
-      return DBRes([{ "rotkey": "rot-token", "provider_name": "google" }], 1)
-    if op == "db:auth:session:create_session:1":
-      return DBRes([{ "session_guid": "sess-guid", "device_guid": "dev-guid" }], 1)
-    if op == "db:auth:session:update_device_token:1":
-      return DBRes(rowcount=1)
-    return DBRes()
-
-class DummyAuth:
-  def __init__(self):
-    self.provider = None
-  def decode_rotation_token(self, token):
-    return {"guid": "user-guid"}
-  async def get_user_roles(self, _guid):
-    return (["user"], 0)
-  def make_session_token(self, user_guid, rot, session_guid, device_guid, roles, exp=None):
-    return ("new-token", exp)
-
-class DummyState:
-  def __init__(self):
-    self.db = DummyDb()
-    self.auth = DummyAuth()
-
-class DummyApp:
-  def __init__(self):
-    self.state = DummyState()
-
-class DummyRequest:
-  def __init__(self):
-    self.app = DummyApp()
-    self.headers = {}
-    self.cookies = {"rotation_token": "rot-token"}
-    self.client = SimpleNamespace(host="127.0.0.1")
-  async def json(self):
-    return {"fingerprint": "fp"}
-
-
-def _setup():
+def test_refresh_token_ignores_provider():
   spec = importlib.util.spec_from_file_location("server.models", "server/models.py")
   models = importlib.util.module_from_spec(spec)
   spec.loader.exec_module(models)
   sys.modules["server.models"] = models
   RPCResponse = models.RPCResponse
+
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox(_req):
     return None
   helpers.unbox_request = fake_unbox
   sys.modules["rpc.helpers"] = helpers
-  sys.modules.setdefault("server", types.ModuleType("server"))
-  sys.modules.setdefault("server.modules", types.ModuleType("server.modules"))
-  class AuthContext: ...
-  models.AuthContext = AuthContext
-  db_mod = types.ModuleType("server.modules.db_module")
-  class DbModule: ...
-  db_mod.DbModule = DbModule
-  sys.modules["server.modules.db_module"] = db_mod
-  auth_mod = types.ModuleType("server.modules.auth_module")
-  class AuthModule: ...
-  auth_mod.AuthModule = AuthModule
-  sys.modules["server.modules.auth_module"] = auth_mod
-  spec = importlib.util.spec_from_file_location("rpc.auth.session.services", "rpc/auth/session/services.py")
-  svc_mod = importlib.util.module_from_spec(spec)
-  spec.loader.exec_module(svc_mod)
-  return svc_mod, RPCResponse
 
+  class DummySession:
+    def __init__(self):
+      self.calls = 0
+    async def refresh_token(self, rotation_token, fingerprint, user_agent, ip_address):
+      self.calls += 1
+      return "new-token"
 
-def test_refresh_token_ignores_provider():
-  svc_mod, RPCResponse = _setup()
+  session_mod = DummySession()
+
+  class DummyState:
+    def __init__(self):
+      self.session = session_mod
+      self.auth = SimpleNamespace(provider=None)
+
+  class DummyApp:
+    def __init__(self):
+      self.state = DummyState()
+
+  class DummyRequest:
+    def __init__(self):
+      self.app = DummyApp()
+      self.headers = {}
+      self.cookies = {"rotation_token": "rot-token"}
+      self.client = SimpleNamespace(host="127.0.0.1")
+    async def json(self):
+      return {"fingerprint": "fp"}
+
+  svc_spec = importlib.util.spec_from_file_location("rpc.auth.session.services", "rpc/auth/session/services.py")
+  svc_mod = importlib.util.module_from_spec(svc_spec)
+  svc_spec.loader.exec_module(svc_mod)
+
   req = DummyRequest()
   resp = asyncio.run(svc_mod.auth_session_refresh_token_v1(req))
   assert isinstance(resp, RPCResponse)
+  assert session_mod.calls == 1
   assert req.app.state.auth.provider is None


### PR DESCRIPTION
## Summary
- add SessionModule encapsulating token issuance, refresh, logout and session lookup logic
- update session RPC services to delegate to SessionModule
- adjust unit tests to mock new session module

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68ba770b2b208325a5fbbdbdb3ae08ec