### PR TITLE
Add Terms of Service page accessible from home

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ const AccountUsersPage = lazy(() => import("./pages/AccountUsersPage"));
 const AccountUserPanel = lazy(() => import("./pages/AccountUserPanel"));
 const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
 const PublicProfile = lazy(() => import("./pages/PublicProfile"));
+const TermsOfService = lazy(() => import("./pages/TermsOfService"));
 
 function App(): JSX.Element {
 	return (
@@ -55,6 +56,7 @@ function App(): JSX.Element {
                                                                         element={<DiscordPersonasPage />}
                                                                 />
                                                                 <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+                                                                <Route path="/terms-of-service" element={<TermsOfService />} />
                                                                 <Route path="/profile/:guid" element={<PublicProfile />} />
                                                         </Routes>
 						</Suspense>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,6 @@
-import { Box, Typography, Link, CardMedia } from '@mui/material';
+import { Box, Typography, Link as MuiLink, CardMedia, Button } from '@mui/material';
 import { useEffect, useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import type { PublicLinksLinkItem1, PublicVarsVersions1 } from '../shared/RpcModels';
 import Logo from '../assets/elideus_group_green.png';
 import { fetchVersions } from '../rpc/public/vars';
@@ -43,17 +44,27 @@ const Home = (): JSX.Element => {
 			<CardMedia component="img" alt="Elideus Group Image" image={Logo} />
 			<Typography variant="body1">AI Engineering and Consulting Services</Typography>
 			<Box sx={{ marginTop: '20px', width: '300px', textAlign: 'center' }}>
-				{links.map((link) => (
-					<Link key={link.title}
-						href={link.url}
-						title={link.title}
-						underline="none"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						{link.title}
-					</Link>
-				))}
+                                {links.map((link) => (
+                                        <MuiLink
+                                                key={link.title}
+                                                href={link.url}
+                                                title={link.title}
+                                                underline="none"
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                        >
+                                                {link.title}
+                                        </MuiLink>
+                                ))}
+                                <Box sx={{ mt: 2 }}>
+                                        <Button
+                                                component={RouterLink}
+                                                to="/terms-of-service"
+                                                variant="outlined"
+                                        >
+                                                Terms of Service
+                                        </Button>
+                                </Box>
 			</Box>
                         <Box sx={{ flexGrow: 1 }} />
                         <BottomBar info={info} />

--- a/frontend/src/pages/TermsOfService.tsx
+++ b/frontend/src/pages/TermsOfService.tsx
@@ -1,0 +1,160 @@
+import { Box, Typography } from "@mui/material";
+import PageTitle from "../components/PageTitle";
+
+const TermsOfService = (): JSX.Element => {
+        return (
+                <Box sx={{ p: 2 }}>
+                        <PageTitle>Terms of Service</PageTitle>
+
+                        <Typography variant="body2" sx={{ mt: 1, fontStyle: "italic" }}>
+                                Last updated: September 1, 2025
+                        </Typography>
+
+                        <Typography variant="body1" sx={{ mt: 2 }}>
+                                Welcome to TheOracle. By accessing or using our service, you agree to these Terms of Service
+                                (&ldquo;Terms&rdquo;). Please read them carefully, as they define your rights, obligations, and acceptable
+                                use of the platform.
+                        </Typography>
+
+                        <Typography variant="h6" sx={{ mt: 2 }}>
+                                I. Eligibility and Accounts
+                        </Typography>
+                        <Typography variant="body1" component="div">
+                                <ul>
+                                        <li>You must be at least 13 years old to use the service (16+ in some jurisdictions).</li>
+                                        <li>
+                                                You must register through an OAuth identity provider (e.g., Discord, Google, Microsoft). We do
+                                                not support direct password accounts.
+                                        </li>
+                                        <li>
+                                                You are responsible for maintaining control of your linked provider accounts and ensuring that
+                                                the information provided is accurate.
+                                        </li>
+                                </ul>
+                        </Typography>
+
+                        <Typography variant="h6" sx={{ mt: 2 }}>
+                                II. Use of Service
+                        </Typography>
+                        <Typography variant="body1" component="div">
+                                <ul>
+                                        <li>
+                                                TheOracle provides AI-powered content creation and management tools, including the ability to
+                                                generate, store, and share AI-generated media.
+                                        </li>
+                                        <li>
+                                                You may purchase credits to use the service. Credits represent a license to access platform
+                                                features; they have no cash value outside the platform.
+                                        </li>
+                                        <li>
+                                                Credits may be refunded within 10 days of purchase in cases of technical failure or upon
+                                                verified request when an account is deactivated.
+                                        </li>
+                                        <li>Excessive, automated, or abusive use of the system is prohibited.</li>
+                                </ul>
+                        </Typography>
+
+                        <Typography variant="h6" sx={{ mt: 2 }}>
+                                III. Prohibited Conduct
+                        </Typography>
+                        <Typography variant="body1" component="div">
+                                <ul>
+                                        <li>
+                                                Do not use the service to generate or share illegal content, including but not limited to child
+                                                sexual abuse material, realistic depictions of extreme violence, or content promoting terrorism.
+                                        </li>
+                                        <li>Do not attempt to hack, reverse-engineer, or otherwise exploit the service or its systems.</li>
+                                        <li>
+                                                Do not use the service to interfere with, overload, or disrupt other services (including DOS/
+                                                DDOS activity).
+                                        </li>
+                                        <li>
+                                                Do not use the service to violate the rights of others, including copyright, trademark, or
+                                                privacy rights.
+                                        </li>
+                                </ul>
+                                Violation of these rules may result in immediate and permanent suspension of your account, with no
+                                refund of credits.
+                        </Typography>
+
+                        <Typography variant="h6" sx={{ mt: 2 }}>
+                                IV. Content Ownership and Licensing
+                        </Typography>
+                        <Typography variant="body1">
+                                You retain ownership of the content you generate and upload. By using the service, you grant us a limited
+                                license to host, display, and distribute your content solely for the operation of the platform. You are solely
+                                responsible for ensuring your content complies with all applicable laws and these Terms.
+                        </Typography>
+
+                        <Typography variant="h6" sx={{ mt: 2 }}>
+                                V. Moderation and Enforcement
+                        </Typography>
+                        <Typography variant="body1">
+                                We use both automated systems and human moderators to enforce content guidelines. Content reported by users
+                                may be temporarily restricted or removed if thresholds are met. We reserve the right to review, remove, or
+                                restrict content and accounts at our discretion, including suspension or permanent termination for serious
+                                violations.
+                        </Typography>
+
+                        <Typography variant="h6" sx={{ mt: 2 }}>
+                                VI. Payments and Refunds
+                        </Typography>
+                        <Typography variant="body1" component="div">
+                                <ul>
+                                        <li>
+                                                Payments for credits are processed through secure third-party providers; we do not store payment
+                                                information.
+                                        </li>
+                                        <li>
+                                                Refunds may be issued within 10 days of purchase for technical failures or account deactivation
+                                                upon request.
+                                        </li>
+                                        <li>Refunds will not be provided for violations of these Terms.</li>
+                                </ul>
+                        </Typography>
+
+                        <Typography variant="h6" sx={{ mt: 2 }}>
+                                VII. Termination
+                        </Typography>
+                        <Typography variant="body1">
+                                We reserve the right to suspend or terminate your account at any time for violation of these Terms, unlawful
+                                conduct, or use of the service in a manner that could harm us, other users, or third parties.
+                        </Typography>
+
+                        <Typography variant="h6" sx={{ mt: 2 }}>
+                                VIII. Disclaimers and Limitation of Liability
+                        </Typography>
+                        <Typography variant="body1">
+                                TheOracle is provided on an &ldquo;as is&rdquo; basis. We make no guarantees of uptime, accuracy, or availability.
+                                To the maximum extent permitted by law, we are not liable for indirect, incidental, or consequential damages
+                                arising from use of the service. Your sole remedy for dissatisfaction with the service is to stop using it.
+                        </Typography>
+
+                        <Typography variant="h6" sx={{ mt: 2 }}>
+                                IX. Changes to Terms
+                        </Typography>
+                        <Typography variant="body1">
+                                We may update these Terms from time to time. Changes will be effective upon posting. Continued use of the
+                                service after changes are posted constitutes acceptance of the new Terms.
+                        </Typography>
+
+                        <Typography variant="h6" sx={{ mt: 2 }}>
+                                X. Governing Law
+                        </Typography>
+                        <Typography variant="body1">
+                                These Terms are governed by and construed in accordance with the laws of the State of Washington, USA, without
+                                regard to conflict of law principles. Any disputes arising under these Terms shall be subject to the exclusive
+                                jurisdiction of the courts located in Washington State.
+                        </Typography>
+
+                        <Typography variant="h6" sx={{ mt: 2 }}>
+                                XI. Contact Us
+                        </Typography>
+                        <Typography variant="body1">
+                                If you have questions about these Terms, please contact us at: contact@elideusgroup.com
+                        </Typography>
+                </Box>
+        );
+};
+
+export default TermsOfService;


### PR DESCRIPTION
## Summary
- add a Terms of Service page and register the `/terms-of-service` route
- add a button on the home page to reach the new Terms of Service page

## Testing
- npm run lint
- npm run type-check
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d1609761bc83259d85efee44a917f5