### PR TITLE
Add helper to dispatch RPC ops for Discord events

### DIFF
--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -1,30 +1,119 @@
 import logging
+from types import SimpleNamespace
 
 from fastapi import HTTPException, Request
+from starlette.datastructures import Headers
 
 from rpc import HANDLERS
 from rpc.helpers import unbox_request
-from server.models import RPCResponse
+from server.models import AuthContext, RPCRequest, RPCResponse
 
 
 async def handle_rpc_request(request: Request) -> RPCResponse:
   rpc_request, _, parts = await unbox_request(request)
+  return await _dispatch_rpc_request(request, rpc_request, parts)
 
-  if parts[:1] != ["urn"]:
-    raise HTTPException(400, "Invalid URN prefix")
 
+async def dispatch_rpc_op(
+  app,
+  op: str,
+  payload: dict | None = None,
+  *,
+  discord_ctx=None,
+  headers: dict | None = None,
+) -> RPCResponse:
+  rpc_request = RPCRequest(op=op, payload=payload)
+  parts = rpc_request.op.split(':')
+  if parts[:1] != ['urn']:
+    raise HTTPException(status_code=400, detail='Invalid URN prefix')
+
+  normalized_ctx = _normalize_discord_ctx(discord_ctx)
+  auth_ctx = await _resolve_auth_context(app, rpc_request, normalized_ctx)
+
+  state = SimpleNamespace(rpc_request=rpc_request, auth_ctx=auth_ctx)
+  if normalized_ctx:
+    setattr(state, 'discord_ctx', normalized_ctx)
+
+  request = SimpleNamespace(
+    app=app,
+    state=state,
+    headers=Headers(headers or {}),
+  )
+
+  return await _dispatch_rpc_request(request, rpc_request, parts)
+
+
+async def _dispatch_rpc_request(request, rpc_request: RPCRequest, parts: list[str]) -> RPCResponse:
+  if parts[:1] != ['urn']:
+    raise HTTPException(status_code=400, detail='Invalid URN prefix')
   try:
     domain = parts[1]
     remainder = parts[2:]
-
     handler = HANDLERS.get(domain)
     if not handler:
-      raise HTTPException(status_code=404, detail="Unknown RPC domain")
+      raise HTTPException(status_code=404, detail='Unknown RPC domain')
     response = await handler(remainder, request)
-
     logging.info(f"RPC completed: {rpc_request.op}")
     return response
   except Exception:
     logging.exception(f"RPC failed: {rpc_request.op}")
     raise
+
+
+def _normalize_discord_ctx(discord_ctx):
+  if not discord_ctx:
+    return None
+  if getattr(discord_ctx, 'author', None):
+    return discord_ctx
+  if isinstance(discord_ctx, dict):
+    data = discord_ctx
+  else:
+    data = getattr(discord_ctx, '__dict__', {})
+  author_id = data.get('user_id') or data.get('author_id')
+  guild_id = data.get('guild_id')
+  channel_id = data.get('channel_id')
+  author = SimpleNamespace(id=author_id) if author_id is not None else None
+  guild = SimpleNamespace(id=guild_id) if guild_id is not None else None
+  channel = SimpleNamespace(id=channel_id) if channel_id is not None else None
+  return SimpleNamespace(author=author, guild=guild, channel=channel)
+
+
+async def _resolve_auth_context(app, rpc_request: RPCRequest, discord_ctx) -> AuthContext:
+  auth_ctx = AuthContext()
+  parts = rpc_request.op.split(':')
+  domain = parts[1] if len(parts) > 1 else ''
+
+  if domain == 'discord':
+    auth = getattr(app.state, 'auth', None)
+    if not auth:
+      raise RuntimeError('Auth module is not configured on the application state')
+    discord_id = None
+    if discord_ctx and getattr(discord_ctx, 'author', None):
+      discord_id = getattr(discord_ctx.author, 'id', None)
+    if not discord_id and rpc_request.payload:
+      discord_id = rpc_request.payload.get('discord_id') or rpc_request.payload.get('user_id')
+    if not discord_id:
+      raise HTTPException(status_code=401, detail='Missing or invalid authorization header')
+    discord_id = str(discord_id)
+    guid, roles, mask = await auth.get_discord_user_security(discord_id)
+    if not guid:
+      raise HTTPException(status_code=401, detail='Missing or invalid authorization header')
+    auth_ctx.user_guid = guid
+    auth_ctx.roles = roles
+    auth_ctx.role_mask = mask
+    rpc_request.user_guid = guid
+    rpc_request.roles = roles
+    rpc_request.role_mask = mask
+    if not (mask & getattr(auth, 'role_registered', 0)):
+      raise HTTPException(status_code=403, detail='Forbidden')
+    logging.debug(
+      "[RPC] Resolved roles for %s: %s (mask=%#018x)",
+      guid,
+      roles,
+      mask,
+    )
+  elif domain not in ('public', 'auth'):
+    raise HTTPException(status_code=401, detail='Missing or invalid authorization header')
+
+  return auth_ctx
 

