### PR TITLE
Use vw_personas for assistant persona lookups

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1310,13 +1310,23 @@ def _assistant_personas_get_by_name(args: Dict[str, Any]):
   sql = """
     SELECT
       ap.recid,
-      ap.element_prompt,
-      ap.element_tokens,
       ap.models_recid,
-      am.element_name AS element_model
-    FROM assistant_personas ap
-    JOIN assistant_models am ON am.recid = ap.models_recid
-    WHERE ap.element_name = ?;
+      vp.persona_name AS persona_name,
+      vp.persona_name AS name,
+      vp.system_role_prompt AS system_role_prompt,
+      vp.system_role_prompt AS prompt,
+      vp.system_role_prompt AS element_prompt,
+      vp.token_allowance AS token_allowance,
+      vp.token_allowance AS tokens,
+      vp.token_allowance AS element_tokens,
+      vp.model_name AS model_name,
+      vp.model_name AS model,
+      vp.model_name AS element_model,
+      vp.element_created_on,
+      vp.element_modified_on
+    FROM vw_personas vp
+    JOIN assistant_personas ap ON ap.element_name = vp.persona_name
+    WHERE vp.persona_name = ?;
   """
   return (DbRunMode.ROW_ONE, sql, (name,))
 
@@ -1341,14 +1351,23 @@ def _assistant_personas_list(_: Dict[str, Any]):
   sql = """
     SELECT
       ap.recid,
-      ap.element_name AS name,
-      ap.element_prompt AS prompt,
-      ap.element_tokens AS tokens,
       ap.models_recid,
-      am.element_name AS model
-    FROM assistant_personas ap
-    JOIN assistant_models am ON am.recid = ap.models_recid
-    ORDER BY ap.element_name
+      vp.persona_name AS persona_name,
+      vp.persona_name AS name,
+      vp.system_role_prompt AS system_role_prompt,
+      vp.system_role_prompt AS prompt,
+      vp.system_role_prompt AS element_prompt,
+      vp.token_allowance AS token_allowance,
+      vp.token_allowance AS tokens,
+      vp.token_allowance AS element_tokens,
+      vp.model_name AS model_name,
+      vp.model_name AS model,
+      vp.model_name AS element_model,
+      vp.element_created_on,
+      vp.element_modified_on
+    FROM vw_personas vp
+    JOIN assistant_personas ap ON ap.element_name = vp.persona_name
+    ORDER BY vp.persona_name
     FOR JSON PATH;
   """
   return (DbRunMode.JSON_MANY, sql, ())

--- a/tests/test_mssql_personas_registry.py
+++ b/tests/test_mssql_personas_registry.py
@@ -7,7 +7,8 @@ def test_persona_lookup_query_targets_element_name():
   mode, sql, params = handler({"name": "stark"})
 
   assert mode is DbRunMode.ROW_ONE
-  assert "FROM assistant_personas ap" in sql
-  assert "WHERE ap.element_name = ?;" in sql
-  assert "am.element_name AS element_model" in sql
+  assert "FROM vw_personas vp" in sql
+  assert "JOIN assistant_personas ap ON ap.element_name = vp.persona_name" in sql
+  assert "WHERE vp.persona_name = ?;" in sql
+  assert "vp.model_name AS element_model" in sql
   assert params == ("stark",)


### PR DESCRIPTION
## Summary
- source persona list and lookup queries from `vw_personas`, projecting the view columns and legacy aliases
- keep downstream consumers compatible by continuing to expose legacy keys in the MSSQL provider
- update the MSSQL registry unit test to assert the view-driven SQL shape

## Testing
- pytest tests/test_mssql_personas_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68c9dcb58acc8325838cb710b3b29975