### PR TITLE
Report user folder counts in storage stats

### DIFF
--- a/frontend/src/pages/system/SystemConfigPage.tsx
+++ b/frontend/src/pages/system/SystemConfigPage.tsx
@@ -244,7 +244,7 @@ const SystemConfigPage = (): JSX.Element => {
                         <Box>
                             <Typography>Files: {stats.file_count}</Typography>
                             <Typography>Total Bytes: {stats.total_bytes}</Typography>
-                            <Typography>User Folders: {stats.folder_count}</Typography>
+                            <Typography>User Folders: {stats.user_folder_count}</Typography>
                             <Typography>DB Rows: {stats.db_rows}</Typography>
                         </Box>
                     )}

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -7,60 +7,38 @@
 import axios from "axios";
 import { getFingerprint } from "./fingerprint";
 
-export interface ServiceRoutesDeleteRoute1 {
-	path: string;
+export interface SystemStorageStats1 {
+	file_count: number;
+	total_bytes: number;
+	folder_count: number;
+	user_folder_count: number;
+	db_rows: number;
 }
-export interface ServiceRoutesList1 {
-	routes: ServiceRoutesRouteItem1[];
-}
-export interface ServiceRoutesRouteItem1 {
-	path: string;
-	name: string;
-	icon: string | null;
-	sequence: number;
-	required_roles: string[];
-}
-export interface ServiceRolesDeleteRole1 {
+export interface SystemRolesDeleteRole1 {
 	name: string;
 }
-export interface ServiceRolesList1 {
-	roles: ServiceRolesRoleItem1[];
+export interface SystemRolesList1 {
+	roles: SystemRolesRoleItem1[];
 }
-export interface ServiceRolesRoleItem1 {
+export interface SystemRolesRoleItem1 {
 	name: string;
 	mask: string;
 	display: any;
 }
-export interface ServiceRolesUpsertRole1 {
+export interface SystemRolesUpsertRole1 {
 	name: string;
 	mask: string;
 	display: any;
 }
-export interface AuthMicrosoftOauthLogin1 {
-	sessionToken: string;
-	display_name: string;
-	credits: number;
-	profile_image: string | null;
+export interface SystemConfigConfigItem1 {
+	key: string;
+	value: string;
 }
-export interface AuthProvidersUnlinkLastProvider1 {
-	guid: string;
-	provider: string;
+export interface SystemConfigDeleteConfig1 {
+	key: string;
 }
-export interface AuthGoogleOauthLogin1 {
-	sessionToken: string;
-	display_name: string;
-	credits: number;
-	profile_image: string | null;
-}
-export interface AuthGoogleOauthLoginPayload1 {
-	provider: string;
-	code: string;
-	confirm: any;
-	reauthToken: any;
-	fingerprint: string;
-}
-export interface DiscordCommandTextUwuResponse1 {
-	message: string;
+export interface SystemConfigList1 {
+	items: SystemConfigConfigItem1[];
 }
 export interface StorageFilesCreateFolder1 {
 	path: string;
@@ -142,6 +120,35 @@ export interface StorageFilesUsageItem1 {
 	content_type: string;
 	size: number;
 }
+export interface ServiceRolesDeleteRole1 {
+	name: string;
+}
+export interface ServiceRolesList1 {
+	roles: ServiceRolesRoleItem1[];
+}
+export interface ServiceRolesRoleItem1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface ServiceRolesUpsertRole1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface ServiceRoutesDeleteRoute1 {
+	path: string;
+}
+export interface ServiceRoutesList1 {
+	routes: ServiceRoutesRouteItem1[];
+}
+export interface ServiceRoutesRouteItem1 {
+	path: string;
+	name: string;
+	icon: string | null;
+	sequence: number;
+	required_roles: string[];
+}
 export interface UsersProfileAuthProvider1 {
 	name: string;
 	display: string;
@@ -196,6 +203,32 @@ export interface UsersProvidersUnlinkProvider1 {
 	provider: string;
 	new_default: any;
 }
+export interface AuthMicrosoftOauthLogin1 {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
+}
+export interface AuthGoogleOauthLogin1 {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
+}
+export interface AuthGoogleOauthLoginPayload1 {
+	provider: string;
+	code: string;
+	confirm: any;
+	reauthToken: any;
+	fingerprint: string;
+}
+export interface AuthProvidersUnlinkLastProvider1 {
+	guid: string;
+	provider: string;
+}
+export interface DiscordCommandTextUwuResponse1 {
+	message: string;
+}
 export interface PublicVarsFfmpegVersion1 {
 	ffmpeg_version: string;
 }
@@ -238,33 +271,6 @@ export interface PublicLinksNavBarRoute1 {
 }
 export interface PublicLinksNavBarRoutes1 {
 	routes: PublicLinksNavBarRoute1[];
-}
-export interface SupportUsersCredits1 {
-	userGuid: string;
-	credits: number;
-}
-export interface SupportUsersDisplayName1 {
-	userGuid: string;
-	displayName: string;
-}
-export interface SupportUsersGuid1 {
-	userGuid: string;
-}
-export interface SupportUsersSetCredits1 {
-	userGuid: string;
-	credits: number;
-}
-export interface SupportRolesMembers1 {
-	members: SupportRolesUserItem1[];
-	nonMembers: SupportRolesUserItem1[];
-}
-export interface SupportRolesRoleMemberUpdate1 {
-	role: string;
-	userGuid: string;
-}
-export interface SupportRolesUserItem1 {
-	guid: string;
-	displayName: string;
 }
 export interface AccountRoleDeleteRole1 {
 	name: string;
@@ -313,37 +319,32 @@ export interface AccountUserSetCredits1 {
 	userGuid: string;
 	credits: number;
 }
-export interface SystemStorageStats1 {
-	file_count: number;
-	total_bytes: number;
-	folder_count: number;
-	db_rows: number;
+export interface SupportRolesMembers1 {
+	members: SupportRolesUserItem1[];
+	nonMembers: SupportRolesUserItem1[];
 }
-export interface SystemConfigConfigItem1 {
-	key: string;
-	value: string;
+export interface SupportRolesRoleMemberUpdate1 {
+	role: string;
+	userGuid: string;
 }
-export interface SystemConfigDeleteConfig1 {
-	key: string;
+export interface SupportRolesUserItem1 {
+	guid: string;
+	displayName: string;
 }
-export interface SystemConfigList1 {
-	items: SystemConfigConfigItem1[];
+export interface SupportUsersCredits1 {
+	userGuid: string;
+	credits: number;
 }
-export interface SystemRolesDeleteRole1 {
-	name: string;
+export interface SupportUsersDisplayName1 {
+	userGuid: string;
+	displayName: string;
 }
-export interface SystemRolesList1 {
-	roles: SystemRolesRoleItem1[];
+export interface SupportUsersGuid1 {
+	userGuid: string;
 }
-export interface SystemRolesRoleItem1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface SystemRolesUpsertRole1 {
-	name: string;
-	mask: string;
-	display: any;
+export interface SupportUsersSetCredits1 {
+	userGuid: string;
+	credits: number;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/system/storage/models.py
+++ b/rpc/system/storage/models.py
@@ -5,5 +5,6 @@ class SystemStorageStats1(BaseModel):
   file_count: int
   total_bytes: int
   folder_count: int
+  user_folder_count: int
   db_rows: int
 

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -595,6 +595,7 @@ class StorageModule(BaseModule):
         "file_count": 0,
         "total_bytes": 0,
         "folder_count": 0,
+        "user_folder_count": 0,
         "db_rows": db_rows,
       }
     res = await self.db.run("db:system:config:get_config:1", {"key": "AzureBlobContainerName"})
@@ -604,6 +605,7 @@ class StorageModule(BaseModule):
         "file_count": 0,
         "total_bytes": 0,
         "folder_count": 0,
+        "user_folder_count": 0,
         "db_rows": db_rows,
       }
     bsc = BlobServiceClient.from_connection_string(self.connection_string)
@@ -611,6 +613,7 @@ class StorageModule(BaseModule):
     file_count = 0
     total_bytes = 0
     folders: set[tuple[str, str]] = set()
+    users: set[str] = set()
     try:
       async for blob in container.list_blobs():
         name = getattr(blob, "name", "")
@@ -624,6 +627,7 @@ class StorageModule(BaseModule):
           UUID(guid)
         except Exception:
           continue
+        users.add(guid)
         parent = ""
         for folder_name in parts[1:-1]:
           parent = f"{parent}/{folder_name}" if parent else folder_name
@@ -642,5 +646,6 @@ class StorageModule(BaseModule):
       "file_count": file_count,
       "total_bytes": total_bytes,
       "folder_count": len(folders),
+      "user_folder_count": len(users),
       "db_rows": db_rows,
     }

--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.modules.providers.database.mssql_provider as mssql_provider
-from server.modules.providers import DBResult
+from server.modules.providers import DBResult, DbRunMode
 
 
 def test_run_json_one(monkeypatch):
@@ -13,7 +13,7 @@ def test_run_json_one(monkeypatch):
     assert op == "test:json_one"
     def handler(args):
       assert args == {}
-      return ("json_one", "select 1", ())
+      return (DbRunMode.JSON_ONE, "select 1", ())
     return handler
 
   async def fake_fetch_json(sql, params, *, many=False):
@@ -38,7 +38,7 @@ def test_run_row_one(monkeypatch):
     assert op == "test:row_one"
     def handler(args):
       assert args == {}
-      return ("row_one", "select 1", ())
+      return (DbRunMode.ROW_ONE, "select 1", ())
     return handler
 
   async def fake_fetch_rows(sql, params, *, one=False, stream=False):
@@ -81,7 +81,7 @@ def test_run_json_many(monkeypatch):
     assert op == "test:json_many"
     def handler(args):
       assert args == {}
-      return ("json_many", "select", ())
+      return (DbRunMode.JSON_MANY, "select", ())
     return handler
 
   async def fake_fetch_json(sql, params, *, many=False):
@@ -104,7 +104,7 @@ def test_run_exec(monkeypatch):
     assert op == "test:exec"
     def handler(args):
       assert args == {}
-      return ("exec", "update", (1,))
+      return (DbRunMode.EXEC, "update", (1,))
     return handler
 
   async def fake_exec_query(sql, params):

--- a/tests/test_system_storage_services.py
+++ b/tests/test_system_storage_services.py
@@ -77,6 +77,7 @@ class DummyStorageModule:
       'file_count': 5,
       'total_bytes': 10,
       'folder_count': 2,
+      'user_folder_count': 1,
       'db_rows': 7,
     }
 
@@ -104,6 +105,7 @@ def test_get_stats_service_triggers_reindex():
     'file_count': 5,
     'total_bytes': 10,
     'folder_count': 2,
+    'user_folder_count': 1,
     'db_rows': 7,
   }
 


### PR DESCRIPTION
## Summary
- track unique user GUID roots during storage reindexing and expose as `user_folder_count`
- surface `user_folder_count` in RPC models and system config UI
- update provider contract tests to use `DbRunMode`

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68c2dd43029c8325b4f4fb372f5cd576