--- a/tests/test_rpc_handler_dispatch.py
+++ b/tests/test_rpc_handler_dispatch.py
@@ -1,0 +1,88 @@
+import asyncio
+
+from fastapi import FastAPI
+
+from server.models import RPCResponse
+
+
+def test_dispatch_rpc_op_uses_discord_metadata():
+  app = FastAPI()
+
+  class DummyAuth:
+    def __init__(self):
+      self.calls = []
+      self.role_registered = 0x1
+      self.roles = {
+        'ROLE_REGISTERED': 0x1,
+        'ROLE_DISCORD_BOT': 0x2,
+      }
+
+    async def get_discord_user_security(self, discord_id):
+      self.calls.append(discord_id)
+      return ('guid-123', ['ROLE_REGISTERED', 'ROLE_DISCORD_BOT'], 0x3)
+
+    async def user_has_role(self, guid, mask):
+      return True
+
+  app.state.auth = DummyAuth()
+
+  import importlib, sys
+  saved_modules = {
+    name: mod
+    for name, mod in sys.modules.items()
+    if name == 'rpc' or name.startswith('rpc.')
+  }
+  for name in list(saved_modules):
+    del sys.modules[name]
+
+  rpc_pkg = importlib.import_module('rpc')
+  from rpc.discord.handler import handle_discord_request
+  import rpc.discord.command as command_mod
+  handler_mod = importlib.import_module('rpc.handler')
+
+  key = ('get_roles', '1')
+  captured = {}
+
+  async def dummy_command(request):
+    captured['request'] = request
+    rpc_request = request.state.rpc_request
+    return RPCResponse(op=rpc_request.op, payload={'ok': True})
+
+  orig_dispatch = command_mod.DISPATCHERS.get(key)
+  command_mod.DISPATCHERS[key] = dummy_command
+  orig_domain = rpc_pkg.HANDLERS.get('discord')
+  rpc_pkg.HANDLERS['discord'] = handle_discord_request
+
+  try:
+    resp = asyncio.run(
+      handler_mod.dispatch_rpc_op(
+        app,
+        'urn:discord:command:get_roles:1',
+        None,
+        discord_ctx={'guild_id': 1, 'channel_id': 2, 'user_id': 42},
+      )
+    )
+  finally:
+    if orig_dispatch is None:
+      del command_mod.DISPATCHERS[key]
+    else:
+      command_mod.DISPATCHERS[key] = orig_dispatch
+    if orig_domain is None:
+      del rpc_pkg.HANDLERS['discord']
+    else:
+      rpc_pkg.HANDLERS['discord'] = orig_domain
+    for name in list(sys.modules):
+      if name == 'rpc' or name.startswith('rpc.'):
+        del sys.modules[name]
+    sys.modules.update(saved_modules)
+
+  assert resp.payload['ok']
+  assert app.state.auth.calls == ['42']
+  request = captured['request']
+  ctx = getattr(request.state, 'discord_ctx', None)
+  assert getattr(getattr(ctx, 'guild', None), 'id', None) == 1
+  assert getattr(getattr(ctx, 'channel', None), 'id', None) == 2
+  assert getattr(getattr(ctx, 'author', None), 'id', None) == 42
+  rpc_request = request.state.rpc_request
+  assert rpc_request.user_guid == 'guid-123'
+  assert 'ROLE_DISCORD_BOT' in rpc_request.roles


### PR DESCRIPTION
## Summary
- add a `dispatch_rpc_op` helper that reuses the existing RPC routing without a full ASGI request
- refactor the Discord input provider to call the helper with normalized metadata and update dependent tests
- add unit coverage to ensure Discord context and security information flow through the helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdaf2f33e48325b7707dc79e083443