### PR TITLE
feat: toggle file publish status

### DIFF
--- a/frontend/src/components/Postcard.tsx
+++ b/frontend/src/components/Postcard.tsx
@@ -2,31 +2,40 @@ import { Box, IconButton, Link } from '@mui/material';
 import FlagIcon from '@mui/icons-material/Flag';
 
 interface PostcardProps {
-	src: string;
-	guid: string;
-	displayName: string;
-	onReport: () => void;
+    src: string;
+    guid: string;
+    displayName: string;
+    onReport: () => void;
+    contentType?: string;
 }
 
-const Postcard = ({ src, guid, displayName, onReport }: PostcardProps): JSX.Element => {
-	return (
-	    <Box sx={{ width: 200 }}>
-	        <Box sx={{ position: 'relative' }}>
-	            <img src={src} alt={displayName} style={{ width: '100%' }} />
-	            <IconButton
-	                size="small"
-	                color="error"
-	                onClick={onReport}
-	                sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'rgba(255,255,255,0.7)' }}
-	            >
-	                <FlagIcon fontSize="small" />
-	            </IconButton>
-	        </Box>
-	        <Link href={`/profile/${guid}`} underline="hover">
-	            {displayName}
-	        </Link>
-	    </Box>
-	);
+const Postcard = ({ src, guid, displayName, onReport, contentType }: PostcardProps): JSX.Element => {
+    const isVideo = contentType?.startsWith('video/');
+    const isAudio = contentType?.startsWith('audio/');
+    return (
+        <Box sx={{ width: 200 }}>
+            <Box sx={{ position: 'relative' }}>
+                {isVideo ? (
+                    <video src={src} controls style={{ width: '100%' }} />
+                ) : isAudio ? (
+                    <audio src={src} controls style={{ width: '100%' }} />
+                ) : (
+                    <img src={src} alt={displayName} style={{ width: '100%' }} />
+                )}
+                <IconButton
+                    size="small"
+                    color="error"
+                    onClick={onReport}
+                    sx={{ position: 'absolute', bottom: 4, right: 4, bgcolor: 'rgba(255,255,255,0.7)' }}
+                >
+                    <FlagIcon fontSize="small" />
+                </IconButton>
+            </Box>
+            <Link href={`/profile/${guid}`} underline="hover">
+                {displayName}
+            </Link>
+        </Box>
+    );
 };
 
 export default Postcard;

