### PR TITLE
feat: add summary queue for discord output

### DIFF
--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -1,15 +1,87 @@
 from __future__ import annotations
-import logging
+import logging, asyncio
 from fastapi import FastAPI
 from openai import AsyncOpenAI
 from . import BaseModule
 from .db_module import DbModule
+
+
+async def send_to_discord(channel, text: str, max_message_size: int = 1998, delay: float = 1.0):
+  for block in text.split("\n"):
+    if not block.strip() or block.strip() == "---":
+      continue
+    start = 0
+    while start < len(block):
+      end = min(start + max_message_size, len(block))
+      if end < len(block) and block[end] != ' ':
+        end = block.rfind(' ', start, end)
+        if end == -1:
+          end = start + max_message_size
+      chunk = block[start:end].strip()
+      if chunk:
+        await channel.send(chunk)
+        await asyncio.sleep(delay)
+      start = end
+
+
+async def send_to_discord_user(user, text: str, max_message_size: int = 1998, delay: float = 1.0):
+  for block in text.split("\n"):
+    if not block.strip() or block.strip() == "---":
+      continue
+    start = 0
+    while start < len(block):
+      end = min(start + max_message_size, len(block))
+      if end < len(block) and block[end] != ' ':
+        end = block.rfind(' ', start, end)
+        if end == -1:
+          end = start + max_message_size
+      chunk = block[start:end].strip()
+      if chunk:
+        await user.send(chunk)
+        await asyncio.sleep(delay)
+      start = end
+
+
+class SummaryQueue:
+  def __init__(self, delay=15):
+    self.queue = asyncio.Queue()
+    self._lock = asyncio.Lock()
+    self.delay = delay
+    self.processing = False
+    self._processing_task: asyncio.Task | None = None
+
+  async def add(self, func, *args, **kwargs):
+    loop = asyncio.get_event_loop()
+    future = loop.create_future()
+    async with self._lock:
+      await self.queue.put((func, args, kwargs, future))
+      if not self.processing:
+        self.processing = True
+        self._processing_task = loop.create_task(self._process_queue())
+    return await future
+
+  async def _process_queue(self):
+    try:
+      while not self.queue.empty():
+        func, args, kwargs, future = await self.queue.get()
+        try:
+          result = await func(*args, **kwargs)
+          future.set_result(result)
+        except Exception as e:
+          future.set_exception(e)
+        await asyncio.sleep(self.delay)
+    except asyncio.CancelledError:
+      raise
+    finally:
+      async with self._lock:
+        self.processing = False
 
 class OpenaiModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.db: DbModule | None = None
     self.client: AsyncOpenAI | None = None
+    self.summary_queue = SummaryQueue()
 
   async def startup(self):
     self.db = self.app.state.db
@@ -21,6 +93,8 @@ class OpenaiModule(BaseModule):
 
   async def shutdown(self):
     logging.info("[OpenaiModule] shutdown")
+    if self.summary_queue._processing_task:
+      self.summary_queue._processing_task.cancel()
     self.client = None
     self.db = None
 

--- a/tests/test_openai_module.py
+++ b/tests/test_openai_module.py
@@ -2,7 +2,7 @@ import asyncio
 from fastapi import FastAPI
 from types import SimpleNamespace
 
-from server.modules.openai_module import OpenaiModule
+from server.modules.openai_module import OpenaiModule, SummaryQueue
 
 
 def test_fetch_chat_message_order_and_return():
@@ -30,3 +30,17 @@ def test_fetch_chat_message_order_and_return():
     {"role": "user", "content": "user"},
   ]
   assert res == {"content": "reply"}
+
+
+def test_summary_queue_executes_in_order():
+  q = SummaryQueue(delay=0)
+  called: list[int] = []
+
+  async def func(x):
+    called.append(x)
+
+  async def run():
+    await asyncio.gather(q.add(func, 1), q.add(func, 2))
+
+  asyncio.run(run())
+  assert called == [1, 2]


### PR DESCRIPTION
## Summary
- add helper functions and SummaryQueue to throttle large Discord outputs
- send summarize DM using queued, chunked messages and handle HTTP errors
- cover SummaryQueue execution order with unit tests

## Testing
- `python scripts/generate_rpc_bindings.py`
- `pytest tests/test_openai_module.py tests/test_discord_bot_commands.py tests/test_discord_bot_macros.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c74ecef1788325864b67f0afb63ae0