### PR TITLE
refactor: namespace database ops

### DIFF
--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -56,7 +56,7 @@ async def auth_google_oauth_login_v1(request: Request):
     raise HTTPException(status_code=500, detail="GOOGLE_AUTH_SECRET not configured")
 
   # Require redirect_uri from system config
-  res_redirect = await db.run("urn:system:config:get_config:1", {"key": "Hostname"})
+  res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
   if not res_redirect.rows:
       raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
   redirect_uri = res_redirect.rows[0]["value"]
@@ -83,7 +83,7 @@ async def auth_google_oauth_login_v1(request: Request):
 
   if user and user.get("element_soft_deleted_at"):
     res = await db.run(
-      f"urn:auth:{provider}:oauth_relink:1",
+      f"db:auth:{provider}:oauth_relink:1",
       {
         "provider_identifier": provider_uid,
         "email": profile["email"],
@@ -97,12 +97,12 @@ async def auth_google_oauth_login_v1(request: Request):
 
   if not user:
     res = await db.run(
-      "urn:users:providers:get_any_by_provider_identifier:1",
+      "db:users:providers:get_any_by_provider_identifier:1",
       {"provider": provider, "provider_identifier": provider_uid},
     )
     if res.rows:
       res2 = await db.run(
-        f"urn:auth:{provider}:oauth_relink:1",
+        f"db:auth:{provider}:oauth_relink:1",
         {
           "provider_identifier": provider_uid,
           "email": profile["email"],
@@ -116,7 +116,7 @@ async def auth_google_oauth_login_v1(request: Request):
 
   if not user:
     res = await db.run(
-      f"urn:auth:{provider}:oauth_relink:1",
+      f"db:auth:{provider}:oauth_relink:1",
       {
         "provider_identifier": provider_uid,
         "email": profile["email"],
@@ -131,7 +131,7 @@ async def auth_google_oauth_login_v1(request: Request):
   if not user:
     logging.debug("[auth_google_oauth_login_v1] user not found, creating new user")
     res = await db.run(
-      "urn:users:providers:create_from_provider:1",
+      "db:users:providers:create_from_provider:1",
       {
         "provider": provider,
         "provider_identifier": provider_uid,
@@ -144,7 +144,7 @@ async def auth_google_oauth_login_v1(request: Request):
     if not user:
       logging.debug("[auth_google_oauth_login_v1] fetching user after creation")
       res = await db.run(
-        "urn:users:providers:get_by_provider_identifier:1",
+        "db:users:providers:get_by_provider_identifier:1",
         {"provider": provider, "provider_identifier": provider_uid},
       )
       user = res.rows[0] if res.rows else None
@@ -156,13 +156,13 @@ async def auth_google_oauth_login_v1(request: Request):
   new_img = profile.get("profilePicture")
   if new_img and new_img != user.get("profile_image"):
     await db.run(
-      "urn:users:profile:set_profile_image:1",
+      "db:users:profile:set_profile_image:1",
       {"guid": user_guid, "image_b64": new_img, "provider": provider},
     )
     user["profile_image"] = new_img
   if user.get("provider_name") == "google":
     res_prof = await db.run(
-      "urn:users:profile:update_if_unedited:1",
+      "db:users:profile:update_if_unedited:1",
       {
         "guid": user_guid,
         "email": profile["email"],

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -60,7 +60,7 @@ async def auth_microsoft_oauth_login_v1(request: Request):
 
   if not user or user.get("element_soft_deleted_at"):
     res = await db.run(
-      f"urn:auth:{provider}:oauth_relink:1",
+      f"db:auth:{provider}:oauth_relink:1",
       {
         "provider_identifier": provider_uid,
         "email": profile["email"],
@@ -75,7 +75,7 @@ async def auth_microsoft_oauth_login_v1(request: Request):
   if not user:
     logging.debug("[auth_microsoft_oauth_login_v1] user not found, creating new user")
     res = await db.run(
-      "urn:users:providers:create_from_provider:1",
+      "db:users:providers:create_from_provider:1",
       {
         "provider": provider,
         "provider_identifier": provider_uid,
@@ -88,7 +88,7 @@ async def auth_microsoft_oauth_login_v1(request: Request):
     if not user:
       logging.debug("[auth_microsoft_oauth_login_v1] fetching user after creation")
       res = await db.run(
-        "urn:users:providers:get_by_provider_identifier:1",
+        "db:users:providers:get_by_provider_identifier:1",
         {"provider": provider, "provider_identifier": provider_uid},
       )
       user = res.rows[0] if res.rows else None
@@ -100,13 +100,13 @@ async def auth_microsoft_oauth_login_v1(request: Request):
   new_img = profile.get("profilePicture")
   if new_img != user.get("profile_image"):
     await db.run(
-      "urn:users:profile:set_profile_image:1",
+      "db:users:profile:set_profile_image:1",
       {"guid": user_guid, "image_b64": new_img, "provider": provider},
     )
     user["profile_image"] = new_img
   if user.get("provider_name") == "microsoft":
     res_prof = await db.run(
-      "urn:users:profile:update_if_unedited:1",
+      "db:users:profile:update_if_unedited:1",
       {
         "guid": user_guid,
         "email": profile["email"],

--- a/rpc/service/routes/services.py
+++ b/rpc/service/routes/services.py
@@ -21,7 +21,7 @@ async def service_routes_get_routes_v1(request: Request):
   )
   db: DbModule = request.app.state.db
   auth: AuthModule = request.app.state.auth
-  res = await db.run(rpc_request.op, {})
+  res = await db.run("db:service:routes:get_routes:1", {})
   routes = []
   for row in res.rows:
     mask = int(row.get("element_roles", 0))
@@ -58,7 +58,7 @@ async def service_routes_upsert_route_v1(request: Request):
   db: DbModule = request.app.state.db
   auth: AuthModule = request.app.state.auth
   mask = auth.names_to_mask(payload.required_roles)
-  await db.run(rpc_request.op, {
+  await db.run("db:service:routes:upsert_route:1", {
     "path": payload.path,
     "name": payload.name,
     "icon": payload.icon,
@@ -86,7 +86,7 @@ async def service_routes_delete_route_v1(request: Request):
   )
   payload = ServiceRoutesDeleteRoute1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run(rpc_request.op, {"path": payload.path})
+  await db.run("db:service:routes:delete_route:1", {"path": payload.path})
   logging.debug(
     "[service_routes_delete_route_v1] deleted route %s",
     payload.path,

--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -27,7 +27,7 @@ async def users_profile_get_profile_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   db: DbModule = request.app.state.db
-  res = await db.run(rpc_request.op, {"guid": user_guid})
+  res = await db.run("db:users:profile:get_profile:1", {"guid": user_guid})
   if not res.rows:
     raise HTTPException(status_code=404, detail="Profile not found")
   row = res.rows[0]
@@ -51,7 +51,7 @@ async def users_profile_set_display_v1(request: Request):
 
   payload = UsersProfileSetDisplay1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run(rpc_request.op, {
+  await db.run("db:users:profile:set_display:1", {
     "guid": user_guid,
     "display_name": payload.display_name,
   })
@@ -69,7 +69,7 @@ async def users_profile_set_optin_v1(request: Request):
 
   payload = UsersProfileSetOptin1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run(rpc_request.op, {
+  await db.run("db:users:profile:set_optin:1", {
     "guid": user_guid,
     "display_email": payload.display_email,
   })
@@ -86,7 +86,7 @@ async def users_profile_get_roles_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   db: DbModule = request.app.state.db
-  res = await db.run(rpc_request.op, {"guid": user_guid})
+  res = await db.run("db:users:profile:get_roles:1", {"guid": user_guid})
   roles = int(res.rows[0].get("element_roles", 0)) if res.rows else 0
   payload = UsersProfileRoles1(roles=roles)
   return RPCResponse(
@@ -103,7 +103,7 @@ async def users_profile_set_profile_image_v1(request: Request):
 
   payload = UsersProfileSetProfileImage1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run(rpc_request.op, {
+  await db.run("db:users:profile:set_profile_image:1", {
     "guid": user_guid,
     "image_b64": payload.image_b64,
     "provider": payload.provider,

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -240,7 +240,7 @@ class AuthModule(BaseModule):
       logging.debug("[AuthModule] Returning cached roles for %s", guid)
       return self._user_roles[guid]
     logging.debug("[AuthModule] Fetching roles for %s", guid)
-    res = await self.db.run("urn:users:profile:get_roles:1", {"guid": guid})
+    res = await self.db.run("db:users:profile:get_roles:1", {"guid": guid})
     mask = int(res.rows[0].get("element_roles", 0)) if res.rows else 0
     names = self.mask_to_names(mask)
     self._user_roles[guid] = (names, mask)

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -135,7 +135,7 @@ class OauthModule(BaseModule):
       checked.add(uid)
       logging.debug(f"[lookup_user] checking identifier={pid[:40]}")
       res = await self.db.run(
-        "urn:users:providers:get_by_provider_identifier:1",
+        "db:users:providers:get_by_provider_identifier:1",
         {"provider": provider, "provider_identifier": uid},
       )
       if res.rows:

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -45,6 +45,10 @@ def _users_select(provider_args: Dict[str, Any]):
     """
     return ("row_one", sql, (provider, identifier))
 
+@register("db:users:providers:get_by_provider_identifier:1")
+def _db_users_select(provider_args: Dict[str, Any]):
+  return _users_select(provider_args)
+
 @register("urn:users:providers:get_any_by_provider_identifier:1")
 def _users_select_any(provider_args: Dict[str, Any]):
     identifier = str(UUID(provider_args["provider_identifier"]))
@@ -57,6 +61,10 @@ def _users_select_any(provider_args: Dict[str, Any]):
       WHERE ua.element_identifier = ?;
     """
     return ("row_one", sql, (identifier,))
+
+@register("db:users:providers:get_any_by_provider_identifier:1")
+def _db_users_select_any(provider_args: Dict[str, Any]):
+  return _users_select_any(provider_args)
 
 @register("urn:users:providers:create_from_provider:1")
 async def _users_insert(args: Dict[str, Any]):
@@ -127,6 +135,10 @@ async def _users_insert(args: Dict[str, Any]):
     sel = _users_select({"provider": provider, "provider_identifier": identifier})
     return await fetch_rows(sel[1], sel[2], one=True)
 
+@register("db:users:providers:create_from_provider:1")
+async def _db_users_insert(args: Dict[str, Any]):
+  return await _users_insert(args)
+
 @register("urn:users:providers:link_provider:1")
 async def _users_link_provider(args: Dict[str, Any]):
     guid = str(UUID(args["guid"]))
@@ -153,6 +165,10 @@ async def _users_link_provider(args: Dict[str, Any]):
       (guid, ap_recid, identifier)
     )
     return rc
+
+@register("db:users:providers:link_provider:1")
+async def _db_users_link_provider(args: Dict[str, Any]):
+  return await _users_link_provider(args)
 
 @register("urn:users:providers:unlink_provider:1")
 async def _users_unlink_provider(args: Dict[str, Any]):
@@ -210,6 +226,10 @@ async def _users_unlink_provider(args: Dict[str, Any]):
           )
     return {"rows": [{"providers_remaining": cnt}], "rowcount": 1}
 
+@register("db:users:providers:unlink_provider:1")
+async def _db_users_unlink_provider(args: Dict[str, Any]):
+  return await _users_unlink_provider(args)
+
 @register("urn:users:providers:soft_delete_account:1")
 def _users_soft_delete_account(args: Dict[str, Any]):
     guid = str(UUID(args["guid"]))
@@ -219,6 +239,10 @@ def _users_soft_delete_account(args: Dict[str, Any]):
       WHERE element_guid = ?;
     """
     return ("exec", sql, (guid,))
+
+@register("db:users:providers:soft_delete_account:1")
+def _db_users_soft_delete_account(args: Dict[str, Any]):
+  return _users_soft_delete_account(args)
 
 @register("urn:users:providers:get_user_by_email:1")
 def _users_get_user_by_email(args: Dict[str, Any]):
@@ -230,6 +254,10 @@ def _users_get_user_by_email(args: Dict[str, Any]):
       WHERE element_email = ?;
     """
     return ("row_one", sql, (email,))
+
+@register("db:users:providers:get_user_by_email:1")
+def _db_users_get_user_by_email(args: Dict[str, Any]):
+  return _users_get_user_by_email(args)
 
 @register("urn:users:profile:get_profile:1")
 def _users_profile(args: Dict[str, Any]):
@@ -264,6 +292,10 @@ def _auth_unlink_last_provider(args: Dict[str, Any]):
     sql = "EXEC auth_unlink_last_provider @guid=?, @provider=?;"
     return ("exec", sql, (guid, provider))
 
+@register("db:auth:providers:unlink_last_provider:1")
+def _db_auth_unlink_last_provider(args: Dict[str, Any]):
+  return _auth_unlink_last_provider(args)
+
 @register("urn:auth:microsoft:oauth_relink:1")
 def _auth_ms_oauth_relink(args: Dict[str, Any]):
     identifier = str(UUID(args["provider_identifier"]))
@@ -273,6 +305,10 @@ def _auth_ms_oauth_relink(args: Dict[str, Any]):
     sql = "EXEC auth_oauth_relink @provider='microsoft', @identifier=?, @email=?, @display=?, @image=?;"
     return ("row_one", sql, (identifier, email, display, img))
 
+@register("db:auth:microsoft:oauth_relink:1")
+def _db_auth_ms_oauth_relink(args: Dict[str, Any]):
+  return _auth_ms_oauth_relink(args)
+
 @register("urn:auth:google:oauth_relink:1")
 def _auth_google_oauth_relink(args: Dict[str, Any]):
     identifier = str(UUID(args["provider_identifier"]))
@@ -281,6 +317,10 @@ def _auth_google_oauth_relink(args: Dict[str, Any]):
     img = args.get("profile_image", "")
     sql = "EXEC auth_oauth_relink @provider='google', @identifier=?, @email=?, @display=?, @image=?;"
     return ("row_one", sql, (identifier, email, display, img))
+
+@register("db:auth:google:oauth_relink:1")
+def _db_auth_google_oauth_relink(args: Dict[str, Any]):
+  return _auth_google_oauth_relink(args)
 
 
 @register("db:users:profile:get_profile:1")
@@ -353,6 +393,10 @@ def _users_set_optin(args: Dict[str, Any]):
     """
     return ("exec", sql, (display_email, guid))
 
+@register("db:users:profile:set_optin:1")
+def _db_users_set_optin(args: Dict[str, Any]):
+  return _users_set_optin(args)
+
 
 @register("urn:users:profile:update_if_unedited:1")
 async def _users_update_if_unedited(args: Dict[str, Any]):
@@ -379,6 +423,10 @@ async def _users_update_if_unedited(args: Dict[str, Any]):
     )
   return DBResult()
 
+@register("db:users:profile:update_if_unedited:1")
+async def _db_users_update_if_unedited(args: Dict[str, Any]):
+  return await _users_update_if_unedited(args)
+
 
 @register("urn:users:providers:set_provider:1")
 async def _users_set_provider(args: Dict[str, Any]):
@@ -395,6 +443,10 @@ async def _users_set_provider(args: Dict[str, Any]):
     (res.rows[0]["recid"], guid),
   )
 
+@register("db:users:providers:set_provider:1")
+async def _db_users_set_provider(args: Dict[str, Any]):
+  return await _users_set_provider(args)
+
 @register("urn:users:profile:get_roles:1")
 def _users_get_roles(args: Dict[str, Any]):
   """Fetch a user's role mask."""
@@ -405,6 +457,10 @@ def _users_get_roles(args: Dict[str, Any]):
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
   return ("json_one", sql, (guid,))
+
+@register("db:users:profile:get_roles:1")
+def _db_users_get_roles(args: Dict[str, Any]):
+  return _users_get_roles(args)
 
 @register("urn:users:profile:set_roles:1")
 async def _users_set_roles(args: Dict[str, Any]):
@@ -422,6 +478,10 @@ async def _users_set_roles(args: Dict[str, Any]):
       (guid, roles),
     )
   return res
+
+@register("db:users:profile:set_roles:1")
+async def _db_users_set_roles(args: Dict[str, Any]):
+  return await _users_set_roles(args)
 
 @register("db:users:session:set_rotkey:1")
 def _users_session_set_rotkey(args: Dict[str, Any]):
@@ -462,6 +522,10 @@ def _public_links_get_home_links(args: Dict[str, Any]):
     """
     return ("json_many", sql, ())
 
+@register("db:public:links:get_home_links:1")
+def _db_public_links_get_home_links(args: Dict[str, Any]):
+  return _public_links_get_home_links(args)
+
 @register("urn:public:links:get_navbar_routes:1")
 def _public_links_get_navbar_routes(args: Dict[str, Any]):
     mask = int(args.get("role_mask", 0))
@@ -476,6 +540,10 @@ def _public_links_get_navbar_routes(args: Dict[str, Any]):
       FOR JSON PATH;
     """
     return ("json_many", sql, (mask,))
+
+@register("db:public:links:get_navbar_routes:1")
+def _db_public_links_get_navbar_routes(args: Dict[str, Any]):
+  return _public_links_get_navbar_routes(args)
 
 # -------------------- SERVICE ROUTES --------------------
 
@@ -493,6 +561,10 @@ def _service_routes_get_routes(_: Dict[str, Any]):
     FOR JSON PATH;
   """
   return ("json_many", sql, ())
+
+@register("db:service:routes:get_routes:1")
+def _db_service_routes_get_routes(args: Dict[str, Any]):
+  return _service_routes_get_routes(args)
 
 @register("urn:service:routes:upsert_route:1")
 async def _service_routes_upsert_route(args: Dict[str, Any]):
@@ -512,11 +584,19 @@ async def _service_routes_upsert_route(args: Dict[str, Any]):
     )
   return rc
 
+@register("db:service:routes:upsert_route:1")
+async def _db_service_routes_upsert_route(args: Dict[str, Any]):
+  return await _service_routes_upsert_route(args)
+
 @register("urn:service:routes:delete_route:1")
 def _service_routes_delete_route(args: Dict[str, Any]):
   path = args["path"]
   sql = "DELETE FROM frontend_routes WHERE element_path = ?;"
   return ("exec", sql, (path,))
+
+@register("db:service:routes:delete_route:1")
+def _db_service_routes_delete_route(args: Dict[str, Any]):
+  return _service_routes_delete_route(args)
 
 @register("urn:public:vars:get_hostname:1")
 def _public_vars_get_hostname(args: Dict[str, Any]):
@@ -528,6 +608,10 @@ def _public_vars_get_hostname(args: Dict[str, Any]):
   """
   return ("json_one", sql, ())
 
+@register("db:public:vars:get_hostname:1")
+def _db_public_vars_get_hostname(args: Dict[str, Any]):
+  return _public_vars_get_hostname(args)
+
 @register("urn:public:vars:get_version:1")
 def _public_vars_get_version(args: Dict[str, Any]):
   sql = """
@@ -538,6 +622,10 @@ def _public_vars_get_version(args: Dict[str, Any]):
   """
   return ("json_one", sql, ())
 
+@register("db:public:vars:get_version:1")
+def _db_public_vars_get_version(args: Dict[str, Any]):
+  return _public_vars_get_version(args)
+
 @register("urn:public:vars:get_repo:1")
 def _public_vars_get_repo(args: Dict[str, Any]):
   sql = """
@@ -547,6 +635,10 @@ def _public_vars_get_repo(args: Dict[str, Any]):
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
   return ("json_one", sql, ())
+
+@register("db:public:vars:get_repo:1")
+def _db_public_vars_get_repo(args: Dict[str, Any]):
+  return _public_vars_get_repo(args)
 
 @register("urn:users:profile:set_profile_image:1")
 async def _users_set_img(args: Dict[str, Any]):
@@ -569,6 +661,10 @@ async def _users_set_img(args: Dict[str, Any]):
       (guid, image_b64, ap_recid),
     )
   return rc
+
+@register("db:users:profile:set_profile_image:1")
+async def _db_users_set_img(args: Dict[str, Any]):
+  return await _users_set_img(args)
 
 @register("db:auth:session:create_session:1")
 async def _auth_session_create_session(args: Dict[str, Any]):

--- a/server/modules/public_links_module.py
+++ b/server/modules/public_links_module.py
@@ -17,9 +17,9 @@ class PublicLinksModule(BaseModule):
     self.db = None
 
   async def get_home_links(self):
-    res = await self.db.run("urn:public:links:get_home_links:1", {})
+    res = await self.db.run("db:public:links:get_home_links:1", {})
     return res.rows
 
   async def get_navbar_routes(self, role_mask: int):
-    res = await self.db.run("urn:public:links:get_navbar_routes:1", {"role_mask": role_mask})
+    res = await self.db.run("db:public:links:get_navbar_routes:1", {"role_mask": role_mask})
     return res.rows

--- a/server/modules/public_vars_module.py
+++ b/server/modules/public_vars_module.py
@@ -30,15 +30,15 @@ class PublicVarsModule(BaseModule):
       return result.stdout, result.stderr
 
   async def get_version(self) -> str:
-    res = await self.db.run("urn:public:vars:get_version:1", {})
+    res = await self.db.run("db:public:vars:get_version:1", {})
     return res.rows[0].get("version") if res.rows else ""
 
   async def get_hostname(self) -> str:
-    res = await self.db.run("urn:public:vars:get_hostname:1", {})
+    res = await self.db.run("db:public:vars:get_hostname:1", {})
     return res.rows[0].get("hostname") if res.rows else ""
 
   async def get_repo(self) -> str:
-    res = await self.db.run("urn:public:vars:get_repo:1", {})
+    res = await self.db.run("db:public:vars:get_repo:1", {})
     return res.rows[0].get("repo") if res.rows else ""
 
   async def get_ffmpeg_version(self) -> str:

--- a/server/modules/system_config_module.py
+++ b/server/modules/system_config_module.py
@@ -24,7 +24,7 @@ class SystemConfigModule(BaseModule):
 
   async def get_configs(self, user_guid: str, roles: list[str]) -> SystemConfigList1:
     logging.debug("[system_config_get_configs_v1] user=%s roles=%s", user_guid, roles)
-    res = await self.db.run("urn:system:config:get_configs:1", {})
+    res = await self.db.run("db:system:config:get_configs:1", {})
     items = [
       SystemConfigConfigItem1(
         key=row.get("element_key", ""),
@@ -47,7 +47,7 @@ class SystemConfigModule(BaseModule):
       value,
     )
     await self.db.run(
-      "urn:system:config:upsert_config:1",
+      "db:system:config:upsert_config:1",
       {"key": key, "value": value},
     )
     logging.debug(
@@ -64,7 +64,7 @@ class SystemConfigModule(BaseModule):
       key,
     )
     await self.db.run(
-      "urn:system:config:delete_config:1",
+      "db:system:config:delete_config:1",
       {"key": key},
     )
     logging.debug(

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -38,13 +38,13 @@ class DummyDb:
     self.linked = False
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       if self.linked:
         return DBRes([
           {"guid": "existing-guid", "display_name": "User", "credits": 0, "profile_image": None}
         ], 1)
       return DBRes([], 0)
-    if op == "urn:auth:google:oauth_relink:1":
+    if op == "db:auth:google:oauth_relink:1":
       if args.get("confirm"):
         self.linked = True
         return DBRes([
@@ -57,7 +57,7 @@ class DummyDb:
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":
       return DBRes(rowcount=1)
-    if op == "urn:system:config:get_config:1":
+    if op == "db:system:config:get_config:1":
       key = args.get("key")
       if key == "Hostname":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
@@ -156,8 +156,8 @@ def test_email_exists_prompt(monkeypatch):
     asyncio.run(auth_google_oauth_login_v1(req))
   assert exc.value.status_code == 409
   assert exc.value.detail == {"default_provider": "microsoft"}
-  assert any(op == "urn:auth:google:oauth_relink:1" for op, _ in req.app.state.db.calls)
-  assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)
+  assert any(op == "db:auth:google:oauth_relink:1" for op, _ in req.app.state.db.calls)
+  assert not any(op == "db:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())
 
 
@@ -224,5 +224,5 @@ def test_email_exists_confirm_links(monkeypatch):
   res = asyncio.run(auth_google_oauth_login_v1(req))
   data = json.loads(res.body)
   assert data["payload"]["display_name"] == "User"
-  assert any(op == "urn:auth:google:oauth_relink:1" for op, _ in req.app.state.db.calls)
+  assert any(op == "db:auth:google:oauth_relink:1" for op, _ in req.app.state.db.calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -40,9 +40,9 @@ class DummyDb:
     self.calls = []
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
-    if op == "urn:system:config:get_config:1":
+    if op == "db:system:config:get_config:1":
       key = args.get("key")
       if key == "Hostname":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
@@ -146,5 +146,5 @@ def test_lookup_existing_user(monkeypatch):
   req.app.state.oauth.exchange_code_for_tokens = fake_exchange
   resp = asyncio.run(auth_google_oauth_login_v1(req))
   assert "rotation_token=" in resp.headers.get("set-cookie", "")
-  assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)
+  assert not any(op == "db:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -40,19 +40,19 @@ class DummyDb:
     self.calls = []
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       if len([c for c in self.calls if c[0] == op]) == 1:
         return DBRes([], 0)
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
-    if op == "urn:system:config:get_config:1":
+    if op == "db:system:config:get_config:1":
       key = args.get("key")
       if key == "Hostname":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
-    if op == "urn:users:providers:create_from_provider:1":
+    if op == "db:users:providers:create_from_provider:1":
       return DBRes([], 1)
     if op == "db:users:session:set_rotkey:1":
       return DBRes([], 1)
-    if op == "urn:users:profile:get_roles:1":
+    if op == "db:users:profile:get_roles:1":
       return DBRes([{ "element_roles": 0 }], 1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
@@ -152,7 +152,7 @@ def test_fetch_user_after_create(monkeypatch):
   req.app.state.oauth.exchange_code_for_tokens = fake_exchange
   resp = asyncio.run(auth_google_oauth_login_v1(req))
   assert "rotation_token=" in resp.headers.get("set-cookie", "")
-  calls = [op for op, _ in req.app.state.db.calls if op == "urn:users:providers:get_by_provider_identifier:1"]
+  calls = [op for op, _ in req.app.state.db.calls if op == "db:users:providers:get_by_provider_identifier:1"]
   assert len(calls) == 2
   assert any(
     op == "db:auth:session:create_session:1" and args.get("provider") == "google"
@@ -160,7 +160,7 @@ def test_fetch_user_after_create(monkeypatch):
   )
   expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "google-id"))
   assert any(
-    op == "urn:users:providers:create_from_provider:1" and args["provider_identifier"] == expected
+    op == "db:users:providers:create_from_provider:1" and args["provider_identifier"] == expected
     for op, args in req.app.state.db.calls
   )
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_profile_image_update.py
+++ b/tests/test_auth_google_profile_image_update.py
@@ -40,15 +40,15 @@ class DummyDb:
     self.calls = []
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
-    if op == "db:users:session:set_rotkey:1" or op == "urn:users:profile:set_profile_image:1":
+    if op == "db:users:session:set_rotkey:1" or op == "db:users:profile:set_profile_image:1":
       return DBRes([], 1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
-    if op == "urn:system:config:get_config:1":
+    if op == "db:system:config:get_config:1":
       key = args.get("key")
       if key == "Hostname":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
@@ -146,5 +146,5 @@ def test_updates_profile_image(monkeypatch):
   req = DummyRequest()
   req.app.state.oauth.exchange_code_for_tokens = fake_exchange
   asyncio.run(auth_google_oauth_login_v1(req))
-  assert any(op == "urn:users:profile:set_profile_image:1" for op, _ in req.app.state.db.calls)
+  assert any(op == "db:users:profile:set_profile_image:1" for op, _ in req.app.state.db.calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_profile_refresh.py
+++ b/tests/test_auth_google_profile_refresh.py
@@ -30,9 +30,9 @@ class DummyDb:
     self.allow_update = allow_update
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "provider_name": "google" }], 1)
-    if op == "urn:users:profile:update_if_unedited:1":
+    if op == "db:users:profile:update_if_unedited:1":
       if self.allow_update:
         return DBRes([{ "display_name": args["display_name"], "email": args["email"] }], 1)
       return DBRes([], 0)
@@ -42,7 +42,7 @@ class DummyDb:
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
-    if op == "urn:system:config:get_config:1":
+    if op == "db:system:config:get_config:1":
       if args.get("key") == "Hostname":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
     return DBRes()
@@ -138,7 +138,7 @@ def test_updates_profile_if_unedited():
   state.oauth.exchange_code_for_tokens = fake_exchange
   req = DummyRequest(state)
   resp = asyncio.run(auth_google_oauth_login_v1(req))
-  assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in db.calls)
+  assert any(op == "db:users:profile:update_if_unedited:1" for op, _ in db.calls)
   data = json.loads(resp.body)
   assert data["payload"]["display_name"] == "New"
 
@@ -150,7 +150,7 @@ def test_leaves_profile_if_edited():
   state.oauth.exchange_code_for_tokens = fake_exchange
   req = DummyRequest(state)
   resp = asyncio.run(auth_google_oauth_login_v1(req))
-  assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in db.calls)
+  assert any(op == "db:users:profile:update_if_unedited:1" for op, _ in db.calls)
   data = json.loads(resp.body)
   assert data["payload"]["display_name"] == "User"
 

--- a/tests/test_auth_google_relink_unlinked.py
+++ b/tests/test_auth_google_relink_unlinked.py
@@ -37,14 +37,14 @@ class DummyDb:
     self._get_by_count = 0
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       self._get_by_count += 1
       if self._get_by_count == 1:
         return DBRes([], 0)
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
-    if op == "urn:users:providers:get_any_by_provider_identifier:1":
+    if op == "db:users:providers:get_any_by_provider_identifier:1":
       return DBRes([{"guid": "user-guid"}], 1)
-    if op == "urn:auth:google:oauth_relink:1":
+    if op == "db:auth:google:oauth_relink:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
     if op == "db:users:session:set_rotkey:1":
       return DBRes([], 1)
@@ -52,7 +52,7 @@ class DummyDb:
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
-    if op == "urn:system:config:get_config:1":
+    if op == "db:system:config:get_config:1":
       return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
     return DBRes()
 
@@ -142,6 +142,6 @@ def test_relinks_unlinked_account(monkeypatch):
   req.app.state.oauth.exchange_code_for_tokens = fake_exchange
   asyncio.run(auth_google_oauth_login_v1(req))
   calls = req.app.state.db.calls
-  assert any(op == "urn:auth:google:oauth_relink:1" for op, _ in calls)
-  assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in calls)
+  assert any(op == "db:auth:google:oauth_relink:1" for op, _ in calls)
+  assert not any(op == "db:users:providers:create_from_provider:1" for op, _ in calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_soft_undelete.py
+++ b/tests/test_auth_google_soft_undelete.py
@@ -45,7 +45,7 @@ class DummyDb:
 
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([
         {
           "guid": "user-guid",
@@ -54,7 +54,7 @@ class DummyDb:
           "element_soft_deleted_at": "2024-01-01T00:00:00Z",
         }
       ], 1)
-    if op == "urn:auth:google:oauth_relink:1":
+    if op == "db:auth:google:oauth_relink:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
     if op == "db:users:session:set_rotkey:1":
       return DBRes([], 1)
@@ -62,7 +62,7 @@ class DummyDb:
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":
       return DBRes([], 1)
-    if op == "urn:system:config:get_config:1":
+    if op == "db:system:config:get_config:1":
       key = args.get("key")
       if key == "Hostname":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
@@ -177,7 +177,7 @@ def test_undeletes_soft_deleted_account(monkeypatch):
   req.app.state.oauth.exchange_code_for_tokens = fake_exchange
   asyncio.run(auth_google_oauth_login_v1(req))
   calls = req.app.state.db.calls
-  assert any(op == "urn:auth:google:oauth_relink:1" for op, _ in calls)
-  assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in calls)
+  assert any(op == "db:auth:google:oauth_relink:1" for op, _ in calls)
+  assert not any(op == "db:users:providers:create_from_provider:1" for op, _ in calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())
 

--- a/tests/test_auth_microsoft_email_exists.py
+++ b/tests/test_auth_microsoft_email_exists.py
@@ -28,13 +28,13 @@ class DummyDb:
     self.linked = False
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       if self.linked:
         return DBRes([
           {"guid": "existing-guid", "display_name": "User", "credits": 0, "profile_image": None}
         ], 1)
       return DBRes([], 0)
-    if op == "urn:auth:microsoft:oauth_relink:1":
+    if op == "db:auth:microsoft:oauth_relink:1":
       if args.get("confirm"):
         self.linked = True
         return DBRes([
@@ -119,8 +119,8 @@ def test_email_exists_prompt(monkeypatch):
     asyncio.run(auth_microsoft_oauth_login_v1(req))
   assert exc.value.status_code == 409
   assert exc.value.detail == {"default_provider": "google"}
-  assert any(op == "urn:auth:microsoft:oauth_relink:1" for op, _ in req.app.state.db.calls)
-  assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)
+  assert any(op == "db:auth:microsoft:oauth_relink:1" for op, _ in req.app.state.db.calls)
+  assert not any(op == "db:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)
 
 def test_email_exists_confirm_links(monkeypatch):
   spec = importlib.util.spec_from_file_location("server.models", "server/models.py")
@@ -173,4 +173,4 @@ def test_email_exists_confirm_links(monkeypatch):
   res = asyncio.run(auth_microsoft_oauth_login_v1(req))
   data = json.loads(res.body)
   assert data["payload"]["display_name"] == "User"
-  assert any(op == "urn:auth:microsoft:oauth_relink:1" for op, _ in req.app.state.db.calls)
+  assert any(op == "db:auth:microsoft:oauth_relink:1" for op, _ in req.app.state.db.calls)

--- a/tests/test_auth_microsoft_home_account_lookup.py
+++ b/tests/test_auth_microsoft_home_account_lookup.py
@@ -28,7 +28,7 @@ class DummyDb:
     self.calls = []
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
     if op == "db:users:session:set_rotkey:1":
       return DBRes([], 1)
@@ -107,4 +107,4 @@ def test_lookup_with_home_account_id(monkeypatch):
   req = DummyRequest()
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
   assert "rotation_token=" in resp.headers.get("set-cookie", "")
-  assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)
+  assert not any(op == "db:users:providers:create_from_provider:1" for op, _ in req.app.state.db.calls)

--- a/tests/test_auth_microsoft_oauth_login_creation.py
+++ b/tests/test_auth_microsoft_oauth_login_creation.py
@@ -26,15 +26,15 @@ class DummyDb:
     self.calls = []
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       if len([c for c in self.calls if c[0] == op]) == 1:
         return DBRes([], 0)
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
-    if op == "urn:users:providers:create_from_provider:1":
+    if op == "db:users:providers:create_from_provider:1":
       return DBRes([], 1)
     if op == "db:users:session:set_rotkey:1":
       return DBRes([], 1)
-    if op == "urn:users:profile:get_roles:1":
+    if op == "db:users:profile:get_roles:1":
       return DBRes([{ "element_roles": 0 }], 1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
@@ -111,7 +111,7 @@ def test_fetch_user_after_create(monkeypatch):
   req = DummyRequest()
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
   assert "rotation_token=" in resp.headers.get("set-cookie", "")
-  calls = [op for op, _ in req.app.state.db.calls if op == "urn:users:providers:get_by_provider_identifier:1"]
+  calls = [op for op, _ in req.app.state.db.calls if op == "db:users:providers:get_by_provider_identifier:1"]
   assert len(calls) == 2
   assert any(
     op == "db:auth:session:create_session:1" and args.get("provider") == "microsoft"

--- a/tests/test_auth_microsoft_profile_image_clear.py
+++ b/tests/test_auth_microsoft_profile_image_clear.py
@@ -26,9 +26,9 @@ class DummyDb:
     self.calls = []
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
-    if op == "db:users:session:set_rotkey:1" or op == "urn:users:profile:set_profile_image:1":
+    if op == "db:users:session:set_rotkey:1" or op == "db:users:profile:set_profile_image:1":
       return DBRes([], 1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
@@ -102,6 +102,6 @@ def test_clears_profile_image(monkeypatch):
   req = DummyRequest()
   asyncio.run(auth_microsoft_oauth_login_v1(req))
   assert any(
-    op == "urn:users:profile:set_profile_image:1" and args.get("image_b64") is None
+    op == "db:users:profile:set_profile_image:1" and args.get("image_b64") is None
     for op, args in req.app.state.db.calls
   )

--- a/tests/test_auth_microsoft_profile_image_update.py
+++ b/tests/test_auth_microsoft_profile_image_update.py
@@ -26,9 +26,9 @@ class DummyDb:
     self.calls = []
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
-    if op == "db:users:session:set_rotkey:1" or op == "urn:users:profile:set_profile_image:1":
+    if op == "db:users:session:set_rotkey:1" or op == "db:users:profile:set_profile_image:1":
       return DBRes([], 1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
@@ -101,4 +101,4 @@ def test_updates_profile_image(monkeypatch):
 
   req = DummyRequest()
   asyncio.run(auth_microsoft_oauth_login_v1(req))
-  assert any(op == "urn:users:profile:set_profile_image:1" for op, _ in req.app.state.db.calls)
+  assert any(op == "db:users:profile:set_profile_image:1" for op, _ in req.app.state.db.calls)

--- a/tests/test_auth_microsoft_profile_refresh.py
+++ b/tests/test_auth_microsoft_profile_refresh.py
@@ -32,9 +32,9 @@ class DummyDb:
     self.allow_update = allow_update
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "provider_name": "microsoft" }], 1)
-    if op == "urn:users:profile:update_if_unedited:1":
+    if op == "db:users:profile:update_if_unedited:1":
       if self.allow_update:
         return DBRes([{ "display_name": args["display_name"], "email": args["email"] }], 1)
       return DBRes([], 0)
@@ -120,7 +120,7 @@ def test_updates_profile_if_unedited():
   state = DummyState(auth, db)
   req = DummyRequest(state)
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
-  assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in db.calls)
+  assert any(op == "db:users:profile:update_if_unedited:1" for op, _ in db.calls)
   data = json.loads(resp.body)
   assert data["payload"]["display_name"] == "New"
 
@@ -131,7 +131,7 @@ def test_leaves_profile_if_edited():
   state = DummyState(auth, db)
   req = DummyRequest(state)
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
-  assert any(op == "urn:users:profile:update_if_unedited:1" for op, _ in db.calls)
+  assert any(op == "db:users:profile:update_if_unedited:1" for op, _ in db.calls)
   data = json.loads(resp.body)
   assert data["payload"]["display_name"] == "User"
 

--- a/tests/test_auth_microsoft_relink_unlinked.py
+++ b/tests/test_auth_microsoft_relink_unlinked.py
@@ -27,14 +27,14 @@ class DummyDb:
     self._get_by_count = 0
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:providers:get_by_provider_identifier:1":
+    if op == "db:users:providers:get_by_provider_identifier:1":
       self._get_by_count += 1
       if self._get_by_count == 1:
         return DBRes([], 0)
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
-    if op == "urn:users:providers:get_any_by_provider_identifier:1":
+    if op == "db:users:providers:get_any_by_provider_identifier:1":
       return DBRes([{"guid": "user-guid"}], 1)
-    if op == "urn:auth:microsoft:oauth_relink:1":
+    if op == "db:auth:microsoft:oauth_relink:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
     if op == "db:users:session:set_rotkey:1":
       return DBRes([], 1)
@@ -110,5 +110,5 @@ def test_relinks_unlinked_account(monkeypatch):
   req = DummyRequest()
   asyncio.run(auth_microsoft_oauth_login_v1(req))
   calls = req.app.state.db.calls
-  assert any(op == "urn:auth:microsoft:oauth_relink:1" for op, _ in calls)
-  assert not any(op == "urn:users:providers:create_from_provider:1" for op, _ in calls)
+  assert any(op == "db:auth:microsoft:oauth_relink:1" for op, _ in calls)
+  assert not any(op == "db:users:providers:create_from_provider:1" for op, _ in calls)

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -50,7 +50,7 @@ spec_registry.loader.exec_module(registry_mod)
 get_mssql_handler = registry_mod.get_handler
 
 def test_mssql_get_by_provider_identifier_uses_user_view():
-  handler = get_mssql_handler("urn:users:providers:get_by_provider_identifier:1")
+  handler = get_mssql_handler("db:users:providers:get_by_provider_identifier:1")
   _, sql, _ = handler({"provider": "microsoft", "provider_identifier": str(uuid4())})
   sql = sql.lower()
   assert "vw_account_user_profile" in sql
@@ -58,7 +58,7 @@ def test_mssql_get_by_provider_identifier_uses_user_view():
   assert "users_credits" not in sql
 
 def test_mssql_get_profile_uses_profile_view():
-  handler = get_mssql_handler("urn:users:profile:get_profile:1")
+  handler = get_mssql_handler("db:users:profile:get_profile:1")
   _, sql, _ = handler({"guid": "gid"})
   sql = sql.lower()
   assert "vw_account_user_profile" in sql

--- a/tests/test_service_routes_services.py
+++ b/tests/test_service_routes_services.py
@@ -99,7 +99,7 @@ class DummyDb:
 
   async def run(self, op: str, args: dict):
     self.calls.append((op, args))
-    if op == 'urn:service:routes:get_routes:1':
+    if op == 'db:service:routes:get_routes:1':
       rows = [{
         'element_path': '/a',
         'element_name': 'A',
@@ -108,7 +108,7 @@ class DummyDb:
         'element_roles': 1,
       }]
       return SimpleNamespace(rows=rows, rowcount=1)
-    if op in ('urn:service:routes:upsert_route:1', 'urn:service:routes:delete_route:1'):
+    if op in ('db:service:routes:upsert_route:1', 'db:service:routes:delete_route:1'):
       return SimpleNamespace(rows=[], rowcount=1)
     raise AssertionError(f'unexpected op {op}')
 
@@ -150,7 +150,7 @@ def test_get_routes_service():
       'required_roles': ['ROLE_SERVICE_ADMIN'],
     }]
   }
-  assert ('urn:service:routes:get_routes:1', {}) in db.calls
+  assert ('db:service:routes:get_routes:1', {}) in db.calls
 
 
 def test_upsert_and_delete_route_service():
@@ -165,11 +165,11 @@ def test_upsert_and_delete_route_service():
   assert resp.status_code == 200
   resp = client.post('/rpc', json={'op': 'urn:service:routes:delete_route:1', 'payload': {'path': '/a'}})
   assert resp.status_code == 200
-  assert ('urn:service:routes:upsert_route:1', {
+  assert ('db:service:routes:upsert_route:1', {
     'path': '/a',
     'name': 'A',
     'icon': 'home',
     'sequence': 1,
     'roles': 1,
   }) in db.calls
-  assert ('urn:service:routes:delete_route:1', {'path': '/a'}) in db.calls
+  assert ('db:service:routes:delete_route:1', {'path': '/a'}) in db.calls

--- a/tests/test_system_config_module.py
+++ b/tests/test_system_config_module.py
@@ -67,12 +67,12 @@ class DummyDb(DbModule):
     pass
   async def run(self, op: str, args: dict):
     self.calls.append((op, args))
-    if op == 'urn:system:config:get_configs:1':
+    if op == 'db:system:config:get_configs:1':
       rows = [{'element_key': 'LoggingLevel', 'element_value': '4'}]
       return SimpleNamespace(rows=rows, rowcount=1)
-    if op == 'urn:system:config:upsert_config:1':
+    if op == 'db:system:config:upsert_config:1':
       return SimpleNamespace(rows=[], rowcount=1)
-    if op == 'urn:system:config:delete_config:1':
+    if op == 'db:system:config:delete_config:1':
       return SimpleNamespace(rows=[], rowcount=1)
     raise AssertionError(f'unexpected op {op}')
 
@@ -85,16 +85,16 @@ asyncio.run(module.startup())
 def test_get_configs_module():
   payload = asyncio.run(module.get_configs('u1', []))
   assert payload.items[0].key == 'LoggingLevel'
-  assert ('urn:system:config:get_configs:1', {}) in db.calls
+  assert ('db:system:config:get_configs:1', {}) in db.calls
 
 def test_upsert_and_delete_module():
   asyncio.run(module.upsert_config('u1', [], 'LoggingLevel', '2'))
   asyncio.run(module.delete_config('u1', [], 'LoggingLevel'))
   assert (
-    'urn:system:config:upsert_config:1',
+    'db:system:config:upsert_config:1',
     {'key': 'LoggingLevel', 'value': '2'}
   ) in db.calls
   assert (
-    'urn:system:config:delete_config:1',
+    'db:system:config:delete_config:1',
     {'key': 'LoggingLevel'}
   ) in db.calls

--- a/tests/test_user_creation_profile_img.py
+++ b/tests/test_user_creation_profile_img.py
@@ -32,7 +32,7 @@ def test_create_from_provider_inserts_profile_image(monkeypatch):
   monkeypatch.setattr(registry, "fetch_json", fake_fetch_json)
   monkeypatch.setattr(registry, "fetch_rows", fake_fetch_rows)
 
-  handler = registry.get_handler("urn:users:providers:create_from_provider:1")
+  handler = registry.get_handler("db:users:providers:create_from_provider:1")
   args = {
     "provider": "microsoft",
     "provider_identifier": str(uuid4()),

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -74,9 +74,9 @@ class DummyDb:
     self.roles = roles
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "urn:users:profile:get_roles:1":
+    if op == "db:users:profile:get_roles:1":
       return DBRes([{"element_roles": self.roles}], 1)
-    if op == "urn:users:profile:set_profile_image:1":
+    if op == "db:users:profile:set_profile_image:1":
       return DBRes([], 1)
     return DBRes()
 
@@ -103,7 +103,7 @@ def test_get_roles_service_returns_mask():
   resp = asyncio.run(users_profile_get_roles_v1(req))
   assert isinstance(resp, RPCResponse)
   assert resp.payload["roles"] == 5
-  assert ("urn:users:profile:get_roles:1", {"guid": "u1"}) in db.calls
+  assert ("db:users:profile:get_roles:1", {"guid": "u1"}) in db.calls
 
 def test_set_profile_image_calls_db():
   async def fake_img(request):
@@ -113,7 +113,7 @@ def test_set_profile_image_calls_db():
   db = DummyDb()
   req = DummyRequest(DummyState(db))
   resp = asyncio.run(users_profile_set_profile_image_v1(req))
-  assert ("urn:users:profile:set_profile_image:1", {"guid": "u1", "image_b64": "abc", "provider": "microsoft"}) in db.calls
+  assert ("db:users:profile:set_profile_image:1", {"guid": "u1", "image_b64": "abc", "provider": "microsoft"}) in db.calls
   assert resp.payload["image_b64"] == "abc"
 
 


### PR DESCRIPTION
## Summary
- namespace MSSQL registry entries under db: and update callers
- route service and profile handlers through database module
- align tests with new db: operation names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb0ceee3e88325b5d3394c3b611bc6