### PR TITLE
Refactor Discord chat summaries to use generate_chat

### DIFF
--- a/tests/test_discord_chat_module.py
+++ b/tests/test_discord_chat_module.py
@@ -21,27 +21,54 @@ def test_summarize_channel(monkeypatch):
   assert "Alice: hello" in res["raw_text_blob"]
 
 
-def test_summarize_chat(monkeypatch):
+def test_summarize_chat_uses_persona_definition(monkeypatch):
   app = FastAPI()
   app.state.discord_bot = SimpleNamespace(on_ready=lambda: None)
 
   class DummyOpenAI:
     def __init__(self):
       self.client = object()
-      self.prompts = []
+      self.persona_requests: list[str] = []
+      self.chat_calls: list[dict] = []
 
     async def on_ready(self):
       pass
 
     async def get_persona_definition(self, name: str):
-      assert name == "summarize"
-      return {"name": "summarize", "prompt": "sum role", "tokens": 32, "model": "gpt"}
+      self.persona_requests.append(name)
+      return {"name": name, "prompt": "sum role", "tokens": 32, "model": "gpt"}
 
-    async def submit_chat_prompt(self, **kwargs):
-      self.prompts.append(kwargs.get("system_prompt"))
-      assert kwargs.get("user_id") == 4
-      assert kwargs.get("persona_name") == "summarize"
-      return {"content": "sum", "model": "gpt", "role": "assistant"}
+    async def generate_chat(
+      self,
+      *,
+      system_prompt: str,
+      user_prompt: str | None = None,
+      model: str | None = None,
+      max_tokens: int | None = None,
+      tools=None,
+      prompt_context: str = "",
+      persona: str | None = None,
+      guild_id: int | None = None,
+      channel_id: int | None = None,
+      user_id: int | None = None,
+      input_log: str | None = None,
+      token_count: int | None = None,
+    ):
+      self.chat_calls.append(
+        {
+          "system_prompt": system_prompt,
+          "user_prompt": user_prompt,
+          "model": model,
+          "max_tokens": max_tokens,
+          "persona": persona,
+          "guild_id": guild_id,
+          "channel_id": channel_id,
+          "user_id": user_id,
+          "input_log": input_log,
+          "token_count": token_count,
+        }
+      )
+      return {"content": "sum", "model": model or "gpt", "role": "assistant"}
 
   app.state.openai = DummyOpenAI()
   module = DiscordChatModule(app)
@@ -61,6 +88,71 @@ def test_summarize_chat(monkeypatch):
   assert res["summary_text"] == "sum"
   assert res["model"] == "gpt"
   assert res["role"] == "sum role"
-  assert app.state.openai.prompts[-1] == "sum role"
+  assert app.state.openai.persona_requests == ["summarize"]
+  last_call = app.state.openai.chat_calls[-1]
+  assert last_call["persona"] == "summarize"
+  assert last_call["system_prompt"] == "sum role"
+  assert last_call["max_tokens"] == 32
+  assert last_call["user_id"] == 4
 
 
+def test_summarize_chat_handles_persona_failure(monkeypatch):
+  app = FastAPI()
+  app.state.discord_bot = SimpleNamespace(on_ready=lambda: None)
+
+  class DummyOpenAI:
+    def __init__(self):
+      self.client = object()
+      self.calls: list[dict] = []
+
+    async def on_ready(self):
+      pass
+
+    async def get_persona_definition(self, name: str):
+      raise RuntimeError("db offline")
+
+    async def generate_chat(
+      self,
+      *,
+      system_prompt: str,
+      user_prompt: str | None = None,
+      model: str | None = None,
+      max_tokens: int | None = None,
+      tools=None,
+      prompt_context: str = "",
+      persona: str | None = None,
+      guild_id: int | None = None,
+      channel_id: int | None = None,
+      user_id: int | None = None,
+      input_log: str | None = None,
+      token_count: int | None = None,
+    ):
+      self.calls.append(
+        {
+          "system_prompt": system_prompt,
+          "persona": persona,
+          "max_tokens": max_tokens,
+        }
+      )
+      return {"content": "fallback", "model": "gpt-4o-mini", "role": "assistant"}
+
+  app.state.openai = DummyOpenAI()
+  module = DiscordChatModule(app)
+
+  async def dummy_summarize(guild_id, channel_id, hours, max_messages=5000):
+    return {
+      "messages_collected": 3,
+      "token_count_estimate": 9,
+      "raw_text_blob": "another",
+      "cap_hit": False,
+    }
+
+  module.summarize_channel = dummy_summarize  # type: ignore
+
+  res = asyncio.run(module.summarize_chat(10, 20, 6, user_id=7))
+  assert res["summary_text"] == "fallback"
+  assert res["model"] == "gpt-4o-mini"
+  assert res["role"] == "assistant"
+  assert app.state.openai.calls[-1]["persona"] == "summarize"
+  assert app.state.openai.calls[-1]["system_prompt"] == ""
+  assert app.state.openai.calls[-1]["max_tokens"] is None


### PR DESCRIPTION
## Summary
- refactor `DiscordChatModule.summarize_chat` to pull persona metadata via `get_persona_definition` and drive summaries through `generate_chat`/`fetch_chat`
- improve persona handling with safe token parsing, model hint propagation, and graceful fallbacks when chat generation fails
- expand Discord chat module tests to cover persona-driven summaries and error handling

## Testing
- `pytest tests/test_discord_chat_module.py`


------
https://chatgpt.com/codex/tasks/task_e_68cb2c522e7483259e28dc8c4546e55f