### PR TITLE
Refactor MSSQL provider operations handling

### DIFF
--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -1,9 +1,10 @@
 # providers/database/mssql_provider/__init__.py
+import inspect
 from typing import Any, Dict
 
-from ... import DbProviderBase, DBResult, DbRunMode
+from ... import DbProviderBase, DBResult
 from .logic import init_pool, close_pool
-from .db_helpers import fetch_rows, fetch_json, exec_query
+from .db_helpers import Operation, execute_operation
 from .registry import get_handler
 
 
@@ -17,18 +18,12 @@ class MssqlProvider(DbProviderBase):
   async def run(self, op: str, args: Dict[str, Any]) -> DBResult:
     handler = get_handler(op)
     spec = handler(args)
-    if hasattr(spec, "__await__"):
-      return await spec
-    mode, sql, params = spec
-    if mode is DbRunMode.JSON_ONE:
-      return await fetch_json(sql, params)
-    if mode is DbRunMode.ROW_ONE:
-      return await fetch_rows(sql, params, one=True)
-    if mode is DbRunMode.ROW_MANY:
-      return await fetch_rows(sql, params)
-    if mode is DbRunMode.JSON_MANY:
-      return await fetch_json(sql, params, many=True)
-    if mode is DbRunMode.EXEC:
-      return await exec_query(sql, params)
-    raise ValueError(f"Unknown mode: {mode}")
+    if inspect.isawaitable(spec):
+      result = await spec  # type: ignore[func-returns-value]
+      if isinstance(result, DBResult):
+        return result
+      raise TypeError(f"Handler '{op}' returned unexpected awaitable result: {type(result)!r}")
+    if isinstance(spec, Operation):
+      return await execute_operation(spec)
+    raise TypeError(f"Handler '{op}' returned unsupported spec type: {type(spec)!r}")
 

--- a/server/modules/providers/database/mssql_provider/db_helpers.py
+++ b/server/modules/providers/database/mssql_provider/db_helpers.py
@@ -1,8 +1,40 @@
 import json, logging
 from dataclasses import dataclass
-from typing import Any, Iterable, AsyncIterator, Callable
+from typing import Any, Iterable, AsyncIterator, Awaitable, Callable, Dict
 from . import logic
-from ... import DBResult
+from ... import DBResult, DbRunMode
+
+
+@dataclass(slots=True)
+class Operation:
+  kind: DbRunMode
+  sql: str
+  params: tuple[Any, ...] = ()
+  postprocess: Callable[[DBResult], DBResult] | None = None
+
+  def __post_init__(self):
+    if not isinstance(self.params, tuple):
+      object.__setattr__(self, "params", tuple(self.params))
+
+
+def row_one(sql: str, params: Iterable[Any] = (), *, postprocess: Callable[[DBResult], DBResult] | None = None) -> Operation:
+  return Operation(DbRunMode.ROW_ONE, sql, tuple(params), postprocess)
+
+
+def row_many(sql: str, params: Iterable[Any] = (), *, postprocess: Callable[[DBResult], DBResult] | None = None) -> Operation:
+  return Operation(DbRunMode.ROW_MANY, sql, tuple(params), postprocess)
+
+
+def json_one(sql: str, params: Iterable[Any] = (), *, postprocess: Callable[[DBResult], DBResult] | None = None) -> Operation:
+  return Operation(DbRunMode.JSON_ONE, sql, tuple(params), postprocess)
+
+
+def json_many(sql: str, params: Iterable[Any] = (), *, postprocess: Callable[[DBResult], DBResult] | None = None) -> Operation:
+  return Operation(DbRunMode.JSON_MANY, sql, tuple(params), postprocess)
+
+
+def exec_op(sql: str, params: Iterable[Any] = (), *, postprocess: Callable[[DBResult], DBResult] | None = None) -> Operation:
+  return Operation(DbRunMode.EXEC, sql, tuple(params), postprocess)
 
 
 @dataclass(slots=True)
