### PR TITLE
Add system storage stats lookup

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -150,6 +150,12 @@ These calls expose system administration functionality. All System domain calls 
 | `urn:system:roles:upsert_role:1` | Create or update a system role.      |
 | `urn:system:roles:delete_role:1` | Delete a system role.                |
 
+### `storage`
+
+| Operation                           | Description                                        |
+| ----------------------------------- | -------------------------------------------------- |
+| `urn:system:storage:get_stats:1`    | Return counts and sizes for storage and cache.     |
+
 ## Service Domain
 
 All Service domain calls require `ROLE_SERVICE_ADMIN`. Role management

--- a/frontend/src/pages/system/SystemConfigPage.tsx
+++ b/frontend/src/pages/system/SystemConfigPage.tsx
@@ -13,8 +13,9 @@ import {
 } from '@mui/material';
 import Notification from '../../components/Notification';
 import PageTitle from '../../components/PageTitle';
-import type { SystemConfigList1 } from '../../shared/RpcModels';
+import type { SystemConfigList1, SystemStorageStats1 } from '../../shared/RpcModels';
 import { fetchConfigs, fetchUpsertConfig } from '../../rpc/system/config';
+import { fetchStats as fetchStorageStats } from '../../rpc/system/storage';
 
 const AUTH_PROVIDERS = ['microsoft', 'discord', 'google', 'apple'];
 const GUID_REGEX = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
