### PR TITLE
Refactor OAuth flows into shared module

### DIFF
--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -1,6 +1,4 @@
-import base64, logging, uuid
-import aiohttp
-from datetime import datetime, timezone, timedelta
+import logging, uuid
 
 from fastapi import HTTPException, Request
 from pydantic import ValidationError
@@ -9,52 +7,16 @@ from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.env_module import EnvModule
 from server.modules.auth_module import AuthModule
-try:
-  from server.modules.auth_module import DEFAULT_SESSION_TOKEN_EXPIRY
-except Exception:
-  DEFAULT_SESSION_TOKEN_EXPIRY = 15
 from server.modules.db_module import DbModule
+from server.modules.oauth_module import (
+  exchange_code_for_tokens,
+  extract_identifiers,
+  lookup_user,
+  create_session,
+)
 from .models import AuthGoogleOauthLogin1, AuthGoogleOauthLoginPayload1
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
-
-
-GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
-
-
-async def exchange_code_for_tokens(
-  code: str,
-  client_id: str,
-  client_secret: str,
-  redirect_uri: str = "http://localhost:8000/userpage",
-) -> tuple[str, str]:
-  data = {
-    "code": code,
-    "client_id": client_id,
-    "client_secret": client_secret,
-    "redirect_uri": redirect_uri,
-    "grant_type": "authorization_code",
-  }
-  logging.debug(
-    "[exchange_code_for_tokens] data=%s",
-    {k: v for k, v in data.items() if k != "client_secret"}
-  )
-  logging.debug("[exchange_code_for_tokens] exchanging code for tokens")
-  async with aiohttp.ClientSession() as session:
-    async with session.post(GOOGLE_TOKEN_ENDPOINT, data=data) as resp:
-      if resp.status != 200:
-        error = await resp.text()
-        logging.error(
-          "[exchange_code_for_tokens] failed status=%s error=%s", resp.status, error
-        )
-        raise HTTPException(status_code=400, detail="Failed to exchange authorization code")
-      token_data = await resp.json()
-  id_token = token_data.get("id_token")
-  access_token = token_data.get("access_token")
-  if not id_token or not access_token:
-    logging.error("[exchange_code_for_tokens] missing tokens in response")
-    raise HTTPException(status_code=400, detail="Invalid token response")
-  return id_token, access_token
 
 
 def normalize_provider_identifier(pid: str) -> str:
@@ -62,112 +24,6 @@ def normalize_provider_identifier(pid: str) -> str:
     return str(uuid.UUID(pid))
   except ValueError:
     return str(uuid.uuid5(uuid.NAMESPACE_URL, pid))
