### PR TITLE
Add social input orchestrator and Discord provider

### DIFF
--- a/server/modules/personas_module.py
+++ b/server/modules/personas_module.py
@@ -70,31 +70,25 @@ class PersonasModule(BaseModule):
         "role": instructions,
       }
 
-    await self.openai.on_ready()
-    generator = getattr(self.openai, "generate_chat", None)
-    if generator:
-      response = await generator(
-        system_prompt=instructions,
-        user_prompt=prompt,
-        max_tokens=tokens,
-        persona=persona_name,
-        guild_id=guild_id,
-        channel_id=channel_id,
-        user_id=user_id,
-        input_log=prompt,
-      )
-    else:
-      response = await self.openai.fetch_chat(
-        [],
-        instructions,
-        prompt,
-        tokens,
-        persona=persona_name,
-        guild_id=guild_id,
-        channel_id=channel_id,
-        user_id=user_id,
-        input_log=prompt,
-      )
+    submit_prompt = getattr(self.openai, "submit_chat_prompt", None)
+    if not submit_prompt:
+      raise AttributeError("OpenAI integration missing submit_chat_prompt method")
+
+    request_payload = {
+      "system_prompt": instructions,
+      "model": model_hint,
+      "max_tokens": tokens,
+      "user_prompt": prompt,
+      "persona_name": persona_name,
+      "persona_recid": persona_recid,
+      "models_recid": models_recid,
+      "guild_id": guild_id,
+      "channel_id": channel_id,
+      "user_id": user_id,
+      "input_log": prompt,
+      "token_count": None,
+    }
+    response = await submit_prompt(**request_payload)
     if isinstance(response, dict):
       content = response.get("content", "")
       model_value = response.get("model")

--- a/server/modules/providers/social/__init__.py
+++ b/server/modules/providers/social/__init__.py
@@ -1,0 +1,32 @@
+"""Base classes for social input providers."""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC
+from typing import Any, Callable, TYPE_CHECKING
+
+from .. import LifecycleProvider
+
+__all__ = ["SocialInputProvider"]
+
+if TYPE_CHECKING:  # pragma: no cover
+  from ...social_input_module import SocialInputModule
+
+
+class SocialInputProvider(LifecycleProvider, ABC):
+  name: str
+
+  def __init__(self, module: "SocialInputModule"):
+    super().__init__()
+    self.module = module
+
+  async def dispatch(self, action: str, *args, **kwargs) -> Any:
+    handler_name = f"handle_{action}"
+    handler: Callable[..., Any] | None = getattr(self, handler_name, None)
+    if not handler:
+      raise ValueError(f"Action '{action}' not supported by provider '{self.name}'")
+    result = handler(*args, **kwargs)
+    if asyncio.iscoroutine(result):
+      return await result
+    return result

