### PR TITLE
Show filenames on content cards and fix profile audio

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -111,7 +111,7 @@ User focused calls used by the React application.
 | Operation                                  | Description                                      |
 | ------------------------------------------- | ------------------------------------------------ |
 | `urn:public:users:get_profile:1`            | Retrieve a user's public profile.                |
-| `urn:public:users:get_published_files:1`    | List files a user has published to the gallery.  |
+| `urn:public:users:get_published_files:1`    | List files a user has published to the gallery including content type.  |
 
 ## Storage Domain
 

--- a/frontend/src/components/Postcard.tsx
+++ b/frontend/src/components/Postcard.tsx
@@ -5,11 +5,12 @@ interface PostcardProps {
     src: string;
     guid: string;
     displayName: string;
+    filename: string;
     onReport: () => void;
-    contentType?: string;
+    contentType?: string | null;
 }
 
-const Postcard = ({ src, guid, displayName, onReport, contentType }: PostcardProps): JSX.Element => {
+const Postcard = ({ src, guid, displayName, filename, onReport, contentType }: PostcardProps): JSX.Element => {
     const isVideo = contentType?.startsWith('video/');
     const isAudio = contentType?.startsWith('audio/');
     return (
@@ -31,9 +32,16 @@ const Postcard = ({ src, guid, displayName, onReport, contentType }: PostcardPro
                     <FlagIcon fontSize="small" />
                 </IconButton>
             </Box>
-            <Link href={`/profile/${guid}`} underline="hover">
-                {displayName}
-            </Link>
+            <Box sx={{ mt: 1 }}>
+                <Box>{filename}</Box>
+                <Link
+                    href={`/profile/${guid}`}
+                    underline="hover"
+                    sx={{ fontSize: '0.8rem', color: 'text.secondary' }}
+                >
+                    {displayName}
+                </Link>
+            </Box>
         </Box>
     );
 };

--- a/frontend/src/pages/Gallery.tsx
+++ b/frontend/src/pages/Gallery.tsx
@@ -56,6 +56,7 @@ const Gallery = (): JSX.Element => {
                                                             src={f.url}
                                                             guid={f.user_guid}
                                                             displayName={f.display_name}
+                                                            filename={f.name}
                                                             contentType={f.content_type}
                                                             onReport={() => handleReport(f.user_guid, name)}
                                                     />

--- a/frontend/src/pages/PublicProfile.tsx
+++ b/frontend/src/pages/PublicProfile.tsx
@@ -49,19 +49,21 @@ const PublicProfile = (): JSX.Element => {
 	        <Stack direction="row" spacing={2} flexWrap="wrap">
 	            {files.map((f, idx) => {
 	                const name = f.path ? `${f.path}/${f.filename}` : f.filename;
-	                return (
-	                    <Postcard
-	                        key={idx}
-	                        src={f.url}
-	                        guid={guid as string}
-	                        displayName={profile?.display_name ?? ''}
-	                        onReport={() => {
-	                            if (guid) void fetchReportFile({ guid, name });
-	                        }}
-	                    />
-	                );
-	            })}
-	        </Stack>
+                        return (
+                            <Postcard
+                                key={idx}
+                                src={f.url}
+                                guid={guid as string}
+                                displayName={profile?.display_name ?? ''}
+                                filename={f.filename}
+                                contentType={f.content_type}
+                                onReport={() => {
+                                    if (guid) void fetchReportFile({ guid, name });
+                                }}
+                            />
+                        );
+                    })}
+                </Stack>
 	    </div>
 	);
 };

--- a/frontend/src/shared/RpcModels.tsx
+++ b/frontend/src/shared/RpcModels.tsx
@@ -7,99 +7,6 @@
 import axios from "axios";
 import { getFingerprint } from "./fingerprint";
 
