### PR TITLE
Log Discord conversations with OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Two tables record persona definitions and usage:
 | Table | Purpose |
 | ----- | ------- |
 | `assistant_personas` | Stores persona names and metadata. |
-| `assistant_conversations` | Logs each interaction including guild/channel IDs, input text, output text, and timestamps. |
+| `assistant_conversations` | Logs each interaction including guild/channel/user IDs, model reference, token counts, input text, output text, and timestamps. |
 
-The Discord chat module upserts the persona and writes a conversation record whenever `!summarize` or `!uwu` is executed.
+The OpenAI module records conversation details whenever `!summarize` or `!uwu` is executed.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,6 @@ Example:
 Each command invocation is logged for auditing:
 
 - **assistant_personas** – stores persona names and optional metadata.
-- **assistant_conversations** – records persona usage along with guild/channel identifiers, input text, output text, and timestamps.
+- **assistant_conversations** – records persona usage along with guild/channel/user IDs, model reference, token counts, input text, output text, and timestamps.
 
-The Discord chat module upserts the persona and appends a conversation record whenever `!summarize` or `!uwu` runs.
+The OpenAI module upserts the persona and appends a conversation record whenever `!summarize` or `!uwu` runs.

--- a/rpc/discord/chat/services.py
+++ b/rpc/discord/chat/services.py
@@ -20,18 +20,7 @@ async def discord_chat_summarize_channel_v1(request: Request):
     raise ValueError("hours must be between 1 and 336")
   module: DiscordChatModule = request.app.state.discord_chat
   await module.on_ready()
-  conv_id = await module.log_conversation(
-    "summarize",
-    guild_id,
-    channel_id,
-    f"summarize {hours}",
-    "",
-  )
   result = await module.summarize_chat(guild_id, channel_id, hours)
-  if conv_id:
-    await module.update_conversation_output(
-      conv_id, result.get("summary_text", "")
-    )
   payload = {
     "summary": result.get("summary_text"),
     "messages_collected": result.get("messages_collected"),
@@ -53,18 +42,7 @@ async def discord_chat_uwu_chat_v1(request: Request):
   req = DiscordChatUwuChatRequest1(**payload_dict)
   module: DiscordChatModule = request.app.state.discord_chat
   await module.on_ready()
-  conv_id = await module.log_conversation(
-    "uwu",
-    req.guild_id,
-    req.channel_id,
-    req.message,
-    "",
-  )
   result = await module.uwu_chat(req.guild_id, req.channel_id, req.user_id, req.message)
-  if conv_id:
-    await module.update_conversation_output(
-      conv_id, result.get("uwu_response_text", "")
-    )
   payload = DiscordChatUwuChatResponse1(**result)
   return RPCResponse(
     op=rpc_request.op,

--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -13,7 +13,9 @@ def test_assistant_conversations_list_by_time(monkeypatch):
 
   async def fake_fetch_json(sql, params, *, many=False):
     assert many
-    assert "FROM assistant_conversations" in sql
+    assert "element_modified_on" in sql
+    assert "element_user_id" in sql
+    assert "element_tokens" in sql
     assert params == (personas_recid, start, end)
     return DBResult(rows=[{"recid": 1}], rowcount=1)
 
@@ -25,4 +27,44 @@ def test_assistant_conversations_list_by_time(monkeypatch):
   ))
   assert isinstance(res, DBResult)
   assert res.rows == [{"recid": 1}]
+
+
+def test_assistant_conversations_insert(monkeypatch):
+  provider = MssqlProvider()
+  args = {
+    'personas_recid': 1,
+    'models_recid': 2,
+    'guild_id': '1',
+    'channel_id': '2',
+    'user_id': '3',
+    'input_data': 'hi',
+    'output_data': '',
+    'tokens': 5,
+  }
+
+  async def fake_fetch_rows(sql, params, *, one=False, stream=False):
+    assert one
+    assert "INSERT INTO assistant_conversations" in sql
+    assert params == (1, 2, '1', '2', '3', 'hi', '', 5)
+    return DBResult(rows=[{'recid': 9}], rowcount=1)
+
+  monkeypatch.setattr(mssql_provider, 'fetch_rows', fake_fetch_rows)
+
+  res = asyncio.run(provider.run('db:assistant:conversations:insert:1', args))
+  assert res.rows == [{'recid': 9}]
+
+
+def test_assistant_conversations_update_output(monkeypatch):
+  provider = MssqlProvider()
+  args = {'recid': 9, 'output_data': 'out'}
+
+  async def fake_exec(sql, params):
+    assert "element_modified_on" in sql
+    assert params == ('out', 9)
+    return DBResult(rowcount=1)
+
+  monkeypatch.setattr(mssql_provider, 'exec_query', fake_exec)
+
+  res = asyncio.run(provider.run('db:assistant:conversations:update_output:1', args))
+  assert res.rowcount == 1
 

