### PR TITLE
Enable storage provisioning check on admin user page

### DIFF
--- a/frontend/src/pages/AccountUserPanel.tsx
+++ b/frontend/src/pages/AccountUserPanel.tsx
@@ -77,22 +77,18 @@ const AccountUserPanel = (): JSX.Element => {
 								setAssigned(assignments);
 								setAvailable(avail);
 								setInitialAssigned(assignments.map((r) => r.name));
-								const hasStorage = assignments.some((r) => (BigInt(r.mask) & STORAGE_ROLE_BIT) !== 0n);
-								if (hasStorage) {
-										try {
-												const res = await fetchCheckStorage({ userGuid: prof.guid });
-												setStorageExists(Boolean(res.exists));
-										} catch {
-												setStorageExists(false);
-										}
-								} else {
-										setStorageExists(false);
+								try {
+									const res = await fetchCheckStorage({ userGuid: prof.guid });
+									setStorageExists(Boolean(res.exists));
+								} catch {
+									setStorageExists(false);
 								}
 						} catch {
 								setProfile(null);
 								setAssigned([]);
 								setAvailable([]);
 								setInitialAssigned([]);
+								setStorageExists(false);
 						}
 				})();
 		}, [guid]);


### PR DESCRIPTION
## Summary
- Always check for user storage folder on admin user panel load
- Track storage existence and enable flag after saving roles
- Cover storage check in user admin module tests

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf07fede88325a59ea57521cd1021