### PR TITLE
Align privacy policy link width with home links

### DIFF
--- a/frontend/src/components/BottomBar.tsx
+++ b/frontend/src/components/BottomBar.tsx
@@ -59,11 +59,11 @@ const BottomBar = ({ info }: Props): JSX.Element => {
 					contact@elideusgroup.com
 				</Link>
 			</Typography>
-			<Typography variant="body1" sx={{ marginTop: '4px' }}>
-				<Link href="/privacy-policy" underline="none">Privacy Policy</Link>
+			<Typography variant="body1" sx={{ marginTop: '4px', width: '300px', mx: 'auto' }}>
+				<Link href="/privacy-policy" underline="none" sx={{ display: 'block' }}>Privacy Policy</Link>
 			</Typography>
-		</Box>
-	);
+	</Box>
+);
 };
 
 export default BottomBar;


### PR DESCRIPTION
## Summary
- style BottomBar privacy policy link to share width with other home page links

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68c78e53e3188325a616f4c8f1062e1c