### PR TITLE
feat(oauth): add provider-based token exchange

### DIFF
--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -68,7 +68,10 @@ async def auth_google_oauth_login_v1(request: Request):
     client_id,
     client_secret,
     redirect_uri,
+    provider,
   )
+  if not id_token:
+    raise HTTPException(status_code=400, detail="Missing id_token")
 
   provider_uid, profile, payload = await auth.handle_auth_login(
     provider, id_token, access_token

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -52,7 +52,10 @@ async def users_providers_set_provider_v1(request: Request):
           client_id,
           client_secret,
           redirect_uri,
+          payload.provider,
         )
+        if not id_token:
+          raise HTTPException(status_code=400, detail="Missing id_token")
       else:
         id_token, access_token = payload.id_token, payload.access_token
     elif payload.provider == "microsoft":
@@ -74,8 +77,10 @@ async def users_providers_set_provider_v1(request: Request):
           client_id,
           client_secret,
           redirect_uri,
-          token_endpoint=oauth.TOKEN_ENDPOINTS["microsoft"],
+          payload.provider,
         )
+        if not id_token:
+          raise HTTPException(status_code=400, detail="Missing id_token")
       else:
         if not payload.id_token or not payload.access_token:
           raise HTTPException(status_code=400, detail="id_token and access_token required")
@@ -134,7 +139,10 @@ async def users_providers_link_provider_v1(request: Request):
       client_id,
       client_secret,
       redirect_uri,
+      payload.provider,
     )
+    if not id_token:
+      raise HTTPException(status_code=400, detail="Missing id_token")
   elif payload.provider == "microsoft":
     ms_provider = getattr(auth, "providers", {}).get("microsoft")
     if not ms_provider or not ms_provider.audience:
@@ -154,8 +162,10 @@ async def users_providers_link_provider_v1(request: Request):
         client_id,
         client_secret,
         redirect_uri,
-        token_endpoint=oauth.TOKEN_ENDPOINTS["microsoft"],
+        payload.provider,
       )
+      if not id_token:
+        raise HTTPException(status_code=400, detail="Missing id_token")
     else:
       if not payload.id_token or not payload.access_token:
         raise HTTPException(status_code=400, detail="id_token and access_token required")

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -144,7 +144,8 @@ def test_email_exists_prompt(monkeypatch):
   )
   svc_mod = importlib.util.module_from_spec(svc_spec)
   svc_spec.loader.exec_module(svc_mod)
-  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri, provider):
+    assert provider == "google"
     assert code == "auth-code"
     assert redirect_uri == "http://localhost:8000/userpage"
     return "id", "acc"
@@ -213,7 +214,8 @@ def test_email_exists_confirm_links(monkeypatch):
   )
   svc_mod = importlib.util.module_from_spec(svc_spec)
   svc_spec.loader.exec_module(svc_mod)
-  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri, provider):
+    assert provider == "google"
     assert code == "auth-code"
     assert redirect_uri == "http://localhost:8000/userpage"
     return "id", "acc"

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -136,7 +136,8 @@ def test_lookup_existing_user(monkeypatch):
   )
   svc_mod = importlib.util.module_from_spec(svc_spec)
   svc_spec.loader.exec_module(svc_mod)
-  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri, provider):
+    assert provider == "google"
     assert code == "auth-code"
     assert redirect_uri == "http://localhost:8000/userpage"
     return "id", "acc"

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -142,7 +142,8 @@ def test_fetch_user_after_create(monkeypatch):
   )
   svc_mod = importlib.util.module_from_spec(svc_spec)
   svc_spec.loader.exec_module(svc_mod)
-  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri, provider):
+    assert provider == "google"
     assert code == "auth-code"
     assert redirect_uri == "http://localhost:8000/userpage"
     return "id", "acc"

--- a/tests/test_auth_google_profile_image_update.py
+++ b/tests/test_auth_google_profile_image_update.py
@@ -137,7 +137,8 @@ def test_updates_profile_image(monkeypatch):
   svc_spec = importlib.util.spec_from_file_location("rpc.auth.google.services", "rpc/auth/google/services.py")
   svc_mod = importlib.util.module_from_spec(svc_spec)
   svc_spec.loader.exec_module(svc_mod)
-  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri, provider):
+    assert provider == "google"
     assert code == "auth-code"
     assert redirect_uri == "http://localhost:8000/userpage"
     return "id", "acc"

--- a/tests/test_auth_google_profile_refresh.py
+++ b/tests/test_auth_google_profile_refresh.py
@@ -123,7 +123,8 @@ def setup_module(mod):
   svc_spec = importlib.util.spec_from_file_location("rpc.auth.google.services", "rpc/auth/google/services.py")
   svc_mod = importlib.util.module_from_spec(svc_spec)
   svc_spec.loader.exec_module(svc_mod)
-  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri, provider):
+    assert provider == "google"
     assert code == "auth-code"
     assert redirect_uri == "http://localhost:8000/userpage"
     return "id", "acc"

--- a/tests/test_auth_google_relink_unlinked.py
+++ b/tests/test_auth_google_relink_unlinked.py
@@ -132,7 +132,8 @@ def test_relinks_unlinked_account(monkeypatch):
   svc_spec = importlib.util.spec_from_file_location("rpc.auth.google.services", "rpc/auth/google/services.py")
   svc_mod = importlib.util.module_from_spec(svc_spec)
   svc_spec.loader.exec_module(svc_mod)
-  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri, provider):
+    assert provider == "google"
     assert code == "auth-code"
     assert redirect_uri == "http://localhost:8000/userpage"
     return "id", "acc"

--- a/tests/test_auth_google_soft_undelete.py
+++ b/tests/test_auth_google_soft_undelete.py
@@ -166,7 +166,8 @@ def test_undeletes_soft_deleted_account(monkeypatch):
   svc_mod = importlib.util.module_from_spec(svc_spec)
   svc_spec.loader.exec_module(svc_mod)
 
-  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri, provider):
+    assert provider == "google"
     assert code == "auth-code"
     assert redirect_uri == "http://localhost:8000/userpage"
     return "id", "acc"

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -153,7 +153,8 @@ def test_link_provider_google_normalizes_identifier():
     return rpc, SimpleNamespace(user_guid="u1"), None
   svc_mod.unbox_request = fake_get
 
-  async def fake_exchange(code, client_id, client_secret, redirect_uri):
+  async def fake_exchange(code, client_id, client_secret, redirect_uri, provider):
+    assert provider == "google"
     return "id", "acc"
 
   class DummyAuth:


### PR DESCRIPTION
## Summary
- support Discord token endpoint and provider-based lookup
- allow missing id_token from token exchange
- update Google/Microsoft auth flows to validate optional id_token

## Testing
- `python scripts/generate_rpc_bindings.py`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run type-check`
- `npm --prefix frontend test`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4bc025af48325a1e71d8c81be3322