### PR TITLE
Handle payload parsing for session refresh token

### DIFF
--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -47,11 +47,9 @@ async def auth_session_refresh_token_v1(request: Request):
   rotation_token = request.cookies.get("rotation_token")
   if not rotation_token:
     raise HTTPException(status_code=401, detail="Missing rotation token")
-  try:
-    body = await request.json()
-  except Exception:
-    body = {}
-  fingerprint = body.get("fingerprint")
+  rpc_request, _auth_ctx, _ = await unbox_request(request)
+  req_payload = rpc_request.payload or {}
+  fingerprint = req_payload.get("fingerprint")
   if not fingerprint:
     raise HTTPException(status_code=400, detail="Missing fingerprint")
   session_mod = _get_session_module(request)
@@ -63,7 +61,7 @@ async def auth_session_refresh_token_v1(request: Request):
     user_agent,
     ip_address,
   )
-  return RPCResponse(op="urn:auth:session:refresh_token:1", payload={"token": session_token}, version=1)
+  return RPCResponse(op=rpc_request.op, payload={"token": session_token}, version=rpc_request.version)
 
 async def auth_session_invalidate_token_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)

--- a/tests/test_auth_session_logout_device.py
+++ b/tests/test_auth_session_logout_device.py
@@ -14,7 +14,8 @@ def _setup():
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox(req):
-    rpc = RPCRequest(op=req.op, payload=None, version=1)
+    payload = {"fingerprint": "fp"} if req.op == "urn:auth:session:refresh_token:1" else None
+    rpc = RPCRequest(op=req.op, payload=payload, version=1)
     return rpc, SimpleNamespace(user_guid="user-guid", claims={}), None
   helpers.unbox_request = fake_unbox
   sys.modules["rpc.helpers"] = helpers

--- a/tests/test_auth_session_refresh_provider.py
+++ b/tests/test_auth_session_refresh_provider.py
@@ -8,10 +8,12 @@ def test_refresh_token_ignores_provider():
   spec.loader.exec_module(models)
   sys.modules["server.models"] = models
   RPCResponse = models.RPCResponse
+  RPCRequest = models.RPCRequest
 
   helpers = types.ModuleType("rpc.helpers")
   async def fake_unbox(_req):
-    return None
+    rpc = RPCRequest(op="urn:auth:session:refresh_token:1", payload={"fingerprint": "fp"}, version=1)
+    return rpc, SimpleNamespace(), None
   helpers.unbox_request = fake_unbox
   sys.modules["rpc.helpers"] = helpers
 


### PR DESCRIPTION
## Summary
- fix auth session refresh to read fingerprint from RPC payload
- adjust logout device tests to provide fingerprint for refresh
- simulate RPC payload in refresh provider test

## Testing
- `python scripts/generate_rpc_library.py`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb814cf6208325a6d91a97bb89980f