### PR TITLE
feat(account): create storage folders for users

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -205,6 +205,7 @@ All Account domain calls require `ROLE_ACCOUNT_ADMIN`.
 | `urn:account:user:get_credits:1`         | Get a user's credit amount.               |
 | `urn:account:user:set_credits:1`         | Set a user's credit amount.               |
 | `urn:account:user:reset_display:1`       | Reset a user's display name to default.   |
+| `urn:account:user:create_folder:1`       | Create a folder for the user in storage.  |
 
 ## Moderation Domain
 

--- a/rpc/account/user/__init__.py
+++ b/rpc/account/user/__init__.py
@@ -3,6 +3,7 @@ from .services import (
   account_user_get_credits_v1,
   account_user_set_credits_v1,
   account_user_reset_display_v1,
+  account_user_create_folder_v1,
 )
 
 
@@ -11,4 +12,5 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("get_credits", "1"): account_user_get_credits_v1,
   ("set_credits", "1"): account_user_set_credits_v1,
   ("reset_display", "1"): account_user_reset_display_v1,
+  ("create_folder", "1"): account_user_create_folder_v1,
 }

--- a/rpc/account/user/models.py
+++ b/rpc/account/user/models.py
@@ -15,3 +15,7 @@ class AccountUserDisplayName1(AccountUserGuid1):
 
 class AccountUserCredits1(AccountUserGuid1):
   credits: int
+
+
+class AccountUserCreateFolder1(AccountUserGuid1):
+  path: str

--- a/rpc/account/user/services.py
+++ b/rpc/account/user/services.py
@@ -2,11 +2,13 @@ from fastapi import Request
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.user_admin_module import UserAdminModule
+from server.modules.storage_module import StorageModule
 from .models import (
   AccountUserGuid1,
   AccountUserSetCredits1,
   AccountUserDisplayName1,
   AccountUserCredits1,
+  AccountUserCreateFolder1,
 )
 
 
@@ -53,6 +55,18 @@ async def account_user_reset_display_v1(request: Request):
   data = AccountUserGuid1(**(rpc_request.payload or {}))
   user_admin: UserAdminModule = request.app.state.user_admin
   await user_admin.reset_display(data.userGuid)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=data.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def account_user_create_folder_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  data = AccountUserCreateFolder1(**(rpc_request.payload or {}))
+  storage: StorageModule = request.app.state.storage
+  await storage.create_user_folder(data.userGuid, data.path)
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),


### PR DESCRIPTION
## Summary
- allow Storage module to create user folders in Azure Blob
- add account RPC endpoint to create folders for users
- document new RPC

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0e4a0d21483258773b442fa0bad0c