### PR TITLE
feat: expose public gallery endpoint

### DIFF
--- a/frontend/src/icons.ts
+++ b/frontend/src/icons.ts
@@ -14,6 +14,7 @@ import {
     PermDataSetting as PermDataSettingIcon,
     Groups as GroupsIcon,
     Person as PersonIcon,
+    Publish as PublishIcon,
 } from '@mui/icons-material';
 
 export const iconMap: Record<string, ElementType> = {
@@ -33,6 +34,7 @@ export const iconMap: Record<string, ElementType> = {
     groups: GroupsIcon,
     support: PersonIcon,
     person: PersonIcon,
+    publish: PublishIcon,
 };
 
 export const defaultIcon = AdjustIcon;

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect, type JSX } from 'react';
 import { Tabs, Tab, Stack } from '@mui/material';
 import PageTitle from '../components/PageTitle';
 import Postcard from '../components/Postcard';
-import { fetchPublicFiles, fetchReportFile } from '../rpc/storage/files';
+import { fetchPublicFiles } from '../rpc/public/gallery';
+import { fetchReportFile } from '../rpc/storage/files';
 
 const Gallery = (): JSX.Element => {
 	    const [value, setValue] = useState(0);

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -7,33 +7,6 @@
 import axios from "axios";
 import { getFingerprint } from "./fingerprint";
 
-export interface UsersProvidersCreateFromProvider1 {
-	provider: string;
-	provider_identifier: string;
-	provider_email: string;
-	provider_displayname: string;
-	provider_profile_image: any;
-}
-export interface UsersProvidersGetByProviderIdentifier1 {
-	provider: string;
-	provider_identifier: string;
-}
-export interface UsersProvidersLinkProvider1 {
-	provider: string;
-	code: any;
-	id_token: any;
-	access_token: any;
-}
-export interface UsersProvidersSetProvider1 {
-	provider: string;
-	code: any;
-	id_token: any;
-	access_token: any;
-}
-export interface UsersProvidersUnlinkProvider1 {
-	provider: string;
-	new_default: any;
-}
 export interface UsersProfileAuthProvider1 {
 	name: string;
 	display: string;
@@ -61,34 +34,32 @@ export interface UsersProfileSetProfileImage1 {
 	image_b64: string;
 	provider: string;
 }
-export interface ServiceRolesDeleteRole1 {
-	name: string;
+export interface UsersProvidersCreateFromProvider1 {
+	provider: string;
+	provider_identifier: string;
+	provider_email: string;
+	provider_displayname: string;
+	provider_profile_image: any;
 }
-export interface ServiceRolesList1 {
-	roles: ServiceRolesRoleItem1[];
+export interface UsersProvidersGetByProviderIdentifier1 {
+	provider: string;
+	provider_identifier: string;
 }
-export interface ServiceRolesRoleItem1 {
-	name: string;
-	mask: string;
-	display: any;
+export interface UsersProvidersLinkProvider1 {
+	provider: string;
+	code: any;
+	id_token: any;
+	access_token: any;
 }
-export interface ServiceRolesUpsertRole1 {
-	name: string;
-	mask: string;
-	display: any;
+export interface UsersProvidersSetProvider1 {
+	provider: string;
+	code: any;
+	id_token: any;
+	access_token: any;
 }
-export interface ServiceRoutesDeleteRoute1 {
-	path: string;
-}
-export interface ServiceRoutesList1 {
-	routes: ServiceRoutesRouteItem1[];
-}
-export interface ServiceRoutesRouteItem1 {
-	path: string;
-	name: string;
-	icon: string | null;
-	sequence: number;
-	required_roles: string[];
+export interface UsersProvidersUnlinkProvider1 {
+	provider: string;
+	new_default: any;
 }
 export interface SystemRolesDeleteRole1 {
 	name: string;
@@ -122,6 +93,29 @@ export interface SystemStorageStats1 {
 	folder_count: number;
 	user_folder_count: number;
 	db_rows: number;
+}
+export interface AuthMicrosoftOauthLogin1 {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
+}
+export interface AuthProvidersUnlinkLastProvider1 {
+	guid: string;
+	provider: string;
+}
+export interface AuthGoogleOauthLogin1 {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
+}
+export interface AuthGoogleOauthLoginPayload1 {
+	provider: string;
+	code: string;
+	confirm: any;
+	reauthToken: any;
+	fingerprint: string;
 }
 export interface PublicUsersProfile1 {
 	display_name: string;
@@ -166,6 +160,20 @@ export interface PublicVarsRepo1 {
 export interface PublicVarsVersion1 {
 	version: string;
 }
+export interface PublicGalleryFileItem1 {
+	path: string;
+	name: string;
+	url: string;
+	content_type: string | null;
+	user_guid: string | null;
+	display_name: string | null;
+}
+export interface PublicGalleryFiles1 {
+	files: PublicGalleryFileItem1[];
+}
+export interface DiscordCommandTextUwuResponse1 {
+	message: string;
+}
 export interface SupportUsersCredits1 {
 	userGuid: string;
 	credits: number;
@@ -193,50 +201,34 @@ export interface SupportRolesUserItem1 {
 	guid: string;
 	displayName: string;
 }
-export interface AuthGoogleOauthLogin1 {
-	sessionToken: string;
-	display_name: string;
-	credits: number;
-	profile_image: string | null;
+export interface ServiceRolesDeleteRole1 {
+	name: string;
 }
-export interface AuthGoogleOauthLoginPayload1 {
-	provider: string;
-	code: string;
-	confirm: any;
-	reauthToken: any;
-	fingerprint: string;
+export interface ServiceRolesList1 {
+	roles: ServiceRolesRoleItem1[];
 }
-export interface AuthProvidersUnlinkLastProvider1 {
-	guid: string;
-	provider: string;
+export interface ServiceRolesRoleItem1 {
+	name: string;
+	mask: string;
+	display: any;
 }
-export interface AuthMicrosoftOauthLogin1 {
-	sessionToken: string;
-	display_name: string;
-	credits: number;
-	profile_image: string | null;
+export interface ServiceRolesUpsertRole1 {
+	name: string;
+	mask: string;
+	display: any;
 }
-export interface DiscordCommandTextUwuResponse1 {
-	message: string;
-}
-export interface AccountUserCreateFolder1 {
-	userGuid: string;
+export interface ServiceRoutesDeleteRoute1 {
 	path: string;
 }
-export interface AccountUserCredits1 {
-	userGuid: string;
-	credits: number;
+export interface ServiceRoutesList1 {
+	routes: ServiceRoutesRouteItem1[];
 }
-export interface AccountUserDisplayName1 {
-	userGuid: string;
-	displayName: string;
-}
-export interface AccountUserGuid1 {
-	userGuid: string;
-}
-export interface AccountUserSetCredits1 {
-	userGuid: string;
-	credits: number;
+export interface ServiceRoutesRouteItem1 {
+	path: string;
+	name: string;
+	icon: string | null;
+	sequence: number;
+	required_roles: string[];
 }
 export interface AccountRoleDeleteRole1 {
 	name: string;
@@ -265,6 +257,25 @@ export interface AccountRoleUpsertRole1 {
 export interface AccountRoleUserItem1 {
 	guid: string;
 	displayName: string;
+}
+export interface AccountUserCreateFolder1 {
+	userGuid: string;
+	path: string;
+}
+export interface AccountUserCredits1 {
+	userGuid: string;
+	credits: number;
+}
+export interface AccountUserDisplayName1 {
+	userGuid: string;
+	displayName: string;
+}
+export interface AccountUserGuid1 {
+	userGuid: string;
+}
+export interface AccountUserSetCredits1 {
+	userGuid: string;
+	credits: number;
 }
 export interface StorageFilesCreateFolder1 {
 	path: string;

--- a/rpc/public/__init__.py
+++ b/rpc/public/__init__.py
@@ -1,11 +1,13 @@
 from .links.handler import handle_links_request
 from .vars.handler import handle_vars_request
 from .users.handler import handle_users_request
+from .gallery.handler import handle_gallery_request
 
 
 HANDLERS: dict[str, callable] = {
   "links": handle_links_request,
   "vars": handle_vars_request,
   "users": handle_users_request,
+  "gallery": handle_gallery_request,
 }
 

--- a/rpc/public/gallery/__init__.py
+++ b/rpc/public/gallery/__init__.py
@@ -1,0 +1,5 @@
+from .services import public_gallery_get_public_files_v1
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("get_public_files", "1"): public_gallery_get_public_files_v1,
+}

--- a/rpc/public/gallery/handler.py
+++ b/rpc/public/gallery/handler.py
@@ -1,0 +1,10 @@
+from fastapi import HTTPException, Request
+from server.models import RPCResponse
+from . import DISPATCHERS
+
+async def handle_gallery_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail="Unknown RPC operation")
+  return await handler(request)

--- a/rpc/public/gallery/models.py
+++ b/rpc/public/gallery/models.py
@@ -1,0 +1,13 @@
+from typing import Optional
+from pydantic import BaseModel
+
+class PublicGalleryFileItem1(BaseModel):
+  path: str
+  name: str
+  url: str
+  content_type: Optional[str] = None
+  user_guid: Optional[str] = None
+  display_name: Optional[str] = None
+
+class PublicGalleryFiles1(BaseModel):
+  files: list[PublicGalleryFileItem1]

--- a/rpc/public/gallery/services.py
+++ b/rpc/public/gallery/services.py
@@ -1,0 +1,19 @@
+from typing import TYPE_CHECKING
+from fastapi import Request
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+if TYPE_CHECKING:
+  from server.modules.public_gallery_module import PublicGalleryModule
+from .models import PublicGalleryFileItem1, PublicGalleryFiles1
+
+async def public_gallery_get_public_files_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  gallery: PublicGalleryModule = request.app.state.public_gallery
+  rows = await gallery.list_public_files()
+  files = [PublicGalleryFileItem1(**row) for row in rows]
+  payload = PublicGalleryFiles1(files=files)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -587,6 +587,24 @@ def _storage_cache_list_public(_: Dict[str, Any]):
   return (DbRunMode.ROW_MANY, sql, ())
 
 
+@register("db:public:gallery:get_public_files:1")
+def _public_gallery_get_public_files(_: Dict[str, Any]):
+  sql = """
+    SELECT usc.users_guid AS user_guid,
+           au.element_display AS display_name,
+           usc.element_path AS path,
+           usc.element_filename AS name,
+           usc.element_url AS url,
+           st.element_mimetype AS content_type
+    FROM users_storage_cache usc
+    JOIN account_users au ON au.element_guid = usc.users_guid
+    JOIN storage_types st ON st.recid = usc.types_recid
+    WHERE usc.element_public = 1 AND usc.element_deleted = 0 AND ISNULL(usc.element_reported,0) = 0
+    ORDER BY usc.element_created_on;
+  """
+  return (DbRunMode.ROW_MANY, sql, ())
+
+
 @register("db:storage:cache:list_reported:1")
 def _storage_cache_list_reported(_: Dict[str, Any]):
   sql = """

--- a/server/modules/public_gallery_module.py
+++ b/server/modules/public_gallery_module.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+from . import BaseModule
+from .db_module import DbModule
+
+class PublicGalleryModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    self.db = None
+
+  async def list_public_files(self):
+    assert self.db
+    res = await self.db.run("db:public:gallery:get_public_files:1", {})
+    return res.rows


### PR DESCRIPTION
## Summary
- add provider query and module for public gallery files
- expose public gallery RPC and wire frontend Gallery to it
- add publish icon to shared icon map

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c44b5b67b08325bd85b413616c6c11