### PR TITLE
fix: ensure Discord auth URL matches system

### DIFF
--- a/frontend/src/config/discord.ts
+++ b/frontend/src/config/discord.ts
@@ -4,4 +4,8 @@ export const discordConfig = {
         redirectUri: `${window.location.origin}`,
         authorizeEndpoint: 'https://discord.com/oauth2/authorize',
 };
+
+export const getDiscordAuthorizeUrl = (): string => {
+        return `${discordConfig.authorizeEndpoint}?response_type=code&client_id=${discordConfig.clientId}&scope=${encodeURIComponent(discordConfig.scope)}&redirect_uri=${encodeURIComponent(discordConfig.redirectUri)}`;
+};
 export default discordConfig;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { PublicClientApplication } from '@azure/msal-browser';
 import { msalConfig, loginRequest } from '../config/msal';
 import googleConfig from '../config/google';
-import discordConfig from '../config/discord';
+import { getDiscordAuthorizeUrl } from '../config/discord';
 import UserContext from '../shared/UserContext';
 import Notification from '../components/Notification';
 import { fetchOauthLogin as fetchMicrosoftOauthLogin } from '../rpc/auth/microsoft';
@@ -60,7 +60,7 @@ const LoginPage = (): JSX.Element => {
 
         const handleDiscordLogin = async (): Promise<void> => {
                 try {
-                        const authorizeUrl = `${discordConfig.authorizeEndpoint}?response_type=code&client_id=${encodeURIComponent(discordConfig.clientId)}&scope=${encodeURIComponent(discordConfig.scope)}&redirect_uri=${encodeURIComponent(discordConfig.redirectUri)}`;
+                        const authorizeUrl = getDiscordAuthorizeUrl();
                         const authWindow = window.open(authorizeUrl, 'discordOAuth', 'width=500,height=600');
                         if (!authWindow) throw new Error('Failed to open Discord login window');
                         const code = await new Promise<string>((resolve, reject) => {

--- a/frontend/src/pages/UserPage.tsx
+++ b/frontend/src/pages/UserPage.tsx
@@ -24,7 +24,7 @@ import {
     fetchUnlinkProvider
 } from "../rpc/users/providers";
 import googleConfig from "../config/google";
-import discordConfig from "../config/discord";
+import { getDiscordAuthorizeUrl } from "../config/discord";
 import { msalConfig, loginRequest } from "../config/msal";
 import EditBox from "../components/EditBox";
 
@@ -121,7 +121,7 @@ const UserPage = (): JSX.Element => {
                 });
                 await fetchSetProvider({ provider: next, code });
             } else if (next === "discord") {
-                const authorizeUrl = `${discordConfig.authorizeEndpoint}?response_type=code&client_id=${encodeURIComponent(discordConfig.clientId)}&scope=${encodeURIComponent(discordConfig.scope)}&redirect_uri=${encodeURIComponent(discordConfig.redirectUri)}`;
+                const authorizeUrl = getDiscordAuthorizeUrl();
                 const authWindow = window.open(authorizeUrl, "discordOAuth", "width=500,height=600");
                 if (!authWindow) throw new Error("Failed to open Discord login window");
                 const code = await new Promise<string>((resolve, reject) => {
@@ -228,7 +228,7 @@ const UserPage = (): JSX.Element => {
         console.debug("[UserPage] authorization code received", code);
         await fetchLinkProvider({ provider: name, code });
       } else if (name === "discord") {
-        const authorizeUrl = `${discordConfig.authorizeEndpoint}?response_type=code&client_id=${encodeURIComponent(discordConfig.clientId)}&scope=${encodeURIComponent(discordConfig.scope)}&redirect_uri=${encodeURIComponent(discordConfig.redirectUri)}`;
+        const authorizeUrl = getDiscordAuthorizeUrl();
         const authWindow = window.open(authorizeUrl, "discordOAuth", "width=500,height=600");
         if (!authWindow) throw new Error("Failed to open Discord login window");
         const code = await new Promise<string>((resolve, reject) => {


### PR DESCRIPTION
## Summary
- centralize Discord authorize URL generation with proper encoding
- update login and user flows to use new helper

## Testing
- `python scripts/generate_rpc_client.py`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5f8e008d883258927bb0b6f11dc11