--- a/server/modules/providers/social/discord_input_provider.py
+++ b/server/modules/providers/social/discord_input_provider.py
@@ -1,0 +1,231 @@
+"""Discord input provider that registers commands and dispatches workflows."""
+
+from __future__ import annotations
+
+import json, logging, time
+from typing import TYPE_CHECKING
+
+from fastapi import Request
+from discord.ext import commands
+
+from . import SocialInputProvider
+
+if TYPE_CHECKING:  # pragma: no cover
+  from ...discord_bot_module import DiscordBotModule
+  from ...discord_output_module import DiscordOutputModule
+  from ...social_input_module import SocialInputModule
+  from discord.ext.commands import Bot
+
+
+class DiscordInputProvider(SocialInputProvider):
+  name = "discord"
+
+  def __init__(self, module: "SocialInputModule", discord: "DiscordBotModule"):
+    super().__init__(module)
+    self.discord = discord
+    self.bot: "Bot" | None = None
+    self._registered: dict[str, commands.Command] = {}
+
+  async def startup(self):
+    await self.discord.on_ready()
+    if not self.discord.bot:
+      raise RuntimeError("Discord bot is not initialized")
+    self.bot = self.discord.bot
+    self._register_commands()
+    self.discord.register_input_provider(self)
+
+  async def shutdown(self):
+    if self.bot:
+      for name in list(self._registered.keys()):
+        self.bot.remove_command(name)
+      self._registered.clear()
+    self.bot = None
+
+  def _register_commands(self) -> None:
+    assert self.bot
+    for name in list(self._registered.keys()):
+      self.bot.remove_command(name)
+    @commands.command(name="rpc")
+    async def rpc_command(ctx, *, op: str):
+      await self._handle_rpc_command(ctx, op=op)
+
+    @commands.command(name="summarize")
+    async def summarize_command(ctx, hours: str):
+      await self._handle_summarize_command(ctx, hours)
+
+    self.bot.add_command(rpc_command)
+    self.bot.add_command(summarize_command)
+    self._registered = {"rpc": rpc_command, "summarize": summarize_command}
+
+  async def _handle_rpc_command(self, ctx, *, op: str):
+    from rpc.handler import handle_rpc_request
+
+    start = time.perf_counter()
+    guild_id = getattr(ctx.guild, "id", 0)
+    user_id = getattr(ctx.author, "id", 0)
+    if guild_id and user_id:
+      self.discord.bump_rate_limits(guild_id, user_id)
+    body = json.dumps({"op": op}).encode()
+
+    async def receive():
+      nonlocal body
+      data = body
+      body = b""
+      return {"type": "http.request", "body": data, "more_body": False}
+
+    scope = {
+      "type": "http",
+      "method": "POST",
+      "path": "/rpc",
+      "headers": [(b"content-type", b"application/json")],
+      "app": self.discord.app,
+    }
+    req = Request(scope, receive)
+    req.state.discord_ctx = ctx
+
+    try:
+      resp = await handle_rpc_request(req)
+      payload = resp.payload
+      if hasattr(payload, "model_dump"):
+        data = json.dumps(payload.model_dump())
+      else:
+        data = str(payload)
+      await self._send_channel(ctx.channel.id, data)
+      elapsed = time.perf_counter() - start
+      logging.info(
+        "[DiscordInputProvider] rpc",
+        extra={
+          "guild_id": guild_id,
+          "channel_id": ctx.channel.id,
+          "user_id": user_id,
+          "op": op,
+          "elapsed": elapsed,
+        },
+      )
+    except Exception as exc:
+      elapsed = time.perf_counter() - start
+      logging.exception(
+        "[DiscordInputProvider] rpc failed",
+        extra={
+          "guild_id": guild_id,
+          "channel_id": getattr(ctx.channel, "id", 0),
+          "user_id": user_id,
+          "op": op,
+          "elapsed": elapsed,
+        },
+      )
+      await self._send_channel(ctx.channel.id, f"Error: {exc}")
+
+  async def _handle_summarize_command(self, ctx, hours: str):
+    from rpc.handler import handle_rpc_request
+
+    start = time.perf_counter()
+    guild_id = getattr(ctx.guild, "id", 0)
+    user_id = getattr(ctx.author, "id", 0)
+    if guild_id and user_id:
+      self.discord.bump_rate_limits(guild_id, user_id)
+
+    try:
+      hrs = int(hours)
+    except ValueError:
+      await self._send_channel(ctx.channel.id, "Usage: !summarize <hours>")
+      return
+    if hrs < 1 or hrs > 336:
+      await self._send_channel(ctx.channel.id, "Hours must be between 1 and 336")
+      return
+
+    body = json.dumps({
+      "op": "urn:discord:chat:summarize_channel:1",
+      "payload": {
+        "guild_id": guild_id,
+        "channel_id": getattr(ctx.channel, "id", 0),
+        "hours": hrs,
+        "user_id": user_id,
+      },
+    }).encode()
+
+    async def receive():
+      nonlocal body
+      data = body
+      body = b""
+      return {"type": "http.request", "body": data, "more_body": False}
+
+    scope = {
+      "type": "http",
+      "method": "POST",
+      "path": "/rpc",
+      "headers": [(b"content-type", b"application/json")],
+      "app": self.discord.app,
+    }
+    req = Request(scope, receive)
+    req.state.discord_ctx = ctx
+
+    try:
+      resp = await handle_rpc_request(req)
+      payload = resp.payload
+      if hasattr(payload, "model_dump"):
+        data = payload.model_dump()
+      elif isinstance(payload, dict):
+        data = payload
+      else:
+        data = {"summary": str(payload)}
+      if not data.get("messages_collected"):
+        await self._send_channel(ctx.channel.id, "No messages found in the specified time range")
+        return
+      if data.get("cap_hit"):
+        await self._send_channel(ctx.channel.id, "Channel too active to summarize; message cap hit")
+        return
+      summary_text = data.get("summary") or json.dumps(data)
+      try:
+        openai = getattr(self.discord.app.state, "openai", None)
+        output: "DiscordOutputModule" | None = getattr(self.discord, "output_module", None)
+        if not output:
+          output = self.discord._get_output_module()
+        if openai and getattr(openai, "summary_queue", None) and output:
+          await openai.summary_queue.add(output.send_to_user, user_id, summary_text)
+        else:
+          await self.discord.send_user_message(user_id, summary_text)
+      except Exception:
+        logging.exception("[DiscordInputProvider] summarize delivery failed")
+        await self._send_channel(ctx.channel.id, "Failed to send summary. Please try again later.")
+        return
+      elapsed = time.perf_counter() - start
+      logging.info(
+        "[DiscordInputProvider] summarize",
+        extra={
+          "guild_id": guild_id,
+          "channel_id": getattr(ctx.channel, "id", 0),
+          "user_id": user_id,
+          "hours": hrs,
+          "token_count_estimate": data.get("token_count_estimate"),
+          "messages_collected": data.get("messages_collected"),
+          "cap_hit": data.get("cap_hit"),
+          "model": data.get("model"),
+          "role": data.get("role"),
+          "elapsed": elapsed,
+        },
+      )
+      logging.debug("[DiscordInputProvider] summarize response", extra=data)
+    except Exception:
+      elapsed = time.perf_counter() - start
+      logging.exception(
+        "[DiscordInputProvider] summarize failed",
+        extra={
+          "guild_id": guild_id,
+          "channel_id": getattr(ctx.channel, "id", 0),
+          "user_id": user_id,
+          "hours": hrs,
+          "elapsed": elapsed,
+        },
+      )
+      await self._send_channel(ctx.channel.id, "Failed to fetch messages. Please try again later.")
+
+  async def _send_channel(self, channel_id: int, message: str) -> None:
+    try:
+      await self.discord.send_channel_message(channel_id, message)
+    except Exception:
+      logging.exception(
+        "[DiscordInputProvider] failed to send channel message",
+        extra={"channel_id": channel_id},
+      )
+

