### PR TITLE
Add public user profile page and RPC

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ const AccountRolesPage = lazy(() => import("./pages/AccountRolesPage"));
 const AccountUsersPage = lazy(() => import("./pages/AccountUsersPage"));
 const AccountUserPanel = lazy(() => import("./pages/AccountUserPanel"));
 const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
+const PublicProfile = lazy(() => import("./pages/PublicProfile"));
 
 function App(): JSX.Element {
 	return (
@@ -46,10 +47,11 @@ function App(): JSX.Element {
                                                                 <Route path="/service-roles" element={<ServiceRolesPage />} />
 								<Route path="/account-roles" element={<AccountRolesPage />} />
 								<Route path="/account-users" element={<AccountUsersPage />} />
-								<Route path="/account-users/:guid" element={<AccountUserPanel />} />
-								<Route path="/file-manager" element={<FileManager />} />
-								<Route path="/privacy-policy" element={<PrivacyPolicy />} />
-							</Routes>
+                                                                <Route path="/account-users/:guid" element={<AccountUserPanel />} />
+                                                                <Route path="/file-manager" element={<FileManager />} />
+                                                                <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+                                                                <Route path="/profile/:guid" element={<PublicProfile />} />
+                                                        </Routes>
 						</Suspense>
 					</Container>
 				</Router>

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -1,9 +1,16 @@
 import { useState, type JSX } from 'react';
 import { Tabs, Tab, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import PageTitle from '../components/PageTitle';
 
 const Gallery = (): JSX.Element => {
         const [value, setValue] = useState(0);
+        const navigate = useNavigate();
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const openProfile = (guid: string): void => {
+                navigate(`/profile/${guid}`);
+        };
 
         return (
                 <div>

--- a/frontend/src/pages/PublicProfile.tsx
+++ b/frontend/src/pages/PublicProfile.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState, type JSX } from 'react';
+import { useParams } from 'react-router-dom';
+import { Avatar, Stack, Typography } from '@mui/material';
+import PageTitle from '../components/PageTitle';
+import { fetchProfile, fetchPublishedFiles } from '../rpc/public/users';
+import type { PublicUsersProfile1, PublicUsersPublishedFile1 } from '../shared/RpcModels';
+
+const PublicProfile = (): JSX.Element => {
+    const { guid } = useParams();
+    const [profile, setProfile] = useState<PublicUsersProfile1 | null>(null);
+    const [files, setFiles] = useState<PublicUsersPublishedFile1[]>([]);
+
+    useEffect(() => {
+        if (!guid) return;
+        void (async () => {
+            try {
+                const p = await fetchProfile({ guid });
+                setProfile(p as PublicUsersProfile1);
+            } catch {
+                setProfile(null);
+            }
+            try {
+                const f = await fetchPublishedFiles({ guid });
+                setFiles((f as any).files ?? []);
+            } catch {
+                setFiles([]);
+            }
+        })();
+    }, [guid]);
+
+    return (
+        <div>
+            <PageTitle>User Profile</PageTitle>
+            {profile && (
+                <Stack spacing={2} alignItems="center" sx={{ mb: 4 }}>
+                    <Avatar
+                        src={profile.profile_image ? `data:image/png;base64,${profile.profile_image}` : undefined}
+                        sx={{ width: 80, height: 80 }}
+                    />
+                    <Typography variant="h5">{profile.display_name}</Typography>
+                    {profile.email && <Typography>{profile.email}</Typography>}
+                </Stack>
+            )}
+            <Typography variant="h6" gutterBottom>
+                Published Files
+            </Typography>
+            <ul>
+                {files.map((f, idx) => (
+                    <li key={idx}>{f.filename}</li>
+                ))}
+            </ul>
+        </div>
+    );
+};
+
+export default PublicProfile;

--- a/rpc/public/__init__.py
+++ b/rpc/public/__init__.py
@@ -1,9 +1,11 @@
 from .links.handler import handle_links_request
 from .vars.handler import handle_vars_request
+from .users.handler import handle_users_request
 
 
 HANDLERS: dict[str, callable] = {
   "links": handle_links_request,
   "vars": handle_vars_request,
+  "users": handle_users_request,
 }
 

--- a/rpc/public/users/__init__.py
+++ b/rpc/public/users/__init__.py
@@ -1,0 +1,9 @@
+from .services import (
+  public_users_get_profile_v1,
+  public_users_get_published_files_v1,
+)
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("get_profile", "1"): public_users_get_profile_v1,
+  ("get_published_files", "1"): public_users_get_published_files_v1,
+}

--- a/rpc/public/users/handler.py
+++ b/rpc/public/users/handler.py
@@ -1,0 +1,10 @@
+from fastapi import HTTPException, Request
+from server.models import RPCResponse
+from . import DISPATCHERS
+
+async def handle_users_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail="Unknown RPC operation")
+  return await handler(request)

--- a/rpc/public/users/models.py
+++ b/rpc/public/users/models.py
@@ -1,0 +1,14 @@
+from typing import Optional
+from pydantic import BaseModel
+
+class PublicUsersProfile1(BaseModel):
+  display_name: str
+  email: Optional[str] = None
+  profile_image: Optional[str] = None
+
+class PublicUsersPublishedFile1(BaseModel):
+  path: str
+  filename: str
+
+class PublicUsersPublishedFiles1(BaseModel):
+  files: list[PublicUsersPublishedFile1]

--- a/rpc/public/users/services.py
+++ b/rpc/public/users/services.py
@@ -1,0 +1,44 @@
+from fastapi import HTTPException, Request
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+  from server.modules.public_users_module import PublicUsersModule
+from .models import (
+  PublicUsersProfile1,
+  PublicUsersPublishedFile1,
+  PublicUsersPublishedFiles1,
+)
+
+async def public_users_get_profile_v1(request: Request):
+  rpc_request, _auth_ctx, _user_ctx = await unbox_request(request)
+  payload = rpc_request.payload or {}
+  guid = payload.get("guid")
+  if not guid:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
+  users_mod: PublicUsersModule = request.app.state.public_users
+  row = await users_mod.get_profile(guid)
+  if not row:
+    raise HTTPException(status_code=404, detail="Profile not found")
+  profile = PublicUsersProfile1(**row)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=profile.model_dump(),
+    version=rpc_request.version,
+  )
+
+async def public_users_get_published_files_v1(request: Request):
+  rpc_request, _auth_ctx, _user_ctx = await unbox_request(request)
+  payload = rpc_request.payload or {}
+  guid = payload.get("guid")
+  if not guid:
+    raise HTTPException(status_code=400, detail="Missing user GUID")
+  users_mod: PublicUsersModule = request.app.state.public_users
+  rows = await users_mod.get_published_files(guid)
+  files = [PublicUsersPublishedFile1(**r) for r in rows]
+  payload_model = PublicUsersPublishedFiles1(files=files)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload_model.model_dump(),
+    version=rpc_request.version,
+  )

--- a/server/modules/public_users_module.py
+++ b/server/modules/public_users_module.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from fastapi import FastAPI
+from . import BaseModule
+from .db_module import DbModule
+
+class PublicUsersModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    self.db = None
+
+  async def get_profile(self, guid: str):
+    assert self.db
+    res = await self.db.run("db:public:users:get_profile:1", {"guid": guid})
+    return res.rows[0] if res.rows else None
+
+  async def get_published_files(self, guid: str):
+    assert self.db
+    res = await self.db.run("db:public:users:get_published_files:1", {"guid": guid})
+    return res.rows

--- a/tests/test_public_users_service.py
+++ b/tests/test_public_users_service.py
@@ -1,0 +1,75 @@
+import sys, types, pathlib
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+# Stub rpc package
+pkg = types.ModuleType('rpc')
+pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc')]
+sys.modules.setdefault('rpc', pkg)
+
+# Stub server package with minimal models
+server_pkg = types.ModuleType('server')
+models_pkg = types.ModuleType('server.models')
+from pydantic import BaseModel
+
+class RPCRequest(BaseModel):
+  op: str
+  payload: dict | None = None
+  version: int = 1
+
+class RPCResponse(BaseModel):
+  op: str
+  payload: dict
+  version: int = 1
+
+models_pkg.RPCRequest = RPCRequest
+models_pkg.RPCResponse = RPCResponse
+server_pkg.models = models_pkg
+sys.modules.setdefault('server', server_pkg)
+sys.modules.setdefault('server.models', models_pkg)
+
+from rpc.public.users.services import (
+  public_users_get_profile_v1,
+  public_users_get_published_files_v1,
+)
+
+class DummyPublicUsersModule:
+  async def get_profile(self, guid: str):
+    assert guid == '123'
+    return {'display_name': 'Alice', 'email': 'alice@example.com', 'profile_image': 'abc'}
+
+  async def get_published_files(self, guid: str):
+    assert guid == '123'
+    return [{'path': '/a', 'filename': 'file.txt'}]
+
+app = FastAPI()
+app.state.public_users = DummyPublicUsersModule()
+
+@app.post('/rpc')
+async def rpc_endpoint(request: Request):
+  body = await request.json()
+  if body['op'] == 'urn:public:users:get_profile:1':
+    return await public_users_get_profile_v1(request)
+  if body['op'] == 'urn:public:users:get_published_files:1':
+    return await public_users_get_published_files_v1(request)
+  raise AssertionError('unexpected op')
+
+client = TestClient(app)
+
+def test_get_profile_service():
+  resp = client.post('/rpc', json={'op': 'urn:public:users:get_profile:1', 'payload': {'guid': '123'}})
+  assert resp.status_code == 200
+  data = resp.json()
+  assert data['payload'] == {
+    'display_name': 'Alice',
+    'email': 'alice@example.com',
+    'profile_image': 'abc',
+  }
+
+def test_get_published_files_service():
+  resp = client.post('/rpc', json={'op': 'urn:public:users:get_published_files:1', 'payload': {'guid': '123'}})
+  assert resp.status_code == 200
+  data = resp.json()
+  assert data['payload'] == {
+    'files': [{'path': '/a', 'filename': 'file.txt'}]
+  }


### PR DESCRIPTION
## Summary
- expose public user profile and published files via new public RPC
- display user profile, avatar, and published files on new public profile page
- add routing and gallery scaffolding for profile navigation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c18fc5f3748325a71bab40af22f3fc