### PR TITLE
Fix MSSQL persona lookup and cover query

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1313,7 +1313,7 @@ def _assistant_personas_get_by_name(args: Dict[str, Any]):
       ap.element_prompt,
       ap.element_tokens,
       ap.models_recid,
-      am.element_model
+      am.element_name AS element_model
     FROM assistant_personas ap
     JOIN assistant_models am ON am.recid = ap.models_recid
     WHERE ap.element_name = ?;

--- a/tests/test_mssql_personas_registry.py
+++ b/tests/test_mssql_personas_registry.py
@@ -1,0 +1,13 @@
+from server.modules.providers import DbRunMode
+from server.modules.providers.database.mssql_provider import registry
+
+
+def test_persona_lookup_query_targets_element_name():
+  handler = registry.get_handler("db:assistant:personas:get_by_name:1")
+  mode, sql, params = handler({"name": "stark"})
+
+  assert mode is DbRunMode.ROW_ONE
+  assert "FROM assistant_personas ap" in sql
+  assert "WHERE ap.element_name = ?;" in sql
+  assert "am.element_name AS element_model" in sql
+  assert params == ("stark",)


### PR DESCRIPTION
## Summary
- fix the MSSQL persona lookup to select the associated model name via `assistant_models.element_name`
- add a regression test that ensures the lookup query targets `assistant_personas.element_name`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c97b72dd0483258331340eebcc1ff7