-
-def extract_identifiers(provider_uid: str | None, payload: dict) -> list[str]:
-  identifiers = []
-  if provider_uid:
-    identifiers.append(provider_uid)
-  oid = payload.get("oid")
-  sub = payload.get("sub")
-  if oid and oid not in identifiers:
-    identifiers.append(oid)
-  if sub and sub not in identifiers:
-    identifiers.append(sub)
-  base_id = None
-  for candidate in (oid, sub, provider_uid):
-    if not candidate:
-      continue
-    try:
-      base_id = str(uuid.UUID(candidate))
-      break
-    except ValueError:
-      continue
-  if base_id:
-    home_account_id = base64.urlsafe_b64encode(
-      b"\x00" * 16 + uuid.UUID(base_id).bytes
-    ).decode("utf-8").rstrip("=")
-    if home_account_id not in identifiers:
-      identifiers.append(home_account_id)
-    logging.debug(
-      f"[extract_identifiers] home_account_id={home_account_id[:40]}"
-    )
-  return identifiers
-
-
-async def lookup_user(db: DbModule, provider: str, identifiers: list[str]):
-  def _norm(pid: str) -> str | None:
-    try:
-      return str(uuid.UUID(pid))
-    except ValueError:
-      try:
-        pad = pid + "=" * (-len(pid) % 4)
-        raw = base64.urlsafe_b64decode(pad)
-        if len(raw) >= 16:
-          return str(uuid.UUID(bytes=raw[-16:]))
-      except Exception:
-        return None
-    return None
-
-  checked = set()
-  for pid in identifiers:
-    uid = _norm(pid)
-    if not uid or uid in checked:
-      continue
-    checked.add(uid)
-    logging.debug(f"[lookup_user] checking identifier={pid[:40]}")
-    res = await db.run(
-      "urn:users:providers:get_by_provider_identifier:1",
-      {"provider": provider, "provider_identifier": uid},
-    )
-    if res.rows:
-      logging.debug(f"[lookup_user] user found with identifier={pid[:40]}")
-      return res.rows[0]
-  return None
-
-
-async def create_session(
-  auth: AuthModule,
-  db: DbModule,
-  user_guid: str,
-  provider: str,
-  fingerprint: str,
-  user_agent: str | None,
-  ip_address: str | None,
-):
-  rotation_token, rot_exp = auth.make_rotation_token(user_guid)
-  logging.debug(f"[create_session] rotation_token={rotation_token[:40]}")
-  now = datetime.now(timezone.utc)
-  await db.run(
-    "db:users:session:set_rotkey:1",
-    {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
-  )
-  roles, _ = await auth.get_user_roles(user_guid)
-  session_exp = now + timedelta(minutes=DEFAULT_SESSION_TOKEN_EXPIRY)
-  placeholder = uuid.uuid4().hex
-  res = await db.run(
-    "db:auth:session:create_session:1",
-    {
-      "access_token": placeholder,
-      "expires": session_exp,
-      "fingerprint": fingerprint,
-      "user_agent": user_agent,
-      "ip_address": ip_address,
-      "user_guid": user_guid,
-      "provider": provider,
-    },
-  )
-  row = res.rows[0] if res.rows else {}
-  session_guid = row.get("session_guid")
-  device_guid = row.get("device_guid")
-  session_token, _ = auth.make_session_token(
-    user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp
-  )
-  await db.run(
-    "db:auth:session:update_device_token:1",
-    {"device_guid": device_guid, "access_token": session_token},
-  )
-  logging.debug(f"[create_session] session_token={session_token[:40]}")
-  return session_token, session_exp, rotation_token, rot_exp
 
 
 async def auth_google_oauth_login_v1(request: Request):
@@ -212,7 +68,10 @@ async def auth_google_oauth_login_v1(request: Request):
   logging.debug("[auth_google_oauth_login_v1] redirect_uri=%s", redirect_uri)
 
   id_token, access_token = await exchange_code_for_tokens(
-    code, client_id, client_secret, redirect_uri
+    code,
+    client_id,
+    client_secret,
+    redirect_uri,
   )
 
   provider_uid, profile, payload = await auth.handle_auth_login(

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -1,6 +1,4 @@
-from datetime import datetime, timezone, timedelta
 import base64, logging, uuid
-import aiohttp
 
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -9,78 +7,13 @@ from fastapi.encoders import jsonable_encoder
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
-try:
-  from server.modules.auth_module import DEFAULT_SESSION_TOKEN_EXPIRY
-except Exception:
-  DEFAULT_SESSION_TOKEN_EXPIRY = 15
 from server.modules.db_module import DbModule
+from server.modules.oauth_module import (
+  extract_identifiers as _extract_identifiers,
+  lookup_user,
+  create_session,
+)
 from .models import AuthMicrosoftOauthLogin1
-
-MICROSOFT_TOKEN_ENDPOINT = "https://login.microsoftonline.com/consumers/oauth2/v2.0/token"
-
-
-async def exchange_code_for_tokens(
-  code: str,
-  client_id: str,
-  client_secret: str,
-  redirect_uri: str = "http://localhost:8000/userpage",
-) -> tuple[str, str]:
-  data = {
-    "client_id": client_id,
-    "client_secret": client_secret,
-    "code": code,
-    "grant_type": "authorization_code",
-    "redirect_uri": redirect_uri,
-  }
-  logging.debug(
-    "[exchange_code_for_tokens] data=%s",
-    {k: v for k, v in data.items() if k != "client_secret"}
-  )
-  logging.debug("[exchange_code_for_tokens] exchanging code for tokens")
-  async with aiohttp.ClientSession() as session:
-    async with session.post(MICROSOFT_TOKEN_ENDPOINT, data=data) as resp:
-      if resp.status != 200:
-        error = await resp.text()
-        logging.error(
-          "[exchange_code_for_tokens] failed status=%s error=%s", resp.status, error
-        )
-        raise HTTPException(status_code=400, detail="Failed to exchange authorization code")
-      token_data = await resp.json()
-  id_token = token_data.get("id_token")
-  access_token = token_data.get("access_token")
-  if not id_token or not access_token:
-    logging.error("[exchange_code_for_tokens] missing tokens in response")
-    raise HTTPException(status_code=400, detail="Invalid token response")
-  return id_token, access_token
-
-
-def extract_identifiers(provider_uid: str | None, payload: dict) -> list[str]:
-  identifiers = []
-  if provider_uid:
-    identifiers.append(provider_uid)
-  oid = payload.get("oid")
-  sub = payload.get("sub")
-  if oid and oid not in identifiers:
-    identifiers.append(oid)
-  if sub and sub not in identifiers:
-    identifiers.append(sub)
-  base_id = oid or sub or provider_uid
-  if base_id:
-    try:
-      home_account_id = base64.urlsafe_b64encode(
-        b"\x00" * 16 + uuid.UUID(base_id).bytes
-      ).decode("utf-8").rstrip("=")
-    except Exception as e:
-      logging.exception(
-        f"[extract_identifiers] home_account_id generation failed for {base_id}: {e}"
-      )
-    else:
-      if home_account_id not in identifiers:
-        identifiers.append(home_account_id)
-      logging.debug(
-        f"[extract_identifiers] home_account_id={home_account_id[:40]}"
-      )
-  return identifiers
 
 
 def normalize_provider_identifier(pid: str) -> str:
@@ -97,80 +30,10 @@ def normalize_provider_identifier(pid: str) -> str:
     return str(uuid.uuid5(uuid.NAMESPACE_URL, pid))
 
 
-async def lookup_user(db: DbModule, provider: str, identifiers: list[str]):
-  def _norm(pid: str) -> str | None:
-    try:
-      return str(uuid.UUID(pid))
-    except ValueError:
-      try:
-        pad = pid + "=" * (-len(pid) % 4)
-        raw = base64.urlsafe_b64decode(pad)
-        if len(raw) >= 16:
-          return str(uuid.UUID(bytes=raw[-16:]))
-      except Exception:
-        return None
-    return None
-
-  checked = set()
-  for pid in identifiers:
-    uid = _norm(pid)
-    if not uid or uid in checked:
-      continue
-    checked.add(uid)
-    logging.debug(f"[lookup_user] checking identifier={pid[:40]}")
-    res = await db.run(
-      "urn:users:providers:get_by_provider_identifier:1",
-      {"provider": provider, "provider_identifier": uid},
-    )
-    if res.rows:
-      logging.debug(f"[lookup_user] user found with identifier={pid[:40]}")
-      return res.rows[0]
-  return None
+def extract_identifiers(provider_uid: str | None, payload: dict) -> list[str]:
+  return _extract_identifiers(provider_uid, payload, "microsoft")
 
 
-async def create_session(
-  auth: AuthModule,
-  db: DbModule,
-  user_guid: str,
-  provider: str,
-  fingerprint: str,
-  user_agent: str | None,
-  ip_address: str | None,
-):
-  rotation_token, rot_exp = auth.make_rotation_token(user_guid)
-  logging.debug(f"[create_session] rotation_token={rotation_token[:40]}")
-  now = datetime.now(timezone.utc)
-  await db.run(
-    "db:users:session:set_rotkey:1",
-    {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
-  )
-  roles, _ = await auth.get_user_roles(user_guid)
-  session_exp = now + timedelta(minutes=DEFAULT_SESSION_TOKEN_EXPIRY)
-  placeholder = uuid.uuid4().hex
-  res = await db.run(
-    "db:auth:session:create_session:1",
-    {
-      "access_token": placeholder,
-      "expires": session_exp,
-      "fingerprint": fingerprint,
-      "user_agent": user_agent,
-      "ip_address": ip_address,
-      "user_guid": user_guid,
-      "provider": provider,
-    },
-  )
-  row = res.rows[0] if res.rows else {}
-  session_guid = row.get("session_guid")
-  device_guid = row.get("device_guid")
-  session_token, _ = auth.make_session_token(
-    user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp
-  )
-  await db.run(
-    "db:auth:session:update_device_token:1",
-    {"device_guid": device_guid, "access_token": session_token},
-  )
-  logging.debug(f"[create_session] session_token={session_token[:40]}")
-  return session_token, session_exp, rotation_token, rot_exp
 
 
 async def auth_microsoft_oauth_login_v1(request: Request):

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -1,7 +1,6 @@
 from fastapi import HTTPException, Request
 from pydantic import ValidationError
 import uuid
-from datetime import datetime, timezone
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
@@ -14,8 +13,12 @@ from .models import (
   UsersProvidersGetByProviderIdentifier1,
   UsersProvidersCreateFromProvider1,
 )
-from rpc.auth.google.services import exchange_code_for_tokens
-from rpc.auth.microsoft.services import exchange_code_for_tokens as ms_exchange_code_for_tokens
+from functools import partial
+from server.modules.oauth_module import (
+  TOKEN_ENDPOINTS,
+  exchange_code_for_tokens,
+)
+ms_exchange_code_for_tokens = partial(exchange_code_for_tokens, token_endpoint=TOKEN_ENDPOINTS["microsoft"])
 
 
 def normalize_provider_identifier(pid: str) -> str:

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -1,0 +1,181 @@
+import base64, logging, uuid
+import aiohttp
+from datetime import datetime, timezone, timedelta
+
+from fastapi import FastAPI, HTTPException
+from . import BaseModule
+
+from server.modules.auth_module import AuthModule
+try:
+  from server.modules.auth_module import DEFAULT_SESSION_TOKEN_EXPIRY
+except Exception:
+  DEFAULT_SESSION_TOKEN_EXPIRY = 15
+from server.modules.db_module import DbModule
+
+TOKEN_ENDPOINTS = {
+  "google": "https://oauth2.googleapis.com/token",
+  "microsoft": "https://login.microsoftonline.com/consumers/oauth2/v2.0/token",
+}
+
+
+class OauthModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+
+  async def startup(self):
+    self.mark_ready()
+
+  async def shutdown(self):
+    pass
+
+async def exchange_code_for_tokens(
+  code: str,
+  client_id: str,
+  client_secret: str,
+  redirect_uri: str,
+  token_endpoint: str = TOKEN_ENDPOINTS["google"],
+) -> tuple[str, str]:
+  data = {
+    "code": code,
+    "client_id": client_id,
+    "client_secret": client_secret,
+    "redirect_uri": redirect_uri,
+    "grant_type": "authorization_code",
+  }
+  logging.debug(
+    "[exchange_code_for_tokens] data=%s",
+    {k: v for k, v in data.items() if k != "client_secret"},
+  )
+  logging.debug("[exchange_code_for_tokens] exchanging code for tokens")
+  async with aiohttp.ClientSession() as session:
+    async with session.post(token_endpoint, data=data) as resp:
+      if resp.status != 200:
+        error = await resp.text()
+        logging.error(
+          "[exchange_code_for_tokens] failed status=%s error=%s", resp.status, error,
+        )
+        raise HTTPException(status_code=400, detail="Failed to exchange authorization code")
+      token_data = await resp.json()
+  id_token = token_data.get("id_token")
+  access_token = token_data.get("access_token")
+  if not id_token or not access_token:
+    logging.error("[exchange_code_for_tokens] missing tokens in response")
+    raise HTTPException(status_code=400, detail="Invalid token response")
+  return id_token, access_token
+
+def extract_identifiers(
+  provider_uid: str | None,
+  payload: dict,
+  provider: str = "google",
+) -> list[str]:
+  identifiers = []
+  if provider_uid:
+    identifiers.append(provider_uid)
+  oid = payload.get("oid")
+  sub = payload.get("sub")
+  if oid and oid not in identifiers:
+    identifiers.append(oid)
+  if sub and sub not in identifiers:
+    identifiers.append(sub)
+  base_id = None
+  for candidate in (oid, sub, provider_uid):
+    if not candidate:
+      continue
+    try:
+      base_id = str(uuid.UUID(candidate))
+      break
+    except ValueError:
+      continue
+  if base_id:
+    home_account_id = base64.urlsafe_b64encode(
+      b"\x00" * 16 + uuid.UUID(base_id).bytes
+    ).decode("utf-8").rstrip("=")
+    if home_account_id not in identifiers:
+      identifiers.append(home_account_id)
+    logging.debug(
+      f"[extract_identifiers] home_account_id={home_account_id[:40]}",
+    )
+  else:
+    bad = oid or sub or provider_uid
+    if bad and provider == "microsoft":
+      try:
+        uuid.UUID(bad)
+      except Exception as e:
+        logging.exception(
+          f"[extract_identifiers] home_account_id generation failed for {bad}: {e}",
+        )
+  return identifiers
+
+async def lookup_user(db: DbModule, provider: str, identifiers: list[str]):
+  def _norm(pid: str) -> str | None:
+    try:
+      return str(uuid.UUID(pid))
+    except ValueError:
+      try:
+        pad = pid + "=" * (-len(pid) % 4)
+        raw = base64.urlsafe_b64decode(pad)
+        if len(raw) >= 16:
+          return str(uuid.UUID(bytes=raw[-16:]))
+      except Exception:
+        return None
+    return None
+
+  checked = set()
+  for pid in identifiers:
+    uid = _norm(pid)
+    if not uid or uid in checked:
+      continue
+    checked.add(uid)
+    logging.debug(f"[lookup_user] checking identifier={pid[:40]}")
+    res = await db.run(
+      "urn:users:providers:get_by_provider_identifier:1",
+      {"provider": provider, "provider_identifier": uid},
+    )
+    if res.rows:
+      logging.debug(f"[lookup_user] user found with identifier={pid[:40]}")
+      return res.rows[0]
+  return None
+
+async def create_session(
+  auth: AuthModule,
+  db: DbModule,
+  user_guid: str,
+  provider: str,
+  fingerprint: str,
+  user_agent: str | None,
+  ip_address: str | None,
+):
+  rotation_token, rot_exp = auth.make_rotation_token(user_guid)
+  logging.debug(f"[create_session] rotation_token={rotation_token[:40]}")
+  now = datetime.now(timezone.utc)
+  await db.run(
+    "db:users:session:set_rotkey:1",
+    {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
+  )
+  roles, _ = await auth.get_user_roles(user_guid)
+  session_exp = now + timedelta(minutes=DEFAULT_SESSION_TOKEN_EXPIRY)
+  placeholder = uuid.uuid4().hex
+  res = await db.run(
+    "db:auth:session:create_session:1",
+    {
+      "access_token": placeholder,
+      "expires": session_exp,
+      "fingerprint": fingerprint,
+      "user_agent": user_agent,
+      "ip_address": ip_address,
+      "user_guid": user_guid,
+      "provider": provider,
+    },
+  )
+  row = res.rows[0] if res.rows else {}
+  session_guid = row.get("session_guid")
+  device_guid = row.get("device_guid")
+  session_token, _ = auth.make_session_token(
+    user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp,
+  )
+  await db.run(
+    "db:auth:session:update_device_token:1",
+    {"device_guid": device_guid, "access_token": session_token},
+  )
+  logging.debug(f"[create_session] session_token={session_token[:40]}")
+  return session_token, session_exp, rotation_token, rot_exp


### PR DESCRIPTION
## Summary
- add shared OAuth helpers for token exchange, identifier extraction, user lookup and session creation
- refactor Google and Microsoft auth services to leverage shared helpers
- update user provider services to use shared token exchange logic
- add OauthModule class to satisfy module discovery

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68baed11b2248325b728783371a8d08f