### PR TITLE
Align privacy policy button styling with terms

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -56,13 +56,27 @@ const Home = (): JSX.Element => {
                                                 {link.title}
                                         </MuiLink>
                                 ))}
-                                <Box sx={{ mt: 2 }}>
+                                <Box
+                                        sx={{
+                                                mt: 2,
+                                                display: 'flex',
+                                                justifyContent: 'center',
+                                                gap: 2,
+                                        }}
+                                >
                                         <Button
                                                 component={RouterLink}
                                                 to="/terms-of-service"
                                                 variant="outlined"
                                         >
                                                 Terms of Service
+                                        </Button>
+                                        <Button
+                                                component={RouterLink}
+                                                to="/privacy-policy"
+                                                variant="outlined"
+                                        >
+                                                Privacy Policy
                                         </Button>
                                 </Box>
 			</Box>


### PR DESCRIPTION
## Summary
- show the Terms of Service and Privacy Policy actions as matching outlined buttons
- place the buttons side by side on the home page for consistent presentation

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d2a155edc48325b36fef45fce1eeb4