### PR TITLE
Add Discord get_roles RPC with Discord ID authentication

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -234,6 +234,7 @@ All Moderation domain calls require `ROLE_MODERATOR`.
 ## Discord Domain
 
 All Discord domain calls require `ROLE_DISCORD_BOT`.
+Requests must include the `x-discord-id` header identifying the caller.
 
 Currently exposes placeholder Discord command operations.
 
@@ -242,4 +243,5 @@ Currently exposes placeholder Discord command operations.
 | Operation                                | Description                      |
 | ---------------------------------------- | -------------------------------- |
 | `urn:discord:command:text_uwu:1`         | Stub command returning "uwu" text. |
+| `urn:discord:command:get_roles:1`        | List security roles for a Discord user. |
 

--- a/rpc/discord/command/__init__.py
+++ b/rpc/discord/command/__init__.py
@@ -1,6 +1,10 @@
-from .services import discord_command_text_uwu_v1
+from .services import (
+  discord_command_text_uwu_v1,
+  discord_command_get_roles_v1,
+)
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("text_uwu", "1"): discord_command_text_uwu_v1,
+  ("get_roles", "1"): discord_command_get_roles_v1,
 }
 

--- a/rpc/discord/command/models.py
+++ b/rpc/discord/command/models.py
@@ -4,3 +4,7 @@ from pydantic import BaseModel
 class DiscordCommandTextUwuResponse1(BaseModel):
   message: str
 
+
+class DiscordCommandGetRolesResponse1(BaseModel):
+  roles: list[str]
+

--- a/rpc/discord/command/services.py
+++ b/rpc/discord/command/services.py
@@ -3,12 +3,25 @@ from fastapi import Request
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
 
-from .models import DiscordCommandTextUwuResponse1
+from .models import (
+  DiscordCommandTextUwuResponse1,
+  DiscordCommandGetRolesResponse1,
+)
 
 
 async def discord_command_text_uwu_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   payload = DiscordCommandTextUwuResponse1(message='uwu')
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def discord_command_get_roles_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  payload = DiscordCommandGetRolesResponse1(roles=auth_ctx.roles)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),

--- a/tests/test_discord_command_get_roles_service.py
+++ b/tests/test_discord_command_get_roles_service.py
@@ -1,0 +1,57 @@
+import importlib.util
+import pathlib
+import sys
+import types
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+# Stub rpc package to avoid side effects from rpc.__init__
+pkg = types.ModuleType('rpc')
+pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc')]
+sys.modules.setdefault('rpc', pkg)
+
+# Load server models
+def _load_models():
+  spec = importlib.util.spec_from_file_location(
+    'server.models', pathlib.Path(__file__).resolve().parent.parent / 'server/models.py'
+  )
+  mod = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(mod)
+  sys.modules['server.models'] = mod
+  return mod
+
+models = _load_models()
+RPCRequest = models.RPCRequest
+AuthContext = models.AuthContext
+
+from rpc.discord.command import services as discord_services
+
+app = FastAPI()
+
+
+@app.post('/rpc')
+async def rpc_endpoint(request: Request):
+  return await discord_services.discord_command_get_roles_v1(request)
+
+
+client = TestClient(app)
+
+
+def test_discord_command_get_roles_service():
+  async def _stub_unbox_request(request):
+    return (
+      RPCRequest(op='urn:discord:command:get_roles:1'),
+      AuthContext(user_guid='u1', roles=['ROLE_STORAGE'], role_mask=0x2),
+      [],
+    )
+
+  original = discord_services.unbox_request
+  discord_services.unbox_request = _stub_unbox_request
+  try:
+    resp = client.post('/rpc', json={'op': 'urn:discord:command:get_roles:1'})
+  finally:
+    discord_services.unbox_request = original
+  assert resp.status_code == 200
+  data = resp.json()
+  assert data['op'] == 'urn:discord:command:get_roles:1'
+  assert data['payload'] == {'roles': ['ROLE_STORAGE']}

--- a/tests/test_discord_unbox_request.py
+++ b/tests/test_discord_unbox_request.py
@@ -1,0 +1,61 @@
+import importlib
+import importlib.util
+import pathlib
+import sys
+import types
+import uuid
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+# Stub rpc package
+pkg = types.ModuleType('rpc')
+pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc')]
+sys.modules.setdefault('rpc', pkg)
+
+# Load server models
+spec = importlib.util.spec_from_file_location(
+  'server.models', pathlib.Path(__file__).resolve().parent.parent / 'server/models.py'
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+sys.modules['server.models'] = mod
+
+# Stub auth module
+modules_pkg = types.ModuleType('server.modules')
+sys.modules.setdefault('server.modules', modules_pkg)
+auth_module_pkg = types.ModuleType('server.modules.auth_module')
+class AuthModule:
+  def __init__(self):
+    self.roles = {"ROLE_REGISTERED": 0x1}
+    self.role_registered = 0x1
+  async def get_user_roles(self, guid: str):
+    return (["ROLE_REGISTERED"], 0x1)
+auth_module_pkg.AuthModule = AuthModule
+modules_pkg.auth_module = auth_module_pkg
+sys.modules['server.modules.auth_module'] = auth_module_pkg
+
+
+def test_unbox_request_with_discord_id():
+  if 'rpc.helpers' in sys.modules:
+    del sys.modules['rpc.helpers']
+  helpers = importlib.import_module('rpc.helpers')
+
+  app = FastAPI()
+  app.state.auth = AuthModule()
+
+  @app.post('/rpc')
+  async def endpoint(request: Request):
+    rpc_request, auth_ctx, _ = await helpers.unbox_request(request)
+    return {'user_guid': rpc_request.user_guid, 'roles': auth_ctx.roles}
+
+  client = TestClient(app)
+  resp = client.post(
+    '/rpc',
+    json={'op': 'urn:discord:command:get_roles:1'},
+    headers={'x-discord-id': '42'}
+  )
+  assert resp.status_code == 200
+  data = resp.json()
+  expected_guid = str(uuid.uuid5(uuid.NAMESPACE_URL, 'discord:42'))
+  assert data['user_guid'] == expected_guid
+  assert data['roles'] == ['ROLE_REGISTERED']


### PR DESCRIPTION
## Summary
- allow Discord RPC requests to resolve user from `x-discord-id`
- add `urn:discord:command:get_roles:1` to list a user's security roles
- document Discord ID header requirement and add tests

## Testing
- `python scripts/generate_rpc_bindings.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6b5069ad08325bcf54bc973eec6d5