### PR TITLE
Refactor OAuth helpers into OauthModule and update services

### DIFF
--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -12,169 +12,177 @@ except Exception:
   DEFAULT_SESSION_TOKEN_EXPIRY = 15
 from server.modules.db_module import DbModule
 
-TOKEN_ENDPOINTS = {
-  "google": "https://oauth2.googleapis.com/token",
-  "microsoft": "https://login.microsoftonline.com/consumers/oauth2/v2.0/token",
-}
 
 class OauthModule(BaseModule):
+  TOKEN_ENDPOINTS = {
+    "google": "https://oauth2.googleapis.com/token",
+    "microsoft": "https://login.microsoftonline.com/consumers/oauth2/v2.0/token",
+  }
+
   def __init__(self, app: FastAPI):
     super().__init__(app)
 
   async def startup(self):
+    self.auth: AuthModule = self.app.state.auth
+    await self.auth.on_ready()
+    self.db: DbModule = self.app.state.db
+    await self.db.on_ready()
     self.mark_ready()
 
   async def shutdown(self):
     pass
 
-async def exchange_code_for_tokens(
-  code: str,
-  client_id: str,
-  client_secret: str,
-  redirect_uri: str,
-  token_endpoint: str = TOKEN_ENDPOINTS["google"],
-) -> tuple[str, str]:
-  data = {
-    "code": code,
-    "client_id": client_id,
-    "client_secret": client_secret,
-    "redirect_uri": redirect_uri,
-    "grant_type": "authorization_code",
-  }
-  logging.debug(
-    "[exchange_code_for_tokens] data=%s",
-    {k: v for k, v in data.items() if k != "client_secret"},
-  )
-  logging.debug("[exchange_code_for_tokens] exchanging code for tokens")
-  async with aiohttp.ClientSession() as session:
-    async with session.post(token_endpoint, data=data) as resp:
-      if resp.status != 200:
-        error = await resp.text()
-        logging.error(
-          "[exchange_code_for_tokens] failed status=%s error=%s", resp.status, error,
-        )
-        raise HTTPException(status_code=400, detail="Failed to exchange authorization code")
-      token_data = await resp.json()
-  id_token = token_data.get("id_token")
-  access_token = token_data.get("access_token")
-  if not id_token or not access_token:
-    logging.error("[exchange_code_for_tokens] missing tokens in response")
-    raise HTTPException(status_code=400, detail="Invalid token response")
-  return id_token, access_token
-
-def extract_identifiers(
-  provider_uid: str | None,
-  payload: dict,
-  provider: str = "google",
-) -> list[str]:
-  identifiers = []
-  if provider_uid:
-    identifiers.append(provider_uid)
-  oid = payload.get("oid")
-  sub = payload.get("sub")
-  if oid and oid not in identifiers:
-    identifiers.append(oid)
-  if sub and sub not in identifiers:
-    identifiers.append(sub)
-  base_id = None
-  for candidate in (oid, sub, provider_uid):
-    if not candidate:
-      continue
-    try:
-      base_id = str(uuid.UUID(candidate))
-      break
-    except ValueError:
-      continue
-  if base_id:
-    home_account_id = base64.urlsafe_b64encode(
-      b"\x00" * 16 + uuid.UUID(base_id).bytes
-    ).decode("utf-8").rstrip("=")
-    if home_account_id not in identifiers:
-      identifiers.append(home_account_id)
+  async def exchange_code_for_tokens(
+    self,
+    code: str,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    token_endpoint: str | None = None,
+  ) -> tuple[str, str]:
+    token_endpoint = token_endpoint or self.TOKEN_ENDPOINTS["google"]
+    data = {
+      "code": code,
+      "client_id": client_id,
+      "client_secret": client_secret,
+      "redirect_uri": redirect_uri,
+      "grant_type": "authorization_code",
+    }
     logging.debug(
-      f"[extract_identifiers] home_account_id={home_account_id[:40]}",
+      "[exchange_code_for_tokens] data=%s",
+      {k: v for k, v in data.items() if k != "client_secret"},
     )
