### PR TITLE
Improve Discord chat error handling and logging

### DIFF
--- a/rpc/discord/chat/services.py
+++ b/rpc/discord/chat/services.py
@@ -2,10 +2,9 @@ from fastapi import Request
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
+from server.modules.discord_chat_module import DiscordChatModule
 
 from .models import (
-  DiscordChatSummarizeChannelRequest1,
-  DiscordChatSummarizeChannelResponse1,
   DiscordChatUwuChatRequest1,
   DiscordChatUwuChatResponse1,
 )
@@ -13,13 +12,24 @@ from .models import (
 
 async def discord_chat_summarize_channel_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
-  req = DiscordChatSummarizeChannelRequest1(**(rpc_request.payload or {}))
-  payload = DiscordChatSummarizeChannelResponse1(
-    summary=f"Summary for {req.channel_id}"
-  )
+  p = rpc_request.payload or {}
+  guild_id = p.get("guild_id")
+  channel_id = p.get("channel_id")
+  hours = int(p.get("hours", 1))
+  if hours < 1 or hours > 336:
+    raise ValueError("hours must be between 1 and 336")
+  module: DiscordChatModule = request.app.state.discord_chat
+  await module.on_ready()
+  summary = await module.summarize_channel(guild_id, channel_id, hours)
+  payload = {
+    "summary": summary.get("raw_text_blob"),
+    "messages_collected": summary.get("messages_collected"),
+    "token_count_estimate": summary.get("token_count_estimate"),
+    "cap_hit": summary.get("cap_hit"),
+  }
   return RPCResponse(
     op=rpc_request.op,
-    payload=payload.model_dump(),
+    payload=payload,
     version=rpc_request.version,
   )
 

--- a/tests/test_discord_bot_commands.py
+++ b/tests/test_discord_bot_commands.py
@@ -81,6 +81,105 @@ def test_summarize_command(monkeypatch):
   assert ctx.author.dm_channel.history_called
 
 
+def test_summarize_command_usage_error(monkeypatch):
+  app = FastAPI()
+  module = DiscordModule(app)
+  module.bot = module._init_discord_bot('!')
+  module._init_bot_routes()
+  ctx = SimpleNamespace(
+    guild=SimpleNamespace(id=1),
+    channel=DummyChannel(),
+    author=DummyAuthor(),
+  )
+  ctx.send = ctx.channel.send
+  cmd = module.bot.get_command("summarize")
+  asyncio.run(cmd.callback(ctx, hours="bad"))
+  assert ctx.channel.sent == ["Usage: !summarize <hours>"]
+
+
+def test_summarize_command_empty_history(monkeypatch):
+  app = FastAPI()
+  module = DiscordModule(app)
+  module.bot = module._init_discord_bot('!')
+  module._init_bot_routes()
+
+  async def dummy_handle(req):
+    class DummyResp:
+      payload = {
+        "summary": "",
+        "messages_collected": 0,
+        "token_count_estimate": 0,
+        "cap_hit": False,
+      }
+    return DummyResp()
+  import importlib
+  rpc_mod = importlib.import_module("rpc.handler")
+  monkeypatch.setattr(rpc_mod, "handle_rpc_request", dummy_handle)
+
+  ctx = SimpleNamespace(
+    guild=SimpleNamespace(id=1),
+    channel=DummyChannel(),
+    author=DummyAuthor(),
+  )
+  ctx.send = ctx.channel.send
+  cmd = module.bot.get_command("summarize")
+  asyncio.run(cmd.callback(ctx, hours="1"))
+  assert ctx.channel.sent == ["No messages found in the specified time range"]
+
+
+def test_summarize_command_cap_hit(monkeypatch):
+  app = FastAPI()
+  module = DiscordModule(app)
+  module.bot = module._init_discord_bot('!')
+  module._init_bot_routes()
+
+  async def dummy_handle(req):
+    class DummyResp:
+      payload = {
+        "summary": "hi",
+        "messages_collected": 5000,
+        "token_count_estimate": 2,
+        "cap_hit": True,
+      }
+    return DummyResp()
+  import importlib
+  rpc_mod = importlib.import_module("rpc.handler")
+  monkeypatch.setattr(rpc_mod, "handle_rpc_request", dummy_handle)
+
+  ctx = SimpleNamespace(
+    guild=SimpleNamespace(id=1),
+    channel=DummyChannel(),
+    author=DummyAuthor(),
+  )
+  ctx.send = ctx.channel.send
+  cmd = module.bot.get_command("summarize")
+  asyncio.run(cmd.callback(ctx, hours="1"))
+  assert ctx.channel.sent == ["Channel too active to summarize; message cap hit"]
+
+
+def test_summarize_command_transient_error(monkeypatch):
+  app = FastAPI()
+  module = DiscordModule(app)
+  module.bot = module._init_discord_bot('!')
+  module._init_bot_routes()
+
+  async def dummy_handle(req):
+    raise RuntimeError("boom")
+  import importlib
+  rpc_mod = importlib.import_module("rpc.handler")
+  monkeypatch.setattr(rpc_mod, "handle_rpc_request", dummy_handle)
+
+  ctx = SimpleNamespace(
+    guild=SimpleNamespace(id=1),
+    channel=DummyChannel(),
+    author=DummyAuthor(),
+  )
+  ctx.send = ctx.channel.send
+  cmd = module.bot.get_command("summarize")
+  asyncio.run(cmd.callback(ctx, hours="1"))
+  assert ctx.channel.sent == ["Failed to fetch messages. Please try again later."]
+
+
 def test_uwu_command(monkeypatch):
   app = FastAPI()
   module = DiscordModule(app)

--- a/tests/test_discord_chat_module.py
+++ b/tests/test_discord_chat_module.py
@@ -13,7 +13,7 @@ def test_summarize_channel(monkeypatch):
 
   async def dummy_fetch(guild_id, channel_id, hours, max_messages=5000):
     msg = SimpleNamespace(content="hello", author=SimpleNamespace(name="Alice"))
-    return [msg]
+    return {"messages": [msg], "cap_hit": False}
 
   module.fetch_channel_history_backwards = dummy_fetch  # type: ignore
 
@@ -32,6 +32,7 @@ def test_uwu_chat(monkeypatch):
       "messages_collected": 12,
       "token_count_estimate": 5,
       "raw_text_blob": "text",
+      "cap_hit": False,
     }
 
   module.summarize_channel = dummy_summarize  # type: ignore


### PR DESCRIPTION
## Summary
- validate summarize hours and handle empty history, cap hit, and fetch failures
- add rate limit tracking and duration logging for Discord bot commands
- return cap-hit info from Discord chat module and expose via RPC

## Testing
- `python scripts/generate_rpc_bindings.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c71ae5f5ac8325a1647c0fe1a4c2e6