### PR TITLE
Add Misc tab to system config

### DIFF
--- a/frontend/src/pages/system/SystemConfigPage.tsx
+++ b/frontend/src/pages/system/SystemConfigPage.tsx
@@ -44,6 +44,8 @@ const SystemConfigPage = (): JSX.Element => {
     const [notification, setNotification] = useState(false);
     const [forbidden, setForbidden] = useState(false);
     const [stats, setStats] = useState<SystemStorageStats1 | null>(null);
+    const [newKey, setNewKey] = useState('');
+    const [newValue, setNewValue] = useState('');
 
     const handleNotificationClose = (): void => {
         setNotification(false);
@@ -148,6 +150,7 @@ const SystemConfigPage = (): JSX.Element => {
                 <Tab label="Storage" />
                 <Tab label="Logging" />
                 <Tab label="DevOps" />
+                <Tab label="Misc" />
             </Tabs>
 
             <TabPanel value={tab} index={0}>
@@ -300,6 +303,50 @@ const SystemConfigPage = (): JSX.Element => {
                     />
                     <Typography>Version: {config.Version || ''}</Typography>
                     <Typography>LastVersion: {config.LastVersion || ''}</Typography>
+                </Stack>
+            </TabPanel>
+
+            <TabPanel value={tab} index={4}>
+                <Stack spacing={2} sx={{ maxWidth: 600 }}>
+                    {Object.keys(config)
+                        .sort()
+                        .map((k) => (
+                            <Box key={k} sx={{ display: 'flex', gap: 1 }}>
+                                <TextField label="Key" value={k} disabled sx={{ flex: 1 }} />
+                                <TextField
+                                    label="Value"
+                                    value={config[k] || ''}
+                                    onChange={(e) => save(k, e.target.value)}
+                                    sx={{ flex: 1 }}
+                                />
+                            </Box>
+                        ))}
+                    <Box sx={{ display: 'flex', gap: 1 }}>
+                        <TextField
+                            label="Key"
+                            value={newKey}
+                            onChange={(e) => setNewKey(e.target.value)}
+                            sx={{ flex: 1 }}
+                        />
+                        <TextField
+                            label="Value"
+                            value={newValue}
+                            onChange={(e) => setNewValue(e.target.value)}
+                            sx={{ flex: 1 }}
+                        />
+                        <Button
+                            variant="outlined"
+                            onClick={() => {
+                                if (newKey) {
+                                    void save(newKey, newValue);
+                                    setNewKey('');
+                                    setNewValue('');
+                                }
+                            }}
+                        >
+                            Add
+                        </Button>
+                    </Box>
                 </Stack>
             </TabPanel>
 

--- a/frontend/tests/system-config.test.ts
+++ b/frontend/tests/system-config.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('system config page', () => {
+    it('has Misc tab', () => {
+        const src = readFileSync(
+            join(__dirname, '../src/pages/system/SystemConfigPage.tsx'),
+            'utf8',
+        );
+        expect(src).toMatch(/label="Misc"/);
+    });
+});
+


### PR DESCRIPTION
## Summary
- add Misc tab with raw key/value editor for system config
- cover SystemConfigPage with simple test for Misc tab

## Testing
- `python scripts/generate_rpc_bindings.py`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c48fc78de48325a86e7665ece012ca