### PR TITLE
Refactor account user RPC and remove storage

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -26,10 +26,9 @@ All Support domain calls require `ROLE_SUPPORT`.
 
 | Operation                            | Description                                      |
 | ------------------------------------ | ------------------------------------------------ |
-| `urn:support:users:get_profile:1`      | Get a user's profile details.                    |
+| `urn:support:users:get_displayname:1`  | Get a user's display name.                       |
+| `urn:support:users:get_credits:1`      | Get a user's credit amount.                      |
 | `urn:support:users:set_credits:1`      | Moderator can set user credit amount.            |
-| `urn:support:users:enable_storage:1`   | Moderator can enable user storage.               |
-| `urn:support:users:check_storage:1`    | Check if user storage folder exists.             |
 | `urn:support:users:reset_display:1`    | Moderator reset of user display name to default. |
 
 ## Users Domain
@@ -182,6 +181,15 @@ All Account domain calls require `ROLE_ACCOUNT_ADMIN`.
 | `urn:account:role:get_role_members:1`       | Get members and non-members for a role.      |
 | `urn:account:role:add_role_member:1`        | Add members to a role.                       |
 | `urn:account:role:remove_role_member:1`     | Remove members from a role.                  |
+
+### `user`
+
+| Operation                                | Description                               |
+| ---------------------------------------- | ----------------------------------------- |
+| `urn:account:user:get_displayname:1`     | Get a user's display name.                |
+| `urn:account:user:get_credits:1`         | Get a user's credit amount.               |
+| `urn:account:user:set_credits:1`         | Set a user's credit amount.               |
+| `urn:account:user:reset_display:1`       | Reset a user's display name to default.   |
 
 ## Moderation Domain
 

--- a/rpc/account/user/__init__.py
+++ b/rpc/account/user/__init__.py
@@ -1,16 +1,14 @@
 from .services import (
-  account_user_get_profile_v1,
+  account_user_get_displayname_v1,
+  account_user_get_credits_v1,
   account_user_set_credits_v1,
   account_user_reset_display_v1,
-  account_user_enable_storage_v1,
-  account_user_check_storage_v1,
 )
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
-  ("get_profile", "1"): account_user_get_profile_v1,
+  ("get_displayname", "1"): account_user_get_displayname_v1,
+  ("get_credits", "1"): account_user_get_credits_v1,
   ("set_credits", "1"): account_user_set_credits_v1,
   ("reset_display", "1"): account_user_reset_display_v1,
-  ("enable_storage", "1"): account_user_enable_storage_v1,
-  ("check_storage", "1"): account_user_check_storage_v1,
 }

--- a/rpc/account/user/models.py
+++ b/rpc/account/user/models.py
@@ -9,5 +9,9 @@ class AccountUserSetCredits1(AccountUserGuid1):
   credits: int
 
 
-class AccountUserStorageStatus1(AccountUserGuid1):
-  exists: bool
+class AccountUserDisplayName1(AccountUserGuid1):
+  displayName: str
+
+
+class AccountUserCredits1(AccountUserGuid1):
+  credits: int

--- a/rpc/account/user/services.py
+++ b/rpc/account/user/services.py
@@ -1,23 +1,37 @@
 from fastapi import Request
-
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.user_admin_module import UserAdminModule
 from .models import (
   AccountUserGuid1,
   AccountUserSetCredits1,
-  AccountUserStorageStatus1,
+  AccountUserDisplayName1,
+  AccountUserCredits1,
 )
 
 
-async def account_user_get_profile_v1(request: Request):
+async def account_user_get_displayname_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountUserGuid1(**(rpc_request.payload or {}))
   user_admin: UserAdminModule = request.app.state.user_admin
-  profile = await user_admin.get_profile(data.userGuid)
+  display = await user_admin.get_displayname(data.userGuid)
+  res = AccountUserDisplayName1(userGuid=data.userGuid, displayName=display)
   return RPCResponse(
     op=rpc_request.op,
-    payload=profile.model_dump(),
+    payload=res.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def account_user_get_credits_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  data = AccountUserGuid1(**(rpc_request.payload or {}))
+  user_admin: UserAdminModule = request.app.state.user_admin
+  credits = await user_admin.get_credits(data.userGuid)
+  res = AccountUserCredits1(userGuid=data.userGuid, credits=credits)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=res.model_dump(),
     version=rpc_request.version,
   )
 
