### PR TITLE
refactor: introduce DbRunMode enum

### DIFF
--- a/server/modules/providers/__init__.py
+++ b/server/modules/providers/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict
+from enum import Enum
 
 import aiohttp
 from fastapi import HTTPException, status
@@ -20,12 +21,21 @@ __all__ = [
   "AuthProviderBase",
   "DbProviderBase",
   "DBResult",
+  "DbRunMode",
 ]
 
 
 class DBResult(BaseModel):
   rows: list[dict] = []
   rowcount: int = 0
+
+
+class DbRunMode(str, Enum):
+  ROW_ONE = "row_one"
+  ROW_MANY = "row_many"
+  JSON_ONE = "json_one"
+  JSON_MANY = "json_many"
+  EXEC = "exec"
 
 
 class BaseProvider(ABC):

--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -1,8 +1,7 @@
 # providers/database/mssql_provider/__init__.py
 from typing import Any, Dict
 
-from ... import DbProviderBase
-from ... import DBResult
+from ... import DbProviderBase, DBResult, DbRunMode
 from .logic import init_pool, close_pool
 from .db_helpers import fetch_rows, fetch_json, exec_query
 from .registry import get_handler
@@ -21,15 +20,15 @@ class MssqlProvider(DbProviderBase):
     if hasattr(spec, "__await__"):
       return await spec
     mode, sql, params = spec
-    if mode == "json_one":
+    if mode is DbRunMode.JSON_ONE:
       return await fetch_json(sql, params)
-    if mode == "row_one":
+    if mode is DbRunMode.ROW_ONE:
       return await fetch_rows(sql, params, one=True)
-    if mode == "row_many":
+    if mode is DbRunMode.ROW_MANY:
       return await fetch_rows(sql, params)
-    if mode == "json_many":
+    if mode is DbRunMode.JSON_MANY:
       return await fetch_json(sql, params, many=True)
-    if mode == "exec":
+    if mode is DbRunMode.EXEC:
       return await exec_query(sql, params)
     raise ValueError(f"Unknown mode: {mode}")
 


### PR DESCRIPTION
## Summary
- add `DbRunMode` enum for database operations
- refactor `MssqlProvider.run` to use `DbRunMode`
- update MSSQL registry handlers to return enum values

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2238e5c448325aa6787b9ede5c929