### PR TITLE
feat: add discord chat module

### DIFF
--- a/tests/test_discord_chat_module.py
+++ b/tests/test_discord_chat_module.py
@@ -1,0 +1,42 @@
+import asyncio
+import pytest
+from fastapi import FastAPI
+from types import SimpleNamespace
+
+from server.modules.discord_chat_module import DiscordChatModule
+
+
+def test_summarize_channel(monkeypatch):
+  app = FastAPI()
+  app.state.discord = SimpleNamespace(on_ready=lambda: None)
+  module = DiscordChatModule(app)
+
+  async def dummy_fetch(guild_id, channel_id, hours, max_messages=5000):
+    msg = SimpleNamespace(content="hello", author=SimpleNamespace(name="Alice"))
+    return [msg]
+
+  module.fetch_channel_history_backwards = dummy_fetch  # type: ignore
+
+  res = asyncio.run(module.summarize_channel(1, 2, 1))
+  assert res["messages_collected"] == 1
+  assert "Alice: hello" in res["raw_text_blob"]
+
+
+def test_uwu_chat(monkeypatch):
+  app = FastAPI()
+  app.state.discord = SimpleNamespace(on_ready=lambda: None)
+  module = DiscordChatModule(app)
+
+  async def dummy_summarize(guild_id, channel_id, hours, max_messages=5000):
+    return {
+      "messages_collected": 12,
+      "token_count_estimate": 5,
+      "raw_text_blob": "text",
+    }
+
+  module.summarize_channel = dummy_summarize  # type: ignore
+
+  res = asyncio.run(module.uwu_chat(1, 2, 3))
+  assert res["token_count_estimate"] == 5
+  assert res["summary_lines"] == ["[[STUB: Persona summary output here]]"]
+  assert res["uwu_response_text"] == "[[STUB: uwu persona output here]]"


### PR DESCRIPTION
## Summary
- add DiscordChatModule to expose Discord chat features
- provide message history, token estimation, and uwu chat stubs with structured logging
- cover new module with unit tests

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68c710eb618483258b6a7baf4ca038a4