@@ -42,6 +43,7 @@ const SystemConfigPage = (): JSX.Element => {
     const [tab, setTab] = useState(0);
     const [notification, setNotification] = useState(false);
     const [forbidden, setForbidden] = useState(false);
+    const [stats, setStats] = useState<SystemStorageStats1 | null>(null);
 
     const handleNotificationClose = (): void => {
         setNotification(false);
@@ -67,6 +69,11 @@ const SystemConfigPage = (): JSX.Element => {
     useEffect(() => {
         void load();
     }, []);
+
+    const lookup = async (): Promise<void> => {
+        const res: SystemStorageStats1 = await fetchStorageStats();
+        setStats(res);
+    };
 
     const validate = (key: string, value: string): boolean => {
         let err = '';
@@ -230,6 +237,17 @@ const SystemConfigPage = (): JSX.Element => {
                         error={Boolean(errors.StorageCacheTime)}
                         helperText={errors.StorageCacheTime}
                     />
+                    <Button variant="outlined" onClick={() => { void lookup(); }}>
+                        Lookup
+                    </Button>
+                    {stats && (
+                        <Box>
+                            <Typography>Files: {stats.file_count}</Typography>
+                            <Typography>Total Bytes: {stats.total_bytes}</Typography>
+                            <Typography>User Folders: {stats.folder_count}</Typography>
+                            <Typography>DB Rows: {stats.db_rows}</Typography>
+                        </Box>
+                    )}
                 </Stack>
             </TabPanel>
 

--- a/rpc/system/__init__.py
+++ b/rpc/system/__init__.py
@@ -5,9 +5,11 @@ Requires ROLE_SYSTEM_ADMIN.
 
 from .config.handler import handle_config_request
 from .roles.handler import handle_roles_request
+from .storage.handler import handle_storage_request
 
 HANDLERS: dict[str, callable] = {
   "config": handle_config_request,
   "roles": handle_roles_request,
+  "storage": handle_storage_request,
 }
 

--- a/rpc/system/storage/__init__.py
+++ b/rpc/system/storage/__init__.py
@@ -1,0 +1,9 @@
+from .services import (
+  system_storage_get_stats_v1,
+)
+
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("get_stats", "1"): system_storage_get_stats_v1,
+}
+

--- a/rpc/system/storage/handler.py
+++ b/rpc/system/storage/handler.py
@@ -1,0 +1,16 @@
+"""System storage RPC handler."""
+
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_storage_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)
+

--- a/rpc/system/storage/models.py
+++ b/rpc/system/storage/models.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class SystemStorageStats1(BaseModel):
+  file_count: int
+  total_bytes: int
+  folder_count: int
+  db_rows: int
+

--- a/rpc/system/storage/services.py
+++ b/rpc/system/storage/services.py
@@ -1,0 +1,18 @@
+from fastapi import Request
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.storage_module import StorageModule
+from .models import SystemStorageStats1
+
+
+async def system_storage_get_stats_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  storage: StorageModule = request.app.state.storage
+  stats = await storage.get_storage_stats()
+  payload = SystemStorageStats1(**stats)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -480,6 +480,17 @@ def _storage_cache_delete(args: Dict[str, Any]):
   return ("exec", sql, (user_guid, path, filename))
 
 
+@register("db:storage:cache:count_rows:1")
+def _storage_cache_count_rows(_: Dict[str, Any]):
+  sql = """
+    SELECT COUNT(*) AS count
+    FROM users_storage_cache
+    WHERE element_deleted = 0
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return ("json_one", sql, ())
+
+
 @register("urn:users:profile:set_optin:1")
 def _users_set_optin(args: Dict[str, Any]):
     guid = args["guid"]

--- a/tests/test_system_storage_services.py
+++ b/tests/test_system_storage_services.py
@@ -1,0 +1,99 @@
+import types, sys, pathlib
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+from types import SimpleNamespace
+from pydantic import BaseModel
+
+# stub rpc package
+pkg = types.ModuleType('rpc')
+pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc')]
+sys.modules.setdefault('rpc', pkg)
+
+rpc_system_pkg = types.ModuleType('rpc.system')
+rpc_system_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc/system')]
+sys.modules.setdefault('rpc.system', rpc_system_pkg)
+
+rpc_system_storage_pkg = types.ModuleType('rpc.system.storage')
+rpc_system_storage_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc/system/storage')]
+sys.modules.setdefault('rpc.system.storage', rpc_system_storage_pkg)
+
+# stub server.models
+server_pkg = types.ModuleType('server')
+models_pkg = types.ModuleType('server.models')
+
+
+class RPCResponse(BaseModel):
+  op: str
+  payload: dict
+  version: int = 1
+
+
+class AuthContext(BaseModel):
+  user_guid: str = ''
+  roles: list[str] = []
+
+
+models_pkg.RPCResponse = RPCResponse
+models_pkg.AuthContext = AuthContext
+server_pkg.models = models_pkg
+sys.modules.setdefault('server', server_pkg)
+sys.modules.setdefault('server.models', models_pkg)
+
+import importlib.util
+
+svc_spec = importlib.util.spec_from_file_location(
+  'rpc.system.storage.services',
+  pathlib.Path(__file__).resolve().parent.parent / 'rpc/system/storage/services.py',
+)
+svc = importlib.util.module_from_spec(svc_spec)
+sys.modules['rpc.system.storage.services'] = svc
+svc_spec.loader.exec_module(svc)
+
+system_storage_get_stats_v1 = svc.system_storage_get_stats_v1
+
+
+async def fake_unbox(request: Request):
+  body = await request.json()
+  op = body.get('op')
+  payload = body.get('payload')
+  rpc_req = SimpleNamespace(op=op, payload=payload, version=1)
+  auth_ctx = SimpleNamespace(user_guid='u1', roles=[])
+  return rpc_req, auth_ctx, None
+
+
+svc.unbox_request = fake_unbox
+
+
+class DummyStorageModule:
+  async def get_storage_stats(self):
+    return {
+      'file_count': 5,
+      'total_bytes': 10,
+      'folder_count': 2,
+      'db_rows': 7,
+    }
+
+
+app = FastAPI()
+app.state.storage = DummyStorageModule()
+
+
+@app.post('/rpc')
+async def rpc_endpoint(request: Request):
+  return await system_storage_get_stats_v1(request)
+
+
+client = TestClient(app)
+
+
+def test_get_stats_service():
+  resp = client.post('/rpc', json={'op': 'urn:system:storage:get_stats:1'})
+  assert resp.status_code == 200
+  assert resp.json()['payload'] == {
+    'file_count': 5,
+    'total_bytes': 10,
+    'folder_count': 2,
+    'db_rows': 7,
+  }
+


### PR DESCRIPTION
## Summary
- add RPC endpoint `urn:system:storage:get_stats:1` for file counts and sizes
- support stats in StorageModule and DB provider
- show storage stats on System Config page

## Testing
- `npm run lint`
- `npm run type-check`
- `CI=true npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf4937cb388325b3a526eec558de4a