### PR TITLE
Order system prompt first in OpenAI messages

### DIFF
--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -42,14 +42,14 @@ class OpenaiModule(BaseModule):
     if not self.client:
       logging.warning("[OpenaiModule] client not initialized")
       return {"content": ""}
+    messages = [{"role": "system", "content": role}]
+    if prompt_context:
+      messages.append({"role": "user", "content": prompt_context})
+    messages.append({"role": "user", "content": prompt})
     completion = await self.client.chat.completions.create(
       model="gpt-4o-mini",
       max_tokens=tokens,
       tools=schemas,
-      messages=[
-        {"role": "user", "content": prompt_context},
-        {"role": "system", "content": role},
-        {"role": "user", "content": prompt},
-      ],
+      messages=messages,
     )
-    return completion.choices[0].message
+    return {"content": completion.choices[0].message.content}

--- a/tests/test_discord_chat_module.py
+++ b/tests/test_discord_chat_module.py
@@ -35,8 +35,8 @@ def test_uwu_chat(monkeypatch):
 
     async def fetch_chat(self, schemas, role, prompt, tokens, prompt_context=""):
       if role == "Summarize the following conversation into bullet points.":
-        return SimpleNamespace(content="hi\nbye")
-      return SimpleNamespace(content="uwu hi")
+        return {"content": "hi\nbye"}
+      return {"content": "uwu hi"}
 
   app.state.openai = DummyOpenAI()
   module = DiscordChatModule(app)

--- a/tests/test_openai_module.py
+++ b/tests/test_openai_module.py
@@ -1,0 +1,32 @@
+import asyncio
+from fastapi import FastAPI
+from types import SimpleNamespace
+
+from server.modules.openai_module import OpenaiModule
+
+
+def test_fetch_chat_message_order_and_return():
+  app = FastAPI()
+  module = OpenaiModule(app)
+
+  class DummyCreate:
+    async def create(self, model, max_tokens, tools, messages):
+      self.args = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "tools": tools,
+        "messages": messages,
+      }
+      return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="reply"))])
+
+  dummy_create = DummyCreate()
+  module.client = SimpleNamespace(chat=SimpleNamespace(completions=dummy_create))
+
+  res = asyncio.run(module.fetch_chat([], "sys", "user", 5, "ctx"))
+
+  assert dummy_create.args["messages"] == [
+    {"role": "system", "content": "sys"},
+    {"role": "user", "content": "ctx"},
+    {"role": "user", "content": "user"},
+  ]
+  assert res == {"content": "reply"}


### PR DESCRIPTION
## Summary
- Ensure system prompt precedes context and user prompt when calling OpenAI
- Return simple `{"content": ...}` dict from `fetch_chat`
- Cover message order and new return type in tests

## Testing
- `pytest`
- `pytest tests/test_openai_module.py tests/test_discord_chat_module.py`

------
https://chatgpt.com/codex/tasks/task_e_68c748280b288325b5e4b929c20da2cb