### PR TITLE
chore: remove storage refresh cache rpc

### DIFF
--- a/rpc/storage/files/__init__.py
+++ b/rpc/storage/files/__init__.py
@@ -10,7 +10,6 @@ from .services import (
   storage_files_set_gallery_v1,
   storage_files_create_folder_v1,
   storage_files_move_file_v1,
-  storage_files_refresh_cache_v1,
 )
 
 
@@ -21,6 +20,5 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("set_gallery", "1"): storage_files_set_gallery_v1,
   ("create_folder", "1"): storage_files_create_folder_v1,
   ("move_file", "1"): storage_files_move_file_v1,
-  ("refresh_cache", "1"): storage_files_refresh_cache_v1,
 }
 

--- a/rpc/storage/files/services.py
+++ b/rpc/storage/files/services.py
@@ -73,13 +73,3 @@ async def storage_files_move_file_v1(request: Request):
     version=rpc_request.version,
   )
 
-
-async def storage_files_refresh_cache_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
-  payload = StorageFilesFiles1(files=[])
-  return RPCResponse(
-    op=rpc_request.op,
-    payload=payload.model_dump(),
-    version=rpc_request.version,
-  )
-


### PR DESCRIPTION
## Summary
- remove internal storage_files_refresh_cache RPC endpoint

## Testing
- `npm lint` *(fails: command not found)*
- `npm type-check` *(fails: command not found)*
- `npm test` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be493709c08325a388afa818162799