### PR TITLE
Include fingerprint in refresh token RPC calls

### DIFF
--- a/scripts/generate_rpc_library.py
+++ b/scripts/generate_rpc_library.py
@@ -36,7 +36,7 @@ RPC_CALL_FUNC = [
   "\t\t\ttry {",
   "\t\t\t\tconst refreshReq = {",
   "\t\t\t\t\top: 'urn:auth:session:refresh_token:1',",
-  "\t\t\t\t\tpayload: null,",
+  "\t\t\t\t\tpayload: { fingerprint: getFingerprint() },",
   "\t\t\t\t\tversion: 1,",
   "\t\t\t\t\ttimestamp: new Date().toISOString(),",
   "\t\t\t\t};",
@@ -114,7 +114,7 @@ def write_interfaces_to_file(interfaces: List[str], output_dir: str) -> None:
   os.makedirs(output_dir, exist_ok=True)
   out_path = os.path.join(output_dir, 'RpcModels.tsx')
   with open(out_path, 'w') as f:
-    lines = HEADER_COMMENT + ['import axios from \"axios\";', '']
+    lines = HEADER_COMMENT + ['import axios from \"axios\";', 'import { getFingerprint } from \"./fingerprint\";', '']
     lines += interfaces + [''] + RPC_CALL_FUNC + ['']
     f.write("\n".join(lines))
   print(f"✅ Wrote {len(interfaces)} TypeScript interfaces to '{out_path}'")


### PR DESCRIPTION
## Summary
- ensure RPC library includes device fingerprint when refreshing session tokens
- add fingerprint import to generated frontend RPC helpers

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb1b9699cc832588c683f42f0a9fff