### PR TITLE
Add Discord chat RPC endpoints

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -245,3 +245,10 @@ Currently exposes placeholder Discord command operations.
 | `urn:discord:command:text_uwu:1`         | Stub command returning "uwu" text. |
 | `urn:discord:command:get_roles:1`        | List security roles for a Discord user. |
 
+
+### `chat`
+
+| Operation                                   | Description                     |
+| ------------------------------------------- | ------------------------------- |
+| `urn:discord:chat:summarize_channel:1`      | Summarize a Discord channel.    |
+| `urn:discord:chat:uwu_chat:1`               | Stub chat returning "uwu" text. |

--- a/rpc/discord/__init__.py
+++ b/rpc/discord/__init__.py
@@ -3,8 +3,10 @@
 Requires ROLE_DISCORD_BOT.
 """
 
+from .chat.handler import handle_chat_request
 from .command.handler import handle_command_request
 
 HANDLERS: dict[str, callable] = {
+  "chat": handle_chat_request,
   "command": handle_command_request,
 }

--- a/rpc/discord/chat/__init__.py
+++ b/rpc/discord/chat/__init__.py
@@ -1,0 +1,9 @@
+from .services import (
+  discord_chat_summarize_channel_v1,
+  discord_chat_uwu_chat_v1,
+)
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("summarize_channel", "1"): discord_chat_summarize_channel_v1,
+  ("uwu_chat", "1"): discord_chat_uwu_chat_v1,
+}

--- a/rpc/discord/chat/handler.py
+++ b/rpc/discord/chat/handler.py
@@ -1,0 +1,15 @@
+"""Discord chat RPC handler."""
+
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_chat_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/discord/chat/models.py
+++ b/rpc/discord/chat/models.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+
+
+class DiscordChatSummarizeChannelRequest1(BaseModel):
+  channel_id: str
+
+
+class DiscordChatSummarizeChannelResponse1(BaseModel):
+  summary: str
+
+
+class DiscordChatUwuChatRequest1(BaseModel):
+  message: str
+
+
+class DiscordChatUwuChatResponse1(BaseModel):
+  message: str

--- a/rpc/discord/chat/services.py
+++ b/rpc/discord/chat/services.py
@@ -1,0 +1,35 @@
+from fastapi import Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+
+from .models import (
+  DiscordChatSummarizeChannelRequest1,
+  DiscordChatSummarizeChannelResponse1,
+  DiscordChatUwuChatRequest1,
+  DiscordChatUwuChatResponse1,
+)
+
+
+async def discord_chat_summarize_channel_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  req = DiscordChatSummarizeChannelRequest1(**(rpc_request.payload or {}))
+  payload = DiscordChatSummarizeChannelResponse1(
+    summary=f"Summary for {req.channel_id}"
+  )
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def discord_chat_uwu_chat_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  req = DiscordChatUwuChatRequest1(**(rpc_request.payload or {}))
+  payload = DiscordChatUwuChatResponse1(message=f"uwu {req.message}")
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )


### PR DESCRIPTION
## Summary
- implement Discord chat RPC services for channel summarization and uwu chat
- register chat handler in discord namespace
- document new chat URNs

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68c6f5a8a55c832580bdc61ab348c145