### PR TITLE
Load Discord OAuth client ID

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -157,7 +157,9 @@ class AuthModule(BaseModule):
         logging.debug("[AuthModule] Google provider ready")
       if "discord" in providers_cfg:
         logging.debug("[AuthModule] Loading Discord provider")
-        provider = DiscordAuthProvider()
+        discord_client_id = await self.db.get_discord_client_id()
+        logging.debug("[AuthModule] DiscordClientId=%s", discord_client_id)
+        provider = DiscordAuthProvider(audience=discord_client_id)
         await provider.startup()
         self.providers["discord"] = provider
         logging.debug("[AuthModule] Discord provider ready")

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -92,6 +92,14 @@ class DbModule(BaseModule):
       raise ValueError("Missing config value for key: GoogleClientId")
     return value
 
+  async def get_discord_client_id(self) -> str:
+    res = await self.run("db:system:config:get_config:1", {"key": "DiscordClientId"})
+    value = res.rows[0]["value"] if res.rows else None
+    logging.debug("[DbModule] DiscordClientId=%s", value)
+    if not value:
+      raise ValueError("Missing config value for key: DiscordClientId")
+    return value
+
   async def get_google_api_secret(self) -> str:
     # Refactored: read Google OAuth client secret from environment
     env: EnvModule = self.app.state.env

--- a/server/modules/providers/auth/discord_provider/__init__.py
+++ b/server/modules/providers/auth/discord_provider/__init__.py
@@ -14,6 +14,10 @@ class DiscordAuthProvider(AuthProviderBase):
   """Discord OAuth provider."""
   requires_id_token = False
 
+  def __init__(self, *, audience: str | None = None):
+    super().__init__()
+    self.audience = audience
+
   async def startup(self) -> None:
     logging.debug("[DiscordAuthProvider] startup")
 

--- a/tests/test_db_module_api_ids.py
+++ b/tests/test_db_module_api_ids.py
@@ -18,6 +18,19 @@ def test_get_google_client_id():
   assert asyncio.run(db.get_google_client_id()) == "gid"
 
 
+def test_get_discord_client_id():
+  app = FastAPI()
+  db = DbModule(app)
+
+  async def fake_run(op, args):
+    assert op == "db:system:config:get_config:1"
+    assert args == {"key": "DiscordClientId"}
+    return DBResult(rows=[{"value": "did"}], rowcount=1)
+
+  db.run = fake_run
+  assert asyncio.run(db.get_discord_client_id()) == "did"
+
+
 def test_get_google_api_secret():
   app = FastAPI()
   db = DbModule(app)


### PR DESCRIPTION
## Summary
- fetch Discord OAuth client ID from config
- initialize Discord auth provider with client ID
- cover database helper with new test

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68c627c319ac8325bb2ca2c62ec1b184