### PR TITLE
Refactor Discord personas to discord admin namespace

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,9 +35,9 @@ low bits are used for user level flags.
 | 62  | `0x4000000000000000`  | `ROLE_SERVICE_ADMIN`      | The configuration of the service, such as API keys |
 | 61  | `0x2000000000000000`  | `ROLE_SYSTEM_ADMIN`       | Access to system configuration features |
 | 60  | `0x1000000000000000`  | `ROLE_ACCOUNT_ADMIN`      | Manage security role definitions and user assignments |
-| 59  | `0x0800000000000000`  | `ROLE_MODERATOR`          | Access to moderation tools |
-| 58  | `0x0400000000000000`  | `ROLE_SUPPORT`            | Access to support utilities |
-| 57  | `0x0200000000000000`  | *(reserved)*              | |
+| 59  | `0x0800000000000000`  | `ROLE_DISCORD_ADMIN`      | Manage Discord personas and integrations |
+| 58  | `0x0400000000000000`  | `ROLE_MODERATOR`          | Access to moderation tools |
+| 57  | `0x0200000000000000`  | `ROLE_SUPPORT`            | Access to support utilities |
 | 56  | `0x0100000000000000`  | *(reserved)*              | |
 | ... | ...                   |                           | |
 | 6   | `0x0000000000000040`  | `ROLE_DISCORD_BOT`        | Allows the user to interact with the system via Discord |

--- a/RPC.md
+++ b/RPC.md
@@ -234,7 +234,11 @@ All Moderation domain calls require `ROLE_MODERATOR`.
 
 ## Discord Domain
 
-All Discord domain calls require `ROLE_DISCORD_BOT`.
+Discord domain calls require Discord-specific roles depending on the subdomain:
+
+- `chat` and `command` operations require `ROLE_DISCORD_BOT`.
+- `personas` operations require `ROLE_DISCORD_ADMIN`.
+
 Requests must include the `x-discord-id` (or `x-discord-user-id`) header identifying the caller. If headers cannot be set, provide the identifier as `discord_id` within the request payload.
 
 Currently exposes placeholder Discord command operations.
@@ -253,6 +257,15 @@ Currently exposes placeholder Discord command operations.
 | ------------------------------------------- | ------------------------------- |
 | `urn:discord:chat:summarize_channel:1`      | Summarize a Discord channel.    |
 | `urn:discord:chat:uwu_chat:1`               | Stub chat returning "uwu" text. |
