### PR TITLE
Add Discord client ID system config field

### DIFF
--- a/frontend/src/pages/system/SystemConfigPage.tsx
+++ b/frontend/src/pages/system/SystemConfigPage.tsx
@@ -99,6 +99,9 @@ const SystemConfigPage = (): JSX.Element => {
                     err = 'Should end with .apps.googleusercontent.com';
                 }
                 break;
+            case 'DiscordClientId':
+                if (!value.trim()) err = 'Required.';
+                break;
             case 'JwksCacheTime':
                 if (Number.isNaN(Number(value)) || Number(value) < 60) {
                     err = 'Must be >= 60.';
@@ -212,6 +215,13 @@ const SystemConfigPage = (): JSX.Element => {
                         onChange={(e) => save('GoogleClientId', e.target.value)}
                         error={Boolean(errors.GoogleClientId)}
                         helperText={errors.GoogleClientId}
+                    />
+                    <TextField
+                        label="DiscordClientId"
+                        value={config.DiscordClientId || ''}
+                        onChange={(e) => save('DiscordClientId', e.target.value)}
+                        error={Boolean(errors.DiscordClientId)}
+                        helperText={errors.DiscordClientId}
                     />
                     <TextField
                         label="JwksCacheTime"


### PR DESCRIPTION
## Summary
- allow configuring DiscordClientId in system Auth tab
- validate DiscordClientId is not empty before saving

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5cc7c83c083259ec356b562ef118a