### PR TITLE
Add folder listing support to file manager

### DIFF
--- a/rpc/storage/files/models.py
+++ b/rpc/storage/files/models.py
@@ -49,6 +49,17 @@ class StorageFilesGetFolderFiles1(BaseModel):
   path: str
 
 
+class StorageFilesFolderItem1(BaseModel):
+  name: str
+  empty: bool
+
+
+class StorageFilesFolderListing1(BaseModel):
+  path: str
+  files: List[StorageFilesFileItem1]
+  folders: List[StorageFilesFolderItem1]
+
+
 class StorageFilesDeleteFolder1(BaseModel):
   path: str
 

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -77,16 +77,27 @@ def test_list_files_by_user():
   ]
 
 
-def test_list_files_by_folder():
+def test_list_folder_returns_files_and_folders():
   app = FastAPI()
   mod = StorageModule(app)
   mod.db = DummyListDb([
     {"path": "", "filename": "a.txt", "content_type": "text/plain", "url": "u/a.txt"},
     {"path": "docs", "filename": "b.txt", "content_type": "text/plain", "url": "u/docs/b.txt"},
     {"path": "docs", "filename": "c.txt", "content_type": "text/plain", "url": "u/docs/c.txt"},
+    {"path": "docs/sub", "filename": "d.txt", "content_type": "text/plain", "url": "u/docs/sub/d.txt"},
   ])
-  files = asyncio.run(mod.list_files_by_folder("u1", "/docs"))
-  assert files == [
-    {"name": "docs/b.txt", "url": "u/docs/b.txt", "content_type": "text/plain"},
-    {"name": "docs/c.txt", "url": "u/docs/c.txt", "content_type": "text/plain"},
-  ]
+  root = asyncio.run(mod.list_folder("u1", ""))
+  assert root == {
+    "path": "",
+    "files": [{"name": "a.txt", "url": "u/a.txt", "content_type": "text/plain"}],
+    "folders": [{"name": "docs", "empty": False}],
+  }
+  docs = asyncio.run(mod.list_folder("u1", "/docs"))
+  assert docs == {
+    "path": "docs",
+    "files": [
+      {"name": "docs/b.txt", "url": "u/docs/b.txt", "content_type": "text/plain"},
+      {"name": "docs/c.txt", "url": "u/docs/c.txt", "content_type": "text/plain"},
+    ],
+    "folders": [{"name": "sub", "empty": False}],
+  }


### PR DESCRIPTION
## Summary
- compute folders from storage cache and return with file listings
- expose folder data through RPC and display in frontend with unified navigation
- cover storage listing with new unit tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf61b13874832584093e4f9997e630