### PR TITLE
feat: add storage module skeleton

### DIFF
--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -1,0 +1,100 @@
+"""Storage management module for indexing Azure Blob contents."""
+
+import asyncio, logging, re
+from fastapi import FastAPI
+from . import BaseModule
+from .env_module import EnvModule
+from .db_module import DbModule
+
+
+class StorageModule(BaseModule):
+  """Module responsible for cataloging files stored in Azure Blob Storage.
+
+  The module maintains a background task that periodically triggers a
+  reindex operation. Database helpers are provided for upserting file
+  metadata and querying indexed data.
+  """
+
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.env: EnvModule | None = None
+    self.db: DbModule | None = None
+    self.connection_string: str | None = None
+    self._reindex_task: asyncio.Task | None = None
+    self.reindex_interval = 15 * 60
+
+  @staticmethod
+  def _parse_duration(value: str) -> int:
+    match = re.fullmatch(r"(\d+)([smhdw])", value.strip().lower())
+    if not match:
+      raise ValueError(f"Invalid duration: {value}")
+    num, unit = match.groups()
+    mult = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+    return int(num) * mult[unit]
+
+  async def startup(self):
+    self.env = self.app.state.env
+    await self.env.on_ready()
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    try:
+      self.connection_string = self.env.get("AZURE_BLOB_CONNECTION_STRING")
+      if not self.connection_string:
+        logging.error("[StorageModule] AZURE_BLOB_CONNECTION_STRING missing")
+    except Exception as e:
+      logging.error("[StorageModule] Failed to load AZURE_BLOB_CONNECTION_STRING: %s", e)
+
+    try:
+      res = await self.db.run("db:system:config:get_config:1", {"key": "StorageCacheTime"})
+      value = res.rows[0]["value"] if res.rows else "15m"
+      try:
+        self.reindex_interval = self._parse_duration(value)
+      except Exception:
+        logging.error("[StorageModule] Invalid StorageCacheTime '%s'", value)
+    except Exception as e:
+      logging.error("[StorageModule] Failed to load StorageCacheTime: %s", e)
+    self._reindex_task = asyncio.create_task(self._reindex_loop())
+    logging.info("Storage module loaded")
+    self.mark_ready()
+
+  async def shutdown(self):
+    if self._reindex_task:
+      self._reindex_task.cancel()
+      try:
+        await self._reindex_task
+      except asyncio.CancelledError:
+        pass
+      self._reindex_task = None
+
+  async def _reindex_loop(self):
+    while True:
+      await asyncio.sleep(self.reindex_interval)
+      try:
+        await self.reindex()
+      except Exception as e:
+        logging.error("[StorageModule] Reindex failed: %s", e)
+
+  async def reindex(self):
+    """Perform a scan of storage and update database cache."""
+    # Placeholder for future implementation
+    raise NotImplementedError
+
+  async def upsert_file_record(self, user_guid: str, path: str, filename: str, file_type: str, **kwargs):
+    """Upsert a file record into the ``users_storage_cache`` table."""
+    raise NotImplementedError
+
+  async def list_files_by_user(self, user_guid: str):
+    """Return files belonging to ``user_guid``."""
+    raise NotImplementedError
+
+  async def list_files_by_folder(self, user_guid: str, folder: str):
+    """Return files under ``folder`` for ``user_guid``."""
+    raise NotImplementedError
+
+  async def list_public_files(self):
+    """Return files marked as publicly accessible."""
+    raise NotImplementedError
+
+  async def list_flagged_for_moderation(self):
+    """Return files that have been reported for moderation review."""
+    raise NotImplementedError

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -1,0 +1,55 @@
+import asyncio
+from fastapi import FastAPI
+
+from server.modules.storage_module import StorageModule
+from server.modules import BaseModule
+
+
+class DummyEnv(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self._env = {"AZURE_BLOB_CONNECTION_STRING": "UseDevelopmentStorage=true"}
+
+  async def startup(self):
+    self.mark_ready()
+
+  async def shutdown(self):
+    pass
+
+  def get(self, key: str):
+    return self._env.get(key)
+
+
+class DummyDb(BaseModule):
+  async def startup(self):
+    self.mark_ready()
+
+  async def shutdown(self):
+    pass
+
+  async def run(self, op, args):
+    class Res:
+      def __init__(self, rows):
+        self.rows = rows
+    if op == "db:system:config:get_config:1" and args.get("key") == "StorageCacheTime":
+      return Res([{ "value": "15m" }])
+    return Res([])
+
+
+def test_storage_module_startup_loads_connection_string_and_interval():
+  app = FastAPI()
+  app.state.env = DummyEnv(app)
+  app.state.db = DummyDb(app)
+  asyncio.run(app.state.env.startup())
+  asyncio.run(app.state.db.startup())
+
+  mod = StorageModule(app)
+  asyncio.run(mod.startup())
+  assert mod.connection_string == "UseDevelopmentStorage=true"
+  assert mod.reindex_interval == 15 * 60
+
+
+def test_parse_duration_shorthand():
+  assert StorageModule._parse_duration("10m") == 600
+  assert StorageModule._parse_duration("1d") == 86400
+  assert StorageModule._parse_duration("2w") == 1209600


### PR DESCRIPTION
## Summary
- add StorageModule with background reindex loop and env/db startup
- stub out storage metadata query helpers
- hook reindex interval to `StorageCacheTime` system config and support duration shorthand
- test storage module startup loads connection string and interval

## Testing
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68bef6972dac83258bc65cd002e8da45