### PR TITLE
Add persona RPC support for Discord commands

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -257,6 +257,7 @@ Currently exposes placeholder Discord command operations.
 | ------------------------------------------- | ------------------------------- |
 | `urn:discord:chat:summarize_channel:1`      | Summarize a Discord channel.    |
 | `urn:discord:chat:uwu_chat:1`               | Stub chat returning "uwu" text. |
+| `urn:discord:chat:persona_response:1`       | Respond using a selected persona. |
 
 ### `personas`
 
@@ -278,3 +279,8 @@ Summarize the last 24 hours of messages in the current channel and send the resu
 !uwu hello there
 ```
 Reply in-channel with a playful uwu-styled message.
+
+```
+!persona stark Tell me about the yearly rainfall in Spain
+```
+Ask a configured persona to respond in-channel using its prompt and model settings.

--- a/rpc/discord/chat/__init__.py
+++ b/rpc/discord/chat/__init__.py
@@ -1,9 +1,11 @@
 from .services import (
+  discord_chat_persona_response_v1,
   discord_chat_summarize_channel_v1,
   discord_chat_uwu_chat_v1,
 )
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("persona_response", "1"): discord_chat_persona_response_v1,
   ("summarize_channel", "1"): discord_chat_summarize_channel_v1,
   ("uwu_chat", "1"): discord_chat_uwu_chat_v1,
 }

--- a/rpc/discord/chat/models.py
+++ b/rpc/discord/chat/models.py
@@ -26,3 +26,18 @@ class DiscordChatUwuChatResponse1(BaseModel):
   uwu_response_text: str
   summary_lines: List[str] = []
   token_count_estimate: Optional[int] = None
+
+
+class DiscordChatPersonaRequest1(BaseModel):
+  persona: str
+  message: str
+  guild_id: Optional[int] = None
+  channel_id: Optional[int] = None
+  user_id: Optional[int] = None
+
+
+class DiscordChatPersonaResponse1(BaseModel):
+  persona: str
+  persona_response_text: str
+  model: Optional[str] = None
+  role: Optional[str] = None

--- a/server/modules/personas_module.py
+++ b/server/modules/personas_module.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI
+
+from . import BaseModule
+from .db_module import DbModule
+from .openai_module import OpenaiModule
+
+
+class PersonasModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+    self.openai: OpenaiModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.openai = getattr(self.app.state, "openai", None)
+    if self.openai:
+      await self.openai.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    self.db = None
+    self.openai = None
+
+  async def _get_persona(self, name: str) -> dict | None:
+    if not self.db:
+      return None
+    try:
+      res = await self.db.run("db:assistant:personas:get_by_name:1", {"name": name})
+    except Exception:
+      logging.exception("[PersonasModule] failed to fetch persona", extra={"persona": name})
+      return None
+    if res.rows:
+      return res.rows[0]
+    return None
+
+  async def persona_response(
+    self,
+    persona: str,
+    message: str,
+    *,
+    guild_id: int | None = None,
+    channel_id: int | None = None,
+    user_id: int | None = None,
+  ) -> dict:
+    persona_name = (persona or "").strip()
+    if not persona_name:
+      raise ValueError("persona is required")
+    prompt = (message or "").strip()
+    if not prompt:
+      raise ValueError("message is required")
+
+    persona_row = await self._get_persona(persona_name)
+    if not persona_row:
+      raise ValueError(f"persona '{persona_name}' was not found")
+
+    instructions = persona_row.get("element_prompt") or ""
+    if not instructions:
+      raise ValueError(f"persona '{persona_name}' is missing instructions")
+
+    tokens = persona_row.get("element_tokens")
+    model_hint = persona_row.get("element_model")
+
+    if not self.openai or not getattr(self.openai, "client", None):
+      logging.warning("[PersonasModule] OpenAI module not available", extra={"persona": persona_name})
+      return {
+        "persona": persona_name,
+        "response_text": "[[STUB: persona response here]]",
+        "model": model_hint,
+        "role": instructions,
+      }
+
+    await self.openai.on_ready()
+    result = await self.openai.fetch_chat(
+      [],
+      instructions,
+      prompt,
+      tokens,
+      persona=persona_name,
+      guild_id=guild_id,
+      channel_id=channel_id,
+      user_id=user_id,
+      input_log=prompt,
+    )
+    return {
+      "persona": persona_name,
+      "response_text": result.get("content", ""),
+      "model": result.get("model"),
+      "role": result.get("role", ""),
+    }

--- a/tests/test_discord_bot_commands.py
+++ b/tests/test_discord_bot_commands.py
@@ -199,6 +199,79 @@ def test_summarize_command_transient_error(monkeypatch):
   assert ctx.channel.sent == ["Failed to fetch messages. Please try again later."]
 
 
+def test_persona_command(monkeypatch):
+  app = FastAPI()
+  module = DiscordModule(app)
+  module.bot = module._init_discord_bot('!')
+  module._init_bot_routes()
+
+  async def dummy_handle(req):
+    body = await req.body()
+    dummy_handle.body = json.loads(body.decode())
+    dummy_handle.called = True
+    class DummyResp:
+      payload = {
+        "persona": "stark",
+        "persona_response_text": "It rains",
+        "model": "gpt",
+        "role": "role",
+      }
+    return DummyResp()
+  dummy_handle.called = False
+  dummy_handle.body = None
+  import importlib
+  rpc_mod = importlib.import_module("rpc.handler")
+  monkeypatch.setattr(rpc_mod, "handle_rpc_request", dummy_handle)
+
+  ctx = SimpleNamespace(
+    guild=SimpleNamespace(id=1),
+    channel=DummyChannel(),
+    author=DummyAuthor(),
+  )
+  ctx.send = ctx.channel.send
+
+  cmd = module.bot.get_command("persona")
+  asyncio.run(cmd.callback(ctx, text="stark Tell me about rain"))
+  assert dummy_handle.called
+  assert dummy_handle.body["op"] == "urn:discord:chat:persona_response:1"
+  assert dummy_handle.body["payload"] == {
+    "persona": "stark",
+    "message": "Tell me about rain",
+    "guild_id": 1,
+    "channel_id": ctx.channel.id,
+    "user_id": ctx.author.id,
+  }
+  assert ctx.channel.sent == ["It rains"]
+  assert ctx.channel.history_called
+
+
+def test_persona_command_usage_error(monkeypatch):
+  app = FastAPI()
+  module = DiscordModule(app)
+  module.bot = module._init_discord_bot('!')
+  module._init_bot_routes()
+
+  import importlib
+  rpc_mod = importlib.import_module("rpc.handler")
+
+  async def fail_handle(*args, **kwargs):
+    raise AssertionError("should not call RPC")
+
+  monkeypatch.setattr(rpc_mod, "handle_rpc_request", fail_handle)
+
+  ctx = SimpleNamespace(
+    guild=SimpleNamespace(id=1),
+    channel=DummyChannel(),
+    author=DummyAuthor(),
+  )
+  ctx.send = ctx.channel.send
+
+  cmd = module.bot.get_command("persona")
+  asyncio.run(cmd.callback(ctx, text="stark"))
+  assert ctx.channel.sent == ["Usage: !persona <name> <message>"]
+  assert not ctx.channel.history_called
+
+
 def test_uwu_command(monkeypatch):
   app = FastAPI()
   module = DiscordModule(app)

--- a/tests/test_discord_bot_macros.py
+++ b/tests/test_discord_bot_macros.py
@@ -141,3 +141,53 @@ def test_uwu_macro_channel(monkeypatch):
   assert channel.history_called
   assert author.dm_channel.sent == []
 
+
+def test_persona_macro_channel(monkeypatch):
+  app = FastAPI()
+  module = DiscordModule(app)
+  module.bot = module._init_discord_bot('!')
+  module.bot._connection.user = SimpleNamespace(id=0)
+  module._init_bot_routes()
+
+  from discord.ext import commands as dc_commands
+
+  async def fake_send(self, content, **kwargs):
+    return await self.channel.send(content)
+
+  monkeypatch.setattr(dc_commands.Context, 'send', fake_send)
+
+  async def dummy_handle(req):
+    body = await req.body()
+    dummy_handle.body = json.loads(body.decode())
+    dummy_handle.called = True
+    class DummyResp:
+      payload = {
+        "persona": "stark",
+        "persona_response_text": "It rains",
+        "model": "gpt",
+        "role": "role",
+      }
+    return DummyResp()
+  dummy_handle.called = False
+  dummy_handle.body = None
+  import importlib
+  rpc_mod = importlib.import_module("rpc.handler")
+  monkeypatch.setattr(rpc_mod, "handle_rpc_request", dummy_handle)
+
+  channel = DummyChannel()
+  author = DummyAuthor()
+  message = DummyMessage("!persona stark Tell me about rain", channel, author, state=module.bot._connection)
+  asyncio.run(module.bot.process_commands(message))
+  assert dummy_handle.called
+  assert dummy_handle.body["op"] == "urn:discord:chat:persona_response:1"
+  assert dummy_handle.body["payload"] == {
+    "persona": "stark",
+    "message": "Tell me about rain",
+    "guild_id": 1,
+    "channel_id": channel.id,
+    "user_id": author.id,
+  }
+  assert channel.sent == ["It rains"]
+  assert channel.history_called
+  assert author.dm_channel.sent == []
+

--- a/tests/test_personas_module.py
+++ b/tests/test_personas_module.py
@@ -1,0 +1,94 @@
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+
+from server.modules.personas_module import PersonasModule
+from server.modules.providers import DBResult
+
+
+class DummyDB:
+  def __init__(self, row):
+    self.row = row
+    self.calls = []
+
+  async def run(self, op, args):
+    assert op == "db:assistant:personas:get_by_name:1"
+    self.calls.append(args)
+    return DBResult(rows=[self.row] if self.row else [], rowcount=1 if self.row else 0)
+
+
+class DummyOpenAI:
+  def __init__(self):
+    self.client = object()
+    self.calls = []
+
+  async def on_ready(self):
+    pass
+
+  async def fetch_chat(self, schemas, role, prompt, tokens, **kwargs):
+    self.calls.append({
+      "persona": kwargs.get("persona"),
+      "prompt": prompt,
+      "role": role,
+      "tokens": tokens,
+      "input_log": kwargs.get("input_log"),
+    })
+    return {"content": "Response", "model": "gpt", "role": "assistant"}
+
+
+def test_persona_response_calls_openai():
+  app = FastAPI()
+  module = PersonasModule(app)
+  module.db = DummyDB({
+    "element_prompt": "be stark",
+    "element_tokens": 42,
+    "element_model": "gpt",
+  })
+  module.openai = DummyOpenAI()
+
+  res = asyncio.run(module.persona_response("stark", "Tell me", guild_id=1, channel_id=2, user_id=3))
+  assert res == {
+    "persona": "stark",
+    "response_text": "Response",
+    "model": "gpt",
+    "role": "assistant",
+  }
+  assert module.openai.calls == [{
+    "persona": "stark",
+    "prompt": "Tell me",
+    "role": "be stark",
+    "tokens": 42,
+    "input_log": "Tell me",
+  }]
+  assert module.db.calls == [{"name": "stark"}]
+
+
+def test_persona_response_missing_persona():
+  app = FastAPI()
+  module = PersonasModule(app)
+  module.db = DummyDB(None)
+  module.openai = DummyOpenAI()
+
+  with pytest.raises(ValueError):
+    asyncio.run(module.persona_response("unknown", "Hello"))
+  assert module.db.calls == [{"name": "unknown"}]
+
+
+def test_persona_response_stub_without_openai():
+  app = FastAPI()
+  module = PersonasModule(app)
+  module.db = DummyDB({
+    "element_prompt": "be stark",
+    "element_tokens": 42,
+    "element_model": "gpt",
+  })
+  module.openai = None
+
+  res = asyncio.run(module.persona_response("stark", "Hi"))
+  assert res == {
+    "persona": "stark",
+    "response_text": "[[STUB: persona response here]]",
+    "model": "gpt",
+    "role": "be stark",
+  }


### PR DESCRIPTION
## Summary
- add a PersonasModule that queries persona prompts and calls OpenAI for persona replies
- expose urn:discord:chat:persona_response:1 via the RPC service and wire it into the Discord bot command and macro
- document the new RPC and cover personas logic with unit tests

## Testing
- pytest tests/test_discord_chat_services.py tests/test_discord_bot_commands.py tests/test_discord_bot_macros.py tests/test_personas_module.py

------
https://chatgpt.com/codex/tasks/task_e_68c8bcb60cdc83259064bf834aea9fa2