### PR TITLE
Include user ID in summarize conversations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,4 +26,6 @@ Each command invocation is logged for auditing:
 - **assistant_personas** – stores persona names and optional metadata.
 - **assistant_conversations** – records persona usage along with guild/channel/user IDs, model reference, token counts, input text, output text, and timestamps.
 
+The user ID of whoever invokes `!summarize` is captured in the conversation log.
+
 The OpenAI module upserts the persona and appends a conversation record whenever `!summarize` or `!uwu` runs.

--- a/rpc/discord/chat/services.py
+++ b/rpc/discord/chat/services.py
@@ -16,11 +16,14 @@ async def discord_chat_summarize_channel_v1(request: Request):
   guild_id = p.get("guild_id")
   channel_id = p.get("channel_id")
   hours = int(p.get("hours", 1))
+  user_id = p.get("user_id")
+  if user_id is not None:
+    user_id = int(user_id)
   if hours < 1 or hours > 336:
     raise ValueError("hours must be between 1 and 336")
   module: DiscordChatModule = request.app.state.discord_chat
   await module.on_ready()
-  result = await module.summarize_chat(guild_id, channel_id, hours)
+  result = await module.summarize_chat(guild_id, channel_id, hours, user_id)
   payload = {
     "summary": result.get("summary_text"),
     "messages_collected": result.get("messages_collected"),

--- a/server/modules/discord_chat_module.py
+++ b/server/modules/discord_chat_module.py
@@ -169,6 +169,7 @@ class DiscordChatModule(BaseModule):
     guild_id: int,
     channel_id: int,
     hours: int,
+    user_id: int | None = None,
     max_messages: int = 5000,
   ) -> dict:
     hours = max(hours, 1)
@@ -189,6 +190,7 @@ class DiscordChatModule(BaseModule):
         persona="summarize",
         guild_id=guild_id,
         channel_id=channel_id,
+        user_id=user_id,
         input_log=str(hours),
         token_count=summary["token_count_estimate"],
       )
@@ -209,6 +211,7 @@ class DiscordChatModule(BaseModule):
         "guild_id": guild_id,
         "channel_id": channel_id,
         "hours": hours,
+        "user_id": user_id,
         "messages_collected": summary["messages_collected"],
         "token_count_estimate": summary["token_count_estimate"],
         "model": model,

--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -181,6 +181,7 @@ class DiscordModule(BaseModule):
           "guild_id": ctx.guild.id,
           "channel_id": ctx.channel.id,
           "hours": hrs,
+          "user_id": ctx.author.id,
         },
       }).encode()
 

--- a/tests/test_discord_bot_macros.py
+++ b/tests/test_discord_bot_macros.py
@@ -94,6 +94,7 @@ def test_summarize_macro_dm(monkeypatch):
   assert dummy_handle.called
   assert dummy_handle.body["op"] == "urn:discord:chat:summarize_channel:1"
   assert dummy_handle.body["payload"]["hours"] == 2
+  assert dummy_handle.body["payload"]["user_id"] == author.id
   assert author.dm_channel.sent == ["hi"]
   assert author.dm_channel.history_called
   assert channel.sent == []

--- a/tests/test_discord_chat_module.py
+++ b/tests/test_discord_chat_module.py
@@ -83,6 +83,7 @@ def test_summarize_chat(monkeypatch):
 
     async def fetch_chat(self, schemas, role, prompt, tokens, prompt_context="", **kwargs):
       self.roles.append(role)
+      assert kwargs.get("user_id") == 4
       return {"content": "sum", "model": "gpt", "role": "assistant"}
 
   app.state.openai = DummyOpenAI()
@@ -106,7 +107,7 @@ def test_summarize_chat(monkeypatch):
 
   module.summarize_channel = dummy_summarize  # type: ignore
 
-  res = asyncio.run(module.summarize_chat(1, 2, 3))
+  res = asyncio.run(module.summarize_chat(1, 2, 3, user_id=4))
   assert res["token_count_estimate"] == 5
   assert res["summary_text"] == "sum"
   assert res["model"] == "gpt"

--- a/tests/test_discord_chat_services.py
+++ b/tests/test_discord_chat_services.py
@@ -42,9 +42,9 @@ class StubModule:
       'cap_hit': False,
     }
 
-  async def summarize_chat(self, guild_id, channel_id, hours, max_messages=5000):
+  async def summarize_chat(self, guild_id, channel_id, hours, user_id=None, max_messages=5000):
     self.summary_called = True
-    self.summary_args = (guild_id, channel_id, hours)
+    self.summary_args = (guild_id, channel_id, hours, user_id)
     return {
       'token_count_estimate': 2,
       'messages_collected': 1,
@@ -105,7 +105,7 @@ def test_summarize_channel_handler():
 
   async def fake_unbox(request):
     return (
-      RPCRequest(op='urn:discord:chat:summarize_channel:1', payload={'guild_id': 1, 'channel_id': 2, 'hours': 1}),
+      RPCRequest(op='urn:discord:chat:summarize_channel:1', payload={'guild_id': 1, 'channel_id': 2, 'hours': 1, 'user_id': 3}),
       AuthContext(),
       [],
     )
@@ -131,5 +131,6 @@ def test_summarize_channel_handler():
     "role": "role",
   }
   assert data["payload"] == expected
+  assert module.summary_args == (1, 2, 1, 3)
 
   chat_services.unbox_request = original


### PR DESCRIPTION
## Summary
- pass requesting user's ID through !summarize RPC payloads
- log user ID when summarizing chat and record it in conversation logs
- adjust documentation and tests for new user_id field

## Testing
- `python scripts/run_tests.py --test`

------
https://chatgpt.com/codex/tasks/task_e_68c8203479ec83258146d0b384be5f71