### PR TITLE
Use configured bot name for ready message

### DIFF
--- a/server/modules/discord_bot_module.py
+++ b/server/modules/discord_bot_module.py
@@ -261,7 +261,9 @@ class DiscordBotModule(BaseModule):
       if channel:
         res = await self.db.run("db:system:config:get_config:1", {"key": "Version"})
         version = res.rows[0]["value"] if res.rows else None
-        msg = f"TheOracleGPT-Dev Online. Version: {version or 'unknown'}"
+        name_res = await self.db.run("db:system:config:get_config:1", {"key": "BotName"})
+        bot_name = name_res.rows[0]["value"] if name_res.rows else None
+        msg = f"{(bot_name or 'TheOracleGPT-Dev')} Online. Version: {version or 'unknown'}"
         if await self._try_send_channel(channel.id, msg):
           logging.info(msg)
         else:


### PR DESCRIPTION
## Summary
- load the Discord bot name from the system configuration when reporting online status
- fall back to the previous static bot name if the configuration value is missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc40237c108325a3ae3e36b1c4864c