### PR TITLE
Separate file paths from filenames in File Manager

### DIFF
--- a/frontend/src/pages/FileManager.tsx
+++ b/frontend/src/pages/FileManager.tsx
@@ -37,6 +37,7 @@ import AudioPreview from '../components/AudioPreview';
 import ImagePreview from '../components/ImagePreview';
 
 interface StorageFile {
+    path: string;
     name: string;
     url: string;
     content_type?: string;
@@ -79,7 +80,11 @@ const FileManager = (): JSX.Element => {
         void load(currentPath);
     }, [userData, currentPath, load]);
 
-    const handleDelete = async (name: string): Promise<void> => {
+    const getFullName = (file: StorageFile): string =>
+        file.path ? `${file.path}/${file.name}` : file.name;
+
+    const handleDelete = async (file: StorageFile): Promise<void> => {
+        const name = getFullName(file);
         await fetchDeleteFiles({ files: [name] });
         await load(currentPath);
     };
@@ -90,8 +95,8 @@ const FileManager = (): JSX.Element => {
         await load(currentPath);
     };
 
-    const handleSetGallery = async (name: string): Promise<void> => {
-        await fetchSetGallery({ name, gallery: true });
+    const handleSetGallery = async (file: StorageFile): Promise<void> => {
+        await fetchSetGallery({ name: getFullName(file), gallery: true });
     };
 
     const handleCopy = async (url: string): Promise<void> => {
@@ -100,11 +105,12 @@ const FileManager = (): JSX.Element => {
         setNotification(true);
     };
 
-    const handleMove = async (name: string): Promise<void> => {
+    const handleMove = async (file: StorageFile): Promise<void> => {
         if (moveTarget === null) return;
-        const base = name.split('/').pop() || name;
+        const src = getFullName(file);
+        const base = file.name;
         const dst = moveTarget ? `${moveTarget}/${base}` : base;
-        await fetchMoveFile({ src: name, dst });
+        await fetchMoveFile({ src, dst });
         await load(currentPath);
     };
 
@@ -231,12 +237,12 @@ const FileManager = (): JSX.Element => {
                                             </IconButton>
                                         </Tooltip>
                                         <Tooltip title="Delete">
-                                            <IconButton size="small" onClick={() => void handleDelete(file.name)}>
+                                            <IconButton size="small" onClick={() => void handleDelete(file)}>
                                                 <Delete />
                                             </IconButton>
                                         </Tooltip>
                                         <Tooltip title="Publish">
-                                            <IconButton size="small" onClick={() => void handleSetGallery(file.name)}>
+                                            <IconButton size="small" onClick={() => void handleSetGallery(file)}>
                                                 <Publish />
                                             </IconButton>
                                         </Tooltip>
@@ -244,7 +250,7 @@ const FileManager = (): JSX.Element => {
                                             <IconButton
                                                 size="small"
                                                 disabled={moveTarget === null}
-                                                onClick={() => void handleMove(file.name)}
+                                                onClick={() => void handleMove(file)}
                                             >
                                                 <DriveFileMove />
                                             </IconButton>

--- a/rpc/storage/files/models.py
+++ b/rpc/storage/files/models.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 
 class StorageFilesFileItem1(BaseModel):
+  path: str
   name: str
   url: str
   content_type: Optional[str] = None

--- a/rpc/storage/files/services.py
+++ b/rpc/storage/files/services.py
@@ -147,7 +147,8 @@ async def storage_files_get_link_v1(request: Request):
   data = StorageFilesGetLink1(**(rpc_request.payload or {}))
   storage: StorageModule = request.app.state.storage
   url = await storage.get_file_link(user_guid, data.name)
-  item = StorageFilesFileItem1(name=data.name, url=url)
+  path, filename = data.name.rsplit('/', 1) if '/' in data.name else ('', data.name)
+  item = StorageFilesFileItem1(path=path, name=filename, url=url)
   await storage.reindex(user_guid)
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -272,10 +272,11 @@ class StorageModule(BaseModule):
         continue
       path = row.get("path") or ""
       filename = row.get("filename", "")
-      name = f"{path}/{filename}" if path else filename
+      full_name = f"{path}/{filename}" if path else filename
       out.append({
-        "name": name,
-        "url": row.get("url") or name,
+        "path": path,
+        "name": filename,
+        "url": row.get("url") or full_name,
         "content_type": row.get("content_type"),
       })
     return out
@@ -301,10 +302,11 @@ class StorageModule(BaseModule):
           folders[subfolder] = False
         continue
       if path == folder:
-        name = f"{path}/{filename}" if path else filename
+        full_name = f"{path}/{filename}" if path else filename
         files.append({
-          "name": name,
-          "url": row.get("url") or name,
+          "path": path,
+          "name": filename,
+          "url": row.get("url") or full_name,
           "content_type": ct,
         })
       elif path.startswith(prefix):

--- a/tests/test_storage_files_services.py
+++ b/tests/test_storage_files_services.py
@@ -126,7 +126,7 @@ class DummyStorage:
     self.list_folder_args = (user_guid, path)
     return {
       "path": path,
-      "files": [{"name": f"{path}/a.txt", "url": f"u/{path}/a.txt", "content_type": "text/plain"}],
+      "files": [{"path": path, "name": "a.txt", "url": f"u/{path}/a.txt", "content_type": "text/plain"}],
       "folders": [{"name": "sub", "empty": False}],
     }
 
@@ -146,7 +146,12 @@ def make_request(op, payload):
 def test_get_link_calls_storage():
   req, storage = make_request("urn:storage:files:get_link:1", {"name": "a.txt"})
   resp = asyncio.run(storage_files_get_link_v1(req))
-  assert resp.payload == {"name": "a.txt", "url": "https://example.com/a.txt", "content_type": None}
+  assert resp.payload == {
+    "path": "",
+    "name": "a.txt",
+    "url": "https://example.com/a.txt",
+    "content_type": None,
+  }
   assert storage.link_args == ("u123", "a.txt")
   assert storage.reindexed == "u123"
 
@@ -208,7 +213,9 @@ def test_get_folder_files_returns_contents():
   resp = asyncio.run(storage_files_get_folder_files_v1(req))
   assert resp.payload == {
     "path": "docs",
-    "files": [{"name": "docs/a.txt", "url": "u/docs/a.txt", "content_type": "text/plain"}],
+    "files": [
+      {"path": "docs", "name": "a.txt", "url": "u/docs/a.txt", "content_type": "text/plain"}
+    ],
     "folders": [{"name": "sub", "empty": False}],
   }
   assert storage.list_folder_args == ("u123", "docs")

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -75,8 +75,8 @@ def test_list_files_by_user():
   ])
   files = asyncio.run(mod.list_files_by_user("u1"))
   assert files == [
-    {"name": "a.txt", "url": "u/a.txt", "content_type": "text/plain"},
-    {"name": "docs/b.txt", "url": "u/docs/b.txt", "content_type": "text/plain"},
+    {"path": "", "name": "a.txt", "url": "u/a.txt", "content_type": "text/plain"},
+    {"path": "docs", "name": "b.txt", "url": "u/docs/b.txt", "content_type": "text/plain"},
   ]
 
 
@@ -95,7 +95,7 @@ def test_list_folder_returns_files_and_folders():
   root = asyncio.run(mod.list_folder("u1", ""))
   assert root["path"] == ""
   assert root["files"] == [
-    {"name": "a.txt", "url": "u/a.txt", "content_type": "text/plain"}
+    {"path": "", "name": "a.txt", "url": "u/a.txt", "content_type": "text/plain"}
   ]
   assert sorted(root["folders"], key=lambda x: x["name"]) == [
     {"name": "docs", "empty": False},
@@ -104,8 +104,8 @@ def test_list_folder_returns_files_and_folders():
   docs = asyncio.run(mod.list_folder("u1", "/docs"))
   assert docs["path"] == "docs"
   assert docs["files"] == [
-    {"name": "docs/b.txt", "url": "u/docs/b.txt", "content_type": "text/plain"},
-    {"name": "docs/c.txt", "url": "u/docs/c.txt", "content_type": "text/plain"},
+    {"path": "docs", "name": "b.txt", "url": "u/docs/b.txt", "content_type": "text/plain"},
+    {"path": "docs", "name": "c.txt", "url": "u/docs/c.txt", "content_type": "text/plain"},
   ]
   assert docs["folders"] == [{"name": "sub", "empty": False}]
 


### PR DESCRIPTION
## Summary
- extend storage file model with explicit `path` field
- update storage module and RPC service to avoid path-prefixed filenames
- update File Manager UI and tests to handle paths separately

## Testing
- `python scripts/generate_rpc_bindings.py`
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c10029117c83258ff01d7c2c0e977d