### PR TITLE
Implement Discord auth provider

### DIFF
--- a/server/modules/providers/auth/discord_provider/__init__.py
+++ b/server/modules/providers/auth/discord_provider/__init__.py
@@ -1,3 +1,4 @@
+import aiohttp, base64, logging, uuid
 from typing import Any, Dict
 
 from fastapi import HTTPException, status
@@ -5,41 +6,58 @@ from fastapi import HTTPException, status
 from server.modules.providers import AuthProviderBase
 
 
-class DiscordAuthProvider(AuthProviderBase):
-  """Placeholder Discord OAuth provider.
+AUTHORIZE_URL = "https://discord.com/oauth2/authorize"
+TOKEN_URL = "https://discord.com/api/oauth2/token"
+USERINFO_URL = "https://discord.com/api/users/@me"
 
-  This provider will handle Discord's OAuth flow and user profile retrieval
-  once implemented. Discord does not issue an ID token, so verification logic
-  will need to be tailored for access tokens and the Discord API.
-  """
+
+class DiscordAuthProvider(AuthProviderBase):
+  """Discord OAuth provider."""
 
   async def startup(self) -> None:
-    """Initialize any resources required for Discord OAuth.
-
-    TODO: Fetch and cache Discord configuration details if necessary.
-    """
-    return None
+    logging.debug("[DiscordAuthProvider] startup")
 
   async def shutdown(self) -> None:
-    """Clean up any resources allocated during startup."""
-    return None
+    logging.debug("[DiscordAuthProvider] shutdown")
 
   async def verify_id_token(self, id_token: str, access_token: str | None = None) -> Dict[str, Any]:
-    """Discord does not provide JWT ID tokens.
-
-    This method will validate access tokens when the implementation is
-    completed.
-    """
-    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Discord token verification not implemented")
+    token = access_token or id_token
+    headers = {"Authorization": f"Bearer {token}"}
+    async with aiohttp.ClientSession() as session:
+      async with session.get(USERINFO_URL, headers=headers) as resp:
+        if resp.status != 200:
+          detail = await resp.text()
+          raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=detail)
+        return await resp.json()
 
   async def fetch_user_profile(self, access_token: str) -> Dict[str, Any]:
-    """Retrieve the user's Discord profile using the provided access token."""
-    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Discord profile fetch not implemented")
+    headers = {"Authorization": f"Bearer {access_token}"}
+    async with aiohttp.ClientSession() as session:
+      async with session.get(USERINFO_URL, headers=headers) as resp:
+        if resp.status != 200:
+          error = await resp.text()
+          raise HTTPException(status_code=500, detail=f"Failed to fetch user profile: {error}")
+        user = await resp.json()
+      avatar_b64 = None
+      avatar_hash = user.get("avatar")
+      user_id = user.get("id")
+      if avatar_hash and user_id:
+        avatar_url = f"https://cdn.discordapp.com/avatars/{user_id}/{avatar_hash}.png"
+        try:
+          async with session.get(avatar_url) as img_resp:
+            if img_resp.status == 200:
+              avatar_bytes = await img_resp.read()
+              avatar_b64 = base64.b64encode(avatar_bytes).decode("utf-8")
+        except Exception as e:
+          logging.exception("[DiscordAuthProvider] failed to fetch avatar: %s", e)
+    return {
+      "email": user.get("email"),
+      "username": user.get("username"),
+      "profilePicture": avatar_b64,
+    }
 
   def extract_guid(self, payload: Dict[str, Any]) -> str | None:
-    """Return the normalized Discord user identifier.
-
-    TODO: Normalize the 'id' field or any other unique identifier returned by
-    Discord once the payload structure is defined.
-    """
-    return payload.get("id")
+    user_id = payload.get("id")
+    if not user_id:
+      return None
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"discord:{user_id}"))

--- a/tests/test_discord_provider.py
+++ b/tests/test_discord_provider.py
@@ -1,0 +1,111 @@
+import asyncio
+import base64
+import types
+import uuid
+
+from server.modules.providers.auth import discord_provider
+
+
+def test_verify_id_token(monkeypatch):
+  provider = discord_provider.DiscordAuthProvider()
+
+  class DummyResp:
+    def __init__(self, status, data):
+      self.status = status
+      self.data = data
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, *args):
+      pass
+    async def json(self):
+      return self.data
+    async def text(self):
+      if isinstance(self.data, bytes):
+        return self.data.decode()
+      return self.data
+    async def read(self):
+      if isinstance(self.data, str):
+        return self.data.encode()
+      return self.data
+
+  class DummySession:
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, *args):
+      pass
+    def get(self, url, headers=None):
+      assert headers["Authorization"] == "Bearer token"
+      return DummyResp(200, {"id": "123"})
+
+  monkeypatch.setattr(
+    discord_provider,
+    "aiohttp",
+    types.SimpleNamespace(ClientSession=lambda: DummySession()),
+  )
+
+  payload = asyncio.run(provider.verify_id_token("token"))
+  assert payload["id"] == "123"
+
+
+def test_fetch_user_profile_downloads_avatar(monkeypatch):
+  provider = discord_provider.DiscordAuthProvider()
+
+  avatar_bytes = b"avatar"
+
+  class DummyResp:
+    def __init__(self, status, data):
+      self.status = status
+      self.data = data
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, *args):
+      pass
+    async def json(self):
+      return self.data
+    async def text(self):
+      if isinstance(self.data, bytes):
+        return self.data.decode()
+      return self.data
+    async def read(self):
+      if isinstance(self.data, str):
+        return self.data.encode()
+      return self.data
+
+  class DummySession:
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, *args):
+      pass
+    def get(self, url, headers=None):
+      if url == discord_provider.USERINFO_URL:
+        return DummyResp(
+          200,
+          {
+            "id": "123",
+            "email": "user@example.com",
+            "username": "User",
+            "avatar": "hash",
+          },
+        )
+      if url == "https://cdn.discordapp.com/avatars/123/hash.png":
+        return DummyResp(200, avatar_bytes)
+      return DummyResp(404, "")
+
+  monkeypatch.setattr(
+    discord_provider,
+    "aiohttp",
+    types.SimpleNamespace(ClientSession=lambda: DummySession()),
+  )
+
+  profile = asyncio.run(provider.fetch_user_profile("token"))
+  expected = base64.b64encode(avatar_bytes).decode("utf-8")
+  assert profile["profilePicture"] == expected
+  assert profile["email"] == "user@example.com"
+  assert profile["username"] == "User"
+
+
+def test_extract_guid():
+  provider = discord_provider.DiscordAuthProvider()
+  payload = {"id": "42"}
+  expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "discord:42"))
+  assert provider.extract_guid(payload) == expected


### PR DESCRIPTION
## Summary
- add Discord OAuth constants and fetch profile with avatar image
- verify access tokens via Discord API and derive stable GUIDs
- cover Discord provider with unit tests

## Testing
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4a2e7383483259cba7d2df3f5707b