### PR TITLE
Add Discord personas placeholder page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ const UserPage = lazy(() => import("./pages/UserPage"));
 const ServiceRoutesPage = lazy(() => import("./pages/service/ServiceRoutesPage"));
 const ServiceRolesPage = lazy(() => import("./pages/service/ServiceRolesPage"));
 const FileManager = lazy(() => import("./pages/FileManager"));
+const DiscordPersonasPage = lazy(() => import("./pages/DiscordPersonasPage"));
 const SystemConfigPage = lazy(() => import("./pages/system/SystemConfigPage"));
 const AccountRolesPage = lazy(() => import("./pages/AccountRolesPage"));
 const AccountUsersPage = lazy(() => import("./pages/AccountUsersPage"));
@@ -49,6 +50,10 @@ function App(): JSX.Element {
 								<Route path="/account-users" element={<AccountUsersPage />} />
                                                                 <Route path="/account-users/:guid" element={<AccountUserPanel />} />
                                                                 <Route path="/file-manager" element={<FileManager />} />
+                                                                <Route
+                                                                        path="/discord-personas"
+                                                                        element={<DiscordPersonasPage />}
+                                                                />
                                                                 <Route path="/privacy-policy" element={<PrivacyPolicy />} />
                                                                 <Route path="/profile/:guid" element={<PublicProfile />} />
                                                         </Routes>

--- a/frontend/src/pages/DiscordPersonasPage.tsx
+++ b/frontend/src/pages/DiscordPersonasPage.tsx
@@ -1,0 +1,15 @@
+import { Box, Typography } from "@mui/material";
+import PageTitle from "../components/PageTitle";
+
+const DiscordPersonasPage = (): JSX.Element => {
+        return (
+                <Box sx={{ p: 2 }}>
+                        <PageTitle>Persona Editor</PageTitle>
+                        <Typography variant="body1" sx={{ mt: 2 }}>
+                                coming soon
+                        </Typography>
+                </Box>
+        );
+};
+
+export default DiscordPersonasPage;


### PR DESCRIPTION
## Summary
- add a lazy-loaded Discord personas page that uses the shared PageTitle component
- register the Discord personas route so the navigation entry renders a placeholder view

## Testing
- npm run lint
- npm run type-check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c85c9d63f08325afaee108533d55e6