### PR TITLE
Load Discord OAuth client ID from config

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -157,7 +157,10 @@ class AuthModule(BaseModule):
         logging.debug("[AuthModule] Google provider ready")
       if "discord" in providers_cfg:
         logging.debug("[AuthModule] Loading Discord provider")
+        discord_client_id = await self.db.get_discord_client_id()
+        logging.debug("[AuthModule] DiscordClientId=%s", discord_client_id)
         provider = DiscordAuthProvider()
+        provider.audience = discord_client_id
         await provider.startup()
         self.providers["discord"] = provider
         logging.debug("[AuthModule] Discord provider ready")

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -101,6 +101,14 @@ class DbModule(BaseModule):
       raise ValueError("Missing env value for key: GOOGLE_AUTH_SECRET")
     return value
 
+  async def get_discord_client_id(self) -> str:
+    res = await self.run("db:system:config:get_config:1", {"key": "DiscordClientId"})
+    value = res.rows[0]["value"] if res.rows else None
+    logging.debug("[DbModule] DiscordClientId=%s", value)
+    if not value:
+      raise ValueError("Missing config value for key: DiscordClientId")
+    return value
+
   async def get_auth_providers(self) -> list[str]:
     res = await self.run("db:system:config:get_config:1", {"key": "AuthProviders"})
     value = res.rows[0]["value"] if res.rows else None

--- a/tests/test_db_module_api_ids.py
+++ b/tests/test_db_module_api_ids.py
@@ -31,6 +31,19 @@ def test_get_google_api_secret():
   assert asyncio.run(db.get_google_api_secret()) == "gsecret"
 
 
+def test_get_discord_client_id():
+  app = FastAPI()
+  db = DbModule(app)
+
+  async def fake_run(op, args):
+    assert op == "db:system:config:get_config:1"
+    assert args == {"key": "DiscordClientId"}
+    return DBResult(rows=[{"value": "dcid"}], rowcount=1)
+
+  db.run = fake_run
+  assert asyncio.run(db.get_discord_client_id()) == "dcid"
+
+
 def test_get_ms_api_id():
   app = FastAPI()
   db = DbModule(app)


### PR DESCRIPTION
## Summary
- load Discord OAuth client ID from system config
- expose Discord client ID via `AuthModule` to avoid runtime errors
- cover Discord config with unit tests

## Testing
- `python scripts/generate_rpc_bindings.py`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c627c319ac8325bb2ca2c62ec1b184