### PR TITLE
Add storage RPC endpoints and tests

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -115,11 +115,20 @@ Calls for user storage management. All Storage domain calls require `ROLE_STORAG
 | Operation                          | Description                                                     |
 | ---------------------------------- | --------------------------------------------------------------- |
 | `urn:storage:files:get_files:1`    | Provide a list of files for the user.                           |
+| `urn:storage:files:get_link:1`     | Get a direct link to a file.                                   |
+| `urn:storage:files:get_folder_files:1` | Provide a list of files within a folder for the user.     |
 | `urn:storage:files:set_gallery:1`  | Flag a file for public inclusion in the gallery.                |
 | `urn:storage:files:upload_files:1` | Upload a file or files from the user into the moderation queue. |
 | `urn:storage:files:delete_files:1` | Delete a file or files specified by the user.                   |
 | `urn:storage:files:create_folder:1` | Create a folder at the specified path.                         |
+| `urn:storage:files:delete_folder:1` | Delete a folder at the specified path.                        |
+| `urn:storage:files:create_user_folder:1` | Create a root folder for the user.                       |
 | `urn:storage:files:move_file:1`    | Move a file to a new location within the user's storage.       |
+| `urn:storage:files:rename_file:1`  | Rename a file within the user's storage.                        |
+| `urn:storage:files:get_public_files:1` | List files flagged as public.                             |
+| `urn:storage:files:get_moderation_files:1` | List files flagged for moderation review.             |
+| `urn:storage:files:get_metadata:1` | Get detailed metadata about a file.                            |
+| `urn:storage:files:get_usage:1`    | Summarize storage utilization by type and total size.          |
 
 ## System Domain
 

--- a/rpc/storage/files/__init__.py
+++ b/rpc/storage/files/__init__.py
@@ -10,6 +10,15 @@ from .services import (
   storage_files_set_gallery_v1,
   storage_files_create_folder_v1,
   storage_files_move_file_v1,
+  storage_files_rename_file_v1,
+  storage_files_get_link_v1,
+  storage_files_get_metadata_v1,
+  storage_files_get_folder_files_v1,
+  storage_files_delete_folder_v1,
+  storage_files_create_user_folder_v1,
+  storage_files_get_usage_v1,
+  storage_files_get_public_files_v1,
+  storage_files_get_moderation_files_v1,
 )
 
 
@@ -20,5 +29,14 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("set_gallery", "1"): storage_files_set_gallery_v1,
   ("create_folder", "1"): storage_files_create_folder_v1,
   ("move_file", "1"): storage_files_move_file_v1,
+  ("rename_file", "1"): storage_files_rename_file_v1,
+  ("get_link", "1"): storage_files_get_link_v1,
+  ("get_metadata", "1"): storage_files_get_metadata_v1,
+  ("get_folder_files", "1"): storage_files_get_folder_files_v1,
+  ("delete_folder", "1"): storage_files_delete_folder_v1,
+  ("create_user_folder", "1"): storage_files_create_user_folder_v1,
+  ("get_usage", "1"): storage_files_get_usage_v1,
+  ("get_public_files", "1"): storage_files_get_public_files_v1,
+  ("get_moderation_files", "1"): storage_files_get_moderation_files_v1,
 }
 

--- a/rpc/storage/files/models.py
+++ b/rpc/storage/files/models.py
@@ -39,3 +39,46 @@ class StorageFilesCreateFolder1(BaseModel):
 class StorageFilesMoveFile1(BaseModel):
   src: str
   dst: str
+
+
+class StorageFilesGetLink1(BaseModel):
+  name: str
+
+
+class StorageFilesGetFolderFiles1(BaseModel):
+  path: str
+
+
+class StorageFilesDeleteFolder1(BaseModel):
+  path: str
+
+
+class StorageFilesCreateUserFolder1(BaseModel):
+  path: str
+
+
+class StorageFilesRenameFile1(BaseModel):
+  old_name: str
+  new_name: str
+
+
+class StorageFilesGetMetadata1(BaseModel):
+  name: str
+
+
+class StorageFilesFileMetadata1(BaseModel):
+  name: str
+  size: int
+  content_type: Optional[str] = None
+  created_on: str
+  modified_on: str
+
+
+class StorageFilesUsageItem1(BaseModel):
+  content_type: str
+  size: int
+
+
+class StorageFilesUsage1(BaseModel):
+  total_size: int
+  by_type: List[StorageFilesUsageItem1]

--- a/rpc/storage/files/services.py
+++ b/rpc/storage/files/services.py
@@ -1,7 +1,8 @@
-from fastapi import Request
+from fastapi import HTTPException, Request
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
+from server.modules.storage_module import StorageModule
 
 from .models import (
   StorageFilesDeleteFiles1,
@@ -11,12 +12,28 @@ from .models import (
   StorageFilesSetGallery1,
   StorageFilesMoveFile1,
   StorageFilesUploadFiles1,
+  StorageFilesGetLink1,
+  StorageFilesGetFolderFiles1,
+  StorageFilesDeleteFolder1,
+  StorageFilesCreateUserFolder1,
+  StorageFilesRenameFile1,
+  StorageFilesGetMetadata1,
+  StorageFilesFileMetadata1,
+  StorageFilesUsageItem1,
+  StorageFilesUsage1,
 )
 
 
 async def storage_files_get_files_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
-  payload = StorageFilesFiles1(files=[])
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
+  storage: StorageModule = request.app.state.storage
+  files = await storage.list_files_by_user(user_guid)
+  items = [StorageFilesFileItem1(**f) for f in files]
+  payload = StorageFilesFiles1(files=items)
+  await storage.reindex(user_guid)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -25,8 +42,14 @@ async def storage_files_get_files_v1(request: Request):
 
 
 async def storage_files_upload_files_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
   data = StorageFilesUploadFiles1(**(rpc_request.payload or {}))
+  storage: StorageModule = request.app.state.storage
+  await storage.upload_files(user_guid, data.files)
+  await storage.reindex(user_guid)
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),
@@ -35,8 +58,14 @@ async def storage_files_upload_files_v1(request: Request):
 
 
 async def storage_files_delete_files_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
   data = StorageFilesDeleteFiles1(**(rpc_request.payload or {}))
+  storage: StorageModule = request.app.state.storage
+  await storage.delete_files(user_guid, data.files)
+  await storage.reindex(user_guid)
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),
@@ -45,8 +74,14 @@ async def storage_files_delete_files_v1(request: Request):
 
 
 async def storage_files_set_gallery_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
   data = StorageFilesSetGallery1(**(rpc_request.payload or {}))
+  storage: StorageModule = request.app.state.storage
+  await storage.set_gallery(user_guid, data.name, data.gallery)
+  await storage.reindex(user_guid)
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),
@@ -55,8 +90,14 @@ async def storage_files_set_gallery_v1(request: Request):
 
 
 async def storage_files_create_folder_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
   data = StorageFilesCreateFolder1(**(rpc_request.payload or {}))
+  storage: StorageModule = request.app.state.storage
+  await storage.create_folder(user_guid, data.path)
+  await storage.reindex(user_guid)
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),
@@ -65,11 +106,162 @@ async def storage_files_create_folder_v1(request: Request):
 
 
 async def storage_files_move_file_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
   data = StorageFilesMoveFile1(**(rpc_request.payload or {}))
+  storage: StorageModule = request.app.state.storage
+  await storage.move_file(user_guid, data.src, data.dst)
+  await storage.reindex(user_guid)
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def storage_files_rename_file_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
+  data = StorageFilesRenameFile1(**(rpc_request.payload or {}))
+  storage: StorageModule = request.app.state.storage
+  await storage.rename_file(user_guid, data.old_name, data.new_name)
+  await storage.reindex(user_guid)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=data.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def storage_files_get_link_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
+  data = StorageFilesGetLink1(**(rpc_request.payload or {}))
+  storage: StorageModule = request.app.state.storage
+  url = await storage.get_file_link(user_guid, data.name)
+  item = StorageFilesFileItem1(name=data.name, url=url)
+  await storage.reindex(user_guid)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=item.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def storage_files_get_metadata_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
+  data = StorageFilesGetMetadata1(**(rpc_request.payload or {}))
+  storage: StorageModule = request.app.state.storage
+  meta = await storage.get_file_metadata(user_guid, data.name)
+  item = StorageFilesFileMetadata1(**meta)
+  await storage.reindex(user_guid)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=item.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def storage_files_get_folder_files_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
+  data = StorageFilesGetFolderFiles1(**(rpc_request.payload or {}))
+  storage: StorageModule = request.app.state.storage
+  files = await storage.list_files_by_folder(user_guid, data.path)
+  items = [StorageFilesFileItem1(**f) for f in files]
+  payload = StorageFilesFiles1(files=items)
+  await storage.reindex(user_guid)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def storage_files_delete_folder_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
+  data = StorageFilesDeleteFolder1(**(rpc_request.payload or {}))
+  storage: StorageModule = request.app.state.storage
+  await storage.delete_folder(user_guid, data.path)
+  await storage.reindex(user_guid)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=data.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def storage_files_create_user_folder_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
+  data = StorageFilesCreateUserFolder1(**(rpc_request.payload or {}))
+  storage: StorageModule = request.app.state.storage
+  await storage.create_user_folder(user_guid, data.path)
+  await storage.reindex(user_guid)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=data.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def storage_files_get_usage_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  user_guid = auth_ctx.user_guid
+  if user_guid is None:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
+  storage: StorageModule = request.app.state.storage
+  usage = await storage.get_usage(user_guid)
+  items = [StorageFilesUsageItem1(**u) for u in usage.get("by_type", [])]
+  payload = StorageFilesUsage1(total_size=usage.get("total_size", 0), by_type=items)
+  await storage.reindex(user_guid)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def storage_files_get_public_files_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  storage: StorageModule = request.app.state.storage
+  files = await storage.list_public_files()
+  items = [StorageFilesFileItem1(**f) for f in files]
+  payload = StorageFilesFiles1(files=items)
+  await storage.reindex()
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def storage_files_get_moderation_files_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  storage: StorageModule = request.app.state.storage
+  files = await storage.list_flagged_for_moderation()
+  items = [StorageFilesFileItem1(**f) for f in files]
+  payload = StorageFilesFiles1(files=items)
+  await storage.reindex()
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
     version=rpc_request.version,
   )
 

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -74,10 +74,10 @@ class StorageModule(BaseModule):
       except Exception as e:
         logging.error("[StorageModule] Reindex failed: %s", e)
 
-  async def reindex(self):
+  async def reindex(self, user_guid: str | None = None):
     """Perform a scan of storage and update database cache."""
     # Placeholder for future implementation
-    raise NotImplementedError
+    return
 
   async def upsert_file_record(self, user_guid: str, path: str, filename: str, file_type: str, **kwargs):
     """Upsert a file record into the ``users_storage_cache`` table."""
@@ -97,4 +97,37 @@ class StorageModule(BaseModule):
 
   async def list_flagged_for_moderation(self):
     """Return files that have been reported for moderation review."""
+    raise NotImplementedError
+
+  async def upload_files(self, user_guid: str, files):
+    raise NotImplementedError
+
+  async def delete_files(self, user_guid: str, names: list[str]):
+    raise NotImplementedError
+
+  async def set_gallery(self, user_guid: str, name: str, gallery: bool):
+    raise NotImplementedError
+
+  async def create_folder(self, user_guid: str, path: str):
+    raise NotImplementedError
+
+  async def delete_folder(self, user_guid: str, path: str):
+    raise NotImplementedError
+
+  async def create_user_folder(self, user_guid: str, path: str):
+    raise NotImplementedError
+
+  async def move_file(self, user_guid: str, src: str, dst: str):
+    raise NotImplementedError
+
+  async def get_file_link(self, user_guid: str, name: str) -> str:
+    raise NotImplementedError
+
+  async def rename_file(self, user_guid: str, old_name: str, new_name: str):
+    raise NotImplementedError
+
+  async def get_file_metadata(self, user_guid: str, name: str):
+    raise NotImplementedError
+
+  async def get_usage(self, user_guid: str):
     raise NotImplementedError

--- a/tests/test_storage_files_services.py
+++ b/tests/test_storage_files_services.py
@@ -1,0 +1,179 @@
+import asyncio
+import importlib.util
+import pathlib
+import types
+import sys
+from pydantic import BaseModel
+
+# stub rpc package and helpers
+rpc_pkg = types.ModuleType("rpc")
+rpc_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / "rpc")]
+sys.modules.setdefault("rpc", rpc_pkg)
+
+storage_pkg = types.ModuleType("rpc.storage")
+storage_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / "rpc/storage")]
+sys.modules.setdefault("rpc.storage", storage_pkg)
+
+files_pkg = types.ModuleType("rpc.storage.files")
+files_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / "rpc/storage/files")]
+sys.modules.setdefault("rpc.storage.files", files_pkg)
+
+models_spec = importlib.util.spec_from_file_location(
+  "rpc.storage.files.models",
+  pathlib.Path(__file__).resolve().parent.parent / "rpc/storage/files/models.py",
+)
+models_module = importlib.util.module_from_spec(models_spec)
+models_spec.loader.exec_module(models_module)
+sys.modules.setdefault("rpc.storage.files.models", models_module)
+
+helpers_pkg = types.ModuleType("rpc.helpers")
+
+async def unbox_request(request):
+  return request.state.rpc_request, request.state.auth_ctx, []
+
+helpers_pkg.unbox_request = unbox_request
+sys.modules.setdefault("rpc.helpers", helpers_pkg)
+
+# stub server models
+server_pkg = types.ModuleType("server")
+models_pkg = types.ModuleType("server.models")
+
+class RPCRequest(BaseModel):
+  op: str
+  payload: dict | None = None
+  version: int = 1
+
+
+class RPCResponse(BaseModel):
+  op: str
+  payload: dict
+  version: int = 1
+
+
+class AuthContext(BaseModel):
+  user_guid: str | None = None
+
+
+models_pkg.RPCRequest = RPCRequest
+models_pkg.RPCResponse = RPCResponse
+models_pkg.AuthContext = AuthContext
+server_pkg.models = models_pkg
+sys.modules.setdefault("server", server_pkg)
+sys.modules.setdefault("server.models", models_pkg)
+
+# load services module
+spec = importlib.util.spec_from_file_location(
+  "rpc.storage.files.services",
+  pathlib.Path(__file__).resolve().parent.parent / "rpc/storage/files/services.py",
+)
+services = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(services)
+
+storage_files_get_link_v1 = services.storage_files_get_link_v1
+storage_files_delete_folder_v1 = services.storage_files_delete_folder_v1
+storage_files_rename_file_v1 = services.storage_files_rename_file_v1
+storage_files_get_metadata_v1 = services.storage_files_get_metadata_v1
+storage_files_get_usage_v1 = services.storage_files_get_usage_v1
+
+
+class DummyStorage:
+  def __init__(self):
+    self.link_args = None
+    self.deleted = None
+    self.reindexed = None
+    self.renamed = None
+    self.metadata_args = None
+    self.usage_called = None
+
+  async def get_file_link(self, user_guid, name):
+    self.link_args = (user_guid, name)
+    return f"https://example.com/{name}"
+
+  async def delete_folder(self, user_guid, path):
+    self.deleted = (user_guid, path)
+
+  async def reindex(self, user_guid=None):
+    self.reindexed = user_guid
+
+  async def rename_file(self, user_guid, old_name, new_name):
+    self.renamed = (user_guid, old_name, new_name)
+
+  async def get_file_metadata(self, user_guid, name):
+    self.metadata_args = (user_guid, name)
+    return {
+      "name": name,
+      "size": 1,
+      "content_type": "text/plain",
+      "created_on": "now",
+      "modified_on": "now",
+    }
+
+  async def get_usage(self, user_guid):
+    self.usage_called = user_guid
+    return {
+      "total_size": 10,
+      "by_type": [{"content_type": "text/plain", "size": 10}],
+    }
+
+
+def make_request(op, payload):
+  storage = DummyStorage()
+  req = types.SimpleNamespace()
+  req.app = types.SimpleNamespace(state=types.SimpleNamespace(storage=storage))
+  req.state = types.SimpleNamespace(
+    rpc_request=RPCRequest(op=op, payload=payload, version=1),
+    auth_ctx=AuthContext(user_guid="u123"),
+  )
+  req.headers = {}
+  return req, storage
+
+
+def test_get_link_calls_storage():
+  req, storage = make_request("urn:storage:files:get_link:1", {"name": "a.txt"})
+  resp = asyncio.run(storage_files_get_link_v1(req))
+  assert resp.payload == {"name": "a.txt", "url": "https://example.com/a.txt", "content_type": None}
+  assert storage.link_args == ("u123", "a.txt")
+  assert storage.reindexed == "u123"
+
+
+def test_delete_folder_triggers_reindex():
+  req, storage = make_request("urn:storage:files:delete_folder:1", {"path": "/docs"})
+  _ = asyncio.run(storage_files_delete_folder_v1(req))
+  assert storage.deleted == ("u123", "/docs")
+  assert storage.reindexed == "u123"
+
+
+def test_rename_file_calls_storage():
+  req, storage = make_request(
+    "urn:storage:files:rename_file:1",
+    {"old_name": "a.txt", "new_name": "b.txt"},
+  )
+  _ = asyncio.run(storage_files_rename_file_v1(req))
+  assert storage.renamed == ("u123", "a.txt", "b.txt")
+  assert storage.reindexed == "u123"
+
+
+def test_get_metadata_returns_details():
+  req, storage = make_request("urn:storage:files:get_metadata:1", {"name": "a.txt"})
+  resp = asyncio.run(storage_files_get_metadata_v1(req))
+  assert resp.payload == {
+    "name": "a.txt",
+    "size": 1,
+    "content_type": "text/plain",
+    "created_on": "now",
+    "modified_on": "now",
+  }
+  assert storage.metadata_args == ("u123", "a.txt")
+  assert storage.reindexed == "u123"
+
+
+def test_get_usage_returns_summary():
+  req, storage = make_request("urn:storage:files:get_usage:1", {})
+  resp = asyncio.run(storage_files_get_usage_v1(req))
+  assert resp.payload == {
+    "total_size": 10,
+    "by_type": [{"content_type": "text/plain", "size": 10}],
+  }
+  assert storage.usage_called == "u123"
+  assert storage.reindexed == "u123"
+


### PR DESCRIPTION
## Summary
- expand storage RPC services with file links, folder management, and public/moderation listing
- hook storage operations into dispatcher and stubbed storage module
- document new storage URNs and add unit tests
- add rename, metadata, and usage reporting RPC endpoints

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf0c380ed0832580a78aae2c41fec5