### PR TITLE
Use persona model and tokens from DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Two tables record persona definitions and usage:
 
 | Table | Purpose |
 | ----- | ------- |
-| `assistant_personas` | Stores persona names and metadata. |
+| `assistant_personas` | Stores persona names, prompts, token limits, and model references. |
 | `assistant_conversations` | Logs each interaction including guild/channel/user IDs, model reference, token counts, input text, output text, and timestamps. |
 
 The OpenAI module records conversation details whenever `!summarize` or `!uwu` is executed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ Example:
 
 Each command invocation is logged for auditing:
 
-- **assistant_personas** – stores persona names and optional metadata.
+- **assistant_personas** – stores persona names, prompts, token limits, and model references.
 - **assistant_conversations** – records persona usage along with guild/channel/user IDs, model reference, token counts, input text, output text, and timestamps.
 
 The user ID of whoever invokes `!summarize` is captured in the conversation log.

--- a/server/modules/discord_chat_module.py
+++ b/server/modules/discord_chat_module.py
@@ -95,7 +95,7 @@ class DiscordChatModule(BaseModule):
       )
       if res.rows:
         row = res.rows[0]
-        instructions = row.get("instructions") or row.get("element_metadata")
+        instructions = row.get("instructions")
         if isinstance(instructions, dict):
           return instructions.get("instructions", "")
         return instructions or ""
@@ -122,7 +122,7 @@ class DiscordChatModule(BaseModule):
       [],
       role,
       user_message,
-      120,
+      None,
       prompt_context,
       persona="uwu",
       guild_id=guild_id,
@@ -186,7 +186,7 @@ class DiscordChatModule(BaseModule):
         [],
         role,
         summary["raw_text_blob"],
-        300,
+        None,
         persona="summarize",
         guild_id=guild_id,
         channel_id=channel_id,

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1307,7 +1307,15 @@ def _security_roles_remove_member(args: Dict[str, Any]):
 def _assistant_personas_get_by_name(args: Dict[str, Any]):
   name = args["name"]
   sql = """
-    SELECT recid, element_metadata FROM assistant_personas WHERE element_name = ?;
+    SELECT
+      ap.recid,
+      ap.element_prompt AS instructions,
+      ap.element_tokens,
+      ap.models_recid,
+      am.element_name AS model
+    FROM assistant_personas ap
+    JOIN assistant_models am ON am.recid = ap.models_recid
+    WHERE ap.element_name = ?;
   """
   return (DbRunMode.ROW_ONE, sql, (name,))
 

--- a/tests/test_discord_chat_module.py
+++ b/tests/test_discord_chat_module.py
@@ -35,7 +35,7 @@ def test_uwu_chat(monkeypatch):
     async def on_ready(self):
       pass
 
-    async def fetch_chat(self, schemas, role, prompt, tokens, prompt_context="", **kwargs):
+    async def fetch_chat(self, schemas, role, prompt, tokens=None, prompt_context="", **kwargs):
       self.roles.append(role)
       if role == "Summarize the following conversation into bullet points.":
         return {"content": "hi\nbye"}
@@ -81,7 +81,7 @@ def test_summarize_chat(monkeypatch):
     async def on_ready(self):
       pass
 
-    async def fetch_chat(self, schemas, role, prompt, tokens, prompt_context="", **kwargs):
+    async def fetch_chat(self, schemas, role, prompt, tokens=None, prompt_context="", **kwargs):
       self.roles.append(role)
       assert kwargs.get("user_id") == 4
       return {"content": "sum", "model": "gpt", "role": "assistant"}


### PR DESCRIPTION
## Summary
- Retrieve persona prompt, token limit, and model via join on `assistant_models`
- OpenAI module now uses persona's model and token settings when sending prompts and logging conversations
- Update docs and tests for new `assistant_personas` schema

## Testing
- `python scripts/generate_rpc_bindings.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8268e62a08325bac6c8c5817b89ef