### PR TITLE
Restore Discord persona command workflow

### DIFF
--- a/rpc/discord/chat/__init__.py
+++ b/rpc/discord/chat/__init__.py
@@ -1,9 +1,23 @@
 from .services import (
+  discord_chat_deliver_persona_response_v1,
+  discord_chat_generate_persona_response_v1,
+  discord_chat_get_channel_history_v1,
+  discord_chat_get_conversation_history_v1,
+  discord_chat_get_persona_v1,
+  discord_chat_insert_conversation_input_v1,
+  discord_chat_persona_command_v1,
   discord_chat_persona_response_v1,
   discord_chat_summarize_channel_v1,
 )
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("persona_command", "1"): discord_chat_persona_command_v1,
   ("persona_response", "1"): discord_chat_persona_response_v1,
+  ("get_persona", "1"): discord_chat_get_persona_v1,
+  ("get_conversation_history", "1"): discord_chat_get_conversation_history_v1,
+  ("get_channel_history", "1"): discord_chat_get_channel_history_v1,
+  ("insert_conversation_input", "1"): discord_chat_insert_conversation_input_v1,
+  ("generate_persona_response", "1"): discord_chat_generate_persona_response_v1,
+  ("deliver_persona_response", "1"): discord_chat_deliver_persona_response_v1,
   ("summarize_channel", "1"): discord_chat_summarize_channel_v1,
 }

--- a/rpc/discord/chat/services.py
+++ b/rpc/discord/chat/services.py
@@ -13,6 +13,21 @@ from .models import (
 )
 
 
+def _persona_stub_response(rpc_request, detail: str) -> RPCResponse:
+  logging.info("[discord_chat_persona_stub] %s", detail)
+  payload = {
+    "success": False,
+    "reason": "not_implemented",
+    "detail": detail,
+    "ack_message": "Persona chat is currently unavailable.",
+  }
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload,
+    version=rpc_request.version,
+  )
+
+
 async def discord_chat_summarize_channel_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   p = rpc_request.payload or {}
@@ -132,4 +147,60 @@ async def discord_chat_persona_response_v1(request: Request):
     op=rpc_request.op,
     payload=payload.model_dump(),
     version=rpc_request.version,
+  )
+
+
+async def discord_chat_persona_command_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  return _persona_stub_response(
+    rpc_request,
+    "Persona command dispatch requires server module implementation.",
+  )
+
+
+async def discord_chat_get_persona_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  return _persona_stub_response(
+    rpc_request,
+    "Persona lookup via OpenAI module is not yet wired.",
+  )
+
+
+async def discord_chat_get_conversation_history_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  return _persona_stub_response(
+    rpc_request,
+    "Conversation history fetch from assistant_conversation is pending.",
+  )
+
+
+async def discord_chat_get_channel_history_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  return _persona_stub_response(
+    rpc_request,
+    "Channel history capture for persona workflow is not implemented.",
+  )
+
+
+async def discord_chat_insert_conversation_input_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  return _persona_stub_response(
+    rpc_request,
+    "Conversation input insertion requires server module support.",
+  )
+
+
+async def discord_chat_generate_persona_response_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  return _persona_stub_response(
+    rpc_request,
+    "Persona response generation is pending OpenAI integration.",
+  )
+
+
+async def discord_chat_deliver_persona_response_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  return _persona_stub_response(
+    rpc_request,
+    "Persona response delivery via Discord output module is not available yet.",
   )


### PR DESCRIPTION
## Summary
- restore the `!persona` Discord command and route it through the chat module to orchestrate persona workflow RPC calls and acknowledgements
- add persona workflow RPC entry points in the Discord chat namespace with not-yet-implemented stubs for downstream modules
- extend Discord bot command tests to cover the persona workflow, usage validation, and failure handling

## Testing
- pytest tests/test_discord_bot_commands.py

------
https://chatgpt.com/codex/tasks/task_e_68ceed5e2ed08325a645ffd0a40a4e76