### PR TITLE
Remove unused modified timestamp in assistant conversation update

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1363,8 +1363,7 @@ def _assistant_conversations_update_output(args: Dict[str, Any]):
   output_data = args.get("output_data")
   sql = """
     UPDATE assistant_conversations
-    SET element_output = ?,
-        element_modified_on = sysutcdatetime()
+    SET element_output = ?
     WHERE recid = ?;
   """
   return (DbRunMode.EXEC, sql, (output_data, recid))

--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -59,7 +59,7 @@ def test_assistant_conversations_update_output(monkeypatch):
   args = {'recid': 9, 'output_data': 'out'}
 
   async def fake_exec(sql, params):
-    assert "element_modified_on" in sql
+    assert "element_modified_on" not in sql
     assert params == ('out', 9)
     return DBResult(rowcount=1)
 


### PR DESCRIPTION
## Summary
- drop `element_modified_on` from assistant conversation output update
- stop tests from expecting `element_modified_on`

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68c78ccd18e4832590d80dccb15f88d8