### PR TITLE
Add Bluesky posting module and Discord RPC

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -241,7 +241,13 @@ Discord domain calls require Discord-specific roles depending on the subdomain:
 
 Requests must include the `x-discord-id` (or `x-discord-user-id`) header identifying the caller. If headers cannot be set, provide the identifier as `discord_id` within the request payload.
 
-Currently exposes placeholder Discord command operations.
+Currently exposes Discord command, chat, persona, and Bluesky bridge operations.
+
+### `bsky`
+
+| Operation                             | Description                                   |
+| ------------------------------------- | --------------------------------------------- |
+| `urn:discord:bsky:post:1`             | Post a message to the configured Bluesky feed. |
 
 ### `command`
 

--- a/rpc/discord/__init__.py
+++ b/rpc/discord/__init__.py
@@ -4,11 +4,13 @@ Provides handlers for Discord bot operations (``ROLE_DISCORD_BOT``) and Discord
 administration flows (``ROLE_DISCORD_ADMIN``).
 """
 
+from .bsky.handler import handle_bsky_request
 from .chat.handler import handle_chat_request
 from .command.handler import handle_command_request
 from .personas.handler import handle_personas_request
 
 HANDLERS: dict[str, callable] = {
+  "bsky": handle_bsky_request,
   "chat": handle_chat_request,
   "command": handle_command_request,
   "personas": handle_personas_request,
@@ -16,6 +18,7 @@ HANDLERS: dict[str, callable] = {
 
 
 REQUIRED_ROLES: dict[str, str] = {
+  "bsky": "ROLE_DISCORD_BOT",
   "chat": "ROLE_DISCORD_BOT",
   "command": "ROLE_DISCORD_BOT",
   "personas": "ROLE_DISCORD_ADMIN",
@@ -23,6 +26,7 @@ REQUIRED_ROLES: dict[str, str] = {
 
 
 FORBIDDEN_DETAILS: dict[str, str] = {
+  "bsky": 'You must have the Discord bot role assigned to use this bot.',
   "chat": 'You must have the Discord bot role assigned to use this bot.',
   "command": 'You must have the Discord bot role assigned to use this bot.',
   "personas": 'Forbidden',

--- a/rpc/discord/bsky/__init__.py
+++ b/rpc/discord/bsky/__init__.py
@@ -1,0 +1,5 @@
+from .services import discord_bsky_post_message_v1
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("post", "1"): discord_bsky_post_message_v1,
+}

--- a/rpc/discord/bsky/handler.py
+++ b/rpc/discord/bsky/handler.py
@@ -1,0 +1,15 @@
+"""Discord Bluesky RPC handler."""
+
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_bsky_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/discord/bsky/models.py
+++ b/rpc/discord/bsky/models.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class DiscordBskyPostRequest1(BaseModel):
+  message: str
+
+
+class DiscordBskyPostResponse1(BaseModel):
+  uri: str
+  cid: str
+  handle: str
+  display_name: str | None = None

--- a/rpc/discord/bsky/services.py
+++ b/rpc/discord/bsky/services.py
@@ -1,0 +1,30 @@
+from fastapi import HTTPException, Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.bsky_module import BskyModule
+
+from .models import DiscordBskyPostRequest1, DiscordBskyPostResponse1
+
+
+async def discord_bsky_post_message_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  payload_dict = rpc_request.payload or {}
+  req = DiscordBskyPostRequest1(**payload_dict)
+  module: BskyModule = request.app.state.bsky
+  await module.on_ready()
+  try:
+    result = await module.post_message(req.message)
+  except ValueError as exc:
+    raise HTTPException(status_code=400, detail=str(exc)) from exc
+  payload = DiscordBskyPostResponse1(
+    uri=result.uri,
+    cid=result.cid,
+    handle=result.handle,
+    display_name=result.display_name,
+  )
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )

--- a/server/modules/bsky_module.py
+++ b/server/modules/bsky_module.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+from atproto import AsyncClient as AsyncBskyClient, client_utils
+from fastapi import FastAPI
+
+from . import BaseModule
+from .db_module import DbModule
+
+
+@dataclass
+class BskyPostResult:
+  uri: str
+  cid: str
+  handle: str
+  display_name: str | None = None
+
+
+class BskyModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+    self._handle: str = "elideusgroup.com"
+    self._password: str | None = None
+    self._client_factory = AsyncBskyClient
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self._handle = await self._load_optional_config("BskyHandle") or self._handle
+    self._password = await self._load_optional_config("BskyPassword") or None
+    if not self._password:
+      logging.warning("[BskyModule] Missing config value for key: BskyPassword")
+    self.mark_ready()
+
+  async def shutdown(self):
+    self.db = None
+    self._password = None
+
+  async def _load_optional_config(self, key: str) -> str:
+    if not self.db:
+      raise RuntimeError("BskyModule requires database module")
+    res = await self.db.run("db:system:config:get_config:1", {"key": key})
+    if not res.rows:
+      return ""
+    return res.rows[0].get("value") or ""
+
+  async def _ensure_credentials(self):
+    if not self.db:
+      raise RuntimeError("BskyModule requires database module")
+    if not self._password:
+      self._password = await self._load_optional_config("BskyPassword") or None
+    if not self._password:
+      raise ValueError("Missing config value for key: BskyPassword")
+    if not self._handle:
+      self._handle = await self._load_optional_config("BskyHandle") or ""
+    if not self._handle:
+      raise ValueError("Missing config value for key: BskyHandle")
+
+  @asynccontextmanager
+  async def _client_session(self):
+    await self._ensure_credentials()
+    client = self._client_factory()
+    try:
+      profile = await client.login(self._handle, self._password)
+      yield client, profile
+    finally:
+      try:
+        await client.request.close()
+      except Exception:  # pragma: no cover - close failures should not break flow
+        logging.exception("[BskyModule] Failed to close Bluesky client session")
+
+  async def post_message(self, message: str) -> BskyPostResult:
+    if not message or not message.strip():
+      raise ValueError("Message must not be empty")
+    async with self._client_session() as (client, profile):
+      text = client_utils.TextBuilder().text(message)
+      record = await client.send_post(text)
+      display_name = getattr(profile, "display_name", None)
+      handle = getattr(profile, "handle", self._handle)
+      return BskyPostResult(
+        uri=record.uri,
+        cid=record.cid,
+        handle=handle,
+        display_name=display_name,
+      )

--- a/tests/test_bsky_module.py
+++ b/tests/test_bsky_module.py
@@ -1,0 +1,122 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+
+from server.modules import BaseModule
+from server.modules.bsky_module import BskyModule
+
+
+class DummyDb(BaseModule):
+  def __init__(self, app: FastAPI, values: dict[str, str]):
+    super().__init__(app)
+    self.values = values
+
+  async def startup(self):
+    self.mark_ready()
+
+  async def shutdown(self):
+    pass
+
+  async def run(self, op: str, args: dict):
+    class Res:
+      def __init__(self, rows):
+        self.rows = rows
+        self.rowcount = len(rows)
+    if op == "db:system:config:get_config:1":
+      key = args.get("key")
+      if key in self.values:
+        return Res([{ "value": self.values[key] }])
+    return Res([])
+
+
+def test_post_message():
+  app = FastAPI()
+  db = DummyDb(app, {"BskyPassword": "secret", "BskyHandle": "custom.handle"})
+  asyncio.run(db.startup())
+  app.state.db = db
+
+  module = BskyModule(app)
+
+  created_clients: list[SimpleNamespace] = []
+
+  class StubRequest:
+    def __init__(self):
+      self.closed = False
+
+    async def close(self):
+      self.closed = True
+
+  class StubClient:
+    def __init__(self):
+      self.request = StubRequest()
+      self.login_calls: list[tuple[str, str]] = []
+      self.send_post_calls: list = []
+
+    async def login(self, handle: str, password: str):
+      self.login_calls.append((handle, password))
+      return SimpleNamespace(handle=handle, display_name="Custom")
+
+    async def send_post(self, text):
+      self.send_post_calls.append(text)
+      return SimpleNamespace(uri="at://custom/1", cid="cid123")
+
+  def factory():
+    client = StubClient()
+    created_clients.append(client)
+    return client
+
+  module._client_factory = factory
+
+  asyncio.run(module.startup())
+
+  result = asyncio.run(module.post_message("Hello Bluesky"))
+
+  assert isinstance(result.uri, str)
+  assert result.uri == "at://custom/1"
+  assert result.cid == "cid123"
+  assert result.handle == "custom.handle"
+  assert result.display_name == "Custom"
+
+  assert created_clients
+  client = created_clients[0]
+  assert client.login_calls == [("custom.handle", "secret")]
+  assert len(client.send_post_calls) == 1
+  assert client.request.closed is True
+
+  asyncio.run(module.shutdown())
+  asyncio.run(db.shutdown())
+
+
+def test_post_message_requires_password():
+  app = FastAPI()
+  db = DummyDb(app, {})
+  asyncio.run(db.startup())
+  app.state.db = db
+
+  module = BskyModule(app)
+  asyncio.run(module.startup())
+
+  with pytest.raises(ValueError) as exc:
+    asyncio.run(module.post_message("Hello"))
+  assert "BskyPassword" in str(exc.value)
+
+  asyncio.run(module.shutdown())
+  asyncio.run(db.shutdown())
+
+
+def test_post_message_rejects_blank():
+  app = FastAPI()
+  db = DummyDb(app, {"BskyPassword": "secret"})
+  asyncio.run(db.startup())
+  app.state.db = db
+
+  module = BskyModule(app)
+  asyncio.run(module.startup())
+
+  with pytest.raises(ValueError):
+    asyncio.run(module.post_message("   "))
+
+  asyncio.run(module.shutdown())
+  asyncio.run(db.shutdown())

--- a/tests/test_discord_bsky_services.py
+++ b/tests/test_discord_bsky_services.py
@@ -1,0 +1,113 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from types import SimpleNamespace
+
+# Stub rpc package to avoid side effects from rpc.__init__
+pkg = types.ModuleType('rpc')
+pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc')]
+pkg.HANDLERS = {}
+sys.modules.setdefault('rpc', pkg)
+
+# Load server models
+spec = importlib.util.spec_from_file_location(
+  'server.models', pathlib.Path(__file__).resolve().parent.parent / 'server/models.py'
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+sys.modules['server.models'] = mod
+RPCRequest = mod.RPCRequest
+AuthContext = mod.AuthContext
+
+from rpc.discord.bsky import services as bsky_services
+
+
+class StubBskyModule:
+  def __init__(self, response=None, error: Exception | None = None):
+    self.calls: list[str] = []
+    self.ready = False
+    self.response = response
+    self.error = error
+
+  async def on_ready(self):
+    self.ready = True
+
+  async def post_message(self, message: str):
+    self.calls.append(message)
+    if self.error:
+      raise self.error
+    return self.response or SimpleNamespace(
+      uri='at://example/record',
+      cid='cid123',
+      handle='example.handle',
+      display_name='Example',
+    )
+
+
+def test_bsky_post_message_handler():
+  app = FastAPI()
+  module = StubBskyModule()
+  app.state.bsky = module
+
+  async def fake_unbox(request):
+    return (
+      RPCRequest(op='urn:discord:bsky:post:1', payload={'message': 'hello world'}),
+      AuthContext(),
+      [],
+    )
+
+  original = bsky_services.unbox_request
+  bsky_services.unbox_request = fake_unbox
+
+  @app.post('/rpc')
+  async def rpc_endpoint(request: Request):
+    return await bsky_services.discord_bsky_post_message_v1(request)
+
+  client = TestClient(app)
+  resp = client.post('/rpc', json={'op': 'urn:discord:bsky:post:1'})
+  assert resp.status_code == 200
+  assert module.ready is True
+  assert module.calls == ['hello world']
+  data = resp.json()
+  expected = {
+    'uri': 'at://example/record',
+    'cid': 'cid123',
+    'handle': 'example.handle',
+    'display_name': 'Example',
+  }
+  assert data['payload'] == expected
+
+  bsky_services.unbox_request = original
+
+
+def test_bsky_post_message_handler_error():
+  app = FastAPI()
+  module = StubBskyModule(error=ValueError('missing creds'))
+  app.state.bsky = module
+
+  async def fake_unbox(request):
+    return (
+      RPCRequest(op='urn:discord:bsky:post:1', payload={'message': 'hello world'}),
+      AuthContext(),
+      [],
+    )
+
+  original = bsky_services.unbox_request
+  bsky_services.unbox_request = fake_unbox
+
+  @app.post('/rpc')
+  async def rpc_endpoint(request: Request):
+    return await bsky_services.discord_bsky_post_message_v1(request)
+
+  client = TestClient(app)
+  resp = client.post('/rpc', json={'op': 'urn:discord:bsky:post:1'})
+  assert resp.status_code == 400
+  assert module.calls == ['hello world']
+  data = resp.json()
+  assert data['detail'] == 'missing creds'
+
+  bsky_services.unbox_request = original


### PR DESCRIPTION
## Summary
- add a Bluesky module that initializes a client per post using credentials from system configuration
- expose a new `urn:discord:bsky:post:1` RPC endpoint and document it for Discord integrations
- cover the Bluesky module and RPC handler with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9d1e97d7c8325b9730e58f14cbd5a