@@ -27,8 +59,13 @@ def _raise_query_error(query: str, params: tuple[Any, ...], error: Exception, *,
 def _rowdict(cols: Iterable[str], row: Iterable[Any]):
   return dict(zip(cols, row))
 
-async def fetch_rows(query: str, params: tuple[Any, ...] = (), *, one: bool = False, stream: bool = False) -> DBResult | AsyncIterator[dict]:
+async def fetch_rows(operation: Operation, *, stream: bool = False) -> DBResult | AsyncIterator[dict]:
   assert logic._pool, "MSSQL pool not initialized"
+  if operation.kind not in (DbRunMode.ROW_ONE, DbRunMode.ROW_MANY):
+    raise ValueError(f"Operation kind '{operation.kind}' is not row fetch capable")
+  query = operation.sql
+  params = operation.params
+  one = operation.kind is DbRunMode.ROW_ONE
   async def _ensure_result_set(cur) -> bool:
     if cur.description is not None:
       return True
@@ -71,8 +108,13 @@ async def fetch_rows(query: str, params: tuple[Any, ...] = (), *, one: bool = Fa
   except Exception as e:
     _raise_query_error(query, params, e, log=logging.debug)
 
-async def fetch_json(query: str, params: tuple[Any, ...] = (), *, many: bool = False) -> DBResult:
+async def fetch_json(operation: Operation) -> DBResult:
   assert logic._pool, "MSSQL pool not initialized"
+  if operation.kind not in (DbRunMode.JSON_ONE, DbRunMode.JSON_MANY):
+    raise ValueError(f"Operation kind '{operation.kind}' is not JSON fetch capable")
+  query = operation.sql
+  params = operation.params
+  many = operation.kind is DbRunMode.JSON_MANY
   try:
     async with logic._pool.acquire() as conn:
       async with conn.cursor() as cur:
@@ -98,8 +140,12 @@ async def fetch_json(query: str, params: tuple[Any, ...] = (), *, many: bool = F
   except Exception as e:
     _raise_query_error(query, params, e, log=logging.error)
 
-async def exec_query(query: str, params: tuple[Any, ...] = ()) -> DBResult:
+async def exec_query(operation: Operation) -> DBResult:
   assert logic._pool, "MSSQL pool not initialized"
+  if operation.kind is not DbRunMode.EXEC:
+    raise ValueError(f"Operation kind '{operation.kind}' is not executable")
+  query = operation.sql
+  params = operation.params
   try:
     async with logic._pool.acquire() as conn:
       async with conn.cursor() as cur:
@@ -107,3 +153,23 @@ async def exec_query(query: str, params: tuple[Any, ...] = ()) -> DBResult:
         return DBResult(rowcount=cur.rowcount or 0)
   except Exception as e:
     _raise_query_error(query, params, e, log=logging.error)
+
+
+_RUNNERS: Dict[DbRunMode, Callable[[Operation], Awaitable[DBResult]]] = {
+  DbRunMode.ROW_ONE: fetch_rows,
+  DbRunMode.ROW_MANY: fetch_rows,
+  DbRunMode.JSON_ONE: fetch_json,
+  DbRunMode.JSON_MANY: fetch_json,
+  DbRunMode.EXEC: exec_query,
+}
+
+
+async def execute_operation(operation: Operation) -> DBResult:
+  try:
+    runner = _RUNNERS[operation.kind]
+  except KeyError:
+    raise ValueError(f"Unknown operation kind: {operation.kind}") from None
+  result = await runner(operation)
+  if operation.postprocess:
+    return operation.postprocess(result)
+  return result

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1,13 +1,13 @@
 # providers/database/mssql_provider/registry.py
-from typing import Any, Awaitable, Callable, Dict, Tuple
+from typing import Any, Callable, Dict
 from uuid import UUID, uuid5, NAMESPACE_URL
 from ... import DBResult, DbRunMode
-from .logic import init_pool, close_pool, transaction
-from .db_helpers import fetch_json, exec_query
+from .logic import transaction
+from .db_helpers import Operation, exec_op, fetch_json, exec_query, json_many, json_one, row_many, row_one
 import logging
 
 # handler can be:
-#  - sync: (mode, sql, params) -> provider will run it
+#  - sync: Operation(kind=..., sql=..., params=...) -> provider will run it
 #  - async: does its own calls and returns {"rows":[...], "rowcount":N}
 _REG: Dict[str, Callable[[Dict[str, Any]], Any]] = {}
 
@@ -45,7 +45,7 @@ def _users_select(provider_args: Dict[str, Any]):
       WHERE ap.element_name = ? AND ua.element_identifier = ?
       FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
     """
-    return (DbRunMode.JSON_ONE, sql, (provider, identifier))
+    return Operation(DbRunMode.JSON_ONE, sql, (provider, identifier))
 
 @register("db:users:providers:get_any_by_provider_identifier:1")
 def _users_select_any(provider_args: Dict[str, Any]):
@@ -59,7 +59,7 @@ def _users_select_any(provider_args: Dict[str, Any]):
       WHERE ua.element_identifier = ?
       FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
     """
-    return (DbRunMode.JSON_ONE, sql, (identifier,))
+    return Operation(DbRunMode.JSON_ONE, sql, (identifier,))
 
 @register("db:users:providers:create_from_provider:1")
 async def _users_insert(args: Dict[str, Any]):
@@ -76,30 +76,30 @@ async def _users_insert(args: Dict[str, Any]):
     provider_displayname = args["provider_displayname"]
     provider_profileimg = args.get("provider_profile_image", "")
 
-    res = await fetch_json(
+    res = await fetch_json(json_one(
       "SELECT recid FROM auth_providers WHERE element_name = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
       (provider,)
-    )
+    ))
     if not res.rows:
       raise ValueError(f"Unknown auth provider: {provider}")
     ap_recid = res.rows[0]["recid"]
 
-    dup = await fetch_json(
+    dup = await fetch_json(json_one(
       "SELECT users_guid FROM users_auth WHERE element_identifier = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
       (identifier,),
-    )
+    ))
     if dup.rows:
       existing_guid = dup.rows[0]["users_guid"]
-      await exec_query(
+      await exec_query(exec_op(
         "UPDATE users_auth SET element_linked = 1, providers_recid = ? WHERE element_identifier = ?;",
         (ap_recid, identifier),
-      )
-      await exec_query(
+      ))
+      await exec_query(exec_op(
         "UPDATE account_users SET providers_recid = ? WHERE element_guid = ?;",
         (ap_recid, existing_guid),
-      )
+      ))
       sel = _users_select({"provider": provider, "provider_identifier": identifier})
-      return await fetch_json(sel[1], sel[2])
+      return await fetch_json(sel)
 
     async with transaction() as cur:
         await cur.execute(
@@ -128,21 +128,21 @@ async def _users_insert(args: Dict[str, Any]):
 
     # return same shape as select_user
     sel = _users_select({"provider": provider, "provider_identifier": identifier})
-    return await fetch_json(sel[1], sel[2])
+    return await fetch_json(sel)
 
 @register("db:users:providers:link_provider:1")
 async def _users_link_provider(args: Dict[str, Any]):
     guid = str(UUID(args["guid"]))
     provider = args["provider"]
     identifier = str(UUID(args["provider_identifier"]))
-    res = await fetch_json(
+    res = await fetch_json(json_one(
       "SELECT recid FROM auth_providers WHERE element_name = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
       (provider,)
-    )
+    ))
     if not res.rows:
       raise ValueError(f"Unknown auth provider: {provider}")
     ap_recid = res.rows[0]["recid"]
-    rc = await exec_query(
+    rc = await exec_query(exec_op(
       """
       MERGE users_auth AS target
       USING (SELECT ? AS users_guid, ? AS providers_recid, ? AS element_identifier) AS source
@@ -154,7 +154,7 @@ async def _users_link_provider(args: Dict[str, Any]):
         VALUES (source.users_guid, source.providers_recid, source.element_identifier, 1);
       """,
       (guid, ap_recid, identifier)
-    )
+    ))
     return rc
 
 @register("db:users:providers:unlink_provider:1")
@@ -221,7 +221,7 @@ def _users_soft_delete_account(args: Dict[str, Any]):
       SET element_soft_deleted_at = SYSDATETIMEOFFSET()
       WHERE element_guid = ?;
     """
-    return (DbRunMode.EXEC, sql, (guid,))
+    return Operation(DbRunMode.EXEC, sql, (guid,))
 
 @register("db:users:providers:get_user_by_email:1")
 def _users_get_user_by_email(args: Dict[str, Any]):
@@ -233,7 +233,7 @@ def _users_get_user_by_email(args: Dict[str, Any]):
       WHERE element_email = ?
       FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
     """
-    return (DbRunMode.JSON_ONE, sql, (email,))
+    return Operation(DbRunMode.JSON_ONE, sql, (email,))
 
 
 @register("db:users:account:exists:1")
@@ -245,7 +245,7 @@ def _db_users_account_exists(args: Dict[str, Any]):
     WHERE element_guid = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (DbRunMode.JSON_ONE, sql, (guid,))
+  return Operation(DbRunMode.JSON_ONE, sql, (guid,))
 
 @register("db:users:profile:get_profile:1")
 def _users_profile(args: Dict[str, Any]):
@@ -272,14 +272,14 @@ def _users_profile(args: Dict[str, Any]):
       WHERE v.user_guid = ?
       FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
     """
-    return (DbRunMode.JSON_ONE, sql, (guid,))
+    return Operation(DbRunMode.JSON_ONE, sql, (guid,))
 
 @register("db:auth:providers:unlink_last_provider:1")
 def _auth_unlink_last_provider(args: Dict[str, Any]):
     guid = str(UUID(args["guid"]))
     provider = args["provider"]
     sql = "EXEC auth_unlink_last_provider @guid=?, @provider=?;"
-    return (DbRunMode.EXEC, sql, (guid, provider))
+    return Operation(DbRunMode.EXEC, sql, (guid, provider))
 
 @register("db:auth:microsoft:oauth_relink:1")
 async def _auth_ms_oauth_relink(args: Dict[str, Any]):
@@ -288,9 +288,9 @@ async def _auth_ms_oauth_relink(args: Dict[str, Any]):
     display = args.get("display_name")
     img = args.get("profile_image", "")
     sql = "EXEC auth_oauth_relink @provider='microsoft', @identifier=?, @email=?, @display=?, @image=?;"
-    await exec_query(sql, (identifier, email, display, img))
+    await exec_query(exec_op(sql, (identifier, email, display, img)))
     sel = _users_select({"provider": "microsoft", "provider_identifier": identifier})
-    return await fetch_json(sel[1], sel[2])
+    return await fetch_json(sel)
 
 @register("db:auth:google:oauth_relink:1")
 async def _auth_google_oauth_relink(args: Dict[str, Any]):
@@ -299,9 +299,9 @@ async def _auth_google_oauth_relink(args: Dict[str, Any]):
     display = args.get("display_name")
     img = args.get("profile_image", "")
     sql = "EXEC auth_oauth_relink @provider='google', @identifier=?, @email=?, @display=?, @image=?;"
-    await exec_query(sql, (identifier, email, display, img))
+    await exec_query(exec_op(sql, (identifier, email, display, img)))
     sel = _users_select({"provider": "google", "provider_identifier": identifier})
-    return await fetch_json(sel[1], sel[2])
+    return await fetch_json(sel)
 
 @register("db:auth:discord:oauth_relink:1")
 async def _auth_discord_oauth_relink(args: Dict[str, Any]):
@@ -311,9 +311,9 @@ async def _auth_discord_oauth_relink(args: Dict[str, Any]):
     display = args.get("display_name")
     img = args.get("profile_image", "")
     sql = "EXEC auth_oauth_relink @provider='discord', @identifier=?, @email=?, @display=?, @image=?;"
-    await exec_query(sql, (identifier, email, display, img))
+    await exec_query(exec_op(sql, (identifier, email, display, img)))
     sel = _users_select({"provider": "discord", "provider_identifier": identifier})
-    return await fetch_json(sel[1], sel[2])
+    return await fetch_json(sel)
 
 @register("db:auth:discord:get_security:1")
 def _auth_discord_get_security(args: Dict[str, Any]):
@@ -329,7 +329,7 @@ def _auth_discord_get_security(args: Dict[str, Any]):
     WHERE ap.element_name = 'discord' AND ua.element_identifier = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (DbRunMode.JSON_ONE, sql, (identifier,))
+  return Operation(DbRunMode.JSON_ONE, sql, (identifier,))
 
 
 @register("db:users:profile:set_display:1")
@@ -341,7 +341,7 @@ def _users_set_display(args: Dict[str, Any]):
       SET element_display = ?
       WHERE element_guid = ?;
     """
-    return (DbRunMode.EXEC, sql, (display_name, guid))
+    return Operation(DbRunMode.EXEC, sql, (display_name, guid))
 
 
 @register("db:support:users:set_credits:1")
@@ -353,7 +353,7 @@ def _support_users_set_credits(args: Dict[str, Any]):
     SET element_credits = ?
     WHERE users_guid = ?;
   """
-  return (DbRunMode.EXEC, sql, (credits, guid))
+  return Operation(DbRunMode.EXEC, sql, (credits, guid))
 
 
 # -------------------- STORAGE CACHE --------------------
@@ -374,7 +374,7 @@ def _storage_cache_list(args: Dict[str, Any]):
     ORDER BY usc.element_path, usc.element_filename
     FOR JSON PATH;
   """
-  return (DbRunMode.JSON_MANY, sql, (user_guid,))
+  return Operation(DbRunMode.JSON_MANY, sql, (user_guid,))
 
 
 @register("db:storage:cache:replace_user:1")
@@ -387,10 +387,10 @@ async def _storage_cache_replace_user(args: Dict[str, Any]):
       path = item.get("path", "")
       filename = item.get("filename", "")
       mimetype = item.get("content_type", "application/octet-stream")
-      res = await fetch_json(
+      res = await fetch_json(json_one(
         "SELECT recid FROM storage_types WHERE element_mimetype = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
         (mimetype,),
-      )
+      ))
       if not res.rows:
         raise ValueError(f"Unknown storage mimetype: {mimetype}")
       type_recid = res.rows[0]["recid"]
@@ -418,13 +418,13 @@ async def _storage_cache_upsert(args: Dict[str, Any]):
   url = args.get("url")
   reported = args.get("reported", 0)
   moderation_recid = args.get("moderation_recid")
-  res = await fetch_json(
+  res = await fetch_json(json_one(
     "SELECT recid FROM storage_types WHERE element_mimetype = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
     (mimetype,),
-  )
+  ))
   if not res.rows:
     if mimetype == "path/folder":
-      await exec_query(
+      await exec_query(exec_op(
         """
         MERGE storage_types AS target
         USING (SELECT 16 AS recid, 'path/folder' AS element_mimetype, 'Folder' AS element_displaytype) AS src
@@ -434,16 +434,16 @@ async def _storage_cache_upsert(args: Dict[str, Any]):
           VALUES (src.recid, src.element_mimetype, src.element_displaytype);
         """,
         (),
-      )
-      res = await fetch_json(
+      ))
+      res = await fetch_json(json_one(
         "SELECT recid FROM storage_types WHERE element_mimetype = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
         (mimetype,),
-      )
+      ))
     else:
-      res = await fetch_json(
+      res = await fetch_json(json_one(
         "SELECT recid FROM storage_types WHERE element_mimetype = 'application/octet-stream' FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
         (),
-      )
+      ))
   type_recid = res.rows[0]["recid"] if res.rows else (16 if mimetype == "path/folder" else 1)
   sql = """
     MERGE users_storage_cache AS target
@@ -481,7 +481,7 @@ async def _storage_cache_upsert(args: Dict[str, Any]):
     reported,
     moderation_recid,
   )
-  rc = await exec_query(sql, params)
+  rc = await exec_query(exec_op(sql, params))
   if rc.rowcount == 0:
     logging.error(
       "[MSSQL] storage_cache_upsert affected 0 rows for %s/%s",
@@ -500,7 +500,7 @@ def _storage_cache_delete(args: Dict[str, Any]):
     DELETE FROM users_storage_cache
     WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
   """
-  return (DbRunMode.EXEC, sql, (user_guid, path, filename))
+  return Operation(DbRunMode.EXEC, sql, (user_guid, path, filename))
 
 
 @register("db:storage:cache:delete_folder:1")
@@ -517,7 +517,7 @@ def _storage_cache_delete_folder(args: Dict[str, Any]):
       OR element_path LIKE ?
     );
   """
-  return (DbRunMode.EXEC, sql, (user_guid, parent, name, path, like))
+  return Operation(DbRunMode.EXEC, sql, (user_guid, parent, name, path, like))
 
 
 @register("db:storage:cache:set_public:1")
@@ -531,7 +531,7 @@ def _storage_cache_set_public(args: Dict[str, Any]):
     SET element_public = ?
     WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
   """
-  return (DbRunMode.EXEC, sql, (public, guid, path, filename))
+  return Operation(DbRunMode.EXEC, sql, (public, guid, path, filename))
 
 
 @register("db:storage:files:set_gallery:1")
@@ -545,7 +545,7 @@ def _storage_files_set_gallery(args: Dict[str, Any]):
     SET element_public = ?
     WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
   """
-  return (DbRunMode.EXEC, sql, (gallery, guid, path, filename))
+  return Operation(DbRunMode.EXEC, sql, (gallery, guid, path, filename))
 
 
 @register("db:storage:cache:set_reported:1")
@@ -559,7 +559,7 @@ def _storage_cache_set_reported(args: Dict[str, Any]):
     SET element_reported = ?
     WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
   """
-  return (DbRunMode.EXEC, sql, (reported, guid, path, filename))
+  return Operation(DbRunMode.EXEC, sql, (reported, guid, path, filename))
 
 
 @register("db:storage:cache:list_public:1")
@@ -578,7 +578,7 @@ def _storage_cache_list_public(_: Dict[str, Any]):
     ORDER BY usc.element_created_on
     FOR JSON PATH;
   """
-  return (DbRunMode.JSON_MANY, sql, ())
+  return Operation(DbRunMode.JSON_MANY, sql, ())
 
 
 @register("db:public:gallery:get_public_files:1")
@@ -597,7 +597,7 @@ def _public_gallery_get_public_files(_: Dict[str, Any]):
     ORDER BY usc.element_created_on
     FOR JSON PATH;
   """
-  return (DbRunMode.JSON_MANY, sql, ())
+  return Operation(DbRunMode.JSON_MANY, sql, ())
 
 
 @register("db:storage:cache:list_reported:1")
@@ -614,7 +614,7 @@ def _storage_cache_list_reported(_: Dict[str, Any]):
     ORDER BY usc.element_created_on
     FOR JSON PATH;
   """
-  return (DbRunMode.JSON_MANY, sql, ())
+  return Operation(DbRunMode.JSON_MANY, sql, ())
 
 
 @register("db:storage:cache:count_rows:1")
@@ -625,7 +625,7 @@ def _storage_cache_count_rows(_: Dict[str, Any]):
     WHERE element_deleted = 0
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (DbRunMode.JSON_ONE, sql, ())
+  return Operation(DbRunMode.JSON_ONE, sql, ())
 
 
 @register("db:users:profile:set_optin:1")
@@ -637,7 +637,7 @@ def _users_set_optin(args: Dict[str, Any]):
       SET element_optin = ?
       WHERE element_guid = ?;
     """
-    return (DbRunMode.EXEC, sql, (display_email, guid))
+    return Operation(DbRunMode.EXEC, sql, (display_email, guid))
 
 
 @register("db:users:profile:update_if_unedited:1")
@@ -645,16 +645,16 @@ async def _users_update_if_unedited(args: Dict[str, Any]):
   guid = str(UUID(args["guid"]))
   email = args.get("email")
   display = args.get("display_name")
-  res = await exec_query(
+  res = await exec_query(exec_op(
     """
     UPDATE account_users
     SET element_email = ?, element_display = ?
     WHERE element_guid = ? AND (element_email <> ? OR element_display <> ?);
     """,
     (email, display, guid, email, display),
-  )
+  ))
   if res.rowcount > 0:
-    return await fetch_json(
+    return await fetch_json(json_one(
       """
       SELECT element_display AS display_name, element_email AS email
       FROM account_users
@@ -662,7 +662,7 @@ async def _users_update_if_unedited(args: Dict[str, Any]):
       FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
       """,
       (guid,),
-    )
+    ))
   return DBResult()
 
 
@@ -670,16 +670,16 @@ async def _users_update_if_unedited(args: Dict[str, Any]):
 async def _users_set_provider(args: Dict[str, Any]):
   guid = args["guid"]
   provider = args["provider"]
-  res = await fetch_json(
+  res = await fetch_json(json_one(
     "SELECT recid FROM auth_providers WHERE element_name = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
     (provider,),
-  )
+  ))
   if not res.rows:
     raise ValueError(f"Unknown auth provider: {provider}")
-  return await exec_query(
+  return await exec_query(exec_op(
     "UPDATE account_users SET providers_recid = ? WHERE element_guid = ?;",
     (res.rows[0]["recid"], guid),
-  )
+  ))
 
 @register("db:users:profile:get_roles:1")
 def _users_get_roles(args: Dict[str, Any]):
@@ -690,23 +690,23 @@ def _users_get_roles(args: Dict[str, Any]):
     WHERE users_guid = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (DbRunMode.JSON_ONE, sql, (guid,))
+  return Operation(DbRunMode.JSON_ONE, sql, (guid,))
 
 @register("db:users:profile:set_roles:1")
 async def _users_set_roles(args: Dict[str, Any]):
   """Upsert a user's role mask."""
   guid, roles = args["guid"], int(args["roles"])
   if roles == 0:
-    return await exec_query("DELETE FROM users_roles WHERE users_guid = ?;", (guid,))
-  res = await exec_query(
+    return await exec_query(exec_op("DELETE FROM users_roles WHERE users_guid = ?;", (guid,)))
+  res = await exec_query(exec_op(
     "UPDATE users_roles SET element_roles = ? WHERE users_guid = ?;",
     (roles, guid),
-  )
+  ))
   if res.rowcount == 0:
-    res = await exec_query(
+    res = await exec_query(exec_op(
       "INSERT INTO users_roles (users_guid, element_roles) VALUES (?, ?);",
       (guid, roles),
-    )
+    ))
   return res
 
 @register("db:users:session:set_rotkey:1")
@@ -720,7 +720,7 @@ def _users_session_set_rotkey(args: Dict[str, Any]):
       SET element_rotkey = ?, element_rotkey_iat = ?, element_rotkey_exp = ?
       WHERE element_guid = ?;
     """
-    return (DbRunMode.EXEC, sql, (rotkey, iat, exp, guid))
+    return Operation(DbRunMode.EXEC, sql, (rotkey, iat, exp, guid))
 
 @register("db:users:session:get_rotkey:1")
 def _users_session_get_rotkey(args: Dict[str, Any]):
@@ -734,7 +734,7 @@ def _users_session_get_rotkey(args: Dict[str, Any]):
       WHERE au.element_guid = ?
       FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
     """
-  return (DbRunMode.JSON_ONE, sql, (guid,))
+  return Operation(DbRunMode.JSON_ONE, sql, (guid,))
 
 @register("db:public:links:get_home_links:1")
 def _public_links_get_home_links(args: Dict[str, Any]):
@@ -746,7 +746,7 @@ def _public_links_get_home_links(args: Dict[str, Any]):
       ORDER BY element_sequence
       FOR JSON PATH;
     """
-    return (DbRunMode.JSON_MANY, sql, ())
+    return Operation(DbRunMode.JSON_MANY, sql, ())
 
 @register("db:public:links:get_navbar_routes:1")
 def _public_links_get_navbar_routes(args: Dict[str, Any]):
@@ -762,7 +762,7 @@ def _public_links_get_navbar_routes(args: Dict[str, Any]):
       ORDER BY element_sequence
       FOR JSON PATH;
     """
-    return (DbRunMode.JSON_MANY, sql, (mask,))
+    return Operation(DbRunMode.JSON_MANY, sql, (mask,))
 
 # -------------------- SERVICE ROUTES --------------------
 
@@ -779,7 +779,7 @@ def _service_routes_get_routes(_: Dict[str, Any]):
     ORDER BY element_sequence
     FOR JSON PATH;
   """
-  return (DbRunMode.JSON_MANY, sql, ())
+  return Operation(DbRunMode.JSON_MANY, sql, ())
 
 @register("db:service:routes:upsert_route:1")
 async def _service_routes_upsert_route(args: Dict[str, Any]):
@@ -788,22 +788,22 @@ async def _service_routes_upsert_route(args: Dict[str, Any]):
   icon = args.get("icon")
   sequence = int(args["sequence"])
   roles = int(args["roles"])
-  rc = await exec_query(
+  rc = await exec_query(exec_op(
     "UPDATE frontend_routes SET element_name = ?, element_icon = ?, element_sequence = ?, element_roles = ? WHERE element_path = ?;",
     (name, icon, sequence, roles, path),
-  )
+  ))
   if rc.rowcount == 0:
-    rc = await exec_query(
+    rc = await exec_query(exec_op(
       "INSERT INTO frontend_routes (element_path, element_name, element_icon, element_sequence, element_roles) VALUES (?, ?, ?, ?, ?);",
       (path, name, icon, sequence, roles),
-    )
+    ))
   return rc
 
 @register("db:service:routes:delete_route:1")
 def _service_routes_delete_route(args: Dict[str, Any]):
   path = args["path"]
   sql = "DELETE FROM frontend_routes WHERE element_path = ?;"
-  return (DbRunMode.EXEC, sql, (path,))
+  return Operation(DbRunMode.EXEC, sql, (path,))
 
 @register("db:public:vars:get_hostname:1")
 def _public_vars_get_hostname(args: Dict[str, Any]):
@@ -813,7 +813,7 @@ def _public_vars_get_hostname(args: Dict[str, Any]):
     WHERE element_key = 'hostname'
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (DbRunMode.JSON_ONE, sql, ())
+  return Operation(DbRunMode.JSON_ONE, sql, ())
 
 @register("db:public:vars:get_version:1")
 def _public_vars_get_version(args: Dict[str, Any]):
@@ -823,7 +823,7 @@ def _public_vars_get_version(args: Dict[str, Any]):
     WHERE element_key = 'version'
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (DbRunMode.JSON_ONE, sql, ())
+  return Operation(DbRunMode.JSON_ONE, sql, ())
 
 @register("db:public:vars:get_repo:1")
 def _public_vars_get_repo(args: Dict[str, Any]):
@@ -833,7 +833,7 @@ def _public_vars_get_repo(args: Dict[str, Any]):
     WHERE element_key = 'repo'
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (DbRunMode.JSON_ONE, sql, ())
+  return Operation(DbRunMode.JSON_ONE, sql, ())
 
 @register("db:public:users:get_profile:1")
 def _public_users_get_profile(args: Dict[str, Any]):
@@ -848,7 +848,7 @@ def _public_users_get_profile(args: Dict[str, Any]):
       WHERE au.element_guid = ?
       FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
     """
-    return (DbRunMode.JSON_ONE, sql, (guid,))
+    return Operation(DbRunMode.JSON_ONE, sql, (guid,))
 
 @register("db:public:users:get_published_files:1")
 def _public_users_get_published_files(args: Dict[str, Any]):
@@ -865,28 +865,28 @@ def _public_users_get_published_files(args: Dict[str, Any]):
       ORDER BY usc.element_created_on
       FOR JSON PATH;
     """
-    return (DbRunMode.JSON_MANY, sql, (guid,))
+    return Operation(DbRunMode.JSON_MANY, sql, (guid,))
 
 @register("db:users:profile:set_profile_image:1")
 async def _users_set_img(args: Dict[str, Any]):
   """Insert or update a user's profile image."""
   guid, image_b64, provider = args["guid"], args["image_b64"], args["provider"]
-  res = await fetch_json(
+  res = await fetch_json(json_one(
     "SELECT recid FROM auth_providers WHERE element_name = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
     (provider,),
-  )
+  ))
   if not res.rows:
     raise ValueError(f"Unknown auth provider: {provider}")
   ap_recid = res.rows[0]["recid"]
-  rc = await exec_query(
+  rc = await exec_query(exec_op(
     "UPDATE users_profileimg SET element_base64 = ?, providers_recid = ? WHERE users_guid = ?;",
     (image_b64, ap_recid, guid),
-  )
+  ))
   if rc.rowcount == 0:
-    rc = await exec_query(
+    rc = await exec_query(exec_op(
       "INSERT INTO users_profileimg (users_guid, element_base64, providers_recid) VALUES (?, ?, ?);",
       (guid, image_b64, ap_recid),
-    )
+    ))
   return rc
 
 @register("db:auth:session:create_session:1")
@@ -994,7 +994,7 @@ def _auth_session_get_by_access_token(args: Dict[str, Any]):
       WHERE element_token = ?
       FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
     """
-    return (DbRunMode.JSON_ONE, sql, (token,))
+    return Operation(DbRunMode.JSON_ONE, sql, (token,))
 
 @register("db:auth:session:update_session:1")
 def _auth_session_update_session(args: Dict[str, Any]):
@@ -1006,7 +1006,7 @@ def _auth_session_update_session(args: Dict[str, Any]):
       SET element_ip_last_seen = ?, element_user_agent = ?
       WHERE element_token = ?;
     """
-  return (DbRunMode.EXEC, sql, (ip_address, user_agent, token))
+  return Operation(DbRunMode.EXEC, sql, (ip_address, user_agent, token))
 
 @register("db:auth:session:update_device_token:1")
 def _auth_session_update_device_token(args: Dict[str, Any]):
@@ -1018,7 +1018,7 @@ def _auth_session_update_device_token(args: Dict[str, Any]):
     SET element_token = ?
     WHERE element_guid = ?;
   """
-  return (DbRunMode.EXEC, sql, (token, device_guid))
+  return Operation(DbRunMode.EXEC, sql, (token, device_guid))
 
 @register("db:auth:session:revoke_device_token:1")
 def _auth_session_revoke_device_token(args: Dict[str, Any]):
@@ -1028,7 +1028,7 @@ def _auth_session_revoke_device_token(args: Dict[str, Any]):
     SET element_revoked_at = SYSDATETIMEOFFSET()
     WHERE element_token = ?;
   """
-  return (DbRunMode.EXEC, sql, (token,))
+  return Operation(DbRunMode.EXEC, sql, (token,))
 
 @register("db:auth:session:revoke_all_device_tokens:1")
 def _auth_session_revoke_all_device_tokens(args: Dict[str, Any]):
@@ -1040,7 +1040,7 @@ def _auth_session_revoke_all_device_tokens(args: Dict[str, Any]):
     JOIN users_sessions us ON us.element_guid = sd.sessions_guid
     WHERE us.users_guid = ?;
   """
-  return (DbRunMode.EXEC, sql, (guid,))
+  return Operation(DbRunMode.EXEC, sql, (guid,))
 
 @register("db:auth:session:revoke_provider_tokens:1")
 def _auth_session_revoke_provider_tokens(args: Dict[str, Any]):
@@ -1054,7 +1054,7 @@ def _auth_session_revoke_provider_tokens(args: Dict[str, Any]):
     JOIN auth_providers ap ON ap.recid = sd.providers_recid
     WHERE us.users_guid = ? AND ap.element_name = ?;
   """
-  return (DbRunMode.EXEC, sql, (guid, provider))
+  return Operation(DbRunMode.EXEC, sql, (guid, provider))
 
 # -------------------- SYSTEM CONFIG --------------------
 
@@ -1067,21 +1067,21 @@ def _config_get(args: Dict[str, Any]):
     WHERE element_key = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (DbRunMode.JSON_ONE, sql, (key,))
+  return Operation(DbRunMode.JSON_ONE, sql, (key,))
 
 @register("db:system:config:upsert_config:1")
 async def _config_set(args: Dict[str, Any]):
   key = args["key"]
   value = args["value"]
-  rc = await exec_query(
+  rc = await exec_query(exec_op(
     "UPDATE system_config SET element_value = ? WHERE element_key = ?;",
     (value, key),
-  )
+  ))
   if rc.rowcount == 0:
-    rc = await exec_query(
+    rc = await exec_query(exec_op(
       "INSERT INTO system_config (element_key, element_value) VALUES (?, ?);",
       (key, value),
-    )
+    ))
   return rc
 
 @register("db:system:config:get_configs:1")
@@ -1092,13 +1092,13 @@ def _config_list(_: Dict[str, Any]):
     ORDER BY element_key
     FOR JSON PATH;
   """
-  return (DbRunMode.JSON_MANY, sql, ())
+  return Operation(DbRunMode.JSON_MANY, sql, ())
 
 @register("db:system:config:delete_config:1")
 def _config_delete(args: Dict[str, Any]):
   key = args["key"]
   sql = "DELETE FROM system_config WHERE element_key = ?;"
-  return (DbRunMode.EXEC, sql, (key,))
+  return Operation(DbRunMode.EXEC, sql, (key,))
 
 
 # -------------------- SECURITY ROLES --------------------
@@ -1111,7 +1111,7 @@ def _system_roles_list(_: Dict[str, Any]):
     ORDER BY element_mask
     FOR JSON PATH;
   """
-  return (DbRunMode.JSON_MANY, sql, ())
+  return Operation(DbRunMode.JSON_MANY, sql, ())
 
 
 @register("db:security:roles:upsert_role:1")
@@ -1119,15 +1119,15 @@ async def _security_roles_upsert_role(args: Dict[str, Any]):
   name = args["name"]
   mask = int(args["mask"])
   display = args.get("display")
-  rc = await exec_query(
+  rc = await exec_query(exec_op(
     "UPDATE system_roles SET element_mask = ?, element_display = ? WHERE element_name = ?;",
     (mask, display, name),
-  )
+  ))
   if rc.rowcount == 0:
-    rc = await exec_query(
+    rc = await exec_query(exec_op(
       "INSERT INTO system_roles (element_name, element_mask, element_display) VALUES (?, ?, ?);",
       (name, mask, display),
-    )
+    ))
   return rc
 
 
@@ -1140,7 +1140,7 @@ async def _security_roles_delete_role(args: Dict[str, Any]):
     UPDATE users_roles SET element_roles = element_roles & ~@mask;
     DELETE FROM system_roles WHERE element_name = ?;
   """
-  rc = await exec_query(sql, (name, name))
+  rc = await exec_query(exec_op(sql, (name, name)))
   return rc
 
 
@@ -1156,7 +1156,7 @@ def _security_roles_get_members(args: Dict[str, Any]):
     ORDER BY au.element_display
     FOR JSON PATH;
   """
-  return (DbRunMode.JSON_MANY, sql, (role,))
+  return Operation(DbRunMode.JSON_MANY, sql, (role,))
 
 
 @register("db:security:roles:get_role_non_members:1")
@@ -1171,7 +1171,7 @@ def _security_roles_get_non_members(args: Dict[str, Any]):
     ORDER BY au.element_display
     FOR JSON PATH;
   """
-  return (DbRunMode.JSON_MANY, sql, (role,))
+  return Operation(DbRunMode.JSON_MANY, sql, (role,))
 
 
 @register("db:security:roles:add_role_member:1")
@@ -1185,7 +1185,7 @@ def _security_roles_add_member(args: Dict[str, Any]):
     WHEN MATCHED THEN UPDATE SET element_roles = ur.element_roles | src.element_mask
     WHEN NOT MATCHED THEN INSERT (users_guid, element_roles) VALUES (src.users_guid, src.element_mask);
   """
-  return (DbRunMode.EXEC, sql, (user_guid, role))
+  return Operation(DbRunMode.EXEC, sql, (user_guid, role))
 
 
 @register("db:security:roles:remove_role_member:1")
@@ -1198,7 +1198,7 @@ def _security_roles_remove_member(args: Dict[str, Any]):
     UPDATE users_roles SET element_roles = element_roles & ~@mask WHERE users_guid = ?;
     DELETE FROM users_roles WHERE users_guid = ? AND element_roles = 0;
   """
-  return (DbRunMode.EXEC, sql, (role, user_guid, user_guid))
+  return Operation(DbRunMode.EXEC, sql, (role, user_guid, user_guid))
 
 @register("db:assistant:personas:get_by_name:1")
 def _assistant_personas_get_by_name(args: Dict[str, Any]):
@@ -1225,7 +1225,7 @@ def _assistant_personas_get_by_name(args: Dict[str, Any]):
     WHERE vp.persona_name = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (DbRunMode.JSON_ONE, sql, (name,))
+  return Operation(DbRunMode.JSON_ONE, sql, (name,))
 
 @register("db:assistant:models:list:1")
 def _assistant_models_list(_: Dict[str, Any]):
@@ -1237,7 +1237,7 @@ def _assistant_models_list(_: Dict[str, Any]):
     ORDER BY element_name
     FOR JSON PATH;
   """
-  return (DbRunMode.JSON_MANY, sql, ())
+  return Operation(DbRunMode.JSON_MANY, sql, ())
 
 @register("db:assistant:personas:list:1")
 def _assistant_personas_list(_: Dict[str, Any]):
@@ -1263,7 +1263,7 @@ def _assistant_personas_list(_: Dict[str, Any]):
     ORDER BY vp.persona_name
     FOR JSON PATH;
   """
-  return (DbRunMode.JSON_MANY, sql, ())
+  return Operation(DbRunMode.JSON_MANY, sql, ())
 
 @register("db:assistant:personas:upsert:1")
 async def _assistant_personas_upsert(args: Dict[str, Any]):
@@ -1273,7 +1273,7 @@ async def _assistant_personas_upsert(args: Dict[str, Any]):
   tokens = int(args["tokens"])
   models_recid = int(args["models_recid"])
   if recid is not None:
-    rc = await exec_query(
+    rc = await exec_query(exec_op(
       """
         UPDATE assistant_personas
         SET element_name = ?,
@@ -1284,10 +1284,10 @@ async def _assistant_personas_upsert(args: Dict[str, Any]):
         WHERE recid = ?;
       """,
       (name, prompt, tokens, models_recid, recid),
-    )
+    ))
     if rc.rowcount:
       return rc
-  rc = await exec_query(
+  rc = await exec_query(exec_op(
     """
       UPDATE assistant_personas
       SET element_prompt = ?,
@@ -1297,10 +1297,10 @@ async def _assistant_personas_upsert(args: Dict[str, Any]):
       WHERE element_name = ?;
     """,
     (prompt, tokens, models_recid, name),
-  )
+  ))
   if rc.rowcount:
     return rc
-  return await exec_query(
+  return await exec_query(exec_op(
     """
       INSERT INTO assistant_personas (
         element_name,
@@ -1310,7 +1310,7 @@ async def _assistant_personas_upsert(args: Dict[str, Any]):
       ) VALUES (?, ?, ?, ?);
     """,
     (name, prompt, tokens, models_recid),
-  )
+  ))
 
 @register("db:assistant:personas:delete:1")
 def _assistant_personas_delete(args: Dict[str, Any]):
@@ -1324,7 +1324,7 @@ def _assistant_personas_delete(args: Dict[str, Any]):
     params = (name,)
   else:
     raise ValueError("Missing identifier for persona delete")
-  return (DbRunMode.EXEC, sql, params)
+  return Operation(DbRunMode.EXEC, sql, params)
 
 @register("db:assistant:models:get_by_name:1")
 def _assistant_models_get_by_name(args: Dict[str, Any]):
@@ -1333,7 +1333,7 @@ def _assistant_models_get_by_name(args: Dict[str, Any]):
     SELECT recid FROM assistant_models WHERE element_name = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (DbRunMode.JSON_ONE, sql, (name,))
+  return Operation(DbRunMode.JSON_ONE, sql, (name,))
 
 @register("db:assistant:conversations:insert:1")
 def _assistant_conversations_insert(args: Dict[str, Any]):
@@ -1359,7 +1359,7 @@ def _assistant_conversations_insert(args: Dict[str, Any]):
     SELECT SCOPE_IDENTITY() AS recid
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (
+  return Operation(
     DbRunMode.JSON_ONE,
     sql,
     (
@@ -1432,7 +1432,7 @@ def _assistant_conversations_update_output(args: Dict[str, Any]):
         element_tokens = ?
     WHERE recid = ?;
   """
-  return (DbRunMode.EXEC, sql, (output_data, tokens, recid))
+  return Operation(DbRunMode.EXEC, sql, (output_data, tokens, recid))
 
 @register("db:assistant:conversations:list_by_time:1")
 def _assistant_conversations_list_by_time(args: Dict[str, Any]):
@@ -1455,7 +1455,7 @@ def _assistant_conversations_list_by_time(args: Dict[str, Any]):
     ORDER BY element_created_on
     FOR JSON PATH, INCLUDE_NULL_VALUES;
   """
-  return (DbRunMode.JSON_MANY, sql, (personas_recid, start, end))
+  return Operation(DbRunMode.JSON_MANY, sql, (personas_recid, start, end))
 
 
 @register("db:assistant:conversations:list_recent:1")
@@ -1475,4 +1475,4 @@ def _assistant_conversations_list_recent(_: Dict[str, Any]):
     ORDER BY element_created_on DESC
     FOR JSON PATH, INCLUDE_NULL_VALUES;
   """
-  return (DbRunMode.JSON_MANY, sql, ())
+  return Operation(DbRunMode.JSON_MANY, sql, ())

--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -13,17 +13,18 @@ def test_run_json_one(monkeypatch):
     assert op == "test:json_one"
     def handler(args):
       assert args == {}
-      return (DbRunMode.JSON_ONE, "select 1", ())
+      return mssql_provider.Operation(DbRunMode.JSON_ONE, "select 1", ())
     return handler
 
-  async def fake_fetch_json(sql, params, *, many=False):
-    assert sql == "select 1"
-    assert params == ()
-    assert not many
+  async def fake_execute_operation(operation):
+    assert isinstance(operation, mssql_provider.Operation)
+    assert operation.kind is DbRunMode.JSON_ONE
+    assert operation.sql == "select 1"
+    assert operation.params == ()
     return DBResult(rows=[{"v": 1}], rowcount=1)
 
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
-  monkeypatch.setattr(mssql_provider, "fetch_json", fake_fetch_json)
+  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
   res = asyncio.run(provider.run("test:json_one", {}))
   assert isinstance(res, DBResult)
@@ -38,17 +39,18 @@ def test_run_row_one(monkeypatch):
     assert op == "test:row_one"
     def handler(args):
       assert args == {}
-      return (DbRunMode.ROW_ONE, "select 1", ())
+      return mssql_provider.Operation(DbRunMode.ROW_ONE, "select 1", ())
     return handler
 
-  async def fake_fetch_rows(sql, params, *, one=False, stream=False):
-    assert sql == "select 1"
-    assert params == ()
-    assert one
+  async def fake_execute_operation(operation):
+    assert isinstance(operation, mssql_provider.Operation)
+    assert operation.kind is DbRunMode.ROW_ONE
+    assert operation.sql == "select 1"
+    assert operation.params == ()
     return DBResult(rows=[{"v": 1}], rowcount=1)
 
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
-  monkeypatch.setattr(mssql_provider, "fetch_rows", fake_fetch_rows)
+  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
   res = asyncio.run(provider.run("test:row_one", {}))
   assert isinstance(res, DBResult)
@@ -61,13 +63,14 @@ def test_run_row_many(monkeypatch):
   guid = "00000000-0000-0000-0000-000000000000"
   expected_guid = str(UUID(guid))
 
-  async def fake_fetch_json(sql, params, *, many=False):
-    assert many
-    assert "FOR JSON PATH" in sql
-    assert params == (expected_guid,)
+  async def fake_execute_operation(operation):
+    assert isinstance(operation, mssql_provider.Operation)
+    assert operation.kind is DbRunMode.JSON_MANY
+    assert "FOR JSON PATH" in operation.sql
+    assert operation.params == (expected_guid,)
     return DBResult(rows=[{"path": "a"}, {"path": "b"}], rowcount=2)
 
-  monkeypatch.setattr(mssql_provider, "fetch_json", fake_fetch_json)
+  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
   res = asyncio.run(provider.run("db:public:users:get_published_files:1", {"guid": guid}))
   assert isinstance(res, DBResult)
@@ -82,15 +85,16 @@ def test_run_json_many(monkeypatch):
     assert op == "test:json_many"
     def handler(args):
       assert args == {}
-      return (DbRunMode.JSON_MANY, "select", ())
+      return mssql_provider.Operation(DbRunMode.JSON_MANY, "select", ())
     return handler
 
-  async def fake_fetch_json(sql, params, *, many=False):
-    assert many
+  async def fake_execute_operation(operation):
+    assert isinstance(operation, mssql_provider.Operation)
+    assert operation.kind is DbRunMode.JSON_MANY
     return DBResult(rows=[{"v": 1}, {"v": 2}], rowcount=2)
 
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
-  monkeypatch.setattr(mssql_provider, "fetch_json", fake_fetch_json)
+  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
   res = asyncio.run(provider.run("test:json_many", {}))
   assert isinstance(res, DBResult)
@@ -105,16 +109,18 @@ def test_run_exec(monkeypatch):
     assert op == "test:exec"
     def handler(args):
       assert args == {}
-      return (DbRunMode.EXEC, "update", (1,))
+      return mssql_provider.Operation(DbRunMode.EXEC, "update", (1,))
     return handler
 
-  async def fake_exec_query(sql, params):
-    assert sql == "update"
-    assert params == (1,)
+  async def fake_execute_operation(operation):
+    assert isinstance(operation, mssql_provider.Operation)
+    assert operation.kind is DbRunMode.EXEC
+    assert operation.sql == "update"
+    assert operation.params == (1,)
     return DBResult(rowcount=1)
 
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
-  monkeypatch.setattr(mssql_provider, "exec_query", fake_exec_query)
+  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
   res = asyncio.run(provider.run("test:exec", {}))
   assert isinstance(res, DBResult)
@@ -127,12 +133,14 @@ def test_storage_files_set_gallery(monkeypatch):
   guid = "00000000-0000-0000-0000-000000000000"
   expected_guid = str(UUID(guid))
 
-  async def fake_exec_query(sql, params):
-    assert "UPDATE users_storage_cache" in sql
-    assert params == (1, expected_guid, "", "file.txt")
+  async def fake_execute_operation(operation):
+    assert isinstance(operation, mssql_provider.Operation)
+    assert operation.kind is DbRunMode.EXEC
+    assert "UPDATE users_storage_cache" in operation.sql
+    assert operation.params == (1, expected_guid, "", "file.txt")
     return DBResult(rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, "exec_query", fake_exec_query)
+  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
   res = asyncio.run(provider.run("db:storage:files:set_gallery:1", {"user_guid": guid, "name": "file.txt", "gallery": True}))
   assert isinstance(res, DBResult)

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -5,6 +5,7 @@ import pathlib
 import sys
 import types
 import pytest
+from server.modules.providers import DbRunMode
 import server.modules.providers.database.mssql_provider  # ensure provider module loaded
 
 # stub server package
@@ -53,49 +54,55 @@ get_mssql_handler = registry_mod.get_handler
 
 def test_mssql_get_by_provider_identifier_uses_user_view():
   handler = get_mssql_handler("db:users:providers:get_by_provider_identifier:1")
-  _, sql, _ = handler({"provider": "microsoft", "provider_identifier": str(uuid4())})
-  sql = sql.lower()
+  op = handler({"provider": "microsoft", "provider_identifier": str(uuid4())})
+  assert isinstance(op, db_helpers.Operation)
+  sql = op.sql.lower()
   assert "vw_account_user_profile" in sql
   assert "v.credits" in sql
   assert "users_credits" not in sql
 
 def test_mssql_get_profile_uses_profile_view():
   handler = get_mssql_handler("db:users:profile:get_profile:1")
-  _, sql, _ = handler({"guid": "gid"})
-  sql = sql.lower()
+  op = handler({"guid": "gid"})
+  assert isinstance(op, db_helpers.Operation)
+  sql = op.sql.lower()
   assert "vw_account_user_profile" in sql
   assert "v.credits" in sql
   assert "users_credits" not in sql
 
 def test_mssql_get_rotkey_queries_users_and_providers():
   handler = get_mssql_handler("db:users:session:get_rotkey:1")
-  _, sql, _ = handler({"guid": "gid"})
-  sql = sql.lower()
+  op = handler({"guid": "gid"})
+  assert isinstance(op, db_helpers.Operation)
+  sql = op.sql.lower()
   assert "from account_users" in sql
   assert "auth_providers" in sql
   assert "vw_account_user_security" not in sql
 
 def test_mssql_get_by_access_token_uses_security_view():
   handler = get_mssql_handler("db:auth:session:get_by_access_token:1")
-  _, sql, _ = handler({"access_token": "tok"})
-  sql = sql.lower()
+  op = handler({"access_token": "tok"})
+  assert isinstance(op, db_helpers.Operation)
+  sql = op.sql.lower()
   assert "vw_user_session_security" in sql
   assert "user_roles" in sql
 
 def test_mssql_discord_get_security_uses_security_view():
   handler = get_mssql_handler("db:auth:discord:get_security:1")
-  _, sql, _ = handler({"discord_id": "42"})
-  sql = sql.lower()
+  op = handler({"discord_id": "42"})
+  assert isinstance(op, db_helpers.Operation)
+  sql = op.sql.lower()
   assert "vw_user_session_security" in sql
   assert "auth_providers" in sql
 
 
 def test_mssql_support_users_set_credits_updates_table():
   handler = get_mssql_handler("db:support:users:set_credits:1")
-  mode, sql, params = handler({"guid": "gid", "credits": 10})
-  assert mode == "exec"
-  assert "update users_credits" in sql.lower()
-  assert params == (10, "gid")
+  op = handler({"guid": "gid", "credits": 10})
+  assert isinstance(op, db_helpers.Operation)
+  assert op.kind is DbRunMode.EXEC
+  assert "update users_credits" in op.sql.lower()
+  assert op.params == (10, "gid")
 
 
 def test_fetch_rows_raises_structured_error(monkeypatch):
@@ -128,7 +135,7 @@ def test_fetch_rows_raises_structured_error(monkeypatch):
 
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
   with pytest.raises(db_helpers.DBQueryError) as exc:
-    asyncio.run(db_helpers.fetch_rows("SELECT 1"))
+    asyncio.run(db_helpers.fetch_rows(db_helpers.row_one("SELECT 1")))
   assert exc.value.detail.query == "SELECT 1"
   assert exc.value.detail.params == ()
 
@@ -163,7 +170,7 @@ def test_fetch_json_raises_structured_error(monkeypatch):
 
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
   with pytest.raises(db_helpers.DBQueryError) as exc:
-    asyncio.run(db_helpers.fetch_json("SELECT 1"))
+    asyncio.run(db_helpers.fetch_json(db_helpers.json_one("SELECT 1")))
   assert exc.value.detail.query == "SELECT 1"
 
 
@@ -203,7 +210,7 @@ def test_fetch_json_handles_multiple_rows(monkeypatch):
       return _Ctx()
 
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
-  res = asyncio.run(db_helpers.fetch_json("SELECT"))
+  res = asyncio.run(db_helpers.fetch_json(db_helpers.json_one("SELECT")))
   assert res.rows == [{"a": 1, "b": "two"}]
   assert res.rowcount == 1
 
@@ -236,7 +243,7 @@ def test_exec_query_raises_structured_error(monkeypatch):
 
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
   with pytest.raises(db_helpers.DBQueryError) as exc:
-    asyncio.run(db_helpers.exec_query("UPDATE x SET y=1"))
+    asyncio.run(db_helpers.exec_query(db_helpers.exec_op("UPDATE x SET y=1")))
   assert exc.value.detail.query == "UPDATE x SET y=1"
 
 
@@ -271,7 +278,7 @@ def test_fetch_rows_stream(monkeypatch):
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
 
   async def run():
-    gen = await db_helpers.fetch_rows("SELECT", stream=True)
+    gen = await db_helpers.fetch_rows(db_helpers.row_many("SELECT"), stream=True)
     return hasattr(gen, "__aiter__")
 
   assert asyncio.run(run())

--- a/tests/test_storage_cache_upsert.py
+++ b/tests/test_storage_cache_upsert.py
@@ -1,4 +1,8 @@
 import asyncio, importlib.util, pathlib, sys, types
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from server.modules.providers import DBResult, DbRunMode
 import server.modules.providers.database.mssql_provider  # ensure provider module loaded
 
 root_path = pathlib.Path(__file__).resolve().parent.parent
@@ -29,16 +33,64 @@ async def _dummy_tx():
 logic_mod.transaction = lambda: _dummy_tx()
 sys.modules['server.modules.providers.database.mssql_provider.logic'] = logic_mod
 
-helpers_mod = types.ModuleType('server.modules.providers.database.mssql_provider.db_helpers')
+
+@dataclass(slots=True)
+class Operation:
+  kind: DbRunMode
+  sql: str
+  params: tuple = ()
+  postprocess: Callable[[DBResult], DBResult] | None = None
+
+
+def json_one(sql: str, params: Iterable = (), *, postprocess: Callable[[DBResult], DBResult] | None = None):
+  return Operation(DbRunMode.JSON_ONE, sql, tuple(params), postprocess)
+
+
+def json_many(sql: str, params: Iterable = (), *, postprocess: Callable[[DBResult], DBResult] | None = None):
+  return Operation(DbRunMode.JSON_MANY, sql, tuple(params), postprocess)
+
+
+def row_one(sql: str, params: Iterable = (), *, postprocess: Callable[[DBResult], DBResult] | None = None):
+  return Operation(DbRunMode.ROW_ONE, sql, tuple(params), postprocess)
+
+
+def row_many(sql: str, params: Iterable = (), *, postprocess: Callable[[DBResult], DBResult] | None = None):
+  return Operation(DbRunMode.ROW_MANY, sql, tuple(params), postprocess)
+
+
+def exec_op(sql: str, params: Iterable = (), *, postprocess: Callable[[DBResult], DBResult] | None = None):
+  return Operation(DbRunMode.EXEC, sql, tuple(params), postprocess)
+
+
 async def dummy_fetch_rows(*args, **kwargs):
-  return None
-async def dummy_fetch_json(*args, **kwargs):
-  return types.SimpleNamespace(rows=[{'recid': 1}], rowcount=1)
-async def dummy_exec_query(*args, **kwargs):
-  return types.SimpleNamespace(rowcount=1)
+  return DBResult()
+
+
+async def dummy_fetch_json(operation: Operation):
+  return DBResult(rows=[{'recid': 1}], rowcount=1)
+
+
+async def dummy_exec_query(operation: Operation):
+  return DBResult(rowcount=1)
+
+
+async def execute_operation(operation: Operation):
+  if operation.kind is DbRunMode.EXEC:
+    return await dummy_exec_query(operation)
+  return await dummy_fetch_json(operation)
+
+
+helpers_mod = types.ModuleType('server.modules.providers.database.mssql_provider.db_helpers')
+helpers_mod.Operation = Operation
+helpers_mod.json_one = json_one
+helpers_mod.json_many = json_many
+helpers_mod.row_one = row_one
+helpers_mod.row_many = row_many
+helpers_mod.exec_op = exec_op
 helpers_mod.fetch_rows = dummy_fetch_rows
 helpers_mod.fetch_json = dummy_fetch_json
 helpers_mod.exec_query = dummy_exec_query
+helpers_mod.execute_operation = execute_operation
 sys.modules['server.modules.providers.database.mssql_provider.db_helpers'] = helpers_mod
 
 spec = importlib.util.spec_from_file_location(
@@ -52,9 +104,9 @@ spec.loader.exec_module(registry_mod)
 
 def test_storage_cache_upsert_sets_created_on(monkeypatch):
   captured = []
-  async def fake_exec_query(sql, params):
-    captured.append(params)
-    return types.SimpleNamespace(rowcount=1)
+  async def fake_exec_query(operation):
+    captured.append(operation.params)
+    return DBResult(rowcount=1)
   monkeypatch.setattr(registry_mod, 'exec_query', fake_exec_query)
   handler = registry_mod.get_handler('db:storage:cache:upsert:1')
   args = {


### PR DESCRIPTION
## Summary
- add a typed Operation dataclass plus execution helpers for MSSQL database interactions
- refactor the MSSQL provider and registry handlers to emit and consume Operation instances
- update provider contract and helper tests to exercise the new Operation API

## Testing
- pytest tests/test_db_provider_contract.py tests/test_provider_queries.py tests/test_storage_cache_upsert.py

------
https://chatgpt.com/codex/tasks/task_e_68dae64f54bc8325944d66b2e3b413b9