### PR TITLE
feat: add storage reindexing

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -125,3 +125,12 @@ class DbModule(BaseModule):
       {"user_guid": user_guid, "items": items},
     )
 
+  async def upsert_storage_cache(self, item: Dict[str, Any]):
+    await self.run("db:storage:cache:upsert:1", item)
+
+  async def delete_storage_cache(self, user_guid: str, path: str, filename: str):
+    await self.run(
+      "db:storage:cache:delete:1",
+      {"user_guid": user_guid, "path": path, "filename": filename},
+    )
+


### PR DESCRIPTION
## Summary
- add MSSQL handlers to upsert and delete storage cache records
- implement storage module reindexing using Azure Blob Storage
- expose helpers on DbModule for cache maintenance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf434c0f1883258c2db855ee410d85