### PR TITLE
Fix Discord ongoing chat persona selection syntax error

### DIFF
--- a/server/modules/discord_ongoing_chat_module.py
+++ b/server/modules/discord_ongoing_chat_module.py
@@ -172,14 +172,13 @@ class DiscordOngoingChatModule(BaseModule):
   async def _select_persona(self) -> dict | None:
     assert self.db
     res = await self.db.run("db:assistant:personas:list:1", {})
-    personas = [
-      {
-        "name": (row.get("name") or "").strip(),
-        "prompt": (row.get("prompt") or "").strip(),
-      }
-      for row in res.rows or []
-      if (row.get("name") or "").strip() and (row.get("prompt") or "").strip())
-    ]
+    personas = []
+    for row in res.rows or []:
+      name = (row.get("name") or "").strip()
+      prompt = (row.get("prompt") or "").strip()
+      if not name or not prompt:
+        continue
+      personas.append({"name": name, "prompt": prompt})
     if not personas:
       return None
     return random.choice(personas)


### PR DESCRIPTION
## Summary
- fix the persona filtering logic in the Discord ongoing chat module to avoid syntax errors
- rewrite the filtering to use a straightforward loop for readability while preserving trimming behavior

## Testing
- python -m compileall server/modules/discord_ongoing_chat_module.py

------
https://chatgpt.com/codex/tasks/task_e_68c9e6b85b3483258b51f2e1c5cd6e4c