### PR TITLE
Add helper for Discord chunked messaging

### DIFF
--- a/server/helpers/__init__.py
+++ b/server/helpers/__init__.py
@@ -1,5 +1,8 @@
 from .strings import camel_case
+from .discord import send_to_discord, send_to_discord_user
 
 __all__ = [
   "camel_case",
+  "send_to_discord",
+  "send_to_discord_user",
 ]

--- a/server/helpers/discord.py
+++ b/server/helpers/discord.py
@@ -1,0 +1,69 @@
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+
+__all__ = [
+  "send_to_discord",
+  "send_to_discord_user",
+]
+
+
+class _SupportsSend(Protocol):
+  async def send(self, message: str) -> None: ...
+
+
+_SendCallable = Callable[[str], Awaitable[None]]
+
+
+async def _chunked_send(
+  send: _SendCallable,
+  text: str,
+  max_message_size: int = 1998,
+  delay: float = 1.0,
+) -> None:
+  """Split ``text`` into Discord-safe messages and send them sequentially."""
+
+  for block in text.split("\n"):
+    if not block.strip() or block.strip() == "---":
+      continue
+
+    start = 0
+    while start < len(block):
+      end = min(start + max_message_size, len(block))
+
+      if end < len(block) and block[end] != " ":
+        adjusted_end = block.rfind(" ", start, end)
+        if adjusted_end == -1 or adjusted_end <= start:
+          adjusted_end = min(start + max_message_size, len(block))
+        end = adjusted_end
+
+      if end <= start:
+        end = min(start + max_message_size, len(block))
+        if end <= start:
+          break
+
+      chunk = block[start:end].strip()
+      if chunk:
+        await send(chunk)
+        if delay > 0:
+          await asyncio.sleep(delay)
+
+      start = end
+
+
+async def send_to_discord(
+  channel: _SupportsSend,
+  text: str,
+  max_message_size: int = 1998,
+  delay: float = 1.0,
+) -> None:
+  await _chunked_send(channel.send, text, max_message_size, delay)
+
+
+async def send_to_discord_user(
+  user: _SupportsSend,
+  text: str,
+  max_message_size: int = 1998,
+  delay: float = 1.0,
+) -> None:
+  await _chunked_send(user.send, text, max_message_size, delay)

--- a/server/modules/discord_module.py
+++ b/server/modules/discord_module.py
@@ -8,6 +8,7 @@ from . import BaseModule
 from .env_module import EnvModule
 from .db_module import DbModule
 
+from server.helpers.discord import send_to_discord
 from server.helpers.logging import configure_discord_logging, remove_discord_logging, update_logging_level
 
 class DiscordModule(BaseModule):
@@ -386,7 +387,7 @@ class DiscordModule(BaseModule):
           or data.get("message")
           or json.dumps(data)
         )
-        await ctx.send(response_text)
+        await send_to_discord(ctx, response_text)
         async for _ in ctx.channel.history(limit=1):
           break
         elapsed = time.perf_counter() - start

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -5,42 +5,7 @@ from openai import AsyncOpenAI
 from . import BaseModule
 from .db_module import DbModule
 from .discord_module import DiscordModule
-
-
-async def send_to_discord(channel, text: str, max_message_size: int = 1998, delay: float = 1.0):
-  for block in text.split("\n"):
-    if not block.strip() or block.strip() == "---":
-      continue
-    start = 0
-    while start < len(block):
-      end = min(start + max_message_size, len(block))
-      if end < len(block) and block[end] != ' ':
-        end = block.rfind(' ', start, end)
-        if end == -1:
-          end = start + max_message_size
-      chunk = block[start:end].strip()
-      if chunk:
-        await channel.send(chunk)
-        await asyncio.sleep(delay)
-      start = end
-
-
-async def send_to_discord_user(user, text: str, max_message_size: int = 1998, delay: float = 1.0):
-  for block in text.split("\n"):
-    if not block.strip() or block.strip() == "---":
-      continue
-    start = 0
-    while start < len(block):
-      end = min(start + max_message_size, len(block))
-      if end < len(block) and block[end] != ' ':
-        end = block.rfind(' ', start, end)
-        if end == -1:
-          end = start + max_message_size
-      chunk = block[start:end].strip()
-      if chunk:
-        await user.send(chunk)
-        await asyncio.sleep(delay)
-      start = end
+from server.helpers.discord import send_to_discord, send_to_discord_user
 
 
 class SummaryQueue:


### PR DESCRIPTION
## Summary
- add a shared helper for trickling Discord messages to avoid hitting message size limits
- reuse the helper in the OpenAI module functions that DM summaries
- update the persona command to send long responses in chunks

## Testing
- pytest tests/test_discord_bot_commands.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b6eb4bb48325816852c15a3b25da