### PR TITLE
feat: add section headers to nav bar

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,14 +1,15 @@
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext, Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import {
-	Drawer,
-	Box,
-	IconButton,
-	Tooltip,
-	List,
-	ListItemButton,
-	ListItemIcon,
-	ListItemText,
+        Drawer,
+        Box,
+        IconButton,
+        Tooltip,
+        List,
+        ListItemButton,
+        ListItemIcon,
+        ListItemText,
+        Divider,
 } from '@mui/material';
 import { Menu as MenuIcon } from '@mui/icons-material';
 import type { PublicLinksNavBarRoute1, PublicLinksNavBarRoutes1 } from '../shared/RpcModels';
@@ -21,8 +22,8 @@ const DRAWER_OPEN = 240;
 const DRAWER_CLOSED = 60;
 
 const NavBar = (): JSX.Element => {
-	const [open, setOpen] = useState(false);
-	const [routes, setRoutes] = useState<PublicLinksNavBarRoute1[]>([]);
+        const [open, setOpen] = useState(false);
+        const [routes, setRoutes] = useState<PublicLinksNavBarRoute1[]>([]);
 	const { userData } = useContext(UserContext);
 
 	useEffect(() => {
@@ -62,19 +63,66 @@ const NavBar = (): JSX.Element => {
 					</IconButton>
 				</Tooltip>
 			</Box>
-			<List sx={{ flexGrow: 1 }}>
-				{routes.map((route) => {
-					const IconComp = iconMap[route.icon ?? ''] || defaultIcon;
-					return (
-						<ListItemButton component={Link} to={route.path} key={route.path}>
-							<ListItemIcon>
-								<IconComp />
-							</ListItemIcon>
-							{open && <ListItemText primary={route.name} />}
-						</ListItemButton>
-					);
-				})}
-			</List>
+                        <List sx={{ flexGrow: 1 }}>
+                                {(() => {
+                                        const publicRoutes = routes.filter((r) => r.path === '/' || r.path.startsWith('/gallery'));
+                                        const roleRoutes = routes.filter((r) => !(r.path === '/' || r.path.startsWith('/gallery')));
+                                        const userRoutes = roleRoutes.filter((r) => r.path.startsWith('/user'));
+                                        const accountRoutes = roleRoutes.filter((r) => r.path.startsWith('/account'));
+                                        const systemRoutes = roleRoutes.filter((r) => r.path.startsWith('/system'));
+                                        const serviceRoutes = roleRoutes.filter((r) => r.path.startsWith('/service'));
+
+                                        const renderItem = (route: PublicLinksNavBarRoute1) => {
+                                                const IconComp = iconMap[route.icon ?? ''] || defaultIcon;
+                                                return (
+                                                        <ListItemButton component={Link} to={route.path} key={route.path}>
+                                                                <ListItemIcon>
+                                                                        <IconComp />
+                                                                </ListItemIcon>
+                                                                {open && <ListItemText primary={route.name} />}
+                                                        </ListItemButton>
+                                                );
+                                        };
+
+                                        const renderSection = (label: string, items: PublicLinksNavBarRoute1[]) => {
+                                                if (!items.length) {
+                                                        return null;
+                                                }
+                                                return (
+                                                        <Fragment key={label}>
+                                                                {open && (
+                                                                        <Divider
+                                                                                component="li"
+                                                                                textAlign="left"
+                                                                                sx={{
+                                                                                        fontSize: '0.55rem',
+                                                                                        textTransform: 'uppercase',
+                                                                                        my: 0.5,
+                                                                                        mx: 1,
+                                                                                        '&::before, &::after': {
+                                                                                                borderColor: 'divider',
+                                                                                        },
+                                                                                }}
+                                                                        >
+                                                                                {label}
+                                                                        </Divider>
+                                                                )}
+                                                                {items.map(renderItem)}
+                                                        </Fragment>
+                                                );
+                                        };
+
+                                        return (
+                                                <>
+                                                        {publicRoutes.map(renderItem)}
+                                                        {renderSection('USER', userRoutes)}
+                                                        {renderSection('ACCOUNT', accountRoutes)}
+                                                        {renderSection('SYSTEM', systemRoutes)}
+                                                        {renderSection('SERVICE', serviceRoutes)}
+                                                </>
+                                        );
+                                })()}
+                        </List>
 			<Box sx={{ p: 1 }}>
 				<Login open={open} />
 			</Box>


### PR DESCRIPTION
## Summary
- show compact role section headers in NavBar with divider lines

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bb242727088325b8ec900da4a89c7a