### PR TITLE
fix: quote public alias in storage cache query

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -374,7 +374,7 @@ def _storage_cache_list(args: Dict[str, Any]):
       usc.element_filename AS filename,
       st.element_mimetype AS content_type,
       usc.element_url AS url,
-      usc.element_public AS public
+      usc.element_public AS [public]
     FROM users_storage_cache usc
     JOIN storage_types st ON st.recid = usc.types_recid
     WHERE usc.users_guid = ? AND usc.element_deleted = 0


### PR DESCRIPTION
## Summary
- quote `public` alias in storage cache list query to avoid SQL Server keyword conflict

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68c42af3f3648325a17120dd296060c9