### PR TITLE
Log and surface storage cache upsert errors

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -125,8 +125,8 @@ class DbModule(BaseModule):
       {"user_guid": user_guid, "items": items},
     )
 
-  async def upsert_storage_cache(self, item: Dict[str, Any]):
-    await self.run("db:storage:cache:upsert:1", item)
+  async def upsert_storage_cache(self, item: Dict[str, Any]) -> DBResult:
+    return await self.run("db:storage:cache:upsert:1", item)
 
   async def delete_storage_cache(self, user_guid: str, path: str, filename: str):
     await self.run(

--- a/server/modules/providers/database/mssql_provider/db_helpers.py
+++ b/server/modules/providers/database/mssql_provider/db_helpers.py
@@ -54,8 +54,8 @@ async def fetch_json(query: str, params: tuple[Any, ...] = (), *, many: bool = F
           return DBResult(rows=data, rowcount=len(data))
         return DBResult(rows=[data], rowcount=1)
   except Exception as e:
-    logging.debug(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
-    return DBResult()
+    logging.error(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
+    raise
 
 async def exec_query(query: str, params: tuple[Any, ...] = ()) -> DBResult:
   assert logic._pool, "MSSQL pool not initialized"
@@ -65,5 +65,5 @@ async def exec_query(query: str, params: tuple[Any, ...] = ()) -> DBResult:
         await cur.execute(query, params)
         return DBResult(rowcount=cur.rowcount or 0)
   except Exception as e:
-    logging.debug(f"Exec failed:\n{query}\nArgs: {params}\nError: {e}")
-    return DBResult()
+    logging.error(f"Exec failed:\n{query}\nArgs: {params}\nError: {e}")
+    raise

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from ... import DBResult
 from .logic import init_pool, close_pool, transaction
 from .db_helpers import fetch_rows, fetch_json, exec_query
+import logging
 
 # handler can be:
 #  - sync: (mode, sql, params) -> provider will run it
@@ -483,7 +484,14 @@ async def _storage_cache_upsert(args: Dict[str, Any]):
     reported,
     moderation_recid,
   )
-  return await exec_query(sql, params)
+  rc = await exec_query(sql, params)
+  if rc.rowcount == 0:
+    logging.error(
+      "[MSSQL] storage_cache_upsert affected 0 rows for %s/%s",
+      path or ".",
+      filename,
+    )
+  return rc
 
 
 @register("db:storage:cache:delete:1")

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -124,7 +124,7 @@ class StorageModule(BaseModule):
             logging.debug(
               "[StorageModule] indexing folder %s/%s", parent or ".", folder_name
             )
-            await self.db.upsert_storage_cache({
+            res = await self.db.upsert_storage_cache({
               "user_guid": guid,
               "path": parent,
               "filename": folder_name,
@@ -136,6 +136,12 @@ class StorageModule(BaseModule):
               "reported": 0,
               "moderation_recid": None,
             })
+            if res.rowcount == 0:
+              logging.error(
+                "[StorageModule] Failed to upsert folder %s/%s",
+                parent or ".",
+                folder_name,
+              )
             fset.add(key)
             folders_indexed += 1
           parent = f"{parent}/{folder_name}" if parent else folder_name
@@ -147,7 +153,7 @@ class StorageModule(BaseModule):
             logging.debug(
               "[StorageModule] indexing folder %s/%s", path or ".", filename
             )
-            await self.db.upsert_storage_cache({
+            res = await self.db.upsert_storage_cache({
               "user_guid": guid,
               "path": path,
               "filename": filename,
@@ -159,6 +165,12 @@ class StorageModule(BaseModule):
               "reported": 0,
               "moderation_recid": None,
             })
+            if res.rowcount == 0:
+              logging.error(
+                "[StorageModule] Failed to upsert folder %s/%s",
+                path or ".",
+                filename,
+              )
             fset.add(key)
             folders_indexed += 1
           continue
@@ -175,7 +187,7 @@ class StorageModule(BaseModule):
         logging.debug(
           "[StorageModule] indexing file %s/%s", path or ".", filename
         )
-        await self.db.upsert_storage_cache({
+        res = await self.db.upsert_storage_cache({
           "user_guid": guid,
           "path": path,
           "filename": filename,
@@ -187,6 +199,12 @@ class StorageModule(BaseModule):
           "reported": 0,
           "moderation_recid": None,
         })
+        if res.rowcount == 0:
+          logging.error(
+            "[StorageModule] Failed to upsert file %s/%s",
+            path or ".",
+            filename,
+          )
         files_seen.setdefault(guid, set()).add((path, filename))
         files_indexed += 1
       if user_guid:
@@ -223,7 +241,7 @@ class StorageModule(BaseModule):
   async def upsert_file_record(self, user_guid: str, path: str, filename: str, file_type: str, **kwargs):
     """Upsert a file record into the ``users_storage_cache`` table."""
     assert self.db
-    await self.db.upsert_storage_cache({
+    res = await self.db.upsert_storage_cache({
       "user_guid": user_guid,
       "path": path,
       "filename": filename,
@@ -235,6 +253,12 @@ class StorageModule(BaseModule):
       "reported": kwargs.get("reported", 0),
       "moderation_recid": kwargs.get("moderation_recid"),
     })
+    if res.rowcount == 0:
+      logging.error(
+        "[StorageModule] Failed to upsert file %s/%s",
+        path or ".",
+        filename,
+      )
 
   async def list_files_by_user(self, user_guid: str):
     """Return files belonging to ``user_guid``."""

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -4,6 +4,7 @@ import importlib.util
 import pathlib
 import sys
 import types
+import pytest
 import server.modules.providers.database.mssql_provider  # ensure provider module loaded
 
 # stub server package
@@ -108,7 +109,7 @@ def test_fetch_rows_returns_empty_on_error(monkeypatch):
   assert res.rowcount == 0
 
 
-def test_fetch_json_returns_empty_on_error(monkeypatch):
+def test_fetch_json_raises_on_error(monkeypatch):
   class Cur:
     async def execute(self, q, p):
       raise Exception("boom")
@@ -124,12 +125,11 @@ def test_fetch_json_returns_empty_on_error(monkeypatch):
       return Conn()
 
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
-  res = asyncio.run(db_helpers.fetch_json("SELECT 1"))
-  assert res.rows == []
-  assert res.rowcount == 0
+  with pytest.raises(Exception):
+    asyncio.run(db_helpers.fetch_json("SELECT 1"))
 
 
-def test_exec_query_returns_empty_on_error(monkeypatch):
+def test_exec_query_raises_on_error(monkeypatch):
   class Cur:
     async def execute(self, q, p):
       raise Exception("boom")
@@ -143,9 +143,8 @@ def test_exec_query_returns_empty_on_error(monkeypatch):
       return Conn()
 
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
-  res = asyncio.run(db_helpers.exec_query("UPDATE x SET y=1"))
-  assert res.rows == []
-  assert res.rowcount == 0
+  with pytest.raises(Exception):
+    asyncio.run(db_helpers.exec_query("UPDATE x SET y=1"))
 
 
 def test_fetch_rows_stream(monkeypatch):

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -135,6 +135,8 @@ def test_reindex_indexes_files_and_folders(monkeypatch):
       return Res([])
     async def upsert_storage_cache(self, item):
       self.upserts.append(item)
+      from types import SimpleNamespace
+      return SimpleNamespace(rowcount=1)
     async def list_storage_cache(self, user_guid):
       return []
     async def shutdown(self):


### PR DESCRIPTION
## Summary
- raise and log MSSQL exec_query and fetch_json errors
- verify MSSQL storage cache upsert rowcount
- log StorageModule upsert failures to expose indexing issues

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68c0a2269bdc832590ded53c7f3c0f2a