--- a/server/modules/social_input_module.py
+++ b/server/modules/social_input_module.py
@@ -1,0 +1,64 @@
+"""Coordinator module for social input providers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, TYPE_CHECKING
+
+from fastapi import FastAPI
+
+from . import BaseModule
+
+if TYPE_CHECKING:  # pragma: no cover
+  from .discord_bot_module import DiscordBotModule
+  from .providers.social import SocialInputProvider
+
+
+class SocialInputModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.providers: Dict[str, "SocialInputProvider"] = {}
+    self.discord: "DiscordBotModule" | None = None
+    self.app.state.social_input = self
+
+  async def startup(self):
+    self.discord = getattr(self.app.state, "discord_bot", None)
+    if self.discord:
+      await self.discord.on_ready()
+      self.discord.register_social_input_module(self)
+      from .providers.social.discord_input_provider import DiscordInputProvider
+
+      provider = DiscordInputProvider(self, self.discord)
+      await self.register_provider(provider)
+    logging.info("[SocialInputModule] loaded providers: %s", list(self.providers.keys()))
+    self.mark_ready()
+
+  async def shutdown(self):
+    for name, provider in list(self.providers.items()):
+      try:
+        await provider.shutdown()
+      finally:
+        state_key = f"{name}_input_provider"
+        if getattr(self.app.state, state_key, None) is provider:
+          delattr(self.app.state, state_key)
+        del self.providers[name]
+    if getattr(self.app.state, "social_input", None) is self:
+      self.app.state.social_input = None
+    self.discord = None
+
+  async def register_provider(self, provider: "SocialInputProvider"):
+    name = provider.name
+    if name in self.providers:
+      raise ValueError(f"Provider '{name}' already registered")
+    await provider.startup()
+    self.providers[name] = provider
+    setattr(self.app.state, f"{name}_input_provider", provider)
+
+  async def dispatch(self, provider_name: str, action: str, *args, **kwargs) -> Any:
+    provider = self.providers.get(provider_name)
+    if not provider:
+      raise ValueError(f"Provider '{provider_name}' not registered")
+    return await provider.dispatch(action, *args, **kwargs)
+
+  def get_provider(self, name: str) -> "SocialInputProvider | None":
+    return self.providers.get(name)

--- a/tests/test_discord_bot_commands.py
+++ b/tests/test_discord_bot_commands.py
@@ -5,53 +5,56 @@ from types import SimpleNamespace
 from fastapi import FastAPI
 
 from server.modules.discord_bot_module import DiscordBotModule
+from server.modules.providers.social.discord_input_provider import DiscordInputProvider
+from server.modules.social_input_module import SocialInputModule
 
 
-class DummyHistory:
-  def __aiter__(self):
-    return self
-
-  async def __anext__(self):
-    raise StopAsyncIteration
-
-
-class DummyChannel:
-  def __init__(self, id: int = 2):
-    self.id = id
-    self.sent: list[str] = []
-    self.history_called = False
-
-  async def send(self, content):
-    self.sent.append(content)
-
-  def history(self, limit=1):
-    self.history_called = True
-    return DummyHistory()
-
-
-class DummyDMChannel(DummyChannel):
-  pass
-
-
-class DummyAuthor:
+class DummyOutput:
   def __init__(self):
-    self.id = 3
-    self.dm_channel = DummyDMChannel()
+    self.channel_messages: list[tuple[int, str]] = []
+    self.user_messages: list[tuple[int, str]] = []
 
-  async def send(self, content):
-    await self.dm_channel.send(content)
+  async def send_to_channel(self, channel_id: int, message: str):
+    self.channel_messages.append((channel_id, message))
+
+  async def send_to_user(self, user_id: int, message: str):
+    self.user_messages.append((user_id, message))
+
+
+def _setup_bot():
+  app = FastAPI()
+  bot_module = DiscordBotModule(app)
+  bot_module.bot = bot_module._init_discord_bot('!')
+  bot_module.mark_ready()
+  output = DummyOutput()
+  bot_module.output_module = output
+  app.state.discord_output = output
+
+  social = SocialInputModule(app)
+  social.discord = bot_module
+  bot_module.register_social_input_module(social)
+
+  provider = DiscordInputProvider(social, bot_module)
+  asyncio.run(social.register_provider(provider))
+
+  return bot_module, provider, output
+
+
+def _make_ctx():
+  guild = SimpleNamespace(id=1)
+  channel = SimpleNamespace(id=2)
+  author = SimpleNamespace(id=3)
+  return SimpleNamespace(guild=guild, channel=channel, author=author)
 
 
 def test_summarize_command(monkeypatch):
-  app = FastAPI()
-  module = DiscordBotModule(app)
-  module.bot = module._init_discord_bot('!')
-  module._init_bot_routes()
+  bot_module, provider, output = _setup_bot()
 
   async def dummy_handle(req):
     body = await req.body()
     dummy_handle.body = json.loads(body.decode())
     dummy_handle.called = True
+
     class DummyResp:
       payload = {
         "summary": "hi",
@@ -60,55 +63,42 @@ def test_summarize_command(monkeypatch):
         "model": "gpt",
         "role": "role",
       }
+
     return DummyResp()
+
   dummy_handle.called = False
   dummy_handle.body = None
   import importlib
   rpc_mod = importlib.import_module("rpc.handler")
   monkeypatch.setattr(rpc_mod, "handle_rpc_request", dummy_handle)
 
-  ctx = SimpleNamespace(
-    guild=SimpleNamespace(id=1),
-    channel=DummyChannel(),
-    author=DummyAuthor(),
-  )
-  ctx.send = ctx.channel.send
-
-  cmd = module.bot.get_command("summarize")
+  ctx = _make_ctx()
+  cmd = bot_module.bot.get_command("summarize")
   asyncio.run(cmd.callback(ctx, hours="2"))
+
   assert dummy_handle.called
   assert dummy_handle.body["op"] == "urn:discord:chat:summarize_channel:1"
   assert dummy_handle.body["payload"]["hours"] == 2
   assert dummy_handle.body["payload"]["user_id"] == ctx.author.id
-  assert ctx.author.dm_channel.sent == ["hi"]
-  assert ctx.author.dm_channel.history_called
+  assert output.user_messages == [(ctx.author.id, "hi")]
+  assert output.channel_messages == []
 
 
 def test_summarize_command_usage_error(monkeypatch):
-  app = FastAPI()
-  module = DiscordBotModule(app)
-  module.bot = module._init_discord_bot('!')
-  module._init_bot_routes()
-  ctx = SimpleNamespace(
-    guild=SimpleNamespace(id=1),
-    channel=DummyChannel(),
-    author=DummyAuthor(),
-  )
-  ctx.send = ctx.channel.send
-  cmd = module.bot.get_command("summarize")
+  bot_module, provider, output = _setup_bot()
+  ctx = _make_ctx()
+  cmd = bot_module.bot.get_command("summarize")
   asyncio.run(cmd.callback(ctx, hours="bad"))
-  assert ctx.channel.sent == ["Usage: !summarize <hours>"]
+  assert output.channel_messages == [(ctx.channel.id, "Usage: !summarize <hours>")]
 
 
 def test_summarize_command_empty_history(monkeypatch):
-  app = FastAPI()
-  module = DiscordBotModule(app)
-  module.bot = module._init_discord_bot('!')
-  module._init_bot_routes()
+  bot_module, provider, output = _setup_bot()
 
   async def dummy_handle(req):
     body = await req.body()
     dummy_handle.body = json.loads(body.decode())
+
     class DummyResp:
       payload = {
         "summary": "",
@@ -118,33 +108,29 @@ def test_summarize_command_empty_history(monkeypatch):
         "model": "gpt",
         "role": "role",
       }
+
     return DummyResp()
+
   dummy_handle.body = None
   import importlib
   rpc_mod = importlib.import_module("rpc.handler")
   monkeypatch.setattr(rpc_mod, "handle_rpc_request", dummy_handle)
 
-  ctx = SimpleNamespace(
-    guild=SimpleNamespace(id=1),
-    channel=DummyChannel(),
-    author=DummyAuthor(),
-  )
-  ctx.send = ctx.channel.send
-  cmd = module.bot.get_command("summarize")
+  ctx = _make_ctx()
+  cmd = bot_module.bot.get_command("summarize")
   asyncio.run(cmd.callback(ctx, hours="1"))
+
   assert dummy_handle.body["payload"]["user_id"] == ctx.author.id
-  assert ctx.channel.sent == ["No messages found in the specified time range"]
+  assert output.channel_messages == [(ctx.channel.id, "No messages found in the specified time range")]
 
 
 def test_summarize_command_cap_hit(monkeypatch):
-  app = FastAPI()
-  module = DiscordBotModule(app)
-  module.bot = module._init_discord_bot('!')
-  module._init_bot_routes()
+  bot_module, provider, output = _setup_bot()
 
   async def dummy_handle(req):
     body = await req.body()
     dummy_handle.body = json.loads(body.decode())
+
     class DummyResp:
       payload = {
         "summary": "hi",
@@ -154,48 +140,40 @@ def test_summarize_command_cap_hit(monkeypatch):
         "model": "gpt",
         "role": "role",
       }
+
     return DummyResp()
+
   dummy_handle.body = None
   import importlib
   rpc_mod = importlib.import_module("rpc.handler")
   monkeypatch.setattr(rpc_mod, "handle_rpc_request", dummy_handle)
 
-  ctx = SimpleNamespace(
-    guild=SimpleNamespace(id=1),
-    channel=DummyChannel(),
-    author=DummyAuthor(),
-  )
-  ctx.send = ctx.channel.send
-  cmd = module.bot.get_command("summarize")
+  ctx = _make_ctx()
+  cmd = bot_module.bot.get_command("summarize")
   asyncio.run(cmd.callback(ctx, hours="1"))
+
   assert dummy_handle.body["payload"]["user_id"] == ctx.author.id
-  assert ctx.channel.sent == ["Channel too active to summarize; message cap hit"]
+  assert output.channel_messages == [(ctx.channel.id, "Channel too active to summarize; message cap hit")]
 
 
 def test_summarize_command_transient_error(monkeypatch):
-  app = FastAPI()
-  module = DiscordBotModule(app)
-  module.bot = module._init_discord_bot('!')
-  module._init_bot_routes()
+  bot_module, provider, output = _setup_bot()
 
   async def dummy_handle(req):
     body = await req.body()
     dummy_handle.body = json.loads(body.decode())
     raise RuntimeError("boom")
+
   dummy_handle.body = None
   import importlib
   rpc_mod = importlib.import_module("rpc.handler")
   monkeypatch.setattr(rpc_mod, "handle_rpc_request", dummy_handle)
 
-  ctx = SimpleNamespace(
-    guild=SimpleNamespace(id=1),
-    channel=DummyChannel(),
-    author=DummyAuthor(),
-  )
-  ctx.send = ctx.channel.send
-  cmd = module.bot.get_command("summarize")
+  ctx = _make_ctx()
+  cmd = bot_module.bot.get_command("summarize")
   asyncio.run(cmd.callback(ctx, hours="1"))
+
   assert dummy_handle.body["payload"]["user_id"] == ctx.author.id
-  assert ctx.channel.sent == ["Failed to fetch messages. Please try again later."]
+  assert output.channel_messages == [(ctx.channel.id, "Failed to fetch messages. Please try again later.")]
 
 

--- a/tests/test_discord_bot_macros.py
+++ b/tests/test_discord_bot_macros.py
@@ -1,46 +1,38 @@
-import asyncio
-import json
+import asyncio, json
 from types import SimpleNamespace
 
 from fastapi import FastAPI
 
 from server.modules.discord_bot_module import DiscordBotModule
+from server.modules.providers.social.discord_input_provider import DiscordInputProvider
+from server.modules.social_input_module import SocialInputModule
 
 
-class DummyHistory:
-  def __aiter__(self):
-    return self
+class DummyOutput:
+  def __init__(self):
+    self.channel_messages: list[tuple[int, str]] = []
+    self.user_messages: list[tuple[int, str]] = []
 
-  async def __anext__(self):
-    raise StopAsyncIteration
+  async def send_to_channel(self, channel_id: int, message: str):
+    self.channel_messages.append((channel_id, message))
+
+  async def send_to_user(self, user_id: int, message: str):
+    self.user_messages.append((user_id, message))
 
 
 class DummyChannel:
   def __init__(self, id: int = 2):
     self.id = id
     self.sent: list[str] = []
-    self.history_called = False
 
   async def send(self, content):
     self.sent.append(content)
-
-  def history(self, limit=1):
-    self.history_called = True
-    return DummyHistory()
-
-
-class DummyDMChannel(DummyChannel):
-  pass
 
 
 class DummyAuthor:
   def __init__(self):
     self.id = 3
     self.bot = False
-    self.dm_channel = DummyDMChannel()
-
-  async def send(self, content):
-    await self.dm_channel.send(content)
 
 
 class DummyMessage:
@@ -54,24 +46,33 @@ class DummyMessage:
     self.id = 1
 
 
-def test_summarize_macro_dm(monkeypatch):
+def _setup_bot():
   app = FastAPI()
   module = DiscordBotModule(app)
   module.bot = module._init_discord_bot('!')
+  module.mark_ready()
+  output = DummyOutput()
+  module.output_module = output
+  app.state.discord_output = output
+
+  social = SocialInputModule(app)
+  social.discord = module
+  module.register_social_input_module(social)
+
+  provider = DiscordInputProvider(social, module)
+  asyncio.run(social.register_provider(provider))
+  return module, output
+
+
+def test_summarize_macro_dm(monkeypatch):
+  module, output = _setup_bot()
   module.bot._connection.user = SimpleNamespace(id=0)
-  module._init_bot_routes()
-
-  from discord.ext import commands as dc_commands
-
-  async def fake_send(self, content, **kwargs):
-    return await self.channel.send(content)
-
-  monkeypatch.setattr(dc_commands.Context, 'send', fake_send)
 
   async def dummy_handle(req):
     body = await req.body()
     dummy_handle.body = json.loads(body.decode())
     dummy_handle.called = True
+
     class DummyResp:
       payload = {
         "summary": "hi",
@@ -80,7 +81,9 @@ def test_summarize_macro_dm(monkeypatch):
         "model": "gpt",
         "role": "role",
       }
+
     return DummyResp()
+
   dummy_handle.called = False
   dummy_handle.body = None
   import importlib
@@ -91,12 +94,11 @@ def test_summarize_macro_dm(monkeypatch):
   author = DummyAuthor()
   message = DummyMessage("!summarize 2", channel, author, state=module.bot._connection)
   asyncio.run(module.bot.process_commands(message))
+
   assert dummy_handle.called
   assert dummy_handle.body["op"] == "urn:discord:chat:summarize_channel:1"
   assert dummy_handle.body["payload"]["hours"] == 2
   assert dummy_handle.body["payload"]["user_id"] == author.id
-  assert author.dm_channel.sent == ["hi"]
-  assert author.dm_channel.history_called
+  assert output.user_messages == [(author.id, "hi")]
+  assert output.channel_messages == []
   assert channel.sent == []
-
-


### PR DESCRIPTION
## Summary
- add a SocialInputModule to coordinate social input providers and register Discord during startup
- implement a DiscordInputProvider that registers commands with the bot and routes all responses through DiscordOutputModule
- update DiscordBot utilities, personas/chat flows, and tests to align with the provider architecture

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb2879da9883259734e6ade511445e