### PR TITLE
Use content attribute for OpenAI chat replies

### DIFF
--- a/server/modules/discord_chat_module.py
+++ b/server/modules/discord_chat_module.py
@@ -78,7 +78,11 @@ class DiscordChatModule(BaseModule):
       text,
       300,
     )
-    content = msg.get("content", "")
+    content = getattr(
+      msg,
+      "content",
+      msg.get("content", "") if isinstance(msg, dict) else "",
+    )
     return [line.strip() for line in content.splitlines() if line.strip()]
 
   async def uwu_persona(self, summary: List[str], user_id: int, user_message: str) -> str:
@@ -89,7 +93,11 @@ class DiscordChatModule(BaseModule):
     prompt_context = "\n".join(summary)
     role = f"You are a playful catgirl assistant responding to user {user_id} in uwu style."
     msg = await openai.fetch_chat([], role, user_message, 120, prompt_context)
-    return msg.get("content", "")
+    return getattr(
+      msg,
+      "content",
+      msg.get("content", "") if isinstance(msg, dict) else "",
+    )
 
   async def log_conversation(
     self,

--- a/tests/test_discord_chat_module.py
+++ b/tests/test_discord_chat_module.py
@@ -25,6 +25,20 @@ def test_summarize_channel(monkeypatch):
 def test_uwu_chat(monkeypatch):
   app = FastAPI()
   app.state.discord = SimpleNamespace(on_ready=lambda: None)
+
+  class DummyOpenAI:
+    def __init__(self):
+      self.client = object()
+
+    async def on_ready(self):
+      pass
+
+    async def fetch_chat(self, schemas, role, prompt, tokens, prompt_context=""):
+      if role == "Summarize the following conversation into bullet points.":
+        return SimpleNamespace(content="hi\nbye")
+      return SimpleNamespace(content="uwu hi")
+
+  app.state.openai = DummyOpenAI()
   module = DiscordChatModule(app)
 
   async def dummy_summarize(guild_id, channel_id, hours, max_messages=5000):
@@ -39,5 +53,5 @@ def test_uwu_chat(monkeypatch):
 
   res = asyncio.run(module.uwu_chat(1, 2, 3, "hey"))
   assert res["token_count_estimate"] == 5
-  assert res["summary_lines"] == ["[[STUB: Persona summary output here]]"]
-  assert res["uwu_response_text"] == "[[STUB: uwu persona output here]]"
+  assert res["summary_lines"] == ["hi", "bye"]
+  assert res["uwu_response_text"] == "uwu hi"


### PR DESCRIPTION
## Summary
- Read `msg.content` in Discord chat module
- Mock OpenAI responses with `.content` in tests

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7467090dc83258670e4cb3436a2a4