### PR TITLE
Accept alternate Discord user ID header

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -234,7 +234,7 @@ All Moderation domain calls require `ROLE_MODERATOR`.
 ## Discord Domain
 
 All Discord domain calls require `ROLE_DISCORD_BOT`.
-Requests must include the `x-discord-id` header identifying the caller.
+Requests must include the `x-discord-id` (or `x-discord-user-id`) header identifying the caller.
 
 Currently exposes placeholder Discord command operations.
 

--- a/rpc/helpers.py
+++ b/rpc/helpers.py
@@ -30,7 +30,7 @@ def _get_token_from_request(request: Request) -> str | None:
   return header.split(' ', 1)[1].strip()
 
 def _get_discord_id_from_request(request: Request) -> str | None:
-  return request.headers.get('x-discord-id')
+  return request.headers.get('x-discord-id') or request.headers.get('x-discord-user-id')
 
 async def _process_rpcrequest(request: Request) -> tuple[RPCRequest, AuthContext]:
   body = await request.json()

--- a/tests/test_discord_unbox_request.py
+++ b/tests/test_discord_unbox_request.py
@@ -59,3 +59,29 @@ def test_unbox_request_with_discord_id():
   expected_guid = str(uuid.uuid5(uuid.NAMESPACE_URL, 'discord:42'))
   assert data['user_guid'] == expected_guid
   assert data['roles'] == ['ROLE_REGISTERED']
+
+
+def test_unbox_request_with_discord_user_id():
+  if 'rpc.helpers' in sys.modules:
+    del sys.modules['rpc.helpers']
+  helpers = importlib.import_module('rpc.helpers')
+
+  app = FastAPI()
+  app.state.auth = AuthModule()
+
+  @app.post('/rpc')
+  async def endpoint(request: Request):
+    rpc_request, auth_ctx, _ = await helpers.unbox_request(request)
+    return {'user_guid': rpc_request.user_guid, 'roles': auth_ctx.roles}
+
+  client = TestClient(app)
+  resp = client.post(
+    '/rpc',
+    json={'op': 'urn:discord:command:get_roles:1'},
+    headers={'x-discord-user-id': '99'}
+  )
+  assert resp.status_code == 200
+  data = resp.json()
+  expected_guid = str(uuid.uuid5(uuid.NAMESPACE_URL, 'discord:99'))
+  assert data['user_guid'] == expected_guid
+  assert data['roles'] == ['ROLE_REGISTERED']


### PR DESCRIPTION
## Summary
- allow Discord RPC requests to use either `x-discord-id` or `x-discord-user-id`
- document supported Discord user ID headers
- test unbox_request with `x-discord-user-id`

## Testing
- `python scripts/run_tests.py` *(fails: KeyboardInterrupt while running npm lint)*
- `pytest -q tests/test_discord_unbox_request.py tests/test_discord_command_get_roles_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6bbd4dea88325a95455efec7e1bae