### PR TITLE
Add Discord chat macro and DB tests

### DIFF
--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -1,0 +1,28 @@
+import asyncio
+
+from server.modules.providers.database.mssql_provider import MssqlProvider
+import server.modules.providers.database.mssql_provider as mssql_provider
+from server.modules.providers import DBResult
+
+
+def test_assistant_conversations_list_by_time(monkeypatch):
+  provider = MssqlProvider()
+  personas_recid = 1
+  start = '2024-01-01'
+  end = '2024-01-02'
+
+  async def fake_fetch_json(sql, params, *, many=False):
+    assert many
+    assert "FROM assistant_conversations" in sql
+    assert params == (personas_recid, start, end)
+    return DBResult(rows=[{"recid": 1}], rowcount=1)
+
+  monkeypatch.setattr(mssql_provider, 'fetch_json', fake_fetch_json)
+
+  res = asyncio.run(provider.run(
+    'db:assistant:conversations:list_by_time:1',
+    {'personas_recid': personas_recid, 'start': start, 'end': end},
+  ))
+  assert isinstance(res, DBResult)
+  assert res.rows == [{"recid": 1}]
+

--- a/tests/test_discord_bot_macros.py
+++ b/tests/test_discord_bot_macros.py
@@ -1,0 +1,140 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+
+from server.modules.discord_module import DiscordModule
+
+
+class DummyHistory:
+  def __aiter__(self):
+    return self
+
+  async def __anext__(self):
+    raise StopAsyncIteration
+
+
+class DummyChannel:
+  def __init__(self, id: int = 2):
+    self.id = id
+    self.sent: list[str] = []
+    self.history_called = False
+
+  async def send(self, content):
+    self.sent.append(content)
+
+  def history(self, limit=1):
+    self.history_called = True
+    return DummyHistory()
+
+
+class DummyDMChannel(DummyChannel):
+  pass
+
+
+class DummyAuthor:
+  def __init__(self):
+    self.id = 3
+    self.bot = False
+    self.dm_channel = DummyDMChannel()
+
+  async def send(self, content):
+    await self.dm_channel.send(content)
+
+
+class DummyMessage:
+  def __init__(self, content: str, channel: DummyChannel, author: DummyAuthor, guild_id: int = 1, state=None):
+    self.content = content
+    self.channel = channel
+    self.author = author
+    self.guild = SimpleNamespace(id=guild_id)
+    self._state = state or SimpleNamespace()
+    self.attachments = []
+    self.id = 1
+
+
+def test_summarize_macro_dm(monkeypatch):
+  app = FastAPI()
+  module = DiscordModule(app)
+  module.bot = module._init_discord_bot('!')
+  module.bot._connection.user = SimpleNamespace(id=0)
+  module._init_bot_routes()
+
+  from discord.ext import commands as dc_commands
+
+  async def fake_send(self, content, **kwargs):
+    return await self.channel.send(content)
+
+  monkeypatch.setattr(dc_commands.Context, 'send', fake_send)
+
+  async def dummy_handle(req):
+    body = await req.body()
+    dummy_handle.body = json.loads(body.decode())
+    dummy_handle.called = True
+    class DummyResp:
+      payload = {
+        "summary": "hi",
+        "messages_collected": 1,
+        "token_count_estimate": 2,
+      }
+    return DummyResp()
+  dummy_handle.called = False
+  dummy_handle.body = None
+  import importlib
+  rpc_mod = importlib.import_module("rpc.handler")
+  monkeypatch.setattr(rpc_mod, "handle_rpc_request", dummy_handle)
+
+  channel = DummyChannel()
+  author = DummyAuthor()
+  message = DummyMessage("!summarize 2", channel, author, state=module.bot._connection)
+  asyncio.run(module.bot.process_commands(message))
+  assert dummy_handle.called
+  assert dummy_handle.body["op"] == "urn:discord:chat:summarize_channel:1"
+  assert dummy_handle.body["payload"]["hours"] == 2
+  assert author.dm_channel.sent == ["hi"]
+  assert author.dm_channel.history_called
+  assert channel.sent == []
+
+
+def test_uwu_macro_channel(monkeypatch):
+  app = FastAPI()
+  module = DiscordModule(app)
+  module.bot = module._init_discord_bot('!')
+  module.bot._connection.user = SimpleNamespace(id=0)
+  module._init_bot_routes()
+
+  from discord.ext import commands as dc_commands
+
+  async def fake_send(self, content, **kwargs):
+    return await self.channel.send(content)
+
+  monkeypatch.setattr(dc_commands.Context, 'send', fake_send)
+
+  async def dummy_handle(req):
+    body = await req.body()
+    dummy_handle.body = json.loads(body.decode())
+    dummy_handle.called = True
+    class DummyResp:
+      payload = {
+        "uwu_response_text": "uwu hi",
+        "token_count_estimate": 3,
+      }
+    return DummyResp()
+  dummy_handle.called = False
+  dummy_handle.body = None
+  import importlib
+  rpc_mod = importlib.import_module("rpc.handler")
+  monkeypatch.setattr(rpc_mod, "handle_rpc_request", dummy_handle)
+
+  channel = DummyChannel()
+  author = DummyAuthor()
+  message = DummyMessage("!uwu hello", channel, author, state=module.bot._connection)
+  asyncio.run(module.bot.process_commands(message))
+  assert dummy_handle.called
+  assert dummy_handle.body["op"] == "urn:discord:chat:uwu_chat:1"
+  assert dummy_handle.body["payload"]["message"] == "hello"
+  assert channel.sent == ["uwu hi"]
+  assert channel.history_called
+  assert author.dm_channel.sent == []
+

--- a/tests/test_discord_chat_services.py
+++ b/tests/test_discord_chat_services.py
@@ -67,6 +67,10 @@ def test_uwu_chat_logs_conversation():
   resp = client.post('/rpc', json={'op': 'urn:discord:chat:uwu_chat:1'})
   assert resp.status_code == 200
   assert module.called
+  data = resp.json()
+  assert data["payload"] == {"message": "uwu hey"}
+  assert module.args[1] == 1
+  assert module.args[2] == 2
   assert module.args[3] == 'hey'
   assert module.args[4] == 'uwu hey'
 
@@ -96,6 +100,16 @@ def test_summarize_channel_logs_conversation():
   resp = client.post('/rpc', json={'op': 'urn:discord:chat:summarize_channel:1'})
   assert resp.status_code == 200
   assert module.called
+  data = resp.json()
+  expected = {
+    "summary": "hi",
+    "messages_collected": 1,
+    "token_count_estimate": 2,
+    "cap_hit": False,
+  }
+  assert data["payload"] == expected
   assert module.args[0] == 'summary'
+  assert module.args[1] == 1
+  assert module.args[2] == 2
 
   chat_services.unbox_request = original


### PR DESCRIPTION
## Summary
- ensure discord chat services return deterministic values and log conversations with IDs
- add bot macro tests for `!summarize` and `!uwu` using a commands.Bot harness
- cover assistant_conversations list_by_time in database tests

## Testing
- `python scripts/generate_rpc_bindings.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c729afcbb08325a16006054376006f