### PR TITLE
Support auth providers without ID tokens

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -179,7 +179,7 @@ class AuthModule(BaseModule):
     if not strategy:
       logging.error("[AuthModule] Unsupported auth provider %s", provider)
       raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported auth provider")
-    if not id_token or not access_token:
+    if not access_token or (getattr(strategy, "requires_id_token", True) and not id_token):
       logging.error("[AuthModule] Missing credentials for provider %s", provider)
       raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing credentials")
     payload = await strategy.verify_id_token(id_token, access_token)

--- a/server/modules/providers/__init__.py
+++ b/server/modules/providers/__init__.py
@@ -52,8 +52,10 @@ class LifecycleProvider(BaseProvider):
 
 
 class AuthProviderBase(LifecycleProvider):
+  requires_id_token = True
+
   @abstractmethod
-  async def verify_id_token(self, id_token: str, access_token: str | None = None) -> Dict[str, Any]: ...
+  async def verify_id_token(self, id_token: str | None, access_token: str | None = None) -> Dict[str, Any]: ...
 
   @abstractmethod
   async def fetch_user_profile(self, access_token: str) -> Dict[str, Any]: ...
@@ -104,7 +106,9 @@ class AuthProvider(AuthProviderBase):
       logging.debug("[AuthProvider] Using cached JWKS")
     return self._jwks
 
-  async def verify_id_token(self, id_token: str, access_token: str | None = None) -> Dict[str, Any]:
+  async def verify_id_token(self, id_token: str | None, access_token: str | None = None) -> Dict[str, Any]:
+    if not id_token:
+      raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid ID token.")
     logging.debug("[AuthProvider] Verifying ID token %s", id_token[:40])
     jwks = await self._get_jwks()
     try:

--- a/server/modules/providers/auth/discord_provider/__init__.py
+++ b/server/modules/providers/auth/discord_provider/__init__.py
@@ -6,6 +6,7 @@ from server.modules.providers import AuthProviderBase
 
 
 class DiscordAuthProvider(AuthProviderBase):
+  requires_id_token = False
   """Placeholder Discord OAuth provider.
 
   This provider will handle Discord's OAuth flow and user profile retrieval

--- a/server/modules/providers/auth/google_provider/__init__.py
+++ b/server/modules/providers/auth/google_provider/__init__.py
@@ -25,6 +25,8 @@ async def _fetch_openid_config() -> Dict[str, Any]:
 
 
 class GoogleAuthProvider(AuthProvider):
+  requires_id_token = True
+
   def __init__(self, *, api_id: str, jwks_uri: str, jwks_expiry: timedelta):
     super().__init__(audience=api_id, issuer=GOOGLE_ISSUER, jwks_uri=jwks_uri, jwks_expiry=jwks_expiry)
     self.userinfo_endpoint: str | None = None

--- a/server/modules/providers/auth/microsoft_provider/__init__.py
+++ b/server/modules/providers/auth/microsoft_provider/__init__.py
@@ -23,6 +23,8 @@ async def _fetch_openid_config() -> Dict[str, Any]:
       return config
 
 class MicrosoftAuthProvider(AuthProvider):
+  requires_id_token = True
+
   def __init__(self, *, api_id: str, jwks_uri: str, jwks_expiry: timedelta):
     super().__init__(audience=api_id, issuer=MICROSOFT_ISSUER, jwks_uri=jwks_uri, jwks_expiry=jwks_expiry)
 

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -163,6 +163,30 @@ def test_handle_auth_login_selects_provider():
   assert module.providers["a"].called is False
 
 
+def test_handle_auth_login_allows_missing_id_token():
+  app = FastAPI()
+  module = AuthModule(app)
+
+  class FakeProvider:
+    requires_id_token = False
+
+    async def verify_id_token(self, token, access_token):
+      return {"sub": "xyz"}
+
+    async def fetch_user_profile(self, token):
+      return {"email": "user@example.com", "username": "User"}
+
+    def extract_guid(self, payload):
+      return payload.get("sub")
+
+  module.providers["discord"] = FakeProvider()
+
+  guid, profile, payload = asyncio.run(module.handle_auth_login("discord", None, "access"))
+  assert guid == "xyz"
+  assert profile["username"] == "User"
+  assert payload["sub"] == "xyz"
+
+
 def test_jwks_refresh_failure(monkeypatch):
   provider = MicrosoftAuthProvider(api_id="api", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
 


### PR DESCRIPTION
## Summary
- Allow auth providers to skip ID token when not required
- Expose optional `requires_id_token` flag on providers
- Cover login without ID token in tests

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68c4acb4c5188325b3653cc6b0f29e07