### PR TITLE
Log OpenAI usage tokens for conversations

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1476,12 +1476,14 @@ def _assistant_conversations_insert(args: Dict[str, Any]):
 def _assistant_conversations_update_output(args: Dict[str, Any]):
   recid = args["recid"]
   output_data = args.get("output_data")
+  tokens = args.get("tokens")
   sql = """
     UPDATE assistant_conversations
-    SET element_output = ?
+    SET element_output = ?,
+        element_tokens = ?
     WHERE recid = ?;
   """
-  return (DbRunMode.EXEC, sql, (output_data, recid))
+  return (DbRunMode.EXEC, sql, (output_data, tokens, recid))
 
 @register("db:assistant:conversations:list_by_time:1")
 def _assistant_conversations_list_by_time(args: Dict[str, Any]):

--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -56,11 +56,12 @@ def test_assistant_conversations_insert(monkeypatch):
 
 def test_assistant_conversations_update_output(monkeypatch):
   provider = MssqlProvider()
-  args = {'recid': 9, 'output_data': 'out'}
+  args = {'recid': 9, 'output_data': 'out', 'tokens': 12}
 
   async def fake_exec(sql, params):
     assert "element_modified_on" not in sql
-    assert params == ('out', 9)
+    assert "element_tokens" in sql
+    assert params == ('out', 12, 9)
     return DBResult(rowcount=1)
 
   monkeypatch.setattr(mssql_provider, 'exec_query', fake_exec)

--- a/tests/test_openai_module.py
+++ b/tests/test_openai_module.py
@@ -16,6 +16,7 @@ def test_fetch_chat_message_order_and_return():
       return SimpleNamespace(
         model=kwargs.get("model"),
         choices=[SimpleNamespace(message=SimpleNamespace(content="reply", role="assistant"))],
+        usage=SimpleNamespace(total_tokens=11),
       )
 
   dummy_create = DummyCreate()
@@ -42,6 +43,7 @@ def test_fetch_chat_includes_tools_when_present():
       return SimpleNamespace(
         model=kwargs.get("model"),
         choices=[SimpleNamespace(message=SimpleNamespace(content="reply", role="assistant"))],
+        usage=SimpleNamespace(total_tokens=13),
       )
 
   dummy_create = DummyCreate()
@@ -84,6 +86,7 @@ def test_fetch_chat_logs_conversation():
       return SimpleNamespace(
         model=kwargs.get("model"),
         choices=[SimpleNamespace(message=SimpleNamespace(content="hi", role="assistant"))],
+        usage=SimpleNamespace(total_tokens=42),
       )
   dummy_create = DummyCreate()
   module.client = SimpleNamespace(chat=SimpleNamespace(completions=dummy_create))
@@ -116,7 +119,7 @@ def test_fetch_chat_logs_conversation():
         assert args["tokens"] == 7
         return DBResult(rows=[{"recid": 99}], rowcount=1)
       if op == "db:assistant:conversations:update_output:1":
-        assert args == {"recid": 99, "output_data": "hi"}
+        assert args == {"recid": 99, "output_data": "hi", "tokens": 42}
         return DBResult(rowcount=1)
       return DBResult()
 


### PR DESCRIPTION
## Summary
- capture total token counts from OpenAI chat completions and forward them to the conversation logger
- update the MSSQL registry update handler to persist both output text and tokens
- refresh OpenAI and database tests to cover the new token logging behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9976110b883258b9ea9bc29a6c59a