### PR TITLE
Add persona seeding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ Several helper scripts in the `scripts` directory manage the project database an
 - `generate_rpc_bindings.py` generates RPC TypeScript models and client accessors.
 - `scriptlib.py` handles common RPC namespace generation functions and version helpers.
 - `msdblib.py` handles most of the mssql querying operations.
-  Schema dumps now record NVARCHAR field lengths for accurate
-  recreation across environments.
+Schema dumps now record NVARCHAR field lengths for accurate
+recreation across environments.
+
+### Seeding Personas
+Personas for the assistant are defined in `scripts/data/assistant_personas.json`. Load them into the database with:
+
+```bash
+python scripts/seed_personas.py
+```
+
+When updating personas, modify the JSON file to keep the source data in sync.
 

--- a/scripts/seed_personas.py
+++ b/scripts/seed_personas.py
@@ -1,0 +1,31 @@
+import asyncio, json
+from pathlib import Path
+from scriptlib import connect
+
+DEFAULT_JSON = Path(__file__).resolve().parent / 'data' / 'assistant_personas.json'
+
+async def seed_personas(json_path: Path) -> None:
+  with json_path.open() as f:
+    personas = json.load(f)
+  conn = await connect()
+  try:
+    async with conn.cursor() as cur:
+      for p in personas:
+        meta = json.dumps({
+          'model': p['model'],
+          'max_tokens': p['max_tokens'],
+          'role': p['role']
+        })
+        await cur.execute(
+          'INSERT INTO assistant_personas (element_name, element_metadata) VALUES (?, ?);',
+          (p['name'], meta)
+        )
+  finally:
+    await conn.close()
+
+if __name__ == '__main__':
+  import argparse
+  parser = argparse.ArgumentParser(description='Seed assistant personas from JSON')
+  parser.add_argument('json', nargs='?', default=DEFAULT_JSON, type=Path)
+  args = parser.parse_args()
+  asyncio.run(seed_personas(args.json))


### PR DESCRIPTION
## Summary
- replace SQL seed with Python script to load personas from JSON
- document running persona seeding script and JSON source

## Testing
- `python scripts/generate_rpc_bindings.py`
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7204311e48325beb67f25add1542e