### PR TITLE
Preserve gallery flag across storage reindex

### DIFF
--- a/rpc/storage/files/services.py
+++ b/rpc/storage/files/services.py
@@ -84,7 +84,6 @@ async def storage_files_set_gallery_v1(request: Request):
   data = StorageFilesSetGallery1(**(rpc_request.payload or {}))
   storage: StorageModule = request.app.state.storage
   await storage.set_gallery(user_guid, data.name, data.gallery)
-  await storage.reindex(user_guid)
   return RPCResponse(
     op=rpc_request.op,
     payload=data.model_dump(),


### PR DESCRIPTION
## Summary
- keep existing gallery status when reindexing storage entries
- avoid unnecessary reindexing after updating gallery flag
- test storage services for gallery persistence

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68c452281d148325a43b51de773aa6b5