### PR TITLE
feat(home): mask component versions for service admins

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -112,6 +112,7 @@ User focused calls used by the React application.
 | `urn:public:vars:get_repo:1`           | Read the GitHub repository URL.                        |
 | `urn:public:vars:get_ffmpeg_version:1` | Return the installed FFmpeg version.                   |
 | `urn:public:vars:get_odbc_version:1`   | Return the installed Linux MSSQL ODBC driver versions. |
+| `urn:public:vars:get_versions:1`       | Return app and component versions; component versions require `ROLE_SERVICE_ADMIN`. |
 
 ### `users`
 

--- a/frontend/src/components/BottomBar.tsx
+++ b/frontend/src/components/BottomBar.tsx
@@ -1,0 +1,69 @@
+import { Box, Typography, Link } from '@mui/material';
+import type { PublicVarsVersions1 } from '../shared/RpcModels';
+
+interface Props {
+	info: PublicVarsVersions1 | null;
+}
+
+const BottomBar = ({ info }: Props): JSX.Element => {
+	return (
+		<Box sx={{ textAlign: 'center', padding: '20px' }}>
+			{info ? (
+				<>
+					<Typography variant="body1">
+						{info.version} running on {info.hostname}
+					</Typography>
+					{info.ffmpeg_version && (
+						<Typography variant="body1" sx={{ marginTop: '4px' }}>
+							{info.ffmpeg_version}
+						</Typography>
+					)}
+					{info.odbc_version && (
+						<Typography variant="body1" sx={{ marginTop: '4px' }}>
+							{info.odbc_version}
+						</Typography>
+					)}
+					{info.repo && (
+						<Typography variant="body1" sx={{ marginTop: '4px' }}>
+							GitHub{' '}
+							<Link
+								href={info.repo}
+								target="_blank"
+								rel="noopener noreferrer"
+								underline="none"
+								sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}
+								>
+									repo
+								</Link>
+								{' '}-{' '}
+								<Link
+									href={`${info.repo}/actions`}
+									target="_blank"
+									rel="noopener noreferrer"
+									underline="none"
+									sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}
+									>
+										build
+									</Link>
+							</Typography>
+					)}
+				</>
+			) : null}
+			<Typography variant="body1" sx={{ marginTop: info ? '20px' : '0px' }}>
+				Contact us at{' '}
+				<Link
+					href="mailto:contact@elideusgroup.com"
+					underline="none"
+					sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}
+					>
+					contact@elideusgroup.com
+				</Link>
+			</Typography>
+			<Typography variant="body1" sx={{ marginTop: '4px' }}>
+				<Link href="/privacy-policy" underline="none">Privacy Policy</Link>
+			</Typography>
+		</Box>
+	);
+};
+
+export default BottomBar;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,64 +1,22 @@
 import { Box, Typography, Link, CardMedia } from '@mui/material';
 import { useEffect, useState } from 'react';
-import type { PublicLinksLinkItem1 } from '../shared/RpcModels';
+import type { PublicLinksLinkItem1, PublicVarsVersions1 } from '../shared/RpcModels';
 import Logo from '../assets/elideus_group_green.png';
-import {
-        fetchHostname,
-        fetchVersion,
-        fetchRepo,
-        fetchFfmpegVersion,
-        fetchOdbcVersion,
-} from '../rpc/public/vars';
+import { fetchVersions } from '../rpc/public/vars';
 import { fetchHomeLinks } from '../rpc/public/links';