-  else:
-    bad = oid or sub or provider_uid
-    if bad and provider == "microsoft":
-      try:
-        uuid.UUID(bad)
-      except Exception as e:
-        logging.exception(
-          f"[extract_identifiers] home_account_id generation failed for {bad}: {e}",
-        )
-  return identifiers
+    logging.debug("[exchange_code_for_tokens] exchanging code for tokens")
+    async with aiohttp.ClientSession() as session:
+      async with session.post(token_endpoint, data=data) as resp:
+        if resp.status != 200:
+          error = await resp.text()
+          logging.error(
+            "[exchange_code_for_tokens] failed status=%s error=%s", resp.status, error,
+          )
+          raise HTTPException(status_code=400, detail="Failed to exchange authorization code")
+        token_data = await resp.json()
+    id_token = token_data.get("id_token")
+    access_token = token_data.get("access_token")
+    if not id_token or not access_token:
+      logging.error("[exchange_code_for_tokens] missing tokens in response")
+      raise HTTPException(status_code=400, detail="Invalid token response")
+    return id_token, access_token
 
-async def lookup_user(db: DbModule, provider: str, identifiers: list[str]):
-  def _norm(pid: str) -> str | None:
-    try:
-      return str(uuid.UUID(pid))
-    except ValueError:
+  def extract_identifiers(
+    self,
+    provider_uid: str | None,
+    payload: dict,
+    provider: str = "google",
+  ) -> list[str]:
+    identifiers = []
+    if provider_uid:
+      identifiers.append(provider_uid)
+    oid = payload.get("oid")
+    sub = payload.get("sub")
+    if oid and oid not in identifiers:
+      identifiers.append(oid)
+    if sub and sub not in identifiers:
+      identifiers.append(sub)
+    base_id = None
+    for candidate in (oid, sub, provider_uid):
+      if not candidate:
+        continue
       try:
-        pad = pid + "=" * (-len(pid) % 4)
-        raw = base64.urlsafe_b64decode(pad)
-        if len(raw) >= 16:
-          return str(uuid.UUID(bytes=raw[-16:]))
-      except Exception:
-        return None
+        base_id = str(uuid.UUID(candidate))
+        break
+      except ValueError:
+        continue
+    if base_id:
+      home_account_id = base64.urlsafe_b64encode(
+        b"\x00" * 16 + uuid.UUID(base_id).bytes
+      ).decode("utf-8").rstrip("=")
+      if home_account_id not in identifiers:
+        identifiers.append(home_account_id)
+      logging.debug(
+        f"[extract_identifiers] home_account_id={home_account_id[:40]}",
+      )
+    else:
+      bad = oid or sub or provider_uid
+      if bad and provider == "microsoft":
+        try:
+          uuid.UUID(bad)
+        except Exception as e:
+          logging.exception(
+            f"[extract_identifiers] home_account_id generation failed for {bad}: {e}",
+          )
+    return identifiers
+
+  async def lookup_user(self, provider: str, identifiers: list[str]):
+    def _norm(pid: str) -> str | None:
+      try:
+        return str(uuid.UUID(pid))
+      except ValueError:
+        try:
+          pad = pid + "=" * (-len(pid) % 4)
+          raw = base64.urlsafe_b64decode(pad)
+          if len(raw) >= 16:
+            return str(uuid.UUID(bytes=raw[-16:]))
+        except Exception:
+          return None
+      return None
+
+    checked = set()
+    for pid in identifiers:
+      uid = _norm(pid)
+      if not uid or uid in checked:
+        continue
+      checked.add(uid)
+      logging.debug(f"[lookup_user] checking identifier={pid[:40]}")
+      res = await self.db.run(
+        "urn:users:providers:get_by_provider_identifier:1",
+        {"provider": provider, "provider_identifier": uid},
+      )
+      if res.rows:
+        logging.debug(f"[lookup_user] user found with identifier={pid[:40]}")
+        return res.rows[0]
     return None
 
