### PR TITLE
Improve MSSQL error propagation

### DIFF
--- a/server/modules/providers/__init__.py
+++ b/server/modules/providers/__init__.py
@@ -12,7 +12,7 @@ from fastapi import HTTPException, status
 from jose import jwt
 import logging
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 __all__ = [
   "AuthProvider",
@@ -26,7 +26,7 @@ __all__ = [
 
 
 class DBResult(BaseModel):
-  rows: list[dict] = []
+  rows: list[dict] = Field(default_factory=list)
   rowcount: int = 0
 
 

--- a/server/modules/providers/database/mssql_provider/db_helpers.py
+++ b/server/modules/providers/database/mssql_provider/db_helpers.py
@@ -1,7 +1,28 @@
 import json, logging
-from typing import Any, Iterable, AsyncIterator
+from dataclasses import dataclass
+from typing import Any, Iterable, AsyncIterator, Callable
 from . import logic
 from ... import DBResult
+
+
+@dataclass(slots=True)
+class QueryErrorDetail:
+  query: str
+  params: tuple[Any, ...]
+  message: str
+
+
+class DBQueryError(RuntimeError):
+  def __init__(self, detail: QueryErrorDetail, *, original: Exception | None = None):
+    super().__init__(detail.message)
+    self.detail = detail
+    self.original = original
+
+
+def _raise_query_error(query: str, params: tuple[Any, ...], error: Exception, *, log: Callable[[str], Any]):
+  log(f"Query failed:\n{query}\nArgs: {params}\nError: {error}")
+  detail = QueryErrorDetail(query=query, params=params, message=str(error))
+  raise DBQueryError(detail, original=error) from error
 
 def _rowdict(cols: Iterable[str], row: Iterable[Any]):
   return dict(zip(cols, row))
@@ -30,7 +51,7 @@ async def fetch_rows(query: str, params: tuple[Any, ...] = (), *, one: bool = Fa
                 break
               yield _rowdict(cols, row)
       except Exception as e:
-        logging.debug(f"Stream failed:\n{query}\nArgs: {params}\nError: {e}")
+        _raise_query_error(query, params, e, log=logging.debug)
     return _stream()
   try:
     async with logic._pool.acquire() as conn:
@@ -48,8 +69,7 @@ async def fetch_rows(query: str, params: tuple[Any, ...] = (), *, one: bool = Fa
         rows = [_rowdict(cols, r) for r in rows_raw]
         return DBResult(rows=rows, rowcount=len(rows))
   except Exception as e:
-    logging.debug(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
-    return DBResult()
+    _raise_query_error(query, params, e, log=logging.debug)
 
 async def fetch_json(query: str, params: tuple[Any, ...] = (), *, many: bool = False) -> DBResult:
   assert logic._pool, "MSSQL pool not initialized"
@@ -76,8 +96,7 @@ async def fetch_json(query: str, params: tuple[Any, ...] = (), *, many: bool = F
           return DBResult(rows=data, rowcount=len(data))
         return DBResult(rows=[data], rowcount=1)
   except Exception as e:
-    logging.error(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
-    raise
+    _raise_query_error(query, params, e, log=logging.error)
 
 async def exec_query(query: str, params: tuple[Any, ...] = ()) -> DBResult:
   assert logic._pool, "MSSQL pool not initialized"
@@ -87,5 +106,4 @@ async def exec_query(query: str, params: tuple[Any, ...] = ()) -> DBResult:
         await cur.execute(query, params)
         return DBResult(rowcount=cur.rowcount or 0)
   except Exception as e:
-    logging.error(f"Exec failed:\n{query}\nArgs: {params}\nError: {e}")
-    raise
+    _raise_query_error(query, params, e, log=logging.error)

--- a/tests/test_db_module_init.py
+++ b/tests/test_db_module_init.py
@@ -1,8 +1,11 @@
 import asyncio
+import pytest
 from fastapi import FastAPI
 
 from server.modules.db_module import DbModule
+from server.modules.providers import DbProviderBase
 from server.modules.providers.database.mssql_provider import MssqlProvider
+from server.modules.providers.database.mssql_provider.db_helpers import DBQueryError, QueryErrorDetail
 
 
 def test_init_uses_concrete_provider():
@@ -10,3 +13,28 @@ def test_init_uses_concrete_provider():
   db = DbModule(app)
   asyncio.run(db.init(provider="mssql"))
   assert isinstance(db._provider, MssqlProvider)
+
+
+def test_db_module_run_propagates_query_error():
+  app = FastAPI()
+  db = DbModule(app)
+  detail = QueryErrorDetail(query="SELECT 1", params=(), message="boom")
+
+  class FailingProvider(DbProviderBase):
+    def __init__(self):
+      super().__init__()
+
+    async def startup(self):
+      pass
+
+    async def shutdown(self):
+      pass
+
+    async def run(self, op, args):
+      raise DBQueryError(detail)
+
+  db._provider = FailingProvider()
+
+  with pytest.raises(DBQueryError) as exc:
+    asyncio.run(db.run("db:test:error", {}))
+  assert exc.value.detail == detail

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -50,6 +50,7 @@ sys.modules["server.modules.providers.database.mssql_provider.registry"] = regis
 spec_registry.loader.exec_module(registry_mod)
 get_mssql_handler = registry_mod.get_handler
 
+
 def test_mssql_get_by_provider_identifier_uses_user_view():
   handler = get_mssql_handler("db:users:providers:get_by_provider_identifier:1")
   _, sql, _ = handler({"provider": "microsoft", "provider_identifier": str(uuid4())})
@@ -97,43 +98,73 @@ def test_mssql_support_users_set_credits_updates_table():
   assert params == (10, "gid")
 
 
-def test_fetch_rows_returns_empty_on_error(monkeypatch):
+def test_fetch_rows_raises_structured_error(monkeypatch):
   class Cur:
-    async def execute(self, q, p):
-      raise Exception("boom")
-
-  class Conn:
-    async def cursor(self):
-      return Cur()
-
-  class Pool:
-    async def acquire(self):
-      return Conn()
-
-  monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
-  res = asyncio.run(db_helpers.fetch_rows("SELECT 1"))
-  assert res.rows == []
-  assert res.rowcount == 0
-
-
-def test_fetch_json_raises_on_error(monkeypatch):
-  class Cur:
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, exc_type, exc, tb):
+      pass
     async def execute(self, q, p):
       raise Exception("boom")
     async def fetchone(self):
       return None
 
   class Conn:
-    async def cursor(self):
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, exc_type, exc, tb):
+      pass
+    def cursor(self):
       return Cur()
 
   class Pool:
-    async def acquire(self):
-      return Conn()
+    def acquire(self):
+      class _Ctx:
+        async def __aenter__(self_inner):
+          return Conn()
+        async def __aexit__(self_inner, exc_type, exc, tb):
+          pass
+      return _Ctx()
 
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
-  with pytest.raises(Exception):
+  with pytest.raises(db_helpers.DBQueryError) as exc:
+    asyncio.run(db_helpers.fetch_rows("SELECT 1"))
+  assert exc.value.detail.query == "SELECT 1"
+  assert exc.value.detail.params == ()
+
+
+def test_fetch_json_raises_structured_error(monkeypatch):
+  class Cur:
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, exc_type, exc, tb):
+      pass
+    async def execute(self, q, p):
+      raise Exception("boom")
+    async def fetchone(self):
+      return None
+
+  class Conn:
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, exc_type, exc, tb):
+      pass
+    def cursor(self):
+      return Cur()
+
+  class Pool:
+    def acquire(self):
+      class _Ctx:
+        async def __aenter__(self_inner):
+          return Conn()
+        async def __aexit__(self_inner, exc_type, exc, tb):
+          pass
+      return _Ctx()
+
+  monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
+  with pytest.raises(db_helpers.DBQueryError) as exc:
     asyncio.run(db_helpers.fetch_json("SELECT 1"))
+  assert exc.value.detail.query == "SELECT 1"
 
 
 def test_fetch_json_handles_multiple_rows(monkeypatch):
@@ -177,22 +208,36 @@ def test_fetch_json_handles_multiple_rows(monkeypatch):
   assert res.rowcount == 1
 
 
-def test_exec_query_raises_on_error(monkeypatch):
+def test_exec_query_raises_structured_error(monkeypatch):
   class Cur:
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, exc_type, exc, tb):
+      pass
     async def execute(self, q, p):
       raise Exception("boom")
 
   class Conn:
-    async def cursor(self):
+    async def __aenter__(self):
+      return self
+    async def __aexit__(self, exc_type, exc, tb):
+      pass
+    def cursor(self):
       return Cur()
 
   class Pool:
-    async def acquire(self):
-      return Conn()
+    def acquire(self):
+      class _Ctx:
+        async def __aenter__(self_inner):
+          return Conn()
+        async def __aexit__(self_inner, exc_type, exc, tb):
+          pass
+      return _Ctx()
 
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
-  with pytest.raises(Exception):
+  with pytest.raises(db_helpers.DBQueryError) as exc:
     asyncio.run(db_helpers.exec_query("UPDATE x SET y=1"))
+  assert exc.value.detail.query == "UPDATE x SET y=1"
 
 
 def test_fetch_rows_stream(monkeypatch):


### PR DESCRIPTION
## Summary
- prevent DBResult from sharing list instances by using a default factory
- introduce structured MSSQL query errors and propagate them instead of returning empty results
- extend database provider tests to cover error propagation through db_module

## Testing
- pytest tests/test_db_module_init.py tests/test_provider_queries.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dadf286cb883258d3b9e08e01bb50b