+import BottomBar from '../components/BottomBar';
 
 const Home = (): JSX.Element => {
-	const [hostname, setHostname] = useState('');
-	const [version, setVersion] = useState('');
-        const [repo, setRepo] = useState('');
-        const [ffmpegVersion, setFfmpegVersion] = useState<string | null>(null);
-        const [odbcVersion, setOdbcVersion] = useState<string | null>(null);
+        const [info, setInfo] = useState<PublicVarsVersions1 | null>(null);
         const [links, setLinks] = useState<PublicLinksLinkItem1[]>([]);
 
 	useEffect(() => {
 		void (async () => {
-			try {
-				const host = await fetchHostname();
-				const cleanHost = host.hostname.replace(/^"|"$/g, '');
-				setHostname(cleanHost);
-			} catch {
-				setHostname('unknown');
-			}
-
-			try {
-				const repoInfo = await fetchRepo();
-				const cleanRepo = repoInfo.repo.replace(/^"|"$/g, '');
-				setRepo(cleanRepo);
-			} catch {
-				setRepo('unknown');
-			}
-
-			try {
-				const versionInfo = await fetchVersion();
-				const cleanVersion = versionInfo.version.replace(/^"|"$/g, '');
-				setVersion(cleanVersion);
-			} catch {
-				setVersion('v0.0.0');
-			}
-
                         try {
-                                const ffmpegInfo = await fetchFfmpegVersion();
-                                const cleanFfmpeg = ffmpegInfo.ffmpeg_version.replace(/^"|"$/g, '');
-                                setFfmpegVersion(cleanFfmpeg);
+                                const versions = await fetchVersions();
+                                setInfo(versions);
                         } catch {
-                                setFfmpegVersion('unknown');
-                        }
-
-                        try {
-                                const odbcInfo = await fetchOdbcVersion();
-                                const cleanOdbc = odbcInfo.odbc_version.replace(/^"|"$/g, '');
-                                setOdbcVersion(cleanOdbc);
-                        } catch {
-                                setOdbcVersion('unknown');
+                                setInfo(null);
                         }
 
 			try {
@@ -97,52 +55,10 @@ const Home = (): JSX.Element => {
 					</Link>
 				))}
 			</Box>
-			<Typography variant="body1" sx={{ marginTop: '20px' }}>
-				{version} running on {hostname}
-			</Typography>
-                        <Typography variant="body1" sx={{ marginTop: '4px' }}>
-                                {ffmpegVersion ? ffmpegVersion : 'Loading version...'}
-                        </Typography>
-                        <Typography variant="body1" sx={{ marginTop: '4px' }}>
-                                {odbcVersion ? odbcVersion : 'Loading version...'}
-                        </Typography>
-                        <Typography variant="body1" sx={{ marginTop: '4px' }}>
-                                GitHub:{' '}
-				<Link
-					href={repo}
-					target="_blank"
-					rel="noopener noreferrer"
-					underline="none"
-					sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}
-				>
-					repo
-				</Link>
-					{' '}-{' '}
-				<Link
-					href={repo ? `${repo}/actions` : ''}
-					target="_blank"
-					rel="noopener noreferrer"
-					underline="none"
-					sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}
-				>
-					build
-				</Link>
-			</Typography>
-			<Typography variant="body1" sx={{ marginTop: '20px' }}>
-				Contact us at:{' '}
-				<Link
-					href="mailto:contact@elideusgroup.com"
-					underline="none"
-					sx={{ display: 'inline', padding: 0, margin: 0, backgroundColor: 'transparent' }}
-				>
-					contact@elideusgroup.com
-				</Link>
-			</Typography>
-			<Typography variant="body1" sx={{ marginTop: '4px' }}>
-				<Link href="/privacy-policy" underline="none">Privacy Policy</Link>
-			</Typography>
-		</Box>
-	);
+                        <Box sx={{ flexGrow: 1 }} />
+                        <BottomBar info={info} />
+                </Box>
+        );
 };
 
 export default Home;

--- a/rpc/public/vars/__init__.py
+++ b/rpc/public/vars/__init__.py
@@ -3,7 +3,8 @@ from .services import (
   public_vars_get_hostname_v1,
   public_vars_get_repo_v1,
   public_vars_get_version_v1,
-  public_vars_get_odbc_version_v1
+  public_vars_get_odbc_version_v1,
+  public_vars_get_versions_v1,
 )
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
@@ -11,6 +12,7 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("get_hostname", "1"): public_vars_get_hostname_v1,
   ("get_repo", "1"): public_vars_get_repo_v1,
   ("get_ffmpeg_version", "1"): public_vars_get_ffmpeg_version_v1,