--- a/frontend/src/pages/FileManager.tsx
+++ b/frontend/src/pages/FileManager.tsx
@@ -19,6 +19,7 @@ import {
     Publish,
     DriveFileMove,
     Folder,
+    Unpublished,
 } from '@mui/icons-material';
 import {
     fetchFolderFiles,
@@ -41,6 +42,7 @@ interface StorageFile {
     name: string;
     url: string;
     content_type?: string;
+    gallery?: boolean;
 }
 
 interface StorageFolder {
@@ -96,7 +98,8 @@ const FileManager = (): JSX.Element => {
     };
 
     const handleSetGallery = async (file: StorageFile): Promise<void> => {
-        await fetchSetGallery({ name: getFullName(file), gallery: true });
+        await fetchSetGallery({ name: getFullName(file), gallery: !file.gallery });
+        await load(currentPath);
     };
 
     const handleCopy = async (url: string): Promise<void> => {
@@ -228,7 +231,10 @@ const FileManager = (): JSX.Element => {
                         {files.map((file) => (
                             <TableRow key={file.name}>
                                 <TableCell sx={{ width: '20%' }}>{renderPreview(file)}</TableCell>
-                                <TableCell sx={{ width: '60%' }}>{file.name}</TableCell>
+                                <TableCell sx={{ width: '60%' }}>
+                                    {file.name}
+                                    {file.gallery && <Publish fontSize="small" sx={{ ml: 1 }} />}
+                                </TableCell>
                                 <TableCell sx={{ width: '20%' }}>
                                     <Stack direction="row" spacing={1}>
                                         <Tooltip title="Get link">
@@ -241,9 +247,9 @@ const FileManager = (): JSX.Element => {
                                                 <Delete />
                                             </IconButton>
                                         </Tooltip>
-                                        <Tooltip title="Publish">
+                                        <Tooltip title={file.gallery ? 'Unpublish' : 'Publish'}>
                                             <IconButton size="small" onClick={() => void handleSetGallery(file)}>
-                                                <Publish />
+                                                {file.gallery ? <Unpublished /> : <Publish />}
                                             </IconButton>
                                         </Tooltip>
                                         <Tooltip title="Move">

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -47,20 +47,21 @@ const Gallery = (): JSX.Element => {
 	                            <Tab label="Misc" />
 	                    </Tabs>
 	                    <Stack direction="row" spacing={2} flexWrap="wrap" sx={{ mt: 2 }}>
-	                            {files.filter((f) => getType(f.content_type) === value).map((f, idx) => {
-	                                    const name = f.path ? `${f.path}/${f.name}` : f.name;
-	                                    return (
-	                                            <Postcard
-	                                                    key={idx}
-	                                                    src={f.url}
-	                                                    guid={f.user_guid}
-	                                                    displayName={f.display_name}
-	                                                    onReport={() => handleReport(f.user_guid, name)}
-	                                            />
-	                                    );
-	                            })}
-	                    </Stack>
-	            </div>
+                                    {files.filter((f) => getType(f.content_type) === value).map((f, idx) => {
+                                            const name = f.path ? `${f.path}/${f.name}` : f.name;
+                                            return (
+                                                    <Postcard
+                                                            key={idx}
+                                                            src={f.url}
+                                                            guid={f.user_guid}
+                                                            displayName={f.display_name}
+                                                            contentType={f.content_type}
+                                                            onReport={() => handleReport(f.user_guid, name)}
+                                                    />
+                                            );
+                                    })}
+                            </Stack>
+                    </div>
 	    );
 };
 

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -7,38 +7,88 @@
 import axios from "axios";
 import { getFingerprint } from "./fingerprint";
 
-export interface SystemStorageStats1 {
-	file_count: number;
-	total_bytes: number;
-	folder_count: number;
-	user_folder_count: number;
-	db_rows: number;
+export interface ServiceRoutesDeleteRoute1 {
+	path: string;
 }
-export interface SystemRolesDeleteRole1 {
+export interface ServiceRoutesList1 {
+	routes: ServiceRoutesRouteItem1[];
+}
+export interface ServiceRoutesRouteItem1 {
+	path: string;
+	name: string;
+	icon: string | null;
+	sequence: number;
+	required_roles: string[];
+}
+export interface ServiceRolesDeleteRole1 {
 	name: string;
 }
-export interface SystemRolesList1 {
-	roles: SystemRolesRoleItem1[];
+export interface ServiceRolesList1 {
+	roles: ServiceRolesRoleItem1[];
 }
-export interface SystemRolesRoleItem1 {
+export interface ServiceRolesRoleItem1 {
 	name: string;
 	mask: string;
 	display: any;
 }
-export interface SystemRolesUpsertRole1 {
+export interface ServiceRolesUpsertRole1 {
 	name: string;
 	mask: string;
 	display: any;
 }
-export interface SystemConfigConfigItem1 {
-	key: string;
-	value: string;
+export interface UsersProvidersCreateFromProvider1 {
+	provider: string;
+	provider_identifier: string;
+	provider_email: string;
+	provider_displayname: string;
+	provider_profile_image: any;
 }
-export interface SystemConfigDeleteConfig1 {
-	key: string;
+export interface UsersProvidersGetByProviderIdentifier1 {
+	provider: string;
+	provider_identifier: string;
 }
-export interface SystemConfigList1 {
-	items: SystemConfigConfigItem1[];
+export interface UsersProvidersLinkProvider1 {
+	provider: string;
+	code: any;
+	id_token: any;
+	access_token: any;
+}
+export interface UsersProvidersSetProvider1 {
+	provider: string;
+	code: any;
+	id_token: any;
+	access_token: any;
+}
+export interface UsersProvidersUnlinkProvider1 {
+	provider: string;
+	new_default: any;
+}
+export interface UsersProfileAuthProvider1 {
+	name: string;
+	display: string;
+}
+export interface UsersProfileProfile1 {
+	guid: string;
+	display_name: string;
+	email: string;
+	display_email: boolean;
+	credits: number;
+	profile_image: string | null;
+	default_provider: string;
+	auth_providers: UsersProfileAuthProvider1[];
+}
+export interface UsersProfileRoles1 {
+	roles: number;
+}
+export interface UsersProfileSetDisplay1 {
+	display_name: string;
+}
+export interface UsersProfileSetOptin1 {
+	display_email: boolean;
+}
+export interface UsersProfileSetProfileImage1 {
+	image_b64: string;
+	provider: string;
 }
 export interface StorageFilesCreateFolder1 {
 	path: string;
@@ -59,6 +109,7 @@ export interface StorageFilesFileItem1 {
 	content_type: string | null;
 	user_guid: string | null;
 	display_name: string | null;
+	gallery: boolean | null;
 }
 export interface StorageFilesFileMetadata1 {
 	name: string;
@@ -120,130 +171,6 @@ export interface StorageFilesUsageItem1 {
 	content_type: string;
 	size: number;
 }
-export interface ServiceRolesDeleteRole1 {
-	name: string;
-}
-export interface ServiceRolesList1 {
-	roles: ServiceRolesRoleItem1[];
-}
-export interface ServiceRolesRoleItem1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface ServiceRolesUpsertRole1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface ServiceRoutesDeleteRoute1 {
-	path: string;
-}
-export interface ServiceRoutesList1 {
-	routes: ServiceRoutesRouteItem1[];
-}
-export interface ServiceRoutesRouteItem1 {
-	path: string;
-	name: string;
-	icon: string | null;
-	sequence: number;
-	required_roles: string[];
-}
-export interface UsersProfileAuthProvider1 {
-	name: string;
-	display: string;
-}
-export interface UsersProfileProfile1 {
-	guid: string;
-	display_name: string;
-	email: string;
-	display_email: boolean;
-	credits: number;
-	profile_image: string | null;
-	default_provider: string;
-	auth_providers: UsersProfileAuthProvider1[];
-}
-export interface UsersProfileRoles1 {
-	roles: number;
-}
-export interface UsersProfileSetDisplay1 {
-	display_name: string;
-}
-export interface UsersProfileSetOptin1 {
-	display_email: boolean;
-}
-export interface UsersProfileSetProfileImage1 {
-	image_b64: string;
-	provider: string;
-}
-export interface UsersProvidersCreateFromProvider1 {
-	provider: string;
-	provider_identifier: string;
-	provider_email: string;
-	provider_displayname: string;
-	provider_profile_image: any;
-}
-export interface UsersProvidersGetByProviderIdentifier1 {
-	provider: string;
-	provider_identifier: string;
-}
-export interface UsersProvidersLinkProvider1 {
-	provider: string;
-	code: any;
-	id_token: any;
-	access_token: any;
-}
-export interface UsersProvidersSetProvider1 {
-	provider: string;
-	code: any;
-	id_token: any;
-	access_token: any;
-}
-export interface UsersProvidersUnlinkProvider1 {
-	provider: string;
-	new_default: any;
-}
-export interface AuthMicrosoftOauthLogin1 {
-	sessionToken: string;
-	display_name: string;
-	credits: number;
-	profile_image: string | null;
-}
-export interface AuthGoogleOauthLogin1 {
-	sessionToken: string;
-	display_name: string;
-	credits: number;
-	profile_image: string | null;
-}
-export interface AuthGoogleOauthLoginPayload1 {
-	provider: string;
-	code: string;
-	confirm: any;
-	reauthToken: any;
-	fingerprint: string;
-}
-export interface AuthProvidersUnlinkLastProvider1 {
-	guid: string;
-	provider: string;
-}
-export interface DiscordCommandTextUwuResponse1 {
-	message: string;
-}
-export interface PublicVarsFfmpegVersion1 {
-	ffmpeg_version: string;
-}
-export interface PublicVarsHostname1 {
-	hostname: string;
-}
-export interface PublicVarsOdbcVersion1 {
-	odbc_version: string;
-}
-export interface PublicVarsRepo1 {
-	repo: string;
-}
-export interface PublicVarsVersion1 {
-	version: string;
-}
 export interface PublicUsersProfile1 {
 	display_name: string;
 	email: string | null;
@@ -271,6 +198,44 @@ export interface PublicLinksNavBarRoute1 {
 }
 export interface PublicLinksNavBarRoutes1 {
 	routes: PublicLinksNavBarRoute1[];
+}
+export interface PublicVarsFfmpegVersion1 {
+	ffmpeg_version: string;
+}
+export interface PublicVarsHostname1 {
+	hostname: string;
+}
+export interface PublicVarsOdbcVersion1 {
+	odbc_version: string;
+}
+export interface PublicVarsRepo1 {
+	repo: string;
+}
+export interface PublicVarsVersion1 {
+	version: string;
+}
+export interface AuthGoogleOauthLogin1 {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
+}
+export interface AuthGoogleOauthLoginPayload1 {
+	provider: string;
+	code: string;
+	confirm: any;
+	reauthToken: any;
+	fingerprint: string;
+}
+export interface AuthMicrosoftOauthLogin1 {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
+}
+export interface AuthProvidersUnlinkLastProvider1 {
+	guid: string;
+	provider: string;
 }
 export interface AccountRoleDeleteRole1 {
 	name: string;
@@ -319,18 +284,6 @@ export interface AccountUserSetCredits1 {
 	userGuid: string;
 	credits: number;
 }
-export interface SupportRolesMembers1 {
-	members: SupportRolesUserItem1[];
-	nonMembers: SupportRolesUserItem1[];
-}
-export interface SupportRolesRoleMemberUpdate1 {
-	role: string;
-	userGuid: string;
-}
-export interface SupportRolesUserItem1 {
-	guid: string;
-	displayName: string;
-}
 export interface SupportUsersCredits1 {
 	userGuid: string;
 	credits: number;
@@ -345,6 +298,54 @@ export interface SupportUsersGuid1 {
 export interface SupportUsersSetCredits1 {
 	userGuid: string;
 	credits: number;
+}
+export interface SupportRolesMembers1 {
+	members: SupportRolesUserItem1[];
+	nonMembers: SupportRolesUserItem1[];
+}
+export interface SupportRolesRoleMemberUpdate1 {
+	role: string;
+	userGuid: string;
+}
+export interface SupportRolesUserItem1 {
+	guid: string;
+	displayName: string;
+}
+export interface SystemStorageStats1 {
+	file_count: number;
+	total_bytes: number;
+	folder_count: number;
+	user_folder_count: number;
+	db_rows: number;
+}
+export interface SystemConfigConfigItem1 {
+	key: string;
+	value: string;
+}
+export interface SystemConfigDeleteConfig1 {
+	key: string;
+}
+export interface SystemConfigList1 {
+	items: SystemConfigConfigItem1[];
+}
+export interface SystemRolesDeleteRole1 {
+	name: string;
+}
+export interface SystemRolesList1 {
+	roles: SystemRolesRoleItem1[];
+}
+export interface SystemRolesRoleItem1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface SystemRolesUpsertRole1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface DiscordCommandTextUwuResponse1 {
+	message: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/storage/files/models.py
+++ b/rpc/storage/files/models.py
@@ -10,6 +10,7 @@ class StorageFilesFileItem1(BaseModel):
   content_type: Optional[str] = None
   user_guid: Optional[str] = None
   display_name: Optional[str] = None
+  gallery: Optional[bool] = None
 
 
 class StorageFilesFiles1(BaseModel):

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -373,7 +373,8 @@ def _storage_cache_list(args: Dict[str, Any]):
       usc.element_path AS path,
       usc.element_filename AS filename,
       st.element_mimetype AS content_type,
-      usc.element_url AS url
+      usc.element_url AS url,
+      usc.element_public AS public
     FROM users_storage_cache usc
     JOIN storage_types st ON st.recid = usc.types_recid
     WHERE usc.users_guid = ? AND usc.element_deleted = 0

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -278,6 +278,7 @@ class StorageModule(BaseModule):
         "name": filename,
         "url": row.get("url") or full_name,
         "content_type": row.get("content_type"),
+        "gallery": bool(row.get("public")),
       })
     return out
 
@@ -308,6 +309,7 @@ class StorageModule(BaseModule):
           "name": filename,
           "url": row.get("url") or full_name,
           "content_type": ct,
+          "gallery": bool(row.get("public")),
         })
       elif path.startswith(prefix):
         subfolder = path[len(prefix):].split("/", 1)[0]

--- a/tests/test_storage_files_services.py
+++ b/tests/test_storage_files_services.py
@@ -136,7 +136,13 @@ class DummyStorage:
     self.list_folder_args = (user_guid, path)
     return {
       "path": path,
-      "files": [{"path": path, "name": "a.txt", "url": f"u/{path}/a.txt", "content_type": "text/plain"}],
+      "files": [{
+        "path": path,
+        "name": "a.txt",
+        "url": f"u/{path}/a.txt",
+        "content_type": "text/plain",
+        "gallery": False,
+      }],
       "folders": [{"name": "sub", "empty": False}],
     }
 
@@ -163,6 +169,7 @@ def test_get_link_calls_storage():
     "content_type": None,
     "user_guid": None,
     "display_name": None,
+    "gallery": None,
   }
   assert storage.link_args == ("u123", "a.txt")
   assert storage.reindexed == "u123"
@@ -243,7 +250,7 @@ def test_get_folder_files_returns_contents():
   assert resp.payload == {
     "path": "docs",
     "files": [
-      {"path": "docs", "name": "a.txt", "url": "u/docs/a.txt", "content_type": "text/plain", "user_guid": None, "display_name": None}
+      {"path": "docs", "name": "a.txt", "url": "u/docs/a.txt", "content_type": "text/plain", "user_guid": None, "display_name": None, "gallery": False}
     ],
     "folders": [{"name": "sub", "empty": False}],
   }

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -94,14 +94,14 @@ def test_list_files_by_user():
   app = FastAPI()
   mod = StorageModule(app)
   mod.db = DummyListDb([
-    {"path": "", "filename": "a.txt", "content_type": "text/plain", "url": "u/a.txt"},
-    {"path": "docs", "filename": "b.txt", "content_type": "text/plain", "url": "u/docs/b.txt"},
+    {"path": "", "filename": "a.txt", "content_type": "text/plain", "url": "u/a.txt", "public": 0},
+    {"path": "docs", "filename": "b.txt", "content_type": "text/plain", "url": "u/docs/b.txt", "public": 0},
     {"path": "", "filename": "docs", "content_type": "path/folder", "url": None},
   ])
   files = asyncio.run(mod.list_files_by_user("u1"))
   assert files == [
-    {"path": "", "name": "a.txt", "url": "u/a.txt", "content_type": "text/plain"},
-    {"path": "docs", "name": "b.txt", "url": "u/docs/b.txt", "content_type": "text/plain"},
+    {"path": "", "name": "a.txt", "url": "u/a.txt", "content_type": "text/plain", "gallery": False},
+    {"path": "docs", "name": "b.txt", "url": "u/docs/b.txt", "content_type": "text/plain", "gallery": False},
   ]
 
 
@@ -109,18 +109,18 @@ def test_list_folder_returns_files_and_folders():
   app = FastAPI()
   mod = StorageModule(app)
   mod.db = DummyListDb([
-    {"path": "", "filename": "a.txt", "content_type": "text/plain", "url": "u/a.txt"},
-    {"path": "", "filename": "docs", "content_type": "path/folder", "url": None},
-    {"path": "", "filename": "empty", "content_type": "path/folder", "url": None},
-    {"path": "docs", "filename": "b.txt", "content_type": "text/plain", "url": "u/docs/b.txt"},
-    {"path": "docs", "filename": "c.txt", "content_type": "text/plain", "url": "u/docs/c.txt"},
-    {"path": "docs", "filename": "sub", "content_type": "path/folder", "url": None},
-    {"path": "docs/sub", "filename": "d.txt", "content_type": "text/plain", "url": "u/docs/sub/d.txt"},
+    {"path": "", "filename": "a.txt", "content_type": "text/plain", "url": "u/a.txt", "public": 0},
+    {"path": "", "filename": "docs", "content_type": "path/folder", "url": None, "public": 0},
+    {"path": "", "filename": "empty", "content_type": "path/folder", "url": None, "public": 0},
+    {"path": "docs", "filename": "b.txt", "content_type": "text/plain", "url": "u/docs/b.txt", "public": 0},
+    {"path": "docs", "filename": "c.txt", "content_type": "text/plain", "url": "u/docs/c.txt", "public": 0},
+    {"path": "docs", "filename": "sub", "content_type": "path/folder", "url": None, "public": 0},
+    {"path": "docs/sub", "filename": "d.txt", "content_type": "text/plain", "url": "u/docs/sub/d.txt", "public": 0},
   ])
   root = asyncio.run(mod.list_folder("u1", ""))
   assert root["path"] == ""
   assert root["files"] == [
-    {"path": "", "name": "a.txt", "url": "u/a.txt", "content_type": "text/plain"}
+    {"path": "", "name": "a.txt", "url": "u/a.txt", "content_type": "text/plain", "gallery": False}
   ]
   assert sorted(root["folders"], key=lambda x: x["name"]) == [
     {"name": "docs", "empty": False},
@@ -129,8 +129,8 @@ def test_list_folder_returns_files_and_folders():
   docs = asyncio.run(mod.list_folder("u1", "/docs"))
   assert docs["path"] == "docs"
   assert docs["files"] == [
-    {"path": "docs", "name": "b.txt", "url": "u/docs/b.txt", "content_type": "text/plain"},
-    {"path": "docs", "name": "c.txt", "url": "u/docs/c.txt", "content_type": "text/plain"},
+    {"path": "docs", "name": "b.txt", "url": "u/docs/b.txt", "content_type": "text/plain", "gallery": False},
+    {"path": "docs", "name": "c.txt", "url": "u/docs/c.txt", "content_type": "text/plain", "gallery": False},
   ]
   assert docs["folders"] == [{"name": "sub", "empty": False}]
 


### PR DESCRIPTION
## Summary
- allow users to publish or unpublish files in the manager with a visual indicator
- show published items in the gallery with media previews and filtering
- surface publication state through storage APIs and models

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3a773f39c83259d82563a2c23a09d