### PR TITLE
Persist uwu output after OpenAI reply

### DIFF
--- a/rpc/discord/chat/services.py
+++ b/rpc/discord/chat/services.py
@@ -47,14 +47,18 @@ async def discord_chat_uwu_chat_v1(request: Request):
   req = DiscordChatUwuChatRequest1(**payload_dict)
   module: DiscordChatModule = request.app.state.discord_chat
   await module.on_ready()
-  result = await module.uwu_chat(req.guild_id, req.channel_id, req.user_id, req.message)
-  await module.log_conversation(
+  conv_id = await module.log_conversation(
     "uwu",
     req.guild_id,
     req.channel_id,
     req.message,
-    result.get("uwu_response_text", ""),
+    "",
   )
+  result = await module.uwu_chat(req.guild_id, req.channel_id, req.user_id, req.message)
+  if conv_id:
+    await module.update_conversation_output(
+      conv_id, result.get("uwu_response_text", "")
+    )
   payload = DiscordChatUwuChatResponse1(**result)
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1332,6 +1332,17 @@ def _assistant_conversations_insert(args: Dict[str, Any]):
   """
   return (DbRunMode.ROW_ONE, sql, (personas_recid, persona, guild_id, channel_id, input_data, output_data))
 
+@register("db:assistant:conversations:update_output:1")
+def _assistant_conversations_update_output(args: Dict[str, Any]):
+  recid = args["recid"]
+  output_data = args.get("output_data")
+  sql = """
+    UPDATE assistant_conversations
+    SET element_output = ?
+    WHERE recid = ?;
+  """
+  return (DbRunMode.EXEC, sql, (output_data, recid))
+
 @register("db:assistant:conversations:list_by_time:1")
 def _assistant_conversations_list_by_time(args: Dict[str, Any]):
   personas_recid = args["personas_recid"]

--- a/tests/test_discord_chat_services.py
+++ b/tests/test_discord_chat_services.py
@@ -30,6 +30,8 @@ class StubModule:
     self.args = None
     self.uwu_called = False
     self.uwu_args = None
+    self.updated = False
+    self.update_args = None
 
   async def on_ready(self):
     pass
@@ -54,7 +56,11 @@ class StubModule:
   async def log_conversation(self, persona, guild_id, channel_id, input_data, output_data):
     self.called = True
     self.args = (persona, guild_id, channel_id, input_data, output_data)
+    return 42
 
+  async def update_conversation_output(self, recid, output_data):
+    self.updated = True
+    self.update_args = (recid, output_data)
 
 def test_uwu_chat_logs_conversation():
   app = FastAPI()
@@ -79,6 +85,7 @@ def test_uwu_chat_logs_conversation():
   resp = client.post('/rpc', json={'op': 'urn:discord:chat:uwu_chat:1'})
   assert resp.status_code == 200
   assert module.called
+  assert module.updated
   assert module.uwu_called
   data = resp.json()
   expected = {
@@ -88,7 +95,8 @@ def test_uwu_chat_logs_conversation():
   }
   assert data["payload"] == expected
   assert module.uwu_args == (1, 2, 3, 'hey')
-  assert module.args == ('uwu', 1, 2, 'hey', 'uwu hey')
+  assert module.args == ('uwu', 1, 2, 'hey', '')
+  assert module.update_args == (42, 'uwu hey')
 
   chat_services.unbox_request = original
 


### PR DESCRIPTION
## Summary
- log Discord chat input then update with model output
- expose DB operation for updating assistant conversation output
- ensure uwu chat service uses two-phase logging and tests cover it

## Testing
- `python scripts/generate_rpc_bindings.py`
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68c74e6c72308325944aed9cdffaf035