### PR TITLE
feat: add StorageCacheTime field to storage config

### DIFF
--- a/frontend/src/pages/system/SystemConfigPage.tsx
+++ b/frontend/src/pages/system/SystemConfigPage.tsx
@@ -223,6 +223,13 @@ const SystemConfigPage = (): JSX.Element => {
                         error={Boolean(errors.AzureBlobContainerName)}
                         helperText={errors.AzureBlobContainerName}
                     />
+                    <TextField
+                        label="StorageCacheTime"
+                        value={config.StorageCacheTime || ''}
+                        onChange={(e) => save('StorageCacheTime', e.target.value)}
+                        error={Boolean(errors.StorageCacheTime)}
+                        helperText={errors.StorageCacheTime}
+                    />
                 </Stack>
             </TabPanel>
 


### PR DESCRIPTION
## Summary
- add StorageCacheTime editable field in system config storage tab

## Testing
- `python scripts/generate_rpc_bindings.py`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run type-check`
- `npx --prefix frontend vitest run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beffe27de08325881cb70aa205e321