### PR TITLE
Fix NavBar section grouping and labels

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -12,7 +12,7 @@ import {
         Divider,
 } from '@mui/material';
 import { Menu as MenuIcon } from '@mui/icons-material';
-import type { PublicLinksNavBarRoute1, PublicLinksNavBarRoutes1 } from '../shared/RpcModels';
+import type { PublicLinksNavBarRoute1 } from '../shared/RpcModels';
 import { fetchNavbarRoutes } from '../rpc/public/links';
 import { iconMap, defaultIcon } from '../icons';
 import UserContext from '../shared/UserContext';
@@ -21,21 +21,58 @@ import Login from './Login';
 const DRAWER_OPEN = 240;
 const DRAWER_CLOSED = 60;
 
+type NavRoute = PublicLinksNavBarRoute1 & {
+        sequence?: number | string | null | undefined;
+};
+
+const isNavRoute = (value: unknown): value is NavRoute => {
+        if (!value || typeof value !== 'object') {
+                return false;
+        }
+        const candidate = value as Record<string, unknown>;
+        return typeof candidate.path === 'string' && typeof candidate.name === 'string';
+};
+
+const getRouteSequence = (route: NavRoute): number => {
+        const raw = route.sequence;
+        if (typeof raw === 'number' && Number.isFinite(raw)) {
+                return raw;
+        }
+        if (typeof raw === 'string') {
+                const parsed = Number.parseInt(raw, 10);
+                if (Number.isFinite(parsed)) {
+                        return parsed;
+                }
+        }
+        return 0;
+};
+
+const getSectionKey = (sequence: number): number => {
+        if (!Number.isFinite(sequence)) {
+                return 0;
+        }
+        const bucketStart = Math.floor(sequence / 100) * 100;
+        return bucketStart < 0 ? 0 : bucketStart;
+};
+
 const NavBar = (): JSX.Element => {
         const [open, setOpen] = useState(false);
-        const [routes, setRoutes] = useState<PublicLinksNavBarRoute1[]>([]);
-	const { userData } = useContext(UserContext);
+        const [routes, setRoutes] = useState<NavRoute[]>([]);
+        const { userData } = useContext(UserContext);
 
-	useEffect(() => {
-		void (async () => {
-			try {
-				const res: PublicLinksNavBarRoutes1 = await fetchNavbarRoutes();
-				setRoutes(res.routes);
-			} catch {
-				setRoutes([]);
-			}
-		})();
-	}, [userData]);
+        useEffect(() => {
+                void (async () => {
+                        try {
+                                const res = await fetchNavbarRoutes();
+                                const payloadRoutes = Array.isArray(res?.routes)
+                                        ? res.routes.filter(isNavRoute)
+                                        : [];
+                                setRoutes(payloadRoutes);
+                        } catch {
+                                setRoutes([]);
+                        }
+                })();
+        }, [userData]);
 
 	return (
 		<Drawer
@@ -65,7 +102,7 @@ const NavBar = (): JSX.Element => {
 			</Box>
                         <List sx={{ flexGrow: 1 }}>
                                 {(() => {
-                                        const renderItem = (route: PublicLinksNavBarRoute1) => {
+                                        const renderItem = (route: NavRoute) => {
 
                                                 const IconComp = iconMap[route.icon ?? ''] || defaultIcon;
                                                 return (
@@ -80,7 +117,7 @@ const NavBar = (): JSX.Element => {
 
                                         const renderSection = (
                                                 label: string | null,
-                                                items: PublicLinksNavBarRoute1[],
+                                                items: NavRoute[],
                                                 key: string,
                                         ) => {
                                                 if (!items.length) {
@@ -119,7 +156,7 @@ const NavBar = (): JSX.Element => {
                                                 return firstWord ? firstWord.toUpperCase() : null;
                                         };
 
-                                        const getSectionLabel = (items: PublicLinksNavBarRoute1[]) => {
+                                        const getSectionLabel = (items: NavRoute[]) => {
                                                 const candidate = items.find(
                                                         (item) => !(item.path === '/' || item.path.startsWith('/gallery')),
                                                 );
@@ -130,10 +167,12 @@ const NavBar = (): JSX.Element => {
                                                 return normalizeLabel(segment) ?? normalizeLabel(candidate.name);
                                         };
 
-                                        const sections = new Map<number, PublicLinksNavBarRoute1[]>();
-                                        const sortedRoutes = [...routes].sort((a, b) => a.sequence - b.sequence);
+                                        const sections = new Map<number, NavRoute[]>();
+                                        const sortedRoutes = [...routes].sort(
+                                                (a, b) => getRouteSequence(a) - getRouteSequence(b),
+                                        );
                                         sortedRoutes.forEach((route) => {
-                                                const groupKey = Math.floor(route.sequence / 100) * 100;
+                                                const groupKey = getSectionKey(getRouteSequence(route));
                                                 const existing = sections.get(groupKey);
                                                 if (existing) {
                                                         existing.push(route);
@@ -145,8 +184,12 @@ const NavBar = (): JSX.Element => {
                                         return Array.from(sections.entries())
                                                 .sort(([a], [b]) => a - b)
                                                 .map(([groupKey, items]) => {
-                                                        const sectionItems = [...items].sort((a, b) => a.sequence - b.sequence);
-                                                        const label = getSectionLabel(sectionItems);
+                                                        const sectionItems = [...items].sort(
+                                                                (a, b) =>
+                                                                        getRouteSequence(a) -
+                                                                        getRouteSequence(b),
+                                                        );
+                                                        const label = groupKey >= 100 ? getSectionLabel(sectionItems) : null;
                                                         return renderSection(label, sectionItems, `${groupKey}-${label ?? 'none'}`);
                                                 });
                                 })()}


### PR DESCRIPTION
## Summary
- normalize the navbar route data before grouping so buckets exist even when the first entry is off the 100s
- compute section keys from the floored sequence and suppress labels for the 0xx bucket

## Testing
- npm run lint
- npm run type-check *(fails: missing Discord personas RPC/model exports)*
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c87b8109688325ad704da5449bf39d