### PR TITLE
Fix assistant conversation lookup to return Operation spec

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1404,8 +1404,7 @@ def _assistant_conversations_find_recent(args: Dict[str, Any]):
     ORDER BY element_created_on DESC
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (
-    DbRunMode.JSON_ONE,
+  return json_one(
     sql,
     (
       personas_recid,

--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -2,7 +2,8 @@ import asyncio
 
 from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.modules.providers.database.mssql_provider as mssql_provider
-from server.modules.providers import DBResult
+from server.modules.providers import DBResult, DbRunMode
+from server.modules.providers.database.mssql_provider.db_helpers import Operation
 
 
 def test_assistant_conversations_list_by_time(monkeypatch):
@@ -11,8 +12,11 @@ def test_assistant_conversations_list_by_time(monkeypatch):
   start = '2024-01-01'
   end = '2024-01-02'
 
-  async def fake_fetch_json(sql, params, *, many=False):
-    assert many
+  async def fake_execute_operation(operation):
+    assert isinstance(operation, Operation)
+    assert operation.kind is DbRunMode.JSON_MANY
+    sql = operation.sql
+    params = operation.params
     assert "element_modified_on" in sql
     assert "element_user_id" in sql
     assert "element_tokens" in sql
@@ -21,7 +25,7 @@ def test_assistant_conversations_list_by_time(monkeypatch):
     assert params == (personas_recid, start, end)
     return DBResult(rows=[{"recid": 1}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, 'fetch_json', fake_fetch_json)
+  monkeypatch.setattr(mssql_provider, 'execute_operation', fake_execute_operation)
 
   res = asyncio.run(provider.run(
     'db:assistant:conversations:list_by_time:1',
@@ -44,14 +48,17 @@ def test_assistant_conversations_insert(monkeypatch):
     'tokens': 5,
   }
 
-  async def fake_fetch_json(sql, params, *, many=False):
-    assert not many
+  async def fake_execute_operation(operation):
+    assert isinstance(operation, Operation)
+    assert operation.kind is DbRunMode.JSON_ONE
+    sql = operation.sql
+    params = operation.params
     assert "INSERT INTO assistant_conversations" in sql
     assert "FOR JSON PATH" in sql
     assert params == (1, 2, '1', '2', '3', 'hi', '', 5)
     return DBResult(rows=[{'recid': 9}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, 'fetch_json', fake_fetch_json)
+  monkeypatch.setattr(mssql_provider, 'execute_operation', fake_execute_operation)
 
   res = asyncio.run(provider.run('db:assistant:conversations:insert:1', args))
   assert res.rows == [{'recid': 9}]
@@ -69,15 +76,18 @@ def test_assistant_conversations_find_recent(monkeypatch):
     'window_seconds': 120,
   }
 
-  async def fake_fetch_json(sql, params, *, many=False):
-    assert not many
+  async def fake_execute_operation(operation):
+    assert isinstance(operation, Operation)
+    assert operation.kind is DbRunMode.JSON_ONE
+    sql = operation.sql
+    params = operation.params
     assert "SELECT TOP 1 recid" in sql
     assert "DATEADD" in sql
     assert "FOR JSON PATH" in sql
     assert params == (1, 2, 'hi', '1', '1', '2', '2', '3', '3', 120)
     return DBResult(rows=[{'recid': 5}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, 'fetch_json', fake_fetch_json)
+  monkeypatch.setattr(mssql_provider, 'execute_operation', fake_execute_operation)
 
   res = asyncio.run(provider.run('db:assistant:conversations:find_recent:1', args))
   assert res.rows == [{'recid': 5}]
@@ -87,13 +97,17 @@ def test_assistant_conversations_update_output(monkeypatch):
   provider = MssqlProvider()
   args = {'recid': 9, 'output_data': 'out', 'tokens': 12}
 
-  async def fake_exec(sql, params):
+  async def fake_execute_operation(operation):
+    assert isinstance(operation, Operation)
+    assert operation.kind is DbRunMode.EXEC
+    sql = operation.sql
+    params = operation.params
     assert "element_modified_on" not in sql
     assert "element_tokens" in sql
     assert params == ('out', 12, 9)
     return DBResult(rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, 'exec_query', fake_exec)
+  monkeypatch.setattr(mssql_provider, 'execute_operation', fake_execute_operation)
 
   res = asyncio.run(provider.run('db:assistant:conversations:update_output:1', args))
   assert res.rowcount == 1
@@ -102,8 +116,11 @@ def test_assistant_conversations_update_output(monkeypatch):
 def test_assistant_conversations_list_recent(monkeypatch):
   provider = MssqlProvider()
 
-  async def fake_fetch_json(sql, params, *, many=False):
-    assert many
+  async def fake_execute_operation(operation):
+    assert isinstance(operation, Operation)
+    assert operation.kind is DbRunMode.JSON_MANY
+    sql = operation.sql
+    params = operation.params
     assert "SELECT TOP (2)" in sql
     assert "element_output" in sql
     assert "ORDER BY element_created_on DESC" in sql
@@ -112,7 +129,7 @@ def test_assistant_conversations_list_recent(monkeypatch):
     assert params == ()
     return DBResult(rows=[{"recid": 2}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, 'fetch_json', fake_fetch_json)
+  monkeypatch.setattr(mssql_provider, 'execute_operation', fake_execute_operation)
 
   res = asyncio.run(provider.run('db:assistant:conversations:list_recent:1', {}))
   assert isinstance(res, DBResult)


### PR DESCRIPTION
## Summary
- update the MSSQL registry to emit a JSON operation for the assistant conversation lookup
- refactor database assistant conversation tests to validate execute_operation usage and DBResult responses

## Testing
- pytest tests/test_db_assistant_conversations.py
- pytest tests/test_openai_module.py

------
https://chatgpt.com/codex/tasks/task_e_68db2dac424c8325bf840e122f7ddcad