### PR TITLE
Limit ongoing chat context to latest history

### DIFF
--- a/server/helpers/discord.py
+++ b/server/helpers/discord.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import Awaitable, Callable
-from typing import Protocol
+from typing import List, Protocol
 
 __all__ = [
   "send_to_discord",
@@ -15,6 +15,67 @@ class _SupportsSend(Protocol):
 _SendCallable = Callable[[str], Awaitable[None]]
 
 
+def _wrap_line(line: str, max_message_size: int) -> List[str]:
+  """Split a single line into message-sized chunks."""
+
+  remaining = line
+  parts: List[str] = []
+
+  while remaining:
+    if len(remaining) <= max_message_size:
+      parts.append(remaining)
+      break
+
+    window = remaining[:max_message_size]
+    split = window.rfind(" ")
+    if split <= 0:
+      split = max_message_size
+
+    parts.append(remaining[:split])
+    remaining = remaining[split:]
+
+  if not parts:
+    parts.append("")
+
+  return parts
+
+
+def _yield_chunks(text: str, max_message_size: int) -> List[str]:
+  """Yield message-sized chunks preserving multi-line formatting."""
+
+  normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+  lines = normalized.split("\n")
+  chunks: List[str] = []
+  buffer = ""
+
+  for raw_line in lines:
+    line = raw_line
+    if not line.strip() and not buffer.strip():
+      continue
+
+    wrapped = _wrap_line(line, max_message_size)
+    for segment in wrapped[:-1]:
+      candidate = segment if not buffer else buffer + "\n" + segment
+      if candidate.strip() and candidate.strip() != "---":
+        chunks.append(candidate)
+      buffer = ""
+
+    last_segment = wrapped[-1]
+    candidate = last_segment if not buffer else buffer + ("\n" + last_segment if last_segment else "\n")
+
+    if len(candidate) <= max_message_size:
+      buffer = candidate
+    else:
+      if buffer.strip() and buffer.strip() != "---":
+        chunks.append(buffer)
+      buffer = last_segment
+
+  if buffer.strip() and buffer.strip() != "---":
+    chunks.append(buffer)
+
+  return chunks
+
+
 async def _chunked_send(
   send: _SendCallable,
   text: str,
@@ -23,32 +84,10 @@ async def _chunked_send(
 ) -> None:
   """Split ``text`` into Discord-safe messages and send them sequentially."""
 
-  for block in text.split("\n"):
-    if not block.strip() or block.strip() == "---":
-      continue
-
-    start = 0
-    while start < len(block):
-      end = min(start + max_message_size, len(block))
-
-      if end < len(block) and block[end] != " ":
-        adjusted_end = block.rfind(" ", start, end)
-        if adjusted_end == -1 or adjusted_end <= start:
-          adjusted_end = min(start + max_message_size, len(block))
-        end = adjusted_end
-
-      if end <= start:
-        end = min(start + max_message_size, len(block))
-        if end <= start:
-          break
-
-      chunk = block[start:end].strip()
-      if chunk:
-        await send(chunk)
-        if delay > 0:
-          await asyncio.sleep(delay)
-
-      start = end
+  for chunk in _yield_chunks(text, max_message_size):
+    await send(chunk)
+    if delay > 0:
+      await asyncio.sleep(delay)
 
 
 async def send_to_discord(

--- a/server/modules/discord_ongoing_chat_module.py
+++ b/server/modules/discord_ongoing_chat_module.py
@@ -21,7 +21,7 @@ class DiscordOngoingChatModule(BaseModule):
     self.discord_chat: DiscordChatModule | None = None
     self.openai: OpenaiModule | None = None
     self.interval_seconds = 300
-    self.context_messages = 5
+    self.context_messages = 2
     self.history_hours = 1
     self.history_limit = 100
     self._task: asyncio.Task | None = None
@@ -145,13 +145,14 @@ class DiscordOngoingChatModule(BaseModule):
       logging.debug("[DiscordOngoingChatModule] cycle skipped: missing guild/channel")
       return
 
-    context_outputs = [
-      (row.get("element_output") or "").strip()
-      for row in reversed(rows)
-      if (row.get("element_output") or "").strip()
-    ]
-    if len(context_outputs) > self.context_messages:
-      context_outputs = context_outputs[-self.context_messages :]
+    context_outputs = []
+    for row in rows:
+      text = (row.get("element_output") or "").strip()
+      if not text:
+        continue
+      context_outputs.append(text)
+      if len(context_outputs) >= self.context_messages:
+        break
 
     persona = await self._select_persona()
     if not persona:

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1577,7 +1577,7 @@ def _assistant_conversations_list_by_time(args: Dict[str, Any]):
 @register("db:assistant:conversations:list_recent:1")
 def _assistant_conversations_list_recent(_: Dict[str, Any]):
   sql = """
-    SELECT TOP (5)
+    SELECT TOP (2)
            recid,
            personas_recid,
            element_guild_id,

--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -102,7 +102,7 @@ def test_assistant_conversations_list_recent(monkeypatch):
 
   async def fake_fetch_json(sql, params, *, many=False):
     assert many
-    assert "SELECT TOP (5)" in sql
+    assert "SELECT TOP (2)" in sql
     assert "element_output" in sql
     assert "ORDER BY element_created_on DESC" in sql
     assert "FOR JSON PATH" in sql

--- a/tests/test_discord_helpers.py
+++ b/tests/test_discord_helpers.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from server.helpers.discord import send_to_discord
+
+
+class DummyChannel:
+  def __init__(self):
+    self.sent: list[str] = []
+
+  async def send(self, message: str) -> None:
+    self.sent.append(message)
+
+
+def test_send_to_discord_chunks_long_message():
+  channel = DummyChannel()
+  text = "A" * 4500
+
+  async def run():
+    await send_to_discord(channel, text, max_message_size=1000, delay=0)
+
+  asyncio.run(run())
+  assert len(channel.sent) == 5
+  assert "".join(channel.sent) == text
+
+
+def test_send_to_discord_handles_multiline_text():
+  channel = DummyChannel()
+  text = "Intro paragraph." "\n\n" "---" "\n\n" + "Section " + "A" * 1200 + "\nConclusion line with trailing spaces  "
+
+  async def run():
+    await send_to_discord(channel, text, max_message_size=500, delay=0)
+
+  asyncio.run(run())
+
+  assert all(len(chunk) <= 500 for chunk in channel.sent)
+  compact_original = text.replace("\n", "")
+  compact_sent = "".join(chunk.replace("\n", "") for chunk in channel.sent)
+  assert compact_sent == compact_original
+  newline_count_sent = sum(chunk.count("\n") for chunk in channel.sent)
+  assert newline_count_sent == text.count("\n")


### PR DESCRIPTION
## Summary
- limit the assistant conversation history query to the two most recent records
- update the ongoing Discord chat module to cap context at two outputs in newest-first order
- rework the Discord send helper so long, multi-line responses are chunked and delivered reliably for ongoing chats
- add tests covering the revised query and Discord message chunking helper

## Testing
- pytest tests/test_discord_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68c9ff1c2eb88325850f2842582e10e8