### PR TITLE
Refactor AuthModule role handling into RoleCache

### DIFF
--- a/tests/test_role_admin_module.py
+++ b/tests/test_role_admin_module.py
@@ -14,17 +14,30 @@ class DummyDb:
       return types.SimpleNamespace(rows=self.roles)
     return types.SimpleNamespace(rows=[])
 
-class DummyAuth:
+class RoleCache:
   def __init__(self, roles=None):
     self.roles = roles or {}
-  async def on_ready(self):
-    pass
   async def refresh_user_roles(self, guid):
     pass
   async def upsert_role(self, name, mask, display):
     self.roles[name] = mask
   async def delete_role(self, name):
     self.roles.pop(name, None)
+
+class DummyAuth:
+  def __init__(self, roles=None):
+    self.role_cache = RoleCache(roles)
+  async def on_ready(self):
+    pass
+  @property
+  def roles(self):
+    return self.role_cache.roles
+  async def refresh_user_roles(self, guid):
+    await self.role_cache.refresh_user_roles(guid)
+  async def upsert_role(self, name, mask, display):
+    await self.role_cache.upsert_role(name, mask, display)
+  async def delete_role(self, name):
+    await self.role_cache.delete_role(name)
 
 async def make_module(roles, auth_roles):
   db = DummyDb(roles)

--- a/tests/test_service_routes_services.py
+++ b/tests/test_service_routes_services.py
@@ -33,7 +33,7 @@ db_module_pkg.DbModule = DbModule
 modules_pkg.db_module = db_module_pkg
 
 
-class AuthModule:
+class RoleCache:
   def __init__(self):
     self.roles = {'ROLE_SERVICE_ADMIN': 1}
 
@@ -45,6 +45,20 @@ class AuthModule:
     for n in names:
       mask |= self.roles.get(n, 0)
     return mask
+
+class AuthModule:
+  def __init__(self):
+    self.role_cache = RoleCache()
+
+  @property
+  def roles(self):
+    return self.role_cache.roles
+
+  def mask_to_names(self, mask):
+    return self.role_cache.mask_to_names(mask)
+
+  def names_to_mask(self, names):
+    return self.role_cache.names_to_mask(names)
 
 
 auth_module_pkg.AuthModule = AuthModule


### PR DESCRIPTION
## Summary
- add RoleCache helper for database-backed role caching
- delegate AuthModule role operations to RoleCache
- update tests to interact with the new RoleCache

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb226f8f4483259d71238e7c0cf5b2