### PR TITLE
Add RPC controls for Discord ongoing chat automation

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -241,7 +241,7 @@ Discord domain calls require Discord-specific roles depending on the subdomain:
 
 Requests must include the `x-discord-id` (or `x-discord-user-id`) header identifying the caller. If headers cannot be set, provide the identifier as `discord_id` within the request payload.
 
-Currently exposes Discord command, chat, persona, and Bluesky bridge operations.
+Currently exposes Discord command, chat, ongoing automation, persona, and Bluesky bridge operations.
 
 ### `bsky`
 
@@ -264,6 +264,13 @@ Currently exposes Discord command, chat, persona, and Bluesky bridge operations.
 | `urn:discord:chat:summarize_channel:1`      | Summarize a Discord channel.    |
 | `urn:discord:chat:uwu_chat:1`               | Stub chat returning "uwu" text. |
 | `urn:discord:chat:persona_response:1`       | Respond using a selected persona. |
+
+### `ongoing`
+
+| Operation                                   | Description                                           |
+| ------------------------------------------- | ----------------------------------------------------- |
+| `urn:discord:ongoing:toggle_active:1`       | Toggle the Discord ongoing chat automation on or off. |
+| `urn:discord:ongoing:countdown:1`           | Get the seconds remaining before the next message.    |
 
 ### `personas`
 

--- a/rpc/discord/__init__.py
+++ b/rpc/discord/__init__.py
@@ -7,12 +7,14 @@ administration flows (``ROLE_DISCORD_ADMIN``).
 from .bsky.handler import handle_bsky_request
 from .chat.handler import handle_chat_request
 from .command.handler import handle_command_request
+from .ongoing.handler import handle_ongoing_request
 from .personas.handler import handle_personas_request
 
 HANDLERS: dict[str, callable] = {
   "bsky": handle_bsky_request,
   "chat": handle_chat_request,
   "command": handle_command_request,
+  "ongoing": handle_ongoing_request,
   "personas": handle_personas_request,
 }
 
@@ -21,6 +23,7 @@ REQUIRED_ROLES: dict[str, str] = {
   "bsky": "ROLE_DISCORD_BOT",
   "chat": "ROLE_DISCORD_BOT",
   "command": "ROLE_DISCORD_BOT",
+  "ongoing": "ROLE_DISCORD_BOT",
   "personas": "ROLE_DISCORD_ADMIN",
 }
 
@@ -29,5 +32,6 @@ FORBIDDEN_DETAILS: dict[str, str] = {
   "bsky": 'You must have the Discord bot role assigned to use this bot.',
   "chat": 'You must have the Discord bot role assigned to use this bot.',
   "command": 'You must have the Discord bot role assigned to use this bot.',
+  "ongoing": 'You must have the Discord bot role assigned to use this bot.',
   "personas": 'Forbidden',
 }

--- a/rpc/discord/ongoing/__init__.py
+++ b/rpc/discord/ongoing/__init__.py
@@ -1,0 +1,10 @@
+from .services import (
+  discord_ongoing_countdown_v1,
+  discord_ongoing_toggle_active_v1,
+)
+
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("toggle_active", "1"): discord_ongoing_toggle_active_v1,
+  ("countdown", "1"): discord_ongoing_countdown_v1,
+}

--- a/rpc/discord/ongoing/handler.py
+++ b/rpc/discord/ongoing/handler.py
@@ -1,0 +1,15 @@
+"""Discord ongoing chat RPC handler."""
+
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_ongoing_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/discord/ongoing/models.py
+++ b/rpc/discord/ongoing/models.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class DiscordOngoingToggleActiveResponse1(BaseModel):
+  active: bool
+
+
+class DiscordOngoingCountdownResponse1(BaseModel):
+  active: bool
+  seconds_remaining: float | None

--- a/rpc/discord/ongoing/services.py
+++ b/rpc/discord/ongoing/services.py
@@ -1,0 +1,40 @@
+from fastapi import Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.discord_ongoing_chat_module import DiscordOngoingChatModule
+
+from .models import (
+  DiscordOngoingCountdownResponse1,
+  DiscordOngoingToggleActiveResponse1,
+)
+
+
+async def discord_ongoing_toggle_active_v1(request: Request) -> RPCResponse:
+  rpc_request, _, _ = await unbox_request(request)
+  module: DiscordOngoingChatModule = request.app.state.discord_ongoing_chat
+  await module.on_ready()
+  active = await module.toggle_active()
+  payload = DiscordOngoingToggleActiveResponse1(active=active)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )
+
+
+async def discord_ongoing_countdown_v1(request: Request) -> RPCResponse:
+  rpc_request, _, _ = await unbox_request(request)
+  module: DiscordOngoingChatModule = request.app.state.discord_ongoing_chat
+  await module.on_ready()
+  seconds_remaining = await module.countdown_seconds()
+  active = await module.is_active()
+  payload = DiscordOngoingCountdownResponse1(
+    active=active,
+    seconds_remaining=seconds_remaining,
+  )
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )


### PR DESCRIPTION
## Summary
- add in-memory active state tracking with countdown support to the Discord ongoing chat module
- expose toggle_active and countdown RPC endpoints via a new discord:ongoing namespace
- document the new operations in RPC.md

## Testing
- python scripts/generate_rpc_bindings.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9ea75bf58832593d3f2445f104fbe