### PR TITLE
Ensure modules start after Discord

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -13,6 +13,7 @@ from server.modules.providers import AuthProviderBase
 from server.modules.providers.auth.microsoft_provider import MicrosoftAuthProvider
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.providers.auth.discord_provider import DiscordAuthProvider
+from server.modules.discord_module import DiscordModule
 
 DEFAULT_SESSION_TOKEN_EXPIRY = 15 # minutes
 DEFAULT_ROTATION_TOKEN_EXPIRY = 90 # days
@@ -110,6 +111,7 @@ class AuthModule(BaseModule):
     self.jwt_algo_int: str = "HS256"
     self.jwks_cache_minutes: int = 60
     self.role_cache = RoleCache()
+    self.discord: DiscordModule | None = None
 
   @property
   def roles(self) -> dict[str, int]:
@@ -132,6 +134,9 @@ class AuthModule(BaseModule):
     await self.env.on_ready()
     self.db: DbModule = self.app.state.db
     await self.db.on_ready()
+    self.discord = getattr(self.app.state, "discord", None)
+    if self.discord:
+      await self.discord.on_ready()
     self.role_cache.db = self.db
     self.jwt_secret = self.env.get("JWT_SECRET")
     self.jwks_cache_minutes = await self.db.get_jwks_cache_time()

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -11,6 +11,7 @@ try:
 except Exception:
   DEFAULT_SESSION_TOKEN_EXPIRY = 15
 from server.modules.db_module import DbModule
+from server.modules.discord_module import DiscordModule
 
 
 class OauthModule(BaseModule):
@@ -22,12 +23,16 @@ class OauthModule(BaseModule):
 
   def __init__(self, app: FastAPI):
     super().__init__(app)
+    self.discord: DiscordModule | None = None
 
   async def startup(self):
     self.auth: AuthModule = self.app.state.auth
     await self.auth.on_ready()
     self.db: DbModule = self.app.state.db
     await self.db.on_ready()
+    self.discord = getattr(self.app.state, "discord", None)
+    if self.discord:
+      await self.discord.on_ready()
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from openai import AsyncOpenAI
 from . import BaseModule
 from .db_module import DbModule
+from .discord_module import DiscordModule
 
 
 async def send_to_discord(channel, text: str, max_message_size: int = 1998, delay: float = 1.0):
@@ -82,10 +83,14 @@ class OpenaiModule(BaseModule):
     self.db: DbModule | None = None
     self.client: AsyncOpenAI | None = None
     self.summary_queue = SummaryQueue()
+    self.discord: DiscordModule | None = None
 
   async def startup(self):
     self.db = self.app.state.db
     await self.db.on_ready()
+    self.discord = getattr(self.app.state, "discord", None)
+    if self.discord:
+      await self.discord.on_ready()
     self.client = await self.init_openai_client()
     self.app.state.openai = self
     logging.info("[OpenaiModule] loaded")

--- a/server/modules/public_gallery_module.py
+++ b/server/modules/public_gallery_module.py
@@ -1,15 +1,20 @@
 from fastapi import FastAPI
 from . import BaseModule
 from .db_module import DbModule
+from .discord_module import DiscordModule
 
 class PublicGalleryModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.db: DbModule | None = None
+    self.discord: DiscordModule | None = None
 
   async def startup(self):
     self.db = self.app.state.db
     await self.db.on_ready()
+    self.discord = getattr(self.app.state, "discord", None)
+    if self.discord:
+      await self.discord.on_ready()
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/public_links_module.py
+++ b/server/modules/public_links_module.py
@@ -2,15 +2,20 @@ from __future__ import annotations
 from fastapi import FastAPI
 from . import BaseModule
 from .db_module import DbModule
+from .discord_module import DiscordModule
 
 class PublicLinksModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.db: DbModule | None = None
+    self.discord: DiscordModule | None = None
 
   async def startup(self):
     self.db = self.app.state.db
     await self.db.on_ready()
+    self.discord = getattr(self.app.state, "discord", None)
+    if self.discord:
+      await self.discord.on_ready()
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/public_users_module.py
+++ b/server/modules/public_users_module.py
@@ -2,15 +2,20 @@ from __future__ import annotations
 from fastapi import FastAPI
 from . import BaseModule
 from .db_module import DbModule
+from .discord_module import DiscordModule
 
 class PublicUsersModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.db: DbModule | None = None
+    self.discord: DiscordModule | None = None
 
   async def startup(self):
     self.db = self.app.state.db
     await self.db.on_ready()
