### PR TITLE
refactor: query persona prompt and model columns

### DIFF
--- a/server/modules/discord_chat_module.py
+++ b/server/modules/discord_chat_module.py
@@ -94,11 +94,7 @@ class DiscordChatModule(BaseModule):
         {"name": name},
       )
       if res.rows:
-        row = res.rows[0]
-        instructions = row.get("instructions")
-        if isinstance(instructions, dict):
-          return instructions.get("instructions", "")
-        return instructions or ""
+        return res.rows[0].get("element_prompt") or ""
     except Exception:
       logging.exception("[DiscordChatModule] get_persona_instructions failed")
     return ""

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -198,7 +198,7 @@ class OpenaiModule(BaseModule):
       if persona_row:
         personas_recid = persona_row.get("recid")
         models_recid = persona_row.get("models_recid")
-        model = persona_row.get("model", model)
+        model = persona_row.get("element_model", model)
         if tokens is None:
           tokens = persona_row.get("element_tokens")
     if tokens is None:

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1310,10 +1310,10 @@ def _assistant_personas_get_by_name(args: Dict[str, Any]):
   sql = """
     SELECT
       ap.recid,
-      ap.element_prompt AS instructions,
+      ap.element_prompt,
       ap.element_tokens,
       ap.models_recid,
-      am.element_name AS model
+      am.element_model
     FROM assistant_personas ap
     JOIN assistant_models am ON am.recid = ap.models_recid
     WHERE ap.element_name = ?;

--- a/tests/test_discord_chat_module.py
+++ b/tests/test_discord_chat_module.py
@@ -48,7 +48,7 @@ def test_uwu_chat(monkeypatch):
     async def run(self, op, args):
       assert op == "db:assistant:personas:get_by_name:1"
       assert args == {"name": "uwu"}
-      return DBResult(rows=[{"instructions": "be fluffy"}], rowcount=1)
+      return DBResult(rows=[{"element_prompt": "be fluffy"}], rowcount=1)
 
   module.db = DummyDB()
 
@@ -93,7 +93,7 @@ def test_summarize_chat(monkeypatch):
     async def run(self, op, args):
       assert op == "db:assistant:personas:get_by_name:1"
       assert args == {"name": "summarize"}
-      return DBResult(rows=[{"instructions": "sum role"}], rowcount=1)
+      return DBResult(rows=[{"element_prompt": "sum role"}], rowcount=1)
 
   module.db = DummyDB()
 

--- a/tests/test_openai_module.py
+++ b/tests/test_openai_module.py
@@ -81,7 +81,7 @@ def test_fetch_chat_logs_conversation():
             {
               "recid": 1,
               "models_recid": 2,
-              "model": "gpt",
+              "element_model": "gpt",
               "element_tokens": 5,
             }
           ],


### PR DESCRIPTION
## Summary
- Look up persona prompt using `element_prompt` field
- Fetch persona model from `element_model` column
- Select persona prompt, tokens, and model in DB query

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c89a42e710832590fca1a111f5bf77