### PR TITLE
Adjust OpenAI tool usage for persona calls

### DIFF
--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -217,12 +217,14 @@ class OpenaiModule(BaseModule):
     if prompt_context:
       messages.append({"role": "user", "content": prompt_context})
     messages.append({"role": "user", "content": prompt})
-    completion = await self.client.chat.completions.create(
-      model=model,
-      max_tokens=tokens,
-      tools=schemas,
-      messages=messages,
-    )
+    params = {
+      "model": model,
+      "max_tokens": tokens,
+      "messages": messages,
+    }
+    if schemas:
+      params["tools"] = schemas
+    completion = await self.client.chat.completions.create(**params)
     choice = completion.choices[0].message
     content = choice.content
     result = {

--- a/tests/test_openai_module.py
+++ b/tests/test_openai_module.py
@@ -11,15 +11,10 @@ def test_fetch_chat_message_order_and_return():
   module = OpenaiModule(app)
 
   class DummyCreate:
-    async def create(self, model, max_tokens, tools, messages):
-      self.args = {
-        "model": model,
-        "max_tokens": max_tokens,
-        "tools": tools,
-        "messages": messages,
-      }
+    async def create(self, **kwargs):
+      self.kwargs = kwargs
       return SimpleNamespace(
-        model=model,
+        model=kwargs.get("model"),
         choices=[SimpleNamespace(message=SimpleNamespace(content="reply", role="assistant"))],
       )
 
@@ -28,12 +23,41 @@ def test_fetch_chat_message_order_and_return():
 
   res = asyncio.run(module.fetch_chat([], "sys", "user", 5, "ctx"))
 
-  assert dummy_create.args["messages"] == [
+  assert dummy_create.kwargs["messages"] == [
     {"role": "system", "content": "sys"},
     {"role": "user", "content": "ctx"},
     {"role": "user", "content": "user"},
   ]
+  assert "tools" not in dummy_create.kwargs
   assert res == {"content": "reply", "model": "gpt-4o-mini", "role": "assistant"}
+
+
+def test_fetch_chat_includes_tools_when_present():
+  app = FastAPI()
+  module = OpenaiModule(app)
+
+  class DummyCreate:
+    async def create(self, **kwargs):
+      self.kwargs = kwargs
+      return SimpleNamespace(
+        model=kwargs.get("model"),
+        choices=[SimpleNamespace(message=SimpleNamespace(content="reply", role="assistant"))],
+      )
+
+  dummy_create = DummyCreate()
+  module.client = SimpleNamespace(chat=SimpleNamespace(completions=dummy_create))
+
+  schemas = [
+    {
+      "type": "function",
+      "function": {"name": "do_thing", "parameters": {"type": "object", "properties": {}}},
+    }
+  ]
+
+  res = asyncio.run(module.fetch_chat(schemas, "sys", "user", 5))
+
+  assert res == {"content": "reply", "model": "gpt-4o-mini", "role": "assistant"}
+  assert dummy_create.kwargs["tools"] == schemas
 
 
 def test_summary_queue_executes_in_order():
@@ -55,15 +79,10 @@ def test_fetch_chat_logs_conversation():
   module = OpenaiModule(app)
 
   class DummyCreate:
-    async def create(self, model, max_tokens, tools, messages):
-      self.args = {
-        "model": model,
-        "max_tokens": max_tokens,
-        "tools": tools,
-        "messages": messages,
-      }
+    async def create(self, **kwargs):
+      self.kwargs = kwargs
       return SimpleNamespace(
-        model=model,
+        model=kwargs.get("model"),
         choices=[SimpleNamespace(message=SimpleNamespace(content="hi", role="assistant"))],
       )
   dummy_create = DummyCreate()
@@ -118,7 +137,8 @@ def test_fetch_chat_logs_conversation():
     )
   )
   assert res["content"] == "hi"
-  assert dummy_create.args["max_tokens"] == 5
+  assert dummy_create.kwargs["max_tokens"] == 5
+  assert "tools" not in dummy_create.kwargs
   calls = [c[0] for c in module.db.calls]
   assert calls == [
     "db:assistant:personas:get_by_name:1",


### PR DESCRIPTION
## Summary
- avoid sending the tools parameter to OpenAI when no schemas are provided so tool-incompatible models work
- extend unit coverage to exercise both tool-less and tool-enabled chat completions

## Testing
- pytest tests/test_openai_module.py

------
https://chatgpt.com/codex/tasks/task_e_68c9868c18ac8325bc9f94e450f04953