--- a/tests/test_discord_chat_module.py
+++ b/tests/test_discord_chat_module.py
@@ -35,7 +35,7 @@ def test_uwu_chat(monkeypatch):
     async def on_ready(self):
       pass
 
-    async def fetch_chat(self, schemas, role, prompt, tokens, prompt_context=""):
+    async def fetch_chat(self, schemas, role, prompt, tokens, prompt_context="", **kwargs):
       self.roles.append(role)
       if role == "Summarize the following conversation into bullet points.":
         return {"content": "hi\nbye"}
@@ -81,7 +81,7 @@ def test_summarize_chat(monkeypatch):
     async def on_ready(self):
       pass
 
-    async def fetch_chat(self, schemas, role, prompt, tokens, prompt_context=""):
+    async def fetch_chat(self, schemas, role, prompt, tokens, prompt_context="", **kwargs):
       self.roles.append(role)
       return {"content": "sum", "model": "gpt", "role": "assistant"}
 
@@ -114,21 +114,3 @@ def test_summarize_chat(monkeypatch):
   assert app.state.openai.roles[-1] == "sum role"
 
 
-def test_log_conversation_records_persona_name():
-  app = FastAPI()
-  module = DiscordChatModule(app)
-
-  class DummyDB:
-    def __init__(self):
-      self.calls = []
-
-    async def run(self, op, args):
-      self.calls.append((op, args))
-      if op == "db:assistant:personas:get_by_name:1":
-        return DBResult(rows=[{"recid": 9}], rowcount=1)
-      return DBResult()
-
-  module.db = DummyDB()
-  asyncio.run(module.log_conversation("uwu", 1, 2, "in", "out"))
-  assert module.db.calls[1][0] == "db:assistant:conversations:insert:1"
-  assert module.db.calls[1][1]["persona"] == "uwu"

--- a/tests/test_discord_chat_services.py
+++ b/tests/test_discord_chat_services.py
@@ -26,12 +26,8 @@ from rpc.discord.chat import services as chat_services
 
 class StubModule:
   def __init__(self):
-    self.called = False
-    self.args = None
     self.uwu_called = False
     self.uwu_args = None
-    self.updated = False
-    self.update_args = None
     self.summary_called = False
     self.summary_args = None
 
@@ -67,16 +63,7 @@ class StubModule:
       'uwu_response_text': 'uwu hey',
     }
 
-  async def log_conversation(self, persona, guild_id, channel_id, input_data, output_data):
-    self.called = True
-    self.args = (persona, guild_id, channel_id, input_data, output_data)
-    return 42
-
-  async def update_conversation_output(self, recid, output_data):
-    self.updated = True
-    self.update_args = (recid, output_data)
-
-def test_uwu_chat_logs_conversation():
+def test_uwu_chat_handler():
   app = FastAPI()
   module = StubModule()
   app.state.discord_chat = module
@@ -98,8 +85,6 @@ def test_uwu_chat_logs_conversation():
   client = TestClient(app)
   resp = client.post('/rpc', json={'op': 'urn:discord:chat:uwu_chat:1'})
   assert resp.status_code == 200
-  assert module.called
-  assert module.updated
   assert module.uwu_called
   data = resp.json()
   expected = {
@@ -109,13 +94,11 @@ def test_uwu_chat_logs_conversation():
   }
   assert data["payload"] == expected
   assert module.uwu_args == (1, 2, 3, 'hey')
-  assert module.args == ('uwu', 1, 2, 'hey', '')
-  assert module.update_args == (42, 'uwu hey')
 
   chat_services.unbox_request = original
 
 
-def test_summarize_channel_logs_conversation():
+def test_summarize_channel_handler():
   app = FastAPI()
   module = StubModule()
   app.state.discord_chat = module
@@ -137,7 +120,6 @@ def test_summarize_channel_logs_conversation():
   client = TestClient(app)
   resp = client.post('/rpc', json={'op': 'urn:discord:chat:summarize_channel:1'})
   assert resp.status_code == 200
-  assert module.called
   assert module.summary_called
   data = resp.json()
   expected = {
@@ -149,7 +131,5 @@ def test_summarize_channel_logs_conversation():
     "role": "role",
   }
   assert data["payload"] == expected
-  assert module.args == ('summarize', 1, 2, 'summarize 1', '')
-  assert module.update_args == (42, 'hi')
 
   chat_services.unbox_request = original


### PR DESCRIPTION
## Summary
- centralize Discord conversation logging in OpenAI module
- track model, user, tokens, and response for !summarize and !uwu
- expand MSSQL queries and tests for new assistant_conversations schema

## Testing
- `python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68c783435d188325b9f52fffdc335252