+    self.discord = getattr(self.app.state, "discord", None)
+    if self.discord:
+      await self.discord.on_ready()
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/public_vars_module.py
+++ b/server/modules/public_vars_module.py
@@ -4,18 +4,23 @@ from fastapi import FastAPI
 from . import BaseModule
 from .db_module import DbModule
 from .auth_module import AuthModule
+from .discord_module import DiscordModule
 
 class PublicVarsModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.db: DbModule | None = None
     self.auth: AuthModule | None = None
+    self.discord: DiscordModule | None = None
 
   async def startup(self):
     self.db = self.app.state.db
     await self.db.on_ready()
     self.auth = self.app.state.auth
     await self.auth.on_ready()
+    self.discord = getattr(self.app.state, "discord", None)
+    if self.discord:
+      await self.discord.on_ready()
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -2,17 +2,22 @@ from fastapi import FastAPI, HTTPException
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.auth_module import AuthModule
+from server.modules.discord_module import DiscordModule
 
 
 class RoleAdminModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
+    self.discord: DiscordModule | None = None
 
   async def startup(self):
     self.db: DbModule = self.app.state.db
     await self.db.on_ready()
     self.auth: AuthModule = self.app.state.auth
     await self.auth.on_ready()
+    self.discord = getattr(self.app.state, "discord", None)
+    if self.discord:
+      await self.discord.on_ready()
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/session_module.py
+++ b/server/modules/session_module.py
@@ -7,11 +7,13 @@ from server.modules import BaseModule
 from server.modules.auth_module import AuthModule, DEFAULT_SESSION_TOKEN_EXPIRY
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
+from server.modules.discord_module import DiscordModule
 
 
 class SessionModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
+    self.discord: DiscordModule | None = None
 
   async def startup(self):
     self.auth: AuthModule = self.app.state.auth
@@ -20,6 +22,9 @@ class SessionModule(BaseModule):
     await self.db.on_ready()
     self.oauth: OauthModule = self.app.state.oauth
     await self.oauth.on_ready()
+    self.discord = getattr(self.app.state, "discord", None)
+    if self.discord:
+      await self.discord.on_ready()
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from . import BaseModule
 from .env_module import EnvModule
 from .db_module import DbModule
+from .discord_module import DiscordModule
 
 
 class StorageModule(BaseModule):
@@ -26,6 +27,7 @@ class StorageModule(BaseModule):
     self.connection_string: str | None = None
     self._reindex_task: asyncio.Task | None = None
     self.reindex_interval = 15 * 60
+    self.discord: DiscordModule | None = None
 
   @staticmethod
   def _parse_duration(value: str) -> int:
@@ -41,6 +43,9 @@ class StorageModule(BaseModule):
     await self.env.on_ready()
     self.db = self.app.state.db
     await self.db.on_ready()
+    self.discord = getattr(self.app.state, "discord", None)
+    if self.discord:
+      await self.discord.on_ready()
     try:
       self.connection_string = self.env.get("AZURE_BLOB_CONNECTION_STRING")
       if not self.connection_string:

--- a/server/modules/system_config_module.py
+++ b/server/modules/system_config_module.py
@@ -3,6 +3,7 @@ import logging
 from fastapi import FastAPI
 from . import BaseModule
 from .db_module import DbModule
+from .discord_module import DiscordModule
 from rpc.system.config.models import (
   SystemConfigConfigItem1,
   SystemConfigDeleteConfig1,
@@ -13,10 +14,14 @@ class SystemConfigModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.db: DbModule | None = None
+    self.discord: DiscordModule | None = None
 
   async def startup(self):
     self.db = self.app.state.db
     await self.db.on_ready()
+    self.discord = getattr(self.app.state, "discord", None)
+    if self.discord:
+      await self.discord.on_ready()
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/user_admin_module.py
+++ b/server/modules/user_admin_module.py
@@ -1,15 +1,20 @@
 from fastapi import FastAPI, HTTPException
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
+from server.modules.discord_module import DiscordModule
 
 
 class UserAdminModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
+    self.discord: DiscordModule | None = None
 
   async def startup(self):
     self.db: DbModule = self.app.state.db
     await self.db.on_ready()
+    self.discord = getattr(self.app.state, "discord", None)
+    if self.discord:
+      await self.discord.on_ready()
     self.mark_ready()
 
   async def shutdown(self):


### PR DESCRIPTION
## Summary
- Add optional Discord dependency to various modules so they wait for Discord to be ready before completing startup
- Keep startup behavior unchanged when Discord is absent (e.g., tests)

## Testing
- `python scripts/run_tests.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68c80d4efb008325ab35b5d76931ddf1