### PR TITLE
Add storage cache module and refresh support

### DIFF
--- a/rpc/storage/files/__init__.py
+++ b/rpc/storage/files/__init__.py
@@ -10,6 +10,7 @@ from .services import (
   storage_files_set_gallery_v1,
   storage_files_create_folder_v1,
   storage_files_move_file_v1,
+  storage_files_refresh_cache_v1,
 )
 
 
@@ -20,5 +21,6 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("set_gallery", "1"): storage_files_set_gallery_v1,
   ("create_folder", "1"): storage_files_create_folder_v1,
   ("move_file", "1"): storage_files_move_file_v1,
+  ("refresh_cache", "1"): storage_files_refresh_cache_v1,
 }
 

--- a/scripts/storage_cache.sql
+++ b/scripts/storage_cache.sql
@@ -1,0 +1,53 @@
+/****** Object:  Table [dbo].[storage_types] ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[storage_types](
+  [recid] [int] IDENTITY(1,1) NOT NULL,
+  [element_mimetype] [varchar](128) NOT NULL,
+  [element_displaytype] [varchar](64) NOT NULL,
+PRIMARY KEY CLUSTERED ([recid] ASC),
+UNIQUE NONCLUSTERED ([element_mimetype] ASC)
+);
+GO
+
+INSERT INTO [dbo].[storage_types] (element_mimetype, element_displaytype) VALUES
+('application/octet-stream', 'Binary'),
+('text/plain',               'Text'),
+('text/markdown',            'Text'),
+('application/json',         'Data'),
+('application/pdf',          'Document'),
+('image/png',                'Image'),
+('image/jpeg',               'Image'),
+('image/gif',                'Image'),
+('image/webp',               'Image'),
+('video/mp4',                'Video'),
+('video/webm',               'Video'),
+('audio/mpeg',               'Audio'),
+('audio/wav',                'Audio'),
+('audio/ogg',                'Audio'),
+('audio/flac',               'Audio');
+GO
+
+/****** Object:  Table [dbo].[users_storage_cache] ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[users_storage_cache](
+  [recid] [bigint] IDENTITY(1,1) NOT NULL,
+  [users_guid] [uniqueidentifier] NOT NULL,
+  [types_recid] [int] NOT NULL,
+  [element_path] [nvarchar](512) NOT NULL,
+  [element_filename] [nvarchar](255) NOT NULL,
+  [element_public] [bit] NOT NULL CONSTRAINT DF_users_storage_cache_public DEFAULT ((0)),
+  [element_created_on] [datetime2](3) NOT NULL CONSTRAINT DF_users_storage_cache_created DEFAULT (sysutcdatetime()),
+  [element_modified_on] [datetime2](3) NULL,
+  [element_deleted] [bit] NOT NULL CONSTRAINT DF_users_storage_cache_deleted DEFAULT ((0)),
+  CONSTRAINT [PK_users_storage_cache] PRIMARY KEY CLUSTERED ([recid] ASC),
+  CONSTRAINT [UQ_users_storage_cache] UNIQUE NONCLUSTERED ([users_guid] ASC, [element_path] ASC, [element_filename] ASC),
+  CONSTRAINT [FK_users_storage_cache_users] FOREIGN KEY([users_guid]) REFERENCES [dbo].[account_users] ([element_guid]),
+  CONSTRAINT [FK_users_storage_types] FOREIGN KEY([types_recid]) REFERENCES [dbo].[storage_types] ([recid])
+);
+GO

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -115,3 +115,13 @@ class DbModule(BaseModule):
       raise ValueError("Missing config value for key: JwksCacheTime")
     return int(value)
 
+  async def list_storage_cache(self, user_guid: str) -> list[Dict[str, Any]]:
+    res = await self.run("db:storage:cache:list:1", {"user_guid": user_guid})
+    return res.rows
+
+  async def replace_storage_cache(self, user_guid: str, items: list[Dict[str, Any]]):
+    await self.run(
+      "db:storage:cache:replace_user:1",
+      {"user_guid": user_guid, "items": items},
+    )
+

--- a/server/modules/storage_cache_module.py
+++ b/server/modules/storage_cache_module.py
@@ -1,0 +1,54 @@
+"""Storage cache module."""
+
+from fastapi import FastAPI
+from . import BaseModule
+from .db_module import DbModule
+from .storage_module import StorageModule
+import logging
+
+
+class StorageCacheModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+    self.storage: StorageModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.storage = self.app.state.storage
+    await self.storage.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    logging.info("Storage cache module shutdown")
+
+  async def list_user_files(self, user_guid: str) -> list[dict[str, str | None]]:
+    assert self.db and self.storage
+    rows = await self.db.list_storage_cache(user_guid)
+    files: list[dict[str, str | None]] = []
+    base = self.storage.client.url if self.storage.client else ""
+    for row in rows:
+      path = row.get("path") or ""
+      filename = row.get("filename") or ""
+      name = f"{path}/{filename}" if path else filename
+      url = f"{base}/{user_guid}/{name}" if base else ""
+      files.append({"name": name, "url": url, "content_type": row.get("content_type")})
+    return files
+
+  async def refresh_user_cache(self, user_guid: str) -> list[dict[str, str | None]]:
+    assert self.db and self.storage
+    files = await self.storage.list_user_files(user_guid)
+    items = []
+    for f in files:
+      name = f.get("name", "")
+      path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
+      items.append({
+        "path": path,
+        "filename": filename,
+        "public": 0,
+        "content_type": f.get("content_type"),
+        "deleted": 0,
+      })
+    await self.db.replace_storage_cache(user_guid, items)
+    return await self.list_user_files(user_guid)


### PR DESCRIPTION
## Summary
- add storage cache module and MSSQL query handlers
- expose cache list/replace helpers in DbModule and RPC refresh endpoint
- include SQL schema for storage cache tables

## Testing
- `npm run lint`
- `npm run type-check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbb5259b748325b6a91575f9df83a9