### PR TITLE
Reduce Azure HTTP logging noise

### DIFF
--- a/server/helpers/logging.py
+++ b/server/helpers/logging.py
@@ -76,6 +76,8 @@ def update_logging_level(level: int = 3):
     2 → errors and warnings
     3 → errors, warnings and info
     ≥4 → errors, warnings, info and debug
+
+  Azure HTTP request/response logging is suppressed unless ``level >= 4``.
   """
   logger = logging.getLogger()
   logger.disabled = level <= 0
@@ -91,13 +93,13 @@ def update_logging_level(level: int = 3):
     log_level = logging.DEBUG
   logger.setLevel(log_level)
 
+  # Azure's HTTP policy logs request/response details at INFO.
+  # Only enable these verbose logs in debug mode.
   azure_logger = logging.getLogger('azure.core.pipeline.policies.http_logging_policy')
   azure_logger.disabled = level <= 0
   if level >= 4:
-    azure_level = logging.DEBUG
-  elif level == 3:
     azure_level = logging.INFO
-  elif level == 2:
+  elif level == 3:
     azure_level = logging.WARNING
   else:
     azure_level = logging.ERROR

--- a/tests/test_logging_azure.py
+++ b/tests/test_logging_azure.py
@@ -1,0 +1,12 @@
+import logging
+from server.helpers.logging import update_logging_level
+
+def test_update_logging_level_sets_warning_for_azure_logger():
+  update_logging_level(3)
+  azure_logger = logging.getLogger('azure.core.pipeline.policies.http_logging_policy')
+  assert azure_logger.level == logging.WARNING
+
+def test_update_logging_level_debug_enables_info_for_azure_logger():
+  update_logging_level(4)
+  azure_logger = logging.getLogger('azure.core.pipeline.policies.http_logging_policy')
+  assert azure_logger.level == logging.INFO


### PR DESCRIPTION
## Summary
- Suppress verbose Azure Blob HTTP request/response logs unless running at debug level
- Add tests verifying Azure logger levels for info and debug modes

## Testing
- `python scripts/generate_rpc_bindings.py`
- `npm run lint`
- `npm run type-check`
- `npx vitest run --coverage`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf528d95588325b86d441116b95c04