### PR TITLE
Log Discord conversations to database

### DIFF
--- a/rpc/discord/chat/services.py
+++ b/rpc/discord/chat/services.py
@@ -27,6 +27,13 @@ async def discord_chat_summarize_channel_v1(request: Request):
     "token_count_estimate": summary.get("token_count_estimate"),
     "cap_hit": summary.get("cap_hit"),
   }
+  await module.log_conversation(
+    "summary",
+    guild_id,
+    channel_id,
+    f"hours={hours}",
+    payload["summary"] or "",
+  )
   return RPCResponse(
     op=rpc_request.op,
     payload=payload,
@@ -36,8 +43,20 @@ async def discord_chat_summarize_channel_v1(request: Request):
 
 async def discord_chat_uwu_chat_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
-  req = DiscordChatUwuChatRequest1(**(rpc_request.payload or {}))
+  payload_dict = rpc_request.payload or {}
+  req = DiscordChatUwuChatRequest1(**payload_dict)
+  guild_id = payload_dict.get("guild_id")
+  channel_id = payload_dict.get("channel_id")
   payload = DiscordChatUwuChatResponse1(message=f"uwu {req.message}")
+  module: DiscordChatModule = request.app.state.discord_chat
+  await module.on_ready()
+  await module.log_conversation(
+    "uwu",
+    guild_id,
+    channel_id,
+    req.message,
+    payload.message,
+  )
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),

--- a/scripts/v0.6.0.1_persona_conversation.sql
+++ b/scripts/v0.6.0.1_persona_conversation.sql
@@ -1,0 +1,20 @@
+CREATE TABLE assistant_personas (
+  recid INT IDENTITY(1,1) PRIMARY KEY,
+  element_name NVARCHAR(256) NOT NULL,
+  element_metadata NVARCHAR(MAX),
+  element_created_on DATETIMEOFFSET DEFAULT sysutcdatetime() NOT NULL
+);
+
+CREATE TABLE assistant_conversations (
+  recid BIGINT IDENTITY(1,1) PRIMARY KEY,
+  personas_recid INT NOT NULL,
+  element_guild_id NVARCHAR(64),
+  element_channel_id NVARCHAR(64),
+  element_input NVARCHAR(MAX),
+  element_output NVARCHAR(MAX),
+  element_created_on DATETIMEOFFSET DEFAULT sysutcdatetime() NOT NULL,
+  FOREIGN KEY (personas_recid) REFERENCES assistant_personas(recid)
+);
+
+CREATE INDEX IX_assistant_conversations_persona_time
+  ON assistant_conversations (personas_recid, element_created_on);

--- a/tests/test_discord_chat_services.py
+++ b/tests/test_discord_chat_services.py
@@ -1,0 +1,101 @@
+import importlib.util
+import pathlib
+import sys
+import types
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+# Stub rpc package to avoid side effects from rpc.__init__
+pkg = types.ModuleType('rpc')
+pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc')]
+sys.modules.setdefault('rpc', pkg)
+
+# Load server models
+spec = importlib.util.spec_from_file_location(
+  'server.models', pathlib.Path(__file__).resolve().parent.parent / 'server/models.py'
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+sys.modules['server.models'] = mod
+RPCRequest = mod.RPCRequest
+AuthContext = mod.AuthContext
+
+from rpc.discord.chat import services as chat_services
+
+
+class StubModule:
+  def __init__(self):
+    self.called = False
+    self.args = None
+
+  async def on_ready(self):
+    pass
+
+  async def summarize_channel(self, guild_id, channel_id, hours, max_messages=5000):
+    return {
+      'raw_text_blob': 'hi',
+      'messages_collected': 1,
+      'token_count_estimate': 2,
+      'cap_hit': False,
+    }
+
+  async def log_conversation(self, persona, guild_id, channel_id, input_data, output_data):
+    self.called = True
+    self.args = (persona, guild_id, channel_id, input_data, output_data)
+
+
+def test_uwu_chat_logs_conversation():
+  app = FastAPI()
+  module = StubModule()
+  app.state.discord_chat = module
+
+  async def fake_unbox(request):
+    return (
+      RPCRequest(op='urn:discord:chat:uwu_chat:1', payload={'message': 'hey', 'guild_id': 1, 'channel_id': 2}),
+      AuthContext(),
+      [],
+    )
+
+  original = chat_services.unbox_request
+  chat_services.unbox_request = fake_unbox
+
+  @app.post('/rpc')
+  async def rpc_endpoint(request: Request):
+    return await chat_services.discord_chat_uwu_chat_v1(request)
+
+  client = TestClient(app)
+  resp = client.post('/rpc', json={'op': 'urn:discord:chat:uwu_chat:1'})
+  assert resp.status_code == 200
+  assert module.called
+  assert module.args[3] == 'hey'
+  assert module.args[4] == 'uwu hey'
+
+  chat_services.unbox_request = original
+
+
+def test_summarize_channel_logs_conversation():
+  app = FastAPI()
+  module = StubModule()
+  app.state.discord_chat = module
+
+  async def fake_unbox(request):
+    return (
+      RPCRequest(op='urn:discord:chat:summarize_channel:1', payload={'guild_id': 1, 'channel_id': 2, 'hours': 1}),
+      AuthContext(),
+      [],
+    )
+
+  original = chat_services.unbox_request
+  chat_services.unbox_request = fake_unbox
+
+  @app.post('/rpc')
+  async def rpc_endpoint(request: Request):
+    return await chat_services.discord_chat_summarize_channel_v1(request)
+
+  client = TestClient(app)
+  resp = client.post('/rpc', json={'op': 'urn:discord:chat:summarize_channel:1'})
+  assert resp.status_code == 200
+  assert module.called
+  assert module.args[0] == 'summary'
+
+  chat_services.unbox_request = original


### PR DESCRIPTION
## Summary
- add assistant_personas and assistant_conversations tables
- record Discord conversations via new db queries
- test Discord chat services log history

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68c71ce79ba08325bb07e276630c6ce0