-  checked = set()
-  for pid in identifiers:
-    uid = _norm(pid)
-    if not uid or uid in checked:
-      continue
-    checked.add(uid)
-    logging.debug(f"[lookup_user] checking identifier={pid[:40]}")
-    res = await db.run(
-      "urn:users:providers:get_by_provider_identifier:1",
-      {"provider": provider, "provider_identifier": uid},
+  async def create_session(
+    self,
+    user_guid: str,
+    provider: str,
+    fingerprint: str,
+    user_agent: str | None,
+    ip_address: str | None,
+  ):
+    rotation_token, rot_exp = self.auth.make_rotation_token(user_guid)
+    logging.debug(f"[create_session] rotation_token={rotation_token[:40]}")
+    now = datetime.now(timezone.utc)
+    await self.db.run(
+      "db:users:session:set_rotkey:1",
+      {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
     )
-    if res.rows:
-      logging.debug(f"[lookup_user] user found with identifier={pid[:40]}")
-      return res.rows[0]
-  return None
+    roles, _ = await self.auth.get_user_roles(user_guid)
+    session_exp = now + timedelta(minutes=DEFAULT_SESSION_TOKEN_EXPIRY)
+    placeholder = uuid.uuid4().hex
+    res = await self.db.run(
+      "db:auth:session:create_session:1",
+      {
+        "access_token": placeholder,
+        "expires": session_exp,
+        "fingerprint": fingerprint,
+        "user_agent": user_agent,
+        "ip_address": ip_address,
+        "user_guid": user_guid,
+        "provider": provider,
+      },
+    )
+    row = res.rows[0] if res.rows else {}
+    session_guid = row.get("session_guid")
+    device_guid = row.get("device_guid")
+    session_token, _ = self.auth.make_session_token(
+      user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp,
+    )
+    await self.db.run(
+      "db:auth:session:update_device_token:1",
+      {"device_guid": device_guid, "access_token": session_token},
+    )
+    logging.debug(f"[create_session] session_token={session_token[:40]}")
+    return session_token, session_exp, rotation_token, rot_exp
 
-async def create_session(
-  auth: AuthModule,
-  db: DbModule,
-  user_guid: str,
-  provider: str,
-  fingerprint: str,
-  user_agent: str | None,
-  ip_address: str | None,
-):
-  rotation_token, rot_exp = auth.make_rotation_token(user_guid)
-  logging.debug(f"[create_session] rotation_token={rotation_token[:40]}")
-  now = datetime.now(timezone.utc)
-  await db.run(
-    "db:users:session:set_rotkey:1",
-    {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
-  )
-  roles, _ = await auth.get_user_roles(user_guid)
-  session_exp = now + timedelta(minutes=DEFAULT_SESSION_TOKEN_EXPIRY)
-  placeholder = uuid.uuid4().hex
-  res = await db.run(
-    "db:auth:session:create_session:1",
-    {
-      "access_token": placeholder,
-      "expires": session_exp,
-      "fingerprint": fingerprint,
-      "user_agent": user_agent,
-      "ip_address": ip_address,
-      "user_guid": user_guid,
-      "provider": provider,
-    },
-  )
-  row = res.rows[0] if res.rows else {}
-  session_guid = row.get("session_guid")
-  device_guid = row.get("device_guid")
-  session_token, _ = auth.make_session_token(
-    user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp,
-  )
-  await db.run(
-    "db:auth:session:update_device_token:1",
-    {"device_guid": device_guid, "access_token": session_token},
-  )
-  logging.debug(f"[create_session] session_token={session_token[:40]}")
-  return session_token, session_exp, rotation_token, rot_exp

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -5,7 +5,9 @@ import importlib.util
 import sys
 import types
 import uuid
+from fastapi import FastAPI
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
+from server.modules.oauth_module import OauthModule
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -67,6 +69,9 @@ class DummyState:
     self.auth = DummyAuth()
     self.db = DummyDb()
     self.env = DummyEnv()
+    self.oauth = OauthModule(FastAPI())
+    self.oauth.auth = self.auth
+    self.oauth.db = self.db
 
 class DummyApp:
   def __init__(self):
@@ -135,10 +140,10 @@ def test_lookup_existing_user(monkeypatch):
     assert code == "auth-code"
     assert redirect_uri == "http://localhost:8000/userpage"
     return "id", "acc"
-  svc_mod.exchange_code_for_tokens = fake_exchange
   auth_google_oauth_login_v1 = svc_mod.auth_google_oauth_login_v1
 
   req = DummyRequest()
+  req.app.state.oauth.exchange_code_for_tokens = fake_exchange
   resp = asyncio.run(auth_google_oauth_login_v1(req))
   assert "rotation_token=" in resp.headers.get("set-cookie", "")
   assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)

--- a/tests/test_auth_microsoft_email_exists.py
+++ b/tests/test_auth_microsoft_email_exists.py
@@ -2,7 +2,9 @@ import sys, types, pytest, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 import json
-from fastapi import HTTPException
+from fastapi import HTTPException, FastAPI
+
+from server.modules.oauth_module import OauthModule
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -51,6 +53,9 @@ class DummyState:
   def __init__(self):
     self.auth = DummyAuth()
     self.db = DummyDb()
+    self.oauth = OauthModule(FastAPI())
+    self.oauth.auth = self.auth
+    self.oauth.db = self.db
 
 class DummyApp:
   def __init__(self):

--- a/tests/test_auth_microsoft_home_account_lookup.py
+++ b/tests/test_auth_microsoft_home_account_lookup.py
@@ -1,6 +1,9 @@
 import sys, types, importlib.util, asyncio, base64, uuid
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
+from fastapi import FastAPI
+
+from server.modules.oauth_module import OauthModule
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -39,6 +42,9 @@ class DummyState:
   def __init__(self):
     self.auth = DummyAuth()
     self.db = DummyDb()
+    self.oauth = OauthModule(FastAPI())
+    self.oauth.auth = self.auth
+    self.oauth.db = self.db
 
 class DummyApp:
   def __init__(self):

--- a/tests/test_auth_microsoft_oauth_login_creation.py
+++ b/tests/test_auth_microsoft_oauth_login_creation.py
@@ -1,6 +1,9 @@
 import sys, types, pytest, importlib.util, importlib.machinery, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
+from fastapi import FastAPI
+
+from server.modules.oauth_module import OauthModule
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -43,6 +46,9 @@ class DummyState:
   def __init__(self):
     self.auth = DummyAuth()
     self.db = DummyDb()
+    self.oauth = OauthModule(FastAPI())
+    self.oauth.auth = self.auth
+    self.oauth.db = self.db
 
 class DummyApp:
   def __init__(self):

--- a/tests/test_auth_microsoft_profile_image_clear.py
+++ b/tests/test_auth_microsoft_profile_image_clear.py
@@ -1,6 +1,9 @@
 import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
+from fastapi import FastAPI
+
+from server.modules.oauth_module import OauthModule
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -37,6 +40,9 @@ class DummyState:
   def __init__(self):
     self.auth = DummyAuth()
     self.db = DummyDb()
+    self.oauth = OauthModule(FastAPI())
+    self.oauth.auth = self.auth
+    self.oauth.db = self.db
 
 class DummyApp:
   def __init__(self):

--- a/tests/test_auth_microsoft_profile_image_update.py
+++ b/tests/test_auth_microsoft_profile_image_update.py
@@ -1,6 +1,9 @@
 import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
+from fastapi import FastAPI
+
+from server.modules.oauth_module import OauthModule
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -37,6 +40,9 @@ class DummyState:
   def __init__(self):
     self.auth = DummyAuth()
     self.db = DummyDb()
+    self.oauth = OauthModule(FastAPI())
+    self.oauth.auth = self.auth
+    self.oauth.db = self.db
 
 class DummyApp:
   def __init__(self):

--- a/tests/test_auth_microsoft_profile_refresh.py
+++ b/tests/test_auth_microsoft_profile_refresh.py
@@ -1,6 +1,9 @@
 import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
+from fastapi import FastAPI
+
+from server.modules.oauth_module import OauthModule
 import json
 
 
@@ -48,6 +51,9 @@ class DummyState:
   def __init__(self, auth, db):
     self.auth = auth
     self.db = db
+    self.oauth = OauthModule(FastAPI())
+    self.oauth.auth = self.auth
+    self.oauth.db = self.db
 
 
 class DummyApp:

--- a/tests/test_auth_microsoft_relink_unlinked.py
+++ b/tests/test_auth_microsoft_relink_unlinked.py
@@ -1,6 +1,9 @@
 import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
+from fastapi import FastAPI
+
+from server.modules.oauth_module import OauthModule
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -45,6 +48,9 @@ class DummyState:
   def __init__(self):
     self.auth = DummyAuth()
     self.db = DummyDb()
+    self.oauth = OauthModule(FastAPI())
+    self.oauth.auth = self.auth
+    self.oauth.db = self.db
 
 class DummyApp:
   def __init__(self):

--- a/tests/test_google_services_helpers.py
+++ b/tests/test_google_services_helpers.py
@@ -1,81 +1,19 @@
-from types import SimpleNamespace
-from datetime import datetime, timezone, timedelta
 import asyncio
-import importlib.util
-import pathlib
-import sys
-import types
-import uuid
-import logging
 import base64
+import logging
+import uuid
+from datetime import datetime, timezone, timedelta
 
-import pytest
 from types import SimpleNamespace
+from fastapi import FastAPI
 
-# stub rpc and server packages
-root_path = pathlib.Path(__file__).resolve().parent.parent
-rpc_pkg = types.ModuleType("rpc")
-rpc_pkg.__path__ = [str(root_path / "rpc")]
-sys.modules["rpc"] = rpc_pkg
-
-spec_models = importlib.util.spec_from_file_location(
-  "server.models", root_path / "server/models.py"
-)
-models_mod = importlib.util.module_from_spec(spec_models)
-spec_models.loader.exec_module(models_mod)
-sys.modules["server.models"] = models_mod
-
-helpers_stub = types.ModuleType("rpc.helpers")
-async def _stub(request):
-  raise NotImplementedError
-helpers_stub.unbox_request = _stub
-sys.modules["rpc.helpers"] = helpers_stub
-
-server_pkg = types.ModuleType("server")
-sys.modules["server"] = server_pkg
-modules_pkg = types.ModuleType("server.modules")
-sys.modules["server.modules"] = modules_pkg
-auth_pkg = types.ModuleType("server.modules.auth_module")
-class AuthModule: ...
-auth_pkg.AuthModule = AuthModule
-modules_pkg.auth_module = auth_pkg
-sys.modules["server.modules.auth_module"] = auth_pkg
-db_pkg = types.ModuleType("server.modules.db_module")
-class DbModule: ...
-db_pkg.DbModule = DbModule
-modules_pkg.db_module = db_pkg
-sys.modules["server.modules.db_module"] = db_pkg
-
-auth_ns = types.ModuleType("rpc.auth")
-auth_ns.__path__ = [str(root_path / "rpc/auth")]
-sys.modules["rpc.auth"] = auth_ns
-google_ns = types.ModuleType("rpc.auth.google")
-google_ns.__path__ = [str(root_path / "rpc/auth/google")]
-sys.modules["rpc.auth.google"] = google_ns
-
-spec_services = importlib.util.spec_from_file_location(
-  "rpc.auth.google.services", root_path / "rpc/auth/google/services.py"
-)
-services_mod = importlib.util.module_from_spec(spec_services)
-sys.modules["rpc.auth.google.services"] = services_mod
-spec_services.loader.exec_module(services_mod)
-
-# restore real helpers for subsequent tests
-real_helpers_spec = importlib.util.spec_from_file_location(
-  "rpc.helpers", root_path / "rpc/helpers.py"
-)
-real_helpers = importlib.util.module_from_spec(real_helpers_spec)
-real_helpers_spec.loader.exec_module(real_helpers)
-sys.modules["rpc.helpers"] = real_helpers
-
-extract_identifiers = services_mod.extract_identifiers
-lookup_user = services_mod.lookup_user
-create_session = services_mod.create_session
+from server.modules.oauth_module import OauthModule
 
 
 def test_extract_identifiers_bad_base(caplog):
+  oauth = OauthModule(FastAPI())
   caplog.set_level(logging.ERROR)
-  ids = extract_identifiers("not-a-uuid", {})
+  ids = oauth.extract_identifiers("not-a-uuid", {})
   assert "not-a-uuid" in ids
   assert len(ids) == 1
   assert not any(
@@ -84,8 +22,9 @@ def test_extract_identifiers_bad_base(caplog):
 
 
 def test_extract_identifiers_fallback_to_provider():
+  oauth = OauthModule(FastAPI())
   uid = str(uuid.uuid4())
-  ids = extract_identifiers(uid, {"sub": "not-a-uuid"})
+  ids = oauth.extract_identifiers(uid, {"sub": "not-a-uuid"})
   expected = base64.urlsafe_b64encode(
     b"\x00" * 16 + uuid.UUID(uid).bytes
   ).decode("utf-8").rstrip("=")
@@ -95,6 +34,7 @@ def test_extract_identifiers_fallback_to_provider():
 class DummyDb:
   def __init__(self):
     self.calls = []
+
   async def run(self, op, args):
     self.calls.append((op, args))
     if op == "db:auth:session:create_session:1":
@@ -105,8 +45,10 @@ class DummyDb:
 
 
 def test_lookup_user_skips_invalid_identifier():
+  oauth = OauthModule(FastAPI())
   db = DummyDb()
-  user = asyncio.run(lookup_user(db, "google", ["bad-id"]))
+  oauth.db = db
+  user = asyncio.run(oauth.lookup_user("google", ["bad-id"]))
   assert user is None
   assert db.calls == []
 
@@ -114,17 +56,22 @@ def test_lookup_user_skips_invalid_identifier():
 class DummyAuth:
   def make_rotation_token(self, guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
+
   def make_session_token(self, guid, rot, session_guid, device_guid, roles, exp=None):
     return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
+
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
 
 
 def test_create_session_handles_missing_roles():
+  oauth = OauthModule(FastAPI())
   db = DummyDb()
   auth = DummyAuth()
+  oauth.db = db
+  oauth.auth = auth
   token, exp, rot, rot_exp = asyncio.run(
-    create_session(auth, db, str(uuid.uuid4()), "google", "fp", None, None)
+    oauth.create_session(str(uuid.uuid4()), "google", "fp", None, None)
   )
   assert token == "sess"
   assert rot == "rot"
@@ -132,3 +79,4 @@ def test_create_session_handles_missing_roles():
   assert "db:auth:session:create_session:1" in ops
   args = [a for op, a in db.calls if op == "db:auth:session:create_session:1"][0]
   assert args["provider"] == "google"
+

--- a/tests/test_microsoft_services_helpers.py
+++ b/tests/test_microsoft_services_helpers.py
@@ -1,81 +1,18 @@
-import asyncio, logging, uuid
-from types import SimpleNamespace
-from datetime import datetime, timezone, timedelta
 import asyncio
-import importlib.util
-import pathlib
-import sys
-import types
-import uuid
 import logging
+import uuid
+from datetime import datetime, timezone, timedelta
 
-import pytest
 from types import SimpleNamespace
+from fastapi import FastAPI
 
-# stub rpc and server packages
-root_path = pathlib.Path(__file__).resolve().parent.parent
-rpc_pkg = types.ModuleType("rpc")
-rpc_pkg.__path__ = [str(root_path / "rpc")]
-sys.modules["rpc"] = rpc_pkg
-
-spec_models = importlib.util.spec_from_file_location(
-  "server.models", root_path / "server/models.py"
-)
-models_mod = importlib.util.module_from_spec(spec_models)
-spec_models.loader.exec_module(models_mod)
-sys.modules["server.models"] = models_mod
-
-helpers_stub = types.ModuleType("rpc.helpers")
-async def _stub(request):
-  raise NotImplementedError
-helpers_stub.unbox_request = _stub
-sys.modules["rpc.helpers"] = helpers_stub
-
-server_pkg = types.ModuleType("server")
-sys.modules["server"] = server_pkg
-modules_pkg = types.ModuleType("server.modules")
-sys.modules["server.modules"] = modules_pkg
-auth_pkg = types.ModuleType("server.modules.auth_module")
-class AuthModule: ...
-auth_pkg.AuthModule = AuthModule
-modules_pkg.auth_module = auth_pkg
-sys.modules["server.modules.auth_module"] = auth_pkg
-db_pkg = types.ModuleType("server.modules.db_module")
-class DbModule: ...
-db_pkg.DbModule = DbModule
-modules_pkg.db_module = db_pkg
-sys.modules["server.modules.db_module"] = db_pkg
-
-auth_ns = types.ModuleType("rpc.auth")
-auth_ns.__path__ = [str(root_path / "rpc/auth")]
-sys.modules["rpc.auth"] = auth_ns
-ms_ns = types.ModuleType("rpc.auth.microsoft")
-ms_ns.__path__ = [str(root_path / "rpc/auth/microsoft")]
-sys.modules["rpc.auth.microsoft"] = ms_ns
-
-spec_services = importlib.util.spec_from_file_location(
-  "rpc.auth.microsoft.services", root_path / "rpc/auth/microsoft/services.py"
-)
-services_mod = importlib.util.module_from_spec(spec_services)
-sys.modules["rpc.auth.microsoft.services"] = services_mod
-spec_services.loader.exec_module(services_mod)
-
-# restore real helpers for subsequent tests
-real_helpers_spec = importlib.util.spec_from_file_location(
-  "rpc.helpers", root_path / "rpc/helpers.py"
-)
-real_helpers = importlib.util.module_from_spec(real_helpers_spec)
-real_helpers_spec.loader.exec_module(real_helpers)
-sys.modules["rpc.helpers"] = real_helpers
-
-extract_identifiers = services_mod.extract_identifiers
-lookup_user = services_mod.lookup_user
-create_session = services_mod.create_session
+from server.modules.oauth_module import OauthModule
 
 
 def test_extract_identifiers_bad_base(caplog):
+  oauth = OauthModule(FastAPI())
   caplog.set_level(logging.ERROR)
-  ids = extract_identifiers("not-a-uuid", {})
+  ids = oauth.extract_identifiers("not-a-uuid", {}, "microsoft")
   assert "not-a-uuid" in ids
   assert len(ids) == 1
   assert any("home_account_id generation failed" in r.message for r in caplog.records)
@@ -84,6 +21,7 @@ def test_extract_identifiers_bad_base(caplog):
 class DummyDb:
   def __init__(self):
     self.calls = []
+
   async def run(self, op, args):
     self.calls.append((op, args))
     if op == "db:auth:session:create_session:1":
@@ -94,8 +32,10 @@ class DummyDb:
 
 
 def test_lookup_user_skips_invalid_identifier():
+  oauth = OauthModule(FastAPI())
   db = DummyDb()
-  user = asyncio.run(lookup_user(db, "microsoft", ["bad-id"]))
+  oauth.db = db
+  user = asyncio.run(oauth.lookup_user("microsoft", ["bad-id"]))
   assert user is None
   assert db.calls == []
 
@@ -103,17 +43,22 @@ def test_lookup_user_skips_invalid_identifier():
 class DummyAuth:
   def make_rotation_token(self, guid):
     return "rot", datetime.now(timezone.utc) + timedelta(hours=1)
+
   def make_session_token(self, guid, rot, session_guid, device_guid, roles, exp=None):
     return "sess", exp or datetime.now(timezone.utc) + timedelta(hours=1)
+
   async def get_user_roles(self, guid, refresh=False):
     return [], 0
 
 
 def test_create_session_handles_missing_roles():
+  oauth = OauthModule(FastAPI())
   db = DummyDb()
   auth = DummyAuth()
+  oauth.db = db
+  oauth.auth = auth
   token, exp, rot, rot_exp = asyncio.run(
-    create_session(auth, db, str(uuid.uuid4()), "microsoft", "fp", None, None)
+    oauth.create_session(str(uuid.uuid4()), "microsoft", "fp", None, None)
   )
   assert token == "sess"
   assert rot == "rot"


### PR DESCRIPTION
## Summary
- centralize OAuth helper functions as OauthModule methods and expose provider token endpoints
- adapt auth and user-provider services to use OauthModule instance from app state
- update tests to align with new module methods

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb0496b8e48325abbad62f35d791d8