### PR TITLE
Fix JSON queries for assistant conversation history

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1568,7 +1568,8 @@ def _assistant_conversations_list_by_time(args: Dict[str, Any]):
            models_recid
     FROM assistant_conversations
     WHERE personas_recid = ? AND element_created_on BETWEEN ? AND ?
-    ORDER BY element_created_on;
+    ORDER BY element_created_on
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
   """
   return (DbRunMode.JSON_MANY, sql, (personas_recid, start, end))
 
@@ -1587,6 +1588,7 @@ def _assistant_conversations_list_recent(_: Dict[str, Any]):
            element_created_on
     FROM assistant_conversations
     WHERE element_output IS NOT NULL AND LTRIM(RTRIM(element_output)) <> ''
-    ORDER BY element_created_on DESC;
+    ORDER BY element_created_on DESC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
   """
   return (DbRunMode.JSON_MANY, sql, ())

--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -16,6 +16,8 @@ def test_assistant_conversations_list_by_time(monkeypatch):
     assert "element_modified_on" in sql
     assert "element_user_id" in sql
     assert "element_tokens" in sql
+    assert "FOR JSON PATH" in sql
+    assert "INCLUDE_NULL_VALUES" in sql
     assert params == (personas_recid, start, end)
     return DBResult(rows=[{"recid": 1}], rowcount=1)
 
@@ -103,6 +105,8 @@ def test_assistant_conversations_list_recent(monkeypatch):
     assert "SELECT TOP (5)" in sql
     assert "element_output" in sql
     assert "ORDER BY element_created_on DESC" in sql
+    assert "FOR JSON PATH" in sql
+    assert "INCLUDE_NULL_VALUES" in sql
     assert params == ()
     return DBResult(rows=[{"recid": 2}], rowcount=1)
 


### PR DESCRIPTION
## Summary
- ensure assistant conversation queries return JSON by adding `FOR JSON PATH, INCLUDE_NULL_VALUES`
- cover the expected SQL shape in the database tests for recent and ranged history lookups

## Testing
- pytest tests/test_db_assistant_conversations.py

------
https://chatgpt.com/codex/tasks/task_e_68c9f1c076388325827792c8714880bc