### PR TITLE
feat: clarify Discord role requirement

### DIFF
--- a/rpc/discord/handler.py
+++ b/rpc/discord/handler.py
@@ -17,7 +17,10 @@ async def handle_discord_request(parts: list[str], request: Request) -> RPCRespo
   auth: AuthModule = request.app.state.auth
   required_mask = auth.roles.get("ROLE_DISCORD_BOT", 0)
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
-    raise HTTPException(status_code=403, detail='Forbidden')
+    raise HTTPException(
+      status_code=403,
+      detail='You must have the Discord bot role assigned to use this bot.'
+    )
 
   subdomain = parts[0]
   handler = HANDLERS.get(subdomain)

--- a/tests/test_discord_handler.py
+++ b/tests/test_discord_handler.py
@@ -67,6 +67,11 @@ def test_discord_handler_rejects_missing_role():
   client = _get_client(False)
   resp = client.post('/rpc', json={'op': 'urn:discord:command:text_uwu:1'})
   assert resp.status_code == 403
+  data = resp.json()
+  assert (
+    data['detail']
+    == 'You must have the Discord bot role assigned to use this bot.'
+  )
 
 def test_discord_handler_allows_role():
   client = _get_client(True)


### PR DESCRIPTION
## Summary
- show friendly message when Discord bot role is missing
- test Discord handler returns descriptive message

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6e8ad200c8325806c31ce587ba174