-export interface UsersProfileAuthProvider1 {
-	name: string;
-	display: string;
-}
-export interface UsersProfileProfile1 {
-	guid: string;
-	display_name: string;
-	email: string;
-	display_email: boolean;
-	credits: number;
-	profile_image: string | null;
-	default_provider: string;
-	auth_providers: UsersProfileAuthProvider1[];
-}
-export interface UsersProfileRoles1 {
-	roles: number;
-}
-export interface UsersProfileSetDisplay1 {
-	display_name: string;
-}
-export interface UsersProfileSetOptin1 {
-	display_email: boolean;
-}
-export interface UsersProfileSetProfileImage1 {
-	image_b64: string;
-	provider: string;
-}
-export interface UsersProvidersCreateFromProvider1 {
-	provider: string;
-	provider_identifier: string;
-	provider_email: string;
-	provider_displayname: string;
-	provider_profile_image: any;
-}
-export interface UsersProvidersGetByProviderIdentifier1 {
-	provider: string;
-	provider_identifier: string;
-}
-export interface UsersProvidersLinkProvider1 {
-	provider: string;
-	code: any;
-	id_token: any;
-	access_token: any;
-}
-export interface UsersProvidersSetProvider1 {
-	provider: string;
-	code: any;
-	id_token: any;
-	access_token: any;
-}
-export interface UsersProvidersUnlinkProvider1 {
-	provider: string;
-	new_default: any;
-}
-export interface SystemRolesDeleteRole1 {
-	name: string;
-}
-export interface SystemRolesList1 {
-	roles: SystemRolesRoleItem1[];
-}
-export interface SystemRolesRoleItem1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface SystemRolesUpsertRole1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface SystemConfigConfigItem1 {
-	key: string;
-	value: string;
-}
-export interface SystemConfigDeleteConfig1 {
-	key: string;
-}
-export interface SystemConfigList1 {
-	items: SystemConfigConfigItem1[];
-}
-export interface SystemStorageStats1 {
-	file_count: number;
-	total_bytes: number;
-	folder_count: number;
-	user_folder_count: number;
-	db_rows: number;
-}
-export interface AuthMicrosoftOauthLogin1 {
-	sessionToken: string;
-	display_name: string;
-	credits: number;
-	profile_image: string | null;
-}
 export interface AuthProvidersUnlinkLastProvider1 {
 	guid: string;
 	provider: string;
@@ -117,165 +24,11 @@ export interface AuthGoogleOauthLoginPayload1 {
 	reauthToken: any;
 	fingerprint: string;
 }
-export interface PublicUsersProfile1 {
+export interface AuthMicrosoftOauthLogin1 {
+	sessionToken: string;
 	display_name: string;
-	email: string | null;
+	credits: number;
 	profile_image: string | null;
-}
-export interface PublicUsersPublishedFile1 {
-	path: string;
-	filename: string;
-	url: string;
-}
-export interface PublicUsersPublishedFiles1 {
-	files: PublicUsersPublishedFile1[];
-}
-export interface PublicLinksHomeLinks1 {
-	links: PublicLinksLinkItem1[];
-}
-export interface PublicLinksLinkItem1 {
-	title: string;
-	url: string;
-}
-export interface PublicLinksNavBarRoute1 {
-	path: string;
-	name: string;
-	icon: string | null;
-}
-export interface PublicLinksNavBarRoutes1 {
-	routes: PublicLinksNavBarRoute1[];
-}
-export interface PublicVarsFfmpegVersion1 {
-	ffmpeg_version: string;
-}
-export interface PublicVarsHostname1 {
-	hostname: string;
-}
-export interface PublicVarsOdbcVersion1 {
-	odbc_version: string;
-}
-export interface PublicVarsRepo1 {
-	repo: string;
-}
-export interface PublicVarsVersion1 {
-	version: string;
-}
-export interface PublicGalleryFileItem1 {
-	path: string;
-	name: string;
-	url: string;
-	content_type: string | null;
-	user_guid: string | null;
-	display_name: string | null;
-}
-export interface PublicGalleryFiles1 {
-	files: PublicGalleryFileItem1[];
-}
-export interface DiscordCommandTextUwuResponse1 {
-	message: string;
-}
-export interface SupportUsersCredits1 {
-	userGuid: string;
-	credits: number;
-}
-export interface SupportUsersDisplayName1 {
-	userGuid: string;
-	displayName: string;
-}
-export interface SupportUsersGuid1 {
-	userGuid: string;
-}
-export interface SupportUsersSetCredits1 {
-	userGuid: string;
-	credits: number;
-}
-export interface SupportRolesMembers1 {
-	members: SupportRolesUserItem1[];
-	nonMembers: SupportRolesUserItem1[];
-}
-export interface SupportRolesRoleMemberUpdate1 {
-	role: string;
-	userGuid: string;
-}
-export interface SupportRolesUserItem1 {
-	guid: string;
-	displayName: string;
-}
-export interface ServiceRolesDeleteRole1 {
-	name: string;
-}
-export interface ServiceRolesList1 {
-	roles: ServiceRolesRoleItem1[];
-}
-export interface ServiceRolesRoleItem1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface ServiceRolesUpsertRole1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface ServiceRoutesDeleteRoute1 {
-	path: string;
-}
-export interface ServiceRoutesList1 {
-	routes: ServiceRoutesRouteItem1[];
-}
-export interface ServiceRoutesRouteItem1 {
-	path: string;
-	name: string;
-	icon: string | null;
-	sequence: number;
-	required_roles: string[];
-}
-export interface AccountRoleDeleteRole1 {
-	name: string;
-}
-export interface AccountRoleList1 {
-	roles: AccountRoleRoleItem1[];
-}
-export interface AccountRoleMemberUpdate1 {
-	role: string;
-	userGuid: string;
-}
-export interface AccountRoleMembers1 {
-	members: AccountRoleUserItem1[];
-	nonMembers: AccountRoleUserItem1[];
-}
-export interface AccountRoleRoleItem1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface AccountRoleUpsertRole1 {
-	name: string;
-	mask: string;
-	display: any;
-}
-export interface AccountRoleUserItem1 {
-	guid: string;
-	displayName: string;
-}
-export interface AccountUserCreateFolder1 {
-	userGuid: string;
-	path: string;
-}
-export interface AccountUserCredits1 {
-	userGuid: string;
-	credits: number;
-}
-export interface AccountUserDisplayName1 {
-	userGuid: string;
-	displayName: string;
-}
-export interface AccountUserGuid1 {
-	userGuid: string;
-}
-export interface AccountUserSetCredits1 {
-	userGuid: string;
-	credits: number;
 }
 export interface StorageFilesCreateFolder1 {
 	path: string;
@@ -357,6 +110,254 @@ export interface StorageFilesUsage1 {
 export interface StorageFilesUsageItem1 {
 	content_type: string;
 	size: number;
+}
+export interface PublicVarsFfmpegVersion1 {
+	ffmpeg_version: string;
+}
+export interface PublicVarsHostname1 {
+	hostname: string;
+}
+export interface PublicVarsOdbcVersion1 {
+	odbc_version: string;
+}
+export interface PublicVarsRepo1 {
+	repo: string;
+}
+export interface PublicVarsVersion1 {
+	version: string;
+}
+export interface PublicLinksHomeLinks1 {
+	links: PublicLinksLinkItem1[];
+}
+export interface PublicLinksLinkItem1 {
+	title: string;
+	url: string;
+}
+export interface PublicLinksNavBarRoute1 {
+	path: string;
+	name: string;
+	icon: string | null;
+}
+export interface PublicLinksNavBarRoutes1 {
+	routes: PublicLinksNavBarRoute1[];
+}
+export interface PublicGalleryFileItem1 {
+	path: string;
+	name: string;
+	url: string;
+	content_type: string | null;
+	user_guid: string | null;
+	display_name: string | null;
+}
+export interface PublicGalleryFiles1 {
+	files: PublicGalleryFileItem1[];
+}
+export interface PublicUsersProfile1 {
+	display_name: string;
+	email: string | null;
+	profile_image: string | null;
+}
+export interface PublicUsersPublishedFile1 {
+	path: string;
+	filename: string;
+	url: string;
+	content_type: string | null;
+}
+export interface PublicUsersPublishedFiles1 {
+	files: PublicUsersPublishedFile1[];
+}
+export interface SystemStorageStats1 {
+	file_count: number;
+	total_bytes: number;
+	folder_count: number;
+	user_folder_count: number;
+	db_rows: number;
+}
+export interface SystemConfigConfigItem1 {
+	key: string;
+	value: string;
+}
+export interface SystemConfigDeleteConfig1 {
+	key: string;
+}
+export interface SystemConfigList1 {
+	items: SystemConfigConfigItem1[];
+}
+export interface SystemRolesDeleteRole1 {
+	name: string;
+}
+export interface SystemRolesList1 {
+	roles: SystemRolesRoleItem1[];
+}
+export interface SystemRolesRoleItem1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface SystemRolesUpsertRole1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface AccountUserCreateFolder1 {
+	userGuid: string;
+	path: string;
+}
+export interface AccountUserCredits1 {
+	userGuid: string;
+	credits: number;
+}
+export interface AccountUserDisplayName1 {
+	userGuid: string;
+	displayName: string;
+}
+export interface AccountUserGuid1 {
+	userGuid: string;
+}
+export interface AccountUserSetCredits1 {
+	userGuid: string;
+	credits: number;
+}
+export interface AccountRoleDeleteRole1 {
+	name: string;
+}
+export interface AccountRoleList1 {
+	roles: AccountRoleRoleItem1[];
+}
+export interface AccountRoleMemberUpdate1 {
+	role: string;
+	userGuid: string;
+}
+export interface AccountRoleMembers1 {
+	members: AccountRoleUserItem1[];
+	nonMembers: AccountRoleUserItem1[];
+}
+export interface AccountRoleRoleItem1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface AccountRoleUpsertRole1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface AccountRoleUserItem1 {
+	guid: string;
+	displayName: string;
+}
+export interface SupportUsersCredits1 {
+	userGuid: string;
+	credits: number;
+}
+export interface SupportUsersDisplayName1 {
+	userGuid: string;
+	displayName: string;
+}
+export interface SupportUsersGuid1 {
+	userGuid: string;
+}
+export interface SupportUsersSetCredits1 {
+	userGuid: string;
+	credits: number;
+}
+export interface SupportRolesMembers1 {
+	members: SupportRolesUserItem1[];
+	nonMembers: SupportRolesUserItem1[];
+}
+export interface SupportRolesRoleMemberUpdate1 {
+	role: string;
+	userGuid: string;
+}
+export interface SupportRolesUserItem1 {
+	guid: string;
+	displayName: string;
+}
+export interface ServiceRoutesDeleteRoute1 {
+	path: string;
+}
+export interface ServiceRoutesList1 {
+	routes: ServiceRoutesRouteItem1[];
+}
+export interface ServiceRoutesRouteItem1 {
+	path: string;
+	name: string;
+	icon: string | null;
+	sequence: number;
+	required_roles: string[];
+}
+export interface ServiceRolesDeleteRole1 {
+	name: string;
+}
+export interface ServiceRolesList1 {
+	roles: ServiceRolesRoleItem1[];
+}
+export interface ServiceRolesRoleItem1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface ServiceRolesUpsertRole1 {
+	name: string;
+	mask: string;
+	display: any;
+}
+export interface DiscordCommandTextUwuResponse1 {
+	message: string;
+}
+export interface UsersProvidersCreateFromProvider1 {
+	provider: string;
+	provider_identifier: string;
+	provider_email: string;
+	provider_displayname: string;
+	provider_profile_image: any;
+}
+export interface UsersProvidersGetByProviderIdentifier1 {
+	provider: string;
+	provider_identifier: string;
+}
+export interface UsersProvidersLinkProvider1 {
+	provider: string;
+	code: any;
+	id_token: any;
+	access_token: any;
+}
+export interface UsersProvidersSetProvider1 {
+	provider: string;
+	code: any;
+	id_token: any;
+	access_token: any;
+}
+export interface UsersProvidersUnlinkProvider1 {
+	provider: string;
+	new_default: any;
+}
+export interface UsersProfileAuthProvider1 {
+	name: string;
+	display: string;
+}
+export interface UsersProfileProfile1 {
+	guid: string;
+	display_name: string;
+	email: string;
+	display_email: boolean;
+	credits: number;
+	profile_image: string | null;
+	default_provider: string;
+	auth_providers: UsersProfileAuthProvider1[];
+}
+export interface UsersProfileRoles1 {
+	roles: number;
+}
+export interface UsersProfileSetDisplay1 {
+	display_name: string;
+}
+export interface UsersProfileSetOptin1 {
+	display_email: boolean;
+}
+export interface UsersProfileSetProfileImage1 {
+	image_b64: string;
+	provider: string;
 }
 
 export async function rpcCall<T>(op: string, payload: any = null): Promise<T> {

--- a/rpc/public/users/models.py
+++ b/rpc/public/users/models.py
@@ -10,6 +10,7 @@ class PublicUsersPublishedFile1(BaseModel):
   path: str
   filename: str
   url: str
+  content_type: Optional[str] = None
 
 class PublicUsersPublishedFiles1(BaseModel):
   files: list[PublicUsersPublishedFile1]

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -913,12 +913,14 @@ def _public_users_get_published_files(args: Dict[str, Any]):
     guid = str(UUID(args["guid"]))
     sql = """
       SELECT
-        element_path AS path,
-        element_filename AS filename,
-        element_url AS url
-      FROM users_storage_cache
-      WHERE users_guid = ? AND element_public = 1 AND element_deleted = 0 AND ISNULL(element_reported,0) = 0
-      ORDER BY element_created_on;
+        usc.element_path AS path,
+        usc.element_filename AS filename,
+        usc.element_url AS url,
+        st.element_mimetype AS content_type
+      FROM users_storage_cache usc
+      JOIN storage_types st ON st.recid = usc.types_recid
+      WHERE usc.users_guid = ? AND usc.element_public = 1 AND usc.element_deleted = 0 AND ISNULL(usc.element_reported,0) = 0
+      ORDER BY usc.element_created_on;
     """
     return (DbRunMode.ROW_MANY, sql, (guid,))
 

--- a/tests/test_public_users_service.py
+++ b/tests/test_public_users_service.py
@@ -40,7 +40,7 @@ class DummyPublicUsersModule:
 
   async def get_published_files(self, guid: str):
     assert guid == '123'
-    return [{'path': '/a', 'filename': 'file.txt', 'url': 'http://example/a/file.txt'}]
+    return [{'path': '/a', 'filename': 'file.txt', 'url': 'http://example/a/file.txt', 'content_type': 'audio/mpeg'}]
 
 app = FastAPI()
 app.state.public_users = DummyPublicUsersModule()
@@ -71,5 +71,5 @@ def test_get_published_files_service():
   assert resp.status_code == 200
   data = resp.json()
   assert data['payload'] == {
-    'files': [{'path': '/a', 'filename': 'file.txt', 'url': 'http://example/a/file.txt'}]
+    'files': [{'path': '/a', 'filename': 'file.txt', 'url': 'http://example/a/file.txt', 'content_type': 'audio/mpeg'}]
   }


### PR DESCRIPTION
## Summary
- show file name on preview cards and de-emphasize profile link
- include content type in public user file API to render audio correctly
- document published files endpoint

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68c45cab408083259d59fab32a3f5669