### PR TITLE
Close Azure storage clients and commit storage cache seed

### DIFF
--- a/scripts/seed_storage_table.py
+++ b/scripts/seed_storage_table.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import asyncio, os
-from typing import Dict, Set
-from azure.storage.blob.aio import BlobServiceClient
+from typing import Dict, Set, Tuple
+from azure.storage.blob.aio import BlobServiceClient, ContainerClient
 from scriptlib import connect
 
 async def _fetch_type_map(conn) -> Dict[str, int]:
@@ -16,7 +16,7 @@ async def _fetch_user_guids(conn) -> Set[str]:
     rows = await cur.fetchall()
   return {r[0] for r in rows}
 
-async def _get_container(conn):
+async def _get_container(conn) -> Tuple[BlobServiceClient, ContainerClient]:
   async with conn.cursor() as cur:
     await cur.execute(
       "SELECT element_value FROM system_config WHERE element_key=?",
@@ -30,12 +30,15 @@ async def _get_container(conn):
   if not dsn:
     raise RuntimeError("AZURE_BLOB_CONNECTION_STRING not set")
   bsc = BlobServiceClient.from_connection_string(dsn)
-  return bsc.get_container_client(container)
+  return bsc, bsc.get_container_client(container)
 
 async def seed_storage_cache():
   conn = await connect()
+  conn.autocommit = False
+  bsc: BlobServiceClient | None = None
+  container: ContainerClient | None = None
   try:
-    container = await _get_container(conn)
+    bsc, container = await _get_container(conn)
     type_map = await _fetch_type_map(conn)
     user_guids = await _fetch_user_guids(conn)
     octet_type = type_map.get("application/octet-stream")
@@ -69,7 +72,12 @@ async def seed_storage_cache():
           "INSERT INTO users_storage_cache (users_guid, types_recid, element_path, element_filename, element_public, element_deleted) VALUES (?, ?, ?, ?, 0, 0)",
           (user_guid, types_recid, path, filename),
         )
+    await conn.commit()
   finally:
+    if container:
+      await container.close()
+    if bsc:
+      await bsc.close()
     await conn.close()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure seed_storage_table closes BlobServiceClient and ContainerClient to avoid unclosed sessions
- disable autocommit and commit inserts so seed script loads database

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68bc72de81008325bddac99d75d67707