### PR TITLE
feat(storage): implement delete file and folder

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -134,3 +134,9 @@ class DbModule(BaseModule):
       {"user_guid": user_guid, "path": path, "filename": filename},
     )
 
+  async def delete_storage_cache_folder(self, user_guid: str, path: str):
+    await self.run(
+      "db:storage:cache:delete_folder:1",
+      {"user_guid": user_guid, "path": path},
+    )
+

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -509,6 +509,23 @@ def _storage_cache_delete(args: Dict[str, Any]):
   return ("exec", sql, (user_guid, path, filename))
 
 
+@register("db:storage:cache:delete_folder:1")
+def _storage_cache_delete_folder(args: Dict[str, Any]):
+  user_guid = args["user_guid"]
+  path = args.get("path", "").lstrip("/")
+  parent, name = path.rsplit("/", 1) if "/" in path else ("", path)
+  like = f"{path}/%" if path else "%"
+  sql = """
+    DELETE FROM users_storage_cache
+    WHERE users_guid = ? AND (
+      (element_path = ? AND element_filename = ?)
+      OR element_path = ?
+      OR element_path LIKE ?
+    );
+  """
+  return ("exec", sql, (user_guid, parent, name, path, like))
+
+
 @register("db:storage:cache:set_public:1")
 def _storage_cache_set_public(args: Dict[str, Any]):
   guid = str(UUID(args["user_guid"]))


### PR DESCRIPTION
## Summary
- implement delete_files and delete_folder in StorageModule
- add MSSQL cache deletion query and database helper
- cover delete_files RPC path with new tests

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run type-check`
- `npm --prefix frontend run test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1b7f490b0832598e65616c83aec4d