### PR TITLE
Add Discord output queue and throughput metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,8 @@ Two tables record persona definitions and usage:
 
 The OpenAI module records conversation details whenever `!summarize` is executed.
 
+### Discord Output Module
+
+- Outbound Discord messages are buffered through an internal asyncio queue that respects the module's chunking and rate-limiting rules. Use `queue_channel_message` and `queue_user_message` helpers to enqueue work.
+- Successful deliveries update per-channel, per-user, and aggregate throughput metrics. Call `get_throughput_snapshot()` to inspect counters and timestamps for monitoring or diagnostics.
+

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from openai import AsyncOpenAI
 from . import BaseModule
 from .db_module import DbModule
-from .discord_bot_module import DiscordBotBotModule
+from .discord_bot_module import DiscordBotModule
 
 if TYPE_CHECKING:  # pragma: no cover
   from .discord_output_module import DiscordOutputModule
@@ -58,7 +58,7 @@ class OpenaiModule(BaseModule):
     self.db: DbModule | None = None
     self.client: AsyncOpenAI | None = None
     self.summary_queue = SummaryQueue()
-    self.discord: DiscordBotBotModule | None = None
+    self.discord: DiscordBotModule | None = None
     self.discord_output: "DiscordOutputModule" | None = None
 
   async def startup(self):


### PR DESCRIPTION
## Summary
- add an internal asyncio queue to DiscordOutputModule with a worker that drains messages using the existing chunking and rate limits
- record per-channel, per-user, and aggregate throughput metrics and expose helpers to enqueue messages and inspect counters
- update documentation and tests for buffered delivery while fixing the Discord bot module import typo that blocked imports

## Testing
- pytest tests/test_discord_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68cb26594f4883259ab8218c041a3057