-  ("get_odbc_version", "1"): public_vars_get_odbc_version_v1
+  ("get_odbc_version", "1"): public_vars_get_odbc_version_v1,
+  ("get_versions", "1"): public_vars_get_versions_v1,
 }
 

--- a/rpc/public/vars/models.py
+++ b/rpc/public/vars/models.py
@@ -19,3 +19,11 @@ class PublicVarsFfmpegVersion1(BaseModel):
 
 class PublicVarsOdbcVersion1(BaseModel):
   odbc_version: str
+
+
+class PublicVarsVersions1(BaseModel):
+  hostname: str
+  version: str
+  repo: str | None = None
+  ffmpeg_version: str | None = None
+  odbc_version: str | None = None

--- a/tests/test_public_vars_service.py
+++ b/tests/test_public_vars_service.py
@@ -32,7 +32,11 @@ server_pkg.models = models_pkg
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)
 
-from rpc.public.vars.services import public_vars_get_hostname_v1, public_vars_get_version_v1
+from rpc.public.vars.services import (
+  public_vars_get_hostname_v1,
+  public_vars_get_version_v1,
+  public_vars_get_versions_v1,
+)
 
 
 class DummyVarsHostnameModule:
@@ -43,6 +47,15 @@ class DummyVarsHostnameModule:
 class DummyVarsVersionModule:
   async def get_version(self):
     return "1.2.3"
+
+
+class DummyVarsVersionsModule:
+  async def get_versions(self, role_mask):
+    res = {"hostname": "example.com", "version": "1.2.3", "repo": "https://repo"}
+    if role_mask:
+      res["ffmpeg_version"] = "ffmpeg 1"
+      res["odbc_version"] = "odbc 1"
+    return res
 
 
 app = FastAPI()
@@ -83,4 +96,54 @@ def test_get_version_service():
   data = resp.json()
   assert data["op"] == "urn:public:vars:get_version:1"
   assert data["payload"] == {"version": "1.2.3"}
+
+
+app_versions = FastAPI()
+app_versions.state.public_vars = DummyVarsVersionsModule()
+
+
+@app_versions.post("/rpc")
+async def rpc_endpoint_versions(request: Request):
+  request.state.rpc_request = RPCRequest(op="urn:public:vars:get_versions:1")
+  request.state.auth_ctx = AuthContext(role_mask=0)
+  return await public_vars_get_versions_v1(request)
+
+
+client_versions = TestClient(app_versions)
+
+
+def test_get_versions_public():
+  resp = client_versions.post("/rpc", json={})
+  assert resp.status_code == 200
+  data = resp.json()
+  assert data["op"] == "urn:public:vars:get_versions:1"
+  assert data["payload"] == {"hostname": "example.com", "version": "1.2.3", "repo": "https://repo"}
+
+
+app_versions_admin = FastAPI()
+app_versions_admin.state.public_vars = DummyVarsVersionsModule()
+
+
+@app_versions_admin.post("/rpc")
+async def rpc_endpoint_versions_admin(request: Request):
+  request.state.rpc_request = RPCRequest(op="urn:public:vars:get_versions:1")
+  request.state.auth_ctx = AuthContext(role_mask=1)
+  return await public_vars_get_versions_v1(request)
+
+
+client_versions_admin = TestClient(app_versions_admin)
+
+
+def test_get_versions_admin():
+  resp = client_versions_admin.post("/rpc", json={})
+  assert resp.status_code == 200
+  data = resp.json()
+  assert data["op"] == "urn:public:vars:get_versions:1"
+  assert data["payload"] == {
+    "hostname": "example.com",
+    "version": "1.2.3",
+    "repo": "https://repo",
+    "ffmpeg_version": "ffmpeg 1",
+    "odbc_version": "odbc 1",
+  }
 


### PR DESCRIPTION
## Summary
- expose new public vars endpoint that hides component versions unless caller has ROLE_SERVICE_ADMIN
- show version details in a reusable BottomBar and only render component versions when provided
- add tests covering version masking logic

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7377bf0ac832596b6be42ee1e922b