+
+### `personas`
+
+| Operation                                   | Description                                   |
+| ------------------------------------------- | --------------------------------------------- |
+| `urn:discord:personas:get_personas:1`       | List Discord assistant personas.              |
+| `urn:discord:personas:get_models:1`         | List available assistant models.              |
+| `urn:discord:personas:upsert_persona:1`     | Create or update a Discord assistant persona. |
+| `urn:discord:personas:delete_persona:1`     | Delete a Discord assistant persona.           |
 
 #### Usage Examples
 

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -67,13 +67,19 @@ const NavBar = (): JSX.Element => {
                                 {(() => {
 					const publicRoutes = routes.filter((r) => r.path === '/' || r.path.startsWith('/gallery'));
 					const roleRoutes = routes.filter((r) => !(r.path === '/' || r.path.startsWith('/gallery')));
-					const userRoutes = roleRoutes.filter((r) => r.path.startsWith('/user'));
-					const accountRoutes = roleRoutes.filter((r) => r.path.startsWith('/account'));
-					const systemRoutes = roleRoutes.filter((r) => r.path.startsWith('/system'));
-					const serviceRoutes = roleRoutes.filter((r) => r.path.startsWith('/service'));
-					const otherRoutes = roleRoutes.filter(
-						(r) => !['/user', '/account', '/system', '/service'].some((p) => r.path.startsWith(p)),
-					);
+                                        const isDiscordRoute = (path: string) =>
+                                                path.startsWith('/discord') || path.startsWith('/discord-');
+                                        const userRoutes = roleRoutes.filter((r) => r.path.startsWith('/user'));
+                                        const accountRoutes = roleRoutes.filter((r) => r.path.startsWith('/account'));
+                                        const systemRoutes = roleRoutes.filter((r) => r.path.startsWith('/system'));
+                                        const serviceRoutes = roleRoutes.filter((r) => r.path.startsWith('/service'));
+                                        const discordRoutes = roleRoutes.filter((r) => isDiscordRoute(r.path));
+                                        const otherRoutes = roleRoutes.filter(
+                                                (r) =>
+                                                        !['/user', '/account', '/system', '/service'].some((p) =>
+                                                                r.path.startsWith(p),
+                                                        ) && !isDiscordRoute(r.path),
+                                        );
 
 					const renderItem = (route: PublicLinksNavBarRoute1) => {
                                                 const IconComp = iconMap[route.icon ?? ''] || defaultIcon;
@@ -120,7 +126,8 @@ const NavBar = (): JSX.Element => {
 							{renderSection('USER', userRoutes)}
 							{renderSection('ACCOUNT', accountRoutes)}
 							{renderSection('SYSTEM', systemRoutes)}
-							{renderSection('SERVICE', serviceRoutes)}
+                                                        {renderSection('SERVICE', serviceRoutes)}
+                                                        {renderSection('DISCORD', discordRoutes)}
 						</>
 					);
                                 })()}

--- a/frontend/src/pages/DiscordPersonasPage.tsx
+++ b/frontend/src/pages/DiscordPersonasPage.tsx
@@ -1,13 +1,266 @@
-import { Box, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+import {
+        Box,
+        Divider,
+        Table,
+        TableHead,
+        TableRow,
+        TableCell,
+        TableBody,
+        Typography,
+        IconButton,
+        TextField,
+        MenuItem,
+} from "@mui/material";
+import { Delete, Add } from "@mui/icons-material";
 import PageTitle from "../components/PageTitle";
+import EditBox from "../components/EditBox";
+import ColumnHeader from "../components/ColumnHeader";
+import type {
+        DiscordPersonasPersonaItem1,
+        DiscordPersonasList1,
+        DiscordPersonasModels1,
+        DiscordPersonasModelItem1,
+        DiscordPersonasUpsertPersona1,
+} from "../shared/RpcModels";
+import {
+        fetchPersonas,
+        fetchModels,
+        fetchUpsertPersona,
+        fetchDeletePersona,
+} from "../rpc/discord/personas";
 
 const DiscordPersonasPage = (): JSX.Element => {
+        const [personas, setPersonas] = useState<DiscordPersonasPersonaItem1[]>([]);
+        const [models, setModels] = useState<DiscordPersonasModelItem1[]>([]);
+        const [newPersona, setNewPersona] = useState<DiscordPersonasUpsertPersona1>({
+                recid: null,
+                name: "",
+                prompt: "",
+                tokens: 0,
+                models_recid: 0,
+        });
+        const [forbidden, setForbidden] = useState(false);
+
+        const load = async (): Promise<void> => {
+                try {
+                        const res: DiscordPersonasList1 = await fetchPersonas();
+                        const sorted = [...(res.personas ?? [])].sort((a, b) => a.name.localeCompare(b.name));
+                        setPersonas(sorted);
+                        setForbidden(false);
+                } catch (e: any) {
+                        if (e?.response?.status === 403) {
+                                setForbidden(true);
+                        } else {
+                                setPersonas([]);
+                        }
+                }
+                try {
+                        const resModels: DiscordPersonasModels1 = await fetchModels();
+                        setModels(resModels.models ?? []);
+                        setNewPersona((prev) => ({
+                                ...prev,
+                                recid: null,
+                                models_recid:
+                                        prev.models_recid || (resModels.models && resModels.models.length ? resModels.models[0].recid : 0),
+                        }));
+                } catch (e: any) {
+                        if (e?.response?.status === 403) {
+                                setForbidden(true);
+                        } else {
+                                setModels([]);
+                        }
+                }
+        };
+
+        useEffect(() => {
+                void load();
+        }, []);
+
+        if (forbidden) {
+                return (
+                        <Box sx={{ p: 2 }}>
+                                <Typography variant="h6">Forbidden</Typography>
+                        </Box>
+                );
+        }
+
+        const updatePersona = async (
+                index: number,
+                changes: Partial<DiscordPersonasPersonaItem1>,
+        ): Promise<void> => {
+                const updated = [...personas];
+                const next = { ...updated[index], ...changes };
+                updated[index] = next;
+                setPersonas(updated);
+                await fetchUpsertPersona({
+                        recid: next.recid ?? null,
+                        name: next.name,
+                        prompt: next.prompt,
+                        tokens: next.tokens,
+                        models_recid: next.models_recid,
+                });
+                void load();
+        };
+
+        const handleDelete = async (item: DiscordPersonasPersonaItem1): Promise<void> => {
+                await fetchDeletePersona({
+                        recid: item.recid ?? null,
+                        name: item.name,
+                });
+                void load();
+        };
+
+        const handleAdd = async (): Promise<void> => {
+                if (!newPersona.name.trim()) return;
+                if (!newPersona.models_recid) return;
+                await fetchUpsertPersona({
+                        recid: null,
+                        name: newPersona.name.trim(),
+                        prompt: newPersona.prompt,
+                        tokens: newPersona.tokens,
+                        models_recid: newPersona.models_recid,
+                });
+                setNewPersona({
+                        recid: null,
+                        name: "",
+                        prompt: "",
+                        tokens: 0,
+                        models_recid: models.length ? models[0].recid : 0,
+                });
+                void load();
+        };
+
         return (
                 <Box sx={{ p: 2 }}>
                         <PageTitle>Persona Editor</PageTitle>
-                        <Typography variant="body1" sx={{ mt: 2 }}>
-                                coming soon
-                        </Typography>
+                        <Divider sx={{ mb: 2 }} />
+                        <Table size="small" sx={{ "& td, & th": { py: 0.5, verticalAlign: "top" } }}>
+                                <TableHead>
+                                        <TableRow>
+                                                <ColumnHeader sx={{ width: "15%" }}>Persona</ColumnHeader>
+                                                <ColumnHeader sx={{ width: "15%" }}>Model</ColumnHeader>
+                                                <ColumnHeader sx={{ width: "10%" }}>Tokens</ColumnHeader>
+                                                <ColumnHeader sx={{ width: "55%" }}>Prompt</ColumnHeader>
+                                                <ColumnHeader sx={{ width: "5%" }} />
+                                        </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                        {personas.map((persona, idx) => (
+                                                <TableRow key={`${persona.name}-${persona.recid ?? idx}`}>
+                                                        <TableCell sx={{ width: "15%" }}>
+                                                                <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                                                        {persona.name}
+                                                                </Typography>
+                                                        </TableCell>
+                                                        <TableCell sx={{ width: "15%" }}>
+                                                                <TextField
+                                                                        select
+                                                                        sx={{ width: "95%" }}
+                                                                        value={persona.models_recid}
+                                                                        onChange={(e) => {
+                                                                                const value = Number(e.target.value);
+                                                                                const modelName = models.find((m) => m.recid === value)?.name ?? persona.model;
+                                                                                void updatePersona(idx, {
+                                                                                        models_recid: value,
+                                                                                        model: modelName,
+                                                                                });
+                                                                        }}
+                                                                >
+                                                                        {models.map((model) => (
+                                                                                <MenuItem key={model.recid} value={model.recid}>
+                                                                                        {model.name}
+                                                                                </MenuItem>
+                                                                        ))}
+                                                                </TextField>
+                                                        </TableCell>
+                                                        <TableCell sx={{ width: "10%" }}>
+                                                                <EditBox
+                                                                        value={persona.tokens}
+                                                                        onCommit={(val) => updatePersona(idx, { tokens: Number(val) })}
+                                                                        width="80px"
+                                                                />
+                                                        </TableCell>
+                                                        <TableCell sx={{ width: "55%" }}>
+                                                                <EditBox
+                                                                        value={persona.prompt}
+                                                                        onCommit={(val) => updatePersona(idx, { prompt: String(val) })}
+                                                                        width="100%"
+                                                                />
+                                                        </TableCell>
+                                                        <TableCell sx={{ width: "5%" }}>
+                                                                <IconButton onClick={() => void handleDelete(persona)}>
+                                                                        <Delete />
+                                                                </IconButton>
+                                                        </TableCell>
+                                                </TableRow>
+                                        ))}
+                                        <TableRow>
+                                                <TableCell sx={{ width: "15%" }}>
+                                                        <TextField
+                                                                sx={{ width: "95%" }}
+                                                                value={newPersona.name}
+                                                                placeholder="Name"
+                                                                onChange={(e) =>
+                                                                        setNewPersona({
+                                                                                ...newPersona,
+                                                                                name: e.target.value,
+                                                                        })
+                                                                }
+                                                        />
+                                                </TableCell>
+                                                <TableCell sx={{ width: "15%" }}>
+                                                        <TextField
+                                                                select
+                                                                sx={{ width: "95%" }}
+                                                                value={newPersona.models_recid}
+                                                                onChange={(e) =>
+                                                                        setNewPersona({
+                                                                                ...newPersona,
+                                                                                models_recid: Number(e.target.value),
+                                                                        })
+                                                                }
+                                                        >
+                                                                {models.map((model) => (
+                                                                        <MenuItem key={model.recid} value={model.recid}>
+                                                                                {model.name}
+                                                                        </MenuItem>
+                                                                ))}
+                                                        </TextField>
+                                                </TableCell>
+                                                <TableCell sx={{ width: "10%" }}>
+                                                        <TextField
+                                                                type="number"
+                                                                sx={{ width: "80px" }}
+                                                                value={newPersona.tokens}
+                                                                onChange={(e) =>
+                                                                        setNewPersona({
+                                                                                ...newPersona,
+                                                                                tokens: Number(e.target.value),
+                                                                        })
+                                                                }
+                                                        />
+                                                </TableCell>
+                                                <TableCell sx={{ width: "55%" }}>
+                                                        <TextField
+                                                                sx={{ width: "100%" }}
+                                                                value={newPersona.prompt}
+                                                                onChange={(e) =>
+                                                                        setNewPersona({
+                                                                                ...newPersona,
+                                                                                prompt: e.target.value,
+                                                                        })
+                                                                }
+                                                        />
+                                                </TableCell>
+                                                <TableCell sx={{ width: "5%" }}>
+                                                        <IconButton onClick={() => void handleAdd()}>
+                                                                <Add />
+                                                        </IconButton>
+                                                </TableCell>
+                                        </TableRow>
+                                </TableBody>
+                        </Table>
                 </Box>
         );
 };

--- a/rpc/discord/__init__.py
+++ b/rpc/discord/__init__.py
@@ -1,12 +1,29 @@
-"""Discord namespace for bot interactions.
+"""Discord RPC namespace.
 
-Requires ROLE_DISCORD_BOT.
+Provides handlers for Discord bot operations (``ROLE_DISCORD_BOT``) and Discord
+administration flows (``ROLE_DISCORD_ADMIN``).
 """
 
 from .chat.handler import handle_chat_request
 from .command.handler import handle_command_request
+from .personas.handler import handle_personas_request
 
 HANDLERS: dict[str, callable] = {
   "chat": handle_chat_request,
   "command": handle_command_request,
+  "personas": handle_personas_request,
+}
+
+
+REQUIRED_ROLES: dict[str, str] = {
+  "chat": "ROLE_DISCORD_BOT",
+  "command": "ROLE_DISCORD_BOT",
+  "personas": "ROLE_DISCORD_ADMIN",
+}
+
+
+FORBIDDEN_DETAILS: dict[str, str] = {
+  "chat": 'You must have the Discord bot role assigned to use this bot.',
+  "command": 'You must have the Discord bot role assigned to use this bot.',
+  "personas": 'Forbidden',
 }

--- a/rpc/discord/handler.py
+++ b/rpc/discord/handler.py
@@ -1,7 +1,4 @@
-"""Handlers for the Discord RPC namespace.
-
-Requires ROLE_DISCORD_BOT.
-"""
+"""Handlers for the Discord RPC namespace."""
 
 from fastapi import HTTPException, Request
 
@@ -9,22 +6,20 @@ from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 
-from . import HANDLERS
+from . import FORBIDDEN_DETAILS, HANDLERS, REQUIRED_ROLES
 
 
 async def handle_discord_request(parts: list[str], request: Request) -> RPCResponse:
-  _, auth_ctx, _ = await unbox_request(request)
-  auth: AuthModule = request.app.state.auth
-  required_mask = auth.roles.get("ROLE_DISCORD_BOT", 0)
-  if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
-    raise HTTPException(
-      status_code=403,
-      detail='You must have the Discord bot role assigned to use this bot.'
-    )
-
   subdomain = parts[0]
   handler = HANDLERS.get(subdomain)
   if not handler:
     raise HTTPException(status_code=404, detail='Unknown RPC subdomain')
+  _, auth_ctx, _ = await unbox_request(request)
+  auth: AuthModule = request.app.state.auth
+  role_name = REQUIRED_ROLES.get(subdomain)
+  required_mask = auth.roles.get(role_name, 0) if role_name else 0
+  if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
+    detail = FORBIDDEN_DETAILS.get(subdomain, 'Forbidden')
+    raise HTTPException(status_code=403, detail=detail)
   return await handler(parts[1:], request)
 

--- a/rpc/discord/personas/__init__.py
+++ b/rpc/discord/personas/__init__.py
@@ -1,0 +1,20 @@
+"""Discord personas RPC namespace.
+
+Handlers are dispatched by :mod:`rpc.discord.handler` after role checks for
+``ROLE_DISCORD_ADMIN`` succeed.
+"""
+
+from .services import (
+  discord_personas_delete_persona_v1,
+  discord_personas_get_models_v1,
+  discord_personas_get_personas_v1,
+  discord_personas_upsert_persona_v1,
+)
+
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("get_personas", "1"): discord_personas_get_personas_v1,
+  ("get_models", "1"): discord_personas_get_models_v1,
+  ("upsert_persona", "1"): discord_personas_upsert_persona_v1,
+  ("delete_persona", "1"): discord_personas_delete_persona_v1,
+}

--- a/rpc/discord/personas/handler.py
+++ b/rpc/discord/personas/handler.py
@@ -1,0 +1,19 @@
+"""Discord personas RPC handler.
+
+Dispatches persona management operations once ``ROLE_DISCORD_ADMIN`` access has
+been verified by the domain handler.
+"""
+
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_personas_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/discord/personas/models.py
+++ b/rpc/discord/personas/models.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class DiscordPersonasModelItem1(BaseModel):
+  recid: int
+  name: str
+
+
+class DiscordPersonasModels1(BaseModel):
+  models: list[DiscordPersonasModelItem1]
+
+
+class DiscordPersonasPersonaItem1(BaseModel):
+  recid: Optional[int] = None
+  name: str
+  prompt: str
+  tokens: int
+  models_recid: int
+  model: Optional[str] = None
+
+
+class DiscordPersonasList1(BaseModel):
+  personas: list[DiscordPersonasPersonaItem1]
+
+
+class DiscordPersonasUpsertPersona1(BaseModel):
+  recid: Optional[int] = None
+  name: str
+  prompt: str
+  tokens: int
+  models_recid: int
+
+
+class DiscordPersonasDeletePersona1(BaseModel):
+  recid: Optional[int] = None
+  name: Optional[str] = None

--- a/rpc/discord/personas/services.py
+++ b/rpc/discord/personas/services.py
@@ -1,0 +1,105 @@
+import logging
+
+from fastapi import Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.discord_personas_module import DiscordPersonasModule
+
+from .models import (
+  DiscordPersonasDeletePersona1,
+  DiscordPersonasList1,
+  DiscordPersonasModelItem1,
+  DiscordPersonasModels1,
+  DiscordPersonasPersonaItem1,
+  DiscordPersonasUpsertPersona1,
+)
+
+
+async def discord_personas_get_personas_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  logging.debug(
+    "[discord_personas_get_personas_v1] user=%s roles=%s",
+    auth_ctx.user_guid,
+    auth_ctx.roles,
+  )
+  module: DiscordPersonasModule = request.app.state.discord_personas
+  rows = await module.list_personas()
+  personas = [DiscordPersonasPersonaItem1(**row) for row in rows]
+  payload = DiscordPersonasList1(personas=personas)
+  logging.debug(
+    "[discord_personas_get_personas_v1] returning %d personas",
+    len(personas),
+  )
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def discord_personas_get_models_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  logging.debug(
+    "[discord_personas_get_models_v1] user=%s roles=%s",
+    auth_ctx.user_guid,
+    auth_ctx.roles,
+  )
+  module: DiscordPersonasModule = request.app.state.discord_personas
+  rows = await module.list_models()
+  models = [DiscordPersonasModelItem1(**row) for row in rows]
+  payload = DiscordPersonasModels1(models=models)
+  logging.debug(
+    "[discord_personas_get_models_v1] returning %d models",
+    len(models),
+  )
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def discord_personas_upsert_persona_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  logging.debug(
+    "[discord_personas_upsert_persona_v1] user=%s roles=%s payload=%s",
+    auth_ctx.user_guid,
+    auth_ctx.roles,
+    rpc_request.payload,
+  )
+  payload = DiscordPersonasUpsertPersona1(**(rpc_request.payload or {}))
+  module: DiscordPersonasModule = request.app.state.discord_personas
+  await module.upsert_persona(payload.model_dump())
+  logging.debug(
+    "[discord_personas_upsert_persona_v1] upserted persona %s",
+    payload.name,
+  )
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def discord_personas_delete_persona_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  logging.debug(
+    "[discord_personas_delete_persona_v1] user=%s roles=%s payload=%s",
+    auth_ctx.user_guid,
+    auth_ctx.roles,
+    rpc_request.payload,
+  )
+  payload = DiscordPersonasDeletePersona1(**(rpc_request.payload or {}))
+  module: DiscordPersonasModule = request.app.state.discord_personas
+  await module.delete_persona(recid=payload.recid, name=payload.name)
+  logging.debug(
+    "[discord_personas_delete_persona_v1] deleted persona recid=%s name=%s",
+    payload.recid,
+    payload.name,
+  )
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )

--- a/server/modules/discord_personas_module.py
+++ b/server/modules/discord_personas_module.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import FastAPI
+
+from server.modules import BaseModule
+from server.modules.db_module import DbModule
+
+
+class DiscordPersonasModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    pass
+
+  async def list_models(self) -> List[Dict[str, Any]]:
+    assert self.db
+    res = await self.db.run("db:assistant:models:list:1", {})
+    return list(res.rows or [])
+
+  async def list_personas(self) -> List[Dict[str, Any]]:
+    assert self.db
+    res = await self.db.run("db:assistant:personas:list:1", {})
+    personas: List[Dict[str, Any]] = []
+    for row in res.rows or []:
+      personas.append({
+        "recid": row.get("recid"),
+        "name": row.get("name", ""),
+        "prompt": row.get("prompt", ""),
+        "tokens": int(row.get("tokens", 0) or 0),
+        "models_recid": (
+          int(row.get("models_recid"))
+          if row.get("models_recid") is not None
+          else None
+        ),
+        "model": row.get("model"),
+      })
+    return personas
+
+  async def upsert_persona(self, persona: Dict[str, Any]) -> None:
+    assert self.db
+    model_recid = persona.get("models_recid")
+    if model_recid is None:
+      raise ValueError("models_recid required")
+    payload = {
+      "recid": persona.get("recid"),
+      "name": persona.get("name", ""),
+      "prompt": persona.get("prompt", ""),
+      "tokens": int(persona.get("tokens", 0) or 0),
+      "models_recid": int(model_recid),
+    }
+    if not payload["name"]:
+      raise ValueError("name required")
+    await self.db.run("db:assistant:personas:upsert:1", payload)
+
+  async def delete_persona(self, recid: int | None = None, name: str | None = None) -> None:
+    assert self.db
+    await self.db.run(
+      "db:assistant:personas:delete:1",
+      {"recid": recid, "name": name},
+    )

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1319,6 +1319,112 @@ def _assistant_personas_get_by_name(args: Dict[str, Any]):
   """
   return (DbRunMode.ROW_ONE, sql, (name,))
 
+@register("urn:assistant:models:list:1")
+def _assistant_models_list(_: Dict[str, Any]):
+  sql = """
+    SELECT
+      recid,
+      element_name AS name
+    FROM assistant_models
+    ORDER BY element_name
+    FOR JSON PATH;
+  """
+  return (DbRunMode.JSON_MANY, sql, ())
+
+@register("db:assistant:models:list:1")
+def _db_assistant_models_list(args: Dict[str, Any]):
+  return _assistant_models_list(args)
+
+@register("urn:assistant:personas:list:1")
+def _assistant_personas_list(_: Dict[str, Any]):
+  sql = """
+    SELECT
+      ap.recid,
+      ap.element_name AS name,
+      ap.element_prompt AS prompt,
+      ap.element_tokens AS tokens,
+      ap.models_recid,
+      am.element_name AS model
+    FROM assistant_personas ap
+    JOIN assistant_models am ON am.recid = ap.models_recid
+    ORDER BY ap.element_name
+    FOR JSON PATH;
+  """
+  return (DbRunMode.JSON_MANY, sql, ())
+
+@register("db:assistant:personas:list:1")
+def _db_assistant_personas_list(args: Dict[str, Any]):
+  return _assistant_personas_list(args)
+
+@register("urn:assistant:personas:upsert:1")
+async def _assistant_personas_upsert(args: Dict[str, Any]):
+  recid = args.get("recid")
+  name = args["name"]
+  prompt = args["prompt"]
+  tokens = int(args["tokens"])
+  models_recid = int(args["models_recid"])
+  if recid is not None:
+    rc = await exec_query(
+      """
+        UPDATE assistant_personas
+        SET element_name = ?,
+            element_prompt = ?,
+            element_tokens = ?,
+            models_recid = ?,
+            element_modified_on = SYSUTCDATETIME()
+        WHERE recid = ?;
+      """,
+      (name, prompt, tokens, models_recid, recid),
+    )
+    if rc.rowcount:
+      return rc
+  rc = await exec_query(
+    """
+      UPDATE assistant_personas
+      SET element_prompt = ?,
+          element_tokens = ?,
+          models_recid = ?,
+          element_modified_on = SYSUTCDATETIME()
+      WHERE element_name = ?;
+    """,
+    (prompt, tokens, models_recid, name),
+  )
+  if rc.rowcount:
+    return rc
+  return await exec_query(
+    """
+      INSERT INTO assistant_personas (
+        element_name,
+        element_prompt,
+        element_tokens,
+        models_recid
+      ) VALUES (?, ?, ?, ?);
+    """,
+    (name, prompt, tokens, models_recid),
+  )
+
+@register("db:assistant:personas:upsert:1")
+async def _db_assistant_personas_upsert(args: Dict[str, Any]):
+  return await _assistant_personas_upsert(args)
+
+@register("urn:assistant:personas:delete:1")
+def _assistant_personas_delete(args: Dict[str, Any]):
+  recid = args.get("recid")
+  name = args.get("name")
+  if recid is not None:
+    sql = "DELETE FROM assistant_personas WHERE recid = ?;"
+    params = (recid,)
+  elif name is not None:
+    sql = "DELETE FROM assistant_personas WHERE element_name = ?;"
+    params = (name,)
+  else:
+    raise ValueError("Missing identifier for persona delete")
+  return (DbRunMode.EXEC, sql, params)
+
+@register("db:assistant:personas:delete:1")
+def _db_assistant_personas_delete(args: Dict[str, Any]):
+  return _assistant_personas_delete(args)
+
 @register("db:assistant:models:get_by_name:1")
 def _assistant_models_get_by_name(args: Dict[str, Any]):
   name = args["name"]

--- a/tests/test_discord_personas_services.py
+++ b/tests/test_discord_personas_services.py
@@ -1,0 +1,176 @@
+import importlib.util
+import pathlib
+import sys
+import types
+from types import SimpleNamespace
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+rpc_discord_pkg = types.ModuleType('rpc.discord')
+rpc_discord_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc/discord')]
+sys.modules.setdefault('rpc.discord', rpc_discord_pkg)
+
+rpc_discord_personas_pkg = types.ModuleType('rpc.discord.personas')
+rpc_discord_personas_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc/discord/personas')]
+sys.modules.setdefault('rpc.discord.personas', rpc_discord_personas_pkg)
+
+server_pkg = types.ModuleType('server')
+modules_pkg = types.ModuleType('server.modules')
+discord_personas_module_pkg = types.ModuleType('server.modules.discord_personas_module')
+models_pkg = types.ModuleType('server.models')
+
+
+class DiscordPersonasModule:
+  def __init__(self):
+    self.personas = [
+      {
+        'recid': 1,
+        'name': 'uwu',
+        'prompt': 'owo',
+        'tokens': 512,
+        'models_recid': 2,
+        'model': 'gpt-4',
+      }
+    ]
+    self.models = [
+      {
+        'recid': 2,
+        'name': 'gpt-4',
+      }
+    ]
+    self.upserts: list[dict] = []
+    self.deletes: list[tuple[int | None, str | None]] = []
+
+  async def list_personas(self):
+    return self.personas
+
+  async def list_models(self):
+    return self.models
+
+  async def upsert_persona(self, payload: dict):
+    self.upserts.append(payload)
+
+  async def delete_persona(self, recid: int | None = None, name: str | None = None):
+    self.deletes.append((recid, name))
+
+
+discord_personas_module_pkg.DiscordPersonasModule = DiscordPersonasModule
+modules_pkg.discord_personas_module = discord_personas_module_pkg
+server_pkg.modules = modules_pkg
+
+
+class RPCResponse:
+  def __init__(self, **data):
+    self.__dict__.update(data)
+
+
+models_pkg.RPCResponse = RPCResponse
+server_pkg.models = models_pkg
+
+sys.modules.setdefault('server', server_pkg)
+sys.modules.setdefault('server.modules', modules_pkg)
+sys.modules.setdefault('server.modules.discord_personas_module', discord_personas_module_pkg)
+sys.modules.setdefault('server.models', models_pkg)
+
+svc_spec = importlib.util.spec_from_file_location(
+  'rpc.discord.personas.services',
+  pathlib.Path(__file__).resolve().parent.parent / 'rpc/discord/personas/services.py',
+)
+svc = importlib.util.module_from_spec(svc_spec)
+sys.modules['rpc.discord.personas.services'] = svc
+svc_spec.loader.exec_module(svc)
+
+discord_personas_get_personas_v1 = svc.discord_personas_get_personas_v1
+discord_personas_get_models_v1 = svc.discord_personas_get_models_v1
+discord_personas_upsert_persona_v1 = svc.discord_personas_upsert_persona_v1
+discord_personas_delete_persona_v1 = svc.discord_personas_delete_persona_v1
+
+
+async def fake_unbox(request: Request):
+  body = await request.json()
+  op = body.get('op')
+  payload = body.get('payload')
+  rpc_req = SimpleNamespace(op=op, payload=payload, version=1)
+  auth_ctx = SimpleNamespace(user_guid='user', roles=['ROLE_DISCORD_ADMIN'])
+  return rpc_req, auth_ctx, None
+
+
+svc.unbox_request = fake_unbox
+
+
+db = DiscordPersonasModule()
+
+app = FastAPI()
+app.state.discord_personas = db
+
+
+@app.post('/rpc')
+async def rpc_endpoint(request: Request):
+  body = await request.json()
+  op = body['op']
+  if op == 'urn:discord:personas:get_personas:1':
+    return await discord_personas_get_personas_v1(request)
+  if op == 'urn:discord:personas:get_models:1':
+    return await discord_personas_get_models_v1(request)
+  if op == 'urn:discord:personas:upsert_persona:1':
+    return await discord_personas_upsert_persona_v1(request)
+  if op == 'urn:discord:personas:delete_persona:1':
+    return await discord_personas_delete_persona_v1(request)
+  raise AssertionError('unexpected op')
+
+
+client = TestClient(app)
+
+
+def test_get_personas_service():
+  resp = client.post('/rpc', json={'op': 'urn:discord:personas:get_personas:1'})
+  assert resp.status_code == 200
+  data = resp.json()
+  assert data['payload'] == {
+    'personas': [
+      {
+        'recid': 1,
+        'name': 'uwu',
+        'prompt': 'owo',
+        'tokens': 512,
+        'models_recid': 2,
+        'model': 'gpt-4',
+      }
+    ]
+  }
+
+
+def test_get_models_service():
+  resp = client.post('/rpc', json={'op': 'urn:discord:personas:get_models:1'})
+  assert resp.status_code == 200
+  data = resp.json()
+  assert data['payload'] == {
+    'models': [
+      {
+        'recid': 2,
+        'name': 'gpt-4',
+      }
+    ]
+  }
+
+
+def test_upsert_and_delete_persona_service():
+  upsert_payload = {
+    'recid': 1,
+    'name': 'uwu',
+    'prompt': 'new prompt',
+    'tokens': 1024,
+    'models_recid': 2,
+  }
+  resp = client.post(
+    '/rpc',
+    json={'op': 'urn:discord:personas:upsert_persona:1', 'payload': upsert_payload},
+  )
+  assert resp.status_code == 200
+  resp = client.post(
+    '/rpc',
+    json={'op': 'urn:discord:personas:delete_persona:1', 'payload': {'recid': 1}},
+  )
+  assert resp.status_code == 200
+  assert db.upserts == [upsert_payload]
+  assert db.deletes == [(1, None)]


### PR DESCRIPTION
## Summary
- refactored Discord persona RPCs into the discord namespace with ROLE_DISCORD_ADMIN access control and updated persona handlers/models
- retargeted the Discord personas editor to the new URNs and added a Discord section to the nav for admin links
- documented ROLE_DISCORD_ADMIN and the `urn:discord:personas` operations while updating the unit tests for the renamed namespace

## Testing
- pytest
- npm run lint
- npm run type-check
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c863af7c748325961bf6c4c82fbb4d