### PR TITLE
Add DB provider contract tests

### DIFF
--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -1,0 +1,121 @@
+import asyncio
+from uuid import UUID
+
+from server.modules.providers.database.mssql_provider import MssqlProvider
+import server.modules.providers.database.mssql_provider as mssql_provider
+from server.modules.providers import DBResult
+
+
+def test_run_json_one(monkeypatch):
+  provider = MssqlProvider()
+
+  def fake_get_handler(op):
+    assert op == "test:json_one"
+    def handler(args):
+      assert args == {}
+      return ("json_one", "select 1", ())
+    return handler
+
+  async def fake_fetch_json(sql, params, *, many=False):
+    assert sql == "select 1"
+    assert params == ()
+    assert not many
+    return DBResult(rows=[{"v": 1}], rowcount=1)
+
+  monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
+  monkeypatch.setattr(mssql_provider, "fetch_json", fake_fetch_json)
+
+  res = asyncio.run(provider.run("test:json_one", {}))
+  assert isinstance(res, DBResult)
+  assert res.rows == [{"v": 1}]
+  assert res.rowcount == 1
+
+
+def test_run_row_one(monkeypatch):
+  provider = MssqlProvider()
+
+  def fake_get_handler(op):
+    assert op == "test:row_one"
+    def handler(args):
+      assert args == {}
+      return ("row_one", "select 1", ())
+    return handler
+
+  async def fake_fetch_rows(sql, params, *, one=False, stream=False):
+    assert sql == "select 1"
+    assert params == ()
+    assert one
+    return DBResult(rows=[{"v": 1}], rowcount=1)
+
+  monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
+  monkeypatch.setattr(mssql_provider, "fetch_rows", fake_fetch_rows)
+
+  res = asyncio.run(provider.run("test:row_one", {}))
+  assert isinstance(res, DBResult)
+  assert res.rows == [{"v": 1}]
+  assert res.rowcount == 1
+
+
+def test_run_row_many(monkeypatch):
+  provider = MssqlProvider()
+  guid = "00000000-0000-0000-0000-000000000000"
+  expected_guid = str(UUID(guid))
+
+  async def fake_fetch_rows(sql, params, *, one=False, stream=False):
+    assert not one
+    assert params == (expected_guid,)
+    return DBResult(rows=[{"path": "a"}, {"path": "b"}], rowcount=2)
+
+  monkeypatch.setattr(mssql_provider, "fetch_rows", fake_fetch_rows)
+
+  res = asyncio.run(provider.run("db:public:users:get_published_files:1", {"guid": guid}))
+  assert isinstance(res, DBResult)
+  assert res.rows == [{"path": "a"}, {"path": "b"}]
+  assert res.rowcount == 2
+
+
+def test_run_json_many(monkeypatch):
+  provider = MssqlProvider()
+
+  def fake_get_handler(op):
+    assert op == "test:json_many"
+    def handler(args):
+      assert args == {}
+      return ("json_many", "select", ())
+    return handler
+
+  async def fake_fetch_json(sql, params, *, many=False):
+    assert many
+    return DBResult(rows=[{"v": 1}, {"v": 2}], rowcount=2)
+
+  monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
+  monkeypatch.setattr(mssql_provider, "fetch_json", fake_fetch_json)
+
+  res = asyncio.run(provider.run("test:json_many", {}))
+  assert isinstance(res, DBResult)
+  assert res.rows == [{"v": 1}, {"v": 2}]
+  assert res.rowcount == 2
+
+
+def test_run_exec(monkeypatch):
+  provider = MssqlProvider()
+
+  def fake_get_handler(op):
+    assert op == "test:exec"
+    def handler(args):
+      assert args == {}
+      return ("exec", "update", (1,))
+    return handler
+
+  async def fake_exec_query(sql, params):
+    assert sql == "update"
+    assert params == (1,)
+    return DBResult(rowcount=1)
+
+  monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
+  monkeypatch.setattr(mssql_provider, "exec_query", fake_exec_query)
+
+  res = asyncio.run(provider.run("test:exec", {}))
+  assert isinstance(res, DBResult)
+  assert res.rows == []
+  assert res.rowcount == 1


### PR DESCRIPTION
## Summary
- add contract test ensuring DB provider returns `DBResult` for all run modes
- cover row_many via `db:public:users:get_published_files:1` to guard against regressions

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68c23c72a3a083258738373ca0abc0a4