@@ -42,26 +56,5 @@ async def account_user_reset_display_v1(request: Request):
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),
-    version=rpc_request.version,
-  )
-
-
-async def account_user_enable_storage_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
-  data = AccountUserGuid1(**(rpc_request.payload or {}))
-  return RPCResponse(
-    op=rpc_request.op,
-    payload=data.model_dump(),
-    version=rpc_request.version,
-  )
-
-
-async def account_user_check_storage_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
-  data = AccountUserGuid1(**(rpc_request.payload or {}))
-  status = AccountUserStorageStatus1(userGuid=data.userGuid, exists=False)
-  return RPCResponse(
-    op=rpc_request.op,
-    payload=status.model_dump(),
     version=rpc_request.version,
   )

--- a/rpc/support/users/__init__.py
+++ b/rpc/support/users/__init__.py
@@ -1,19 +1,17 @@
 from .services import (
-  support_users_get_profile_v1,
+  support_users_get_displayname_v1,
+  support_users_get_credits_v1,
   support_users_reset_display_v1,
   support_users_set_credits_v1,
-  support_users_enable_storage_v1,
-  support_users_check_storage_v1
 )
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   # This module is used by moderators to manage user accounts.
   # This namespace is restricted to those with the SUPPORT role.
-  ("get_profile", "1"): support_users_get_profile_v1,
+  ("get_displayname", "1"): support_users_get_displayname_v1,
+  ("get_credits", "1"): support_users_get_credits_v1,
   ("set_credits", "1"): support_users_set_credits_v1,
   ("reset_display", "1"): support_users_reset_display_v1,
-  ("enable_storage", "1"): support_users_enable_storage_v1,
-  ("check_storage", "1"): support_users_check_storage_v1
 }
 

--- a/rpc/support/users/models.py
+++ b/rpc/support/users/models.py
@@ -9,6 +9,9 @@ class SupportUsersSetCredits1(SupportUsersGuid1):
   credits: int
 
 
-class SupportUsersStorageStatus1(SupportUsersGuid1):
-  exists: bool
+class SupportUsersDisplayName1(SupportUsersGuid1):
+  displayName: str
 
+
+class SupportUsersCredits1(SupportUsersGuid1):
+  credits: int

--- a/rpc/support/users/services.py
+++ b/rpc/support/users/services.py
@@ -2,17 +2,14 @@ from fastapi import Request
 from server.models import RPCResponse
 from rpc.account.user import services as account_user_services
 
-async def support_users_get_profile_v1(request: Request) -> RPCResponse:
-  return await account_user_services.account_user_get_profile_v1(request)
+async def support_users_get_displayname_v1(request: Request) -> RPCResponse:
+  return await account_user_services.account_user_get_displayname_v1(request)
+
+async def support_users_get_credits_v1(request: Request) -> RPCResponse:
+  return await account_user_services.account_user_get_credits_v1(request)
 
 async def support_users_set_credits_v1(request: Request) -> RPCResponse:
   return await account_user_services.account_user_set_credits_v1(request)
 
 async def support_users_reset_display_v1(request: Request) -> RPCResponse:
   return await account_user_services.account_user_reset_display_v1(request)
-
-async def support_users_enable_storage_v1(request: Request) -> RPCResponse:
-  return await account_user_services.account_user_enable_storage_v1(request)
-
-async def support_users_check_storage_v1(request: Request) -> RPCResponse:
-  return await account_user_services.account_user_check_storage_v1(request)

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -362,26 +362,6 @@ def _db_support_users_set_credits(args: Dict[str, Any]):
   return _support_users_set_credits(args)
 
 
-@register("urn:support:users:enable_storage:1")
-def _support_users_enable_storage(args: Dict[str, Any]):
-  guid = args["guid"]
-  sql = """
-    MERGE users_enablements AS ue
-    USING (SELECT ? AS users_guid) AS src
-    ON ue.users_guid = src.users_guid
-    WHEN MATCHED THEN UPDATE SET element_enablements =
-      CONVERT(NVARCHAR(MAX), CONVERT(BIGINT, ue.element_enablements) | 1)
-    WHEN NOT MATCHED THEN INSERT (users_guid, element_enablements)
-      VALUES (src.users_guid, '1');
-  """
-  return ("exec", sql, (guid,))
-
-
-@register("db:support:users:enable_storage:1")
-def _db_support_users_enable_storage(args: Dict[str, Any]):
-  return _support_users_enable_storage(args)
-
-
 # -------------------- STORAGE CACHE --------------------
 
 @register("db:storage:cache:list:1")


### PR DESCRIPTION
## Summary
- Replace account user profile RPC with separate get_displayname and get_credits endpoints
- Drop storage RPCs and related frontend logic on the account user management page
- Update support user routes and documentation for new endpoints

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be4e696c5c8325a90d36e80b635a07