### PR TITLE
Refactor MSSQL storage public operations

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -520,32 +520,55 @@ def _storage_cache_delete_folder(args: Dict[str, Any]):
   return Operation(DbRunMode.EXEC, sql, (user_guid, parent, name, path, like))
 
 
+_STORAGE_PUBLIC_TOGGLE_SQL = """
+  UPDATE users_storage_cache
+  SET element_public = ?
+  WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
+"""
+
+
+_STORAGE_PUBLIC_LIST_SQL = """
+  SELECT usc.users_guid AS user_guid,
+         au.element_display AS display_name,
+         usc.element_path AS path,
+         usc.element_filename AS name,
+         usc.element_url AS url,
+         st.element_mimetype AS content_type
+  FROM users_storage_cache usc
+  JOIN account_users au ON au.element_guid = usc.users_guid
+  JOIN storage_types st ON st.recid = usc.types_recid
+  WHERE usc.element_public = 1 AND usc.element_deleted = 0 AND ISNULL(usc.element_reported,0) = 0
+  ORDER BY usc.element_created_on
+  FOR JSON PATH;
+"""
+
+
+def _storage_public_operation(action: str, *, args: Dict[str, Any] | None = None, flag_key: str = "public") -> Operation:
+  if action == "toggle":
+    if args is None:
+      raise ValueError("toggle action requires args")
+    guid = str(UUID(args["user_guid"]))
+    name = args.get("name")
+    if name:
+      path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
+    else:
+      path = args.get("path", "")
+      filename = args.get("filename", "")
+    flag_value = 1 if args.get(flag_key) else 0
+    return Operation(DbRunMode.EXEC, _STORAGE_PUBLIC_TOGGLE_SQL, (flag_value, guid, path, filename))
+  if action == "list":
+    return Operation(DbRunMode.JSON_MANY, _STORAGE_PUBLIC_LIST_SQL, ())
+  raise ValueError(f"Unknown storage public action: {action}")
+
+
 @register("db:storage:cache:set_public:1")
 def _storage_cache_set_public(args: Dict[str, Any]):
-  guid = str(UUID(args["user_guid"]))
-  path = args.get("path", "")
-  filename = args.get("filename", "")
-  public = 1 if args.get("public") else 0
-  sql = """
-    UPDATE users_storage_cache
-    SET element_public = ?
-    WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
-  """
-  return Operation(DbRunMode.EXEC, sql, (public, guid, path, filename))
+  return _storage_public_operation("toggle", args=args, flag_key="public")
 
 
 @register("db:storage:files:set_gallery:1")
 def _storage_files_set_gallery(args: Dict[str, Any]):
-  guid = str(UUID(args["user_guid"]))
-  name = args.get("name", "")
-  path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
-  gallery = 1 if args.get("gallery") else 0
-  sql = """
-    UPDATE users_storage_cache
-    SET element_public = ?
-    WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
-  """
-  return Operation(DbRunMode.EXEC, sql, (gallery, guid, path, filename))
+  return _storage_public_operation("toggle", args=args, flag_key="gallery")
 
 
 @register("db:storage:cache:set_reported:1")
@@ -564,40 +587,12 @@ def _storage_cache_set_reported(args: Dict[str, Any]):
 
 @register("db:storage:cache:list_public:1")
 def _storage_cache_list_public(_: Dict[str, Any]):
-  sql = """
-    SELECT usc.users_guid AS user_guid,
-           au.element_display AS display_name,
-           usc.element_path AS path,
-           usc.element_filename AS name,
-           usc.element_url AS url,
-           st.element_mimetype AS content_type
-    FROM users_storage_cache usc
-    JOIN account_users au ON au.element_guid = usc.users_guid
-    JOIN storage_types st ON st.recid = usc.types_recid
-    WHERE usc.element_public = 1 AND usc.element_deleted = 0 AND ISNULL(usc.element_reported,0) = 0
-    ORDER BY usc.element_created_on
-    FOR JSON PATH;
-  """
-  return Operation(DbRunMode.JSON_MANY, sql, ())
+  return _storage_public_operation("list")
 
 
 @register("db:public:gallery:get_public_files:1")
 def _public_gallery_get_public_files(_: Dict[str, Any]):
-  sql = """
-    SELECT usc.users_guid AS user_guid,
-           au.element_display AS display_name,
-           usc.element_path AS path,
-           usc.element_filename AS name,
-           usc.element_url AS url,
-           st.element_mimetype AS content_type
-    FROM users_storage_cache usc
-    JOIN account_users au ON au.element_guid = usc.users_guid
-    JOIN storage_types st ON st.recid = usc.types_recid
-    WHERE usc.element_public = 1 AND usc.element_deleted = 0 AND ISNULL(usc.element_reported,0) = 0
-    ORDER BY usc.element_created_on
-    FOR JSON PATH;
-  """
-  return Operation(DbRunMode.JSON_MANY, sql, ())
+  return _storage_public_operation("list")
 
 
 @register("db:storage:cache:list_reported:1")

--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -145,3 +145,47 @@ def test_storage_files_set_gallery(monkeypatch):
   res = asyncio.run(provider.run("db:storage:files:set_gallery:1", {"user_guid": guid, "name": "file.txt", "gallery": True}))
   assert isinstance(res, DBResult)
   assert res.rowcount == 1
+
+
+def test_storage_cache_set_public(monkeypatch):
+  provider = MssqlProvider()
+  guid = "00000000-0000-0000-0000-000000000001"
+  expected_guid = str(UUID(guid))
+
+  async def fake_execute_operation(operation):
+    assert isinstance(operation, mssql_provider.Operation)
+    assert operation.kind is DbRunMode.EXEC
+    assert operation.params == (0, expected_guid, "docs", "file.txt")
+    assert "UPDATE users_storage_cache" in operation.sql
+    return DBResult(rowcount=1)
+
+  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+
+  res = asyncio.run(provider.run("db:storage:cache:set_public:1", {
+    "user_guid": guid,
+    "path": "docs",
+    "filename": "file.txt",
+    "public": False,
+  }))
+  assert isinstance(res, DBResult)
+  assert res.rowcount == 1
+
+
+def test_storage_public_lists_share_query(monkeypatch):
+  provider = MssqlProvider()
+  seen = []
+
+  async def fake_execute_operation(operation):
+    seen.append(operation)
+    assert isinstance(operation, mssql_provider.Operation)
+    assert operation.kind is DbRunMode.JSON_MANY
+    assert operation.params == ()
+    return DBResult(rows=[], rowcount=0)
+
+  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+
+  asyncio.run(provider.run("db:storage:cache:list_public:1", {}))
+  asyncio.run(provider.run("db:public:gallery:get_public_files:1", {}))
+
+  assert len(seen) == 2
+  assert seen[0].sql == seen[1].sql

--- a/tests/test_storage_files_services.py
+++ b/tests/test_storage_files_services.py
@@ -336,3 +336,51 @@ def test_published_file_listed_with_gallery_flag():
   resp = asyncio.run(storage_files_get_folder_files_v1(req2))
   assert resp.payload["files"][0]["gallery"] is True
 
+
+def test_gallery_flag_can_be_cleared():
+  storage = DummyStorage()
+
+  # publish the file
+  req1 = types.SimpleNamespace()
+  req1.app = types.SimpleNamespace(state=types.SimpleNamespace(storage=storage))
+  req1.state = types.SimpleNamespace(
+    rpc_request=RPCRequest(
+      op="urn:storage:files:set_gallery:1",
+      payload={"name": "docs/a.txt", "gallery": True},
+      version=1,
+    ),
+    auth_ctx=AuthContext(user_guid="u123"),
+  )
+  req1.headers = {}
+  asyncio.run(storage_files_set_gallery_v1(req1))
+
+  # unpublish the file
+  req2 = types.SimpleNamespace()
+  req2.app = types.SimpleNamespace(state=types.SimpleNamespace(storage=storage))
+  req2.state = types.SimpleNamespace(
+    rpc_request=RPCRequest(
+      op="urn:storage:files:set_gallery:1",
+      payload={"name": "docs/a.txt", "gallery": False},
+      version=1,
+    ),
+    auth_ctx=AuthContext(user_guid="u123"),
+  )
+  req2.headers = {}
+  asyncio.run(storage_files_set_gallery_v1(req2))
+  assert storage.gallery_args == ("u123", "docs/a.txt", False)
+
+  # list folder contents to ensure gallery flag cleared
+  req3 = types.SimpleNamespace()
+  req3.app = types.SimpleNamespace(state=types.SimpleNamespace(storage=storage))
+  req3.state = types.SimpleNamespace(
+    rpc_request=RPCRequest(
+      op="urn:storage:files:get_folder_files:1",
+      payload={"path": "docs"},
+      version=1,
+    ),
+    auth_ctx=AuthContext(user_guid="u123"),
+  )
+  req3.headers = {}
+  resp = asyncio.run(storage_files_get_folder_files_v1(req3))
+  assert resp.payload["files"][0]["gallery"] is False
+

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -7,7 +7,7 @@ import server.modules.storage_module as storage_module
 from server.modules import BaseModule
 from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.modules.providers.database.mssql_provider as mssql_provider
-from server.modules.providers import DBResult
+from server.modules.providers import DBResult, DbRunMode
 
 
 class DummyEnv(BaseModule):
@@ -75,15 +75,16 @@ def test_list_public_files(monkeypatch):
   app = FastAPI()
   provider = MssqlProvider()
 
-  async def fake_fetch_json(sql, params, *, many=False):
-    assert many
-    assert "FOR JSON PATH" in sql
+  async def fake_execute_operation(operation):
+    assert operation.kind is DbRunMode.JSON_MANY
+    assert "FOR JSON PATH" in operation.sql
+    assert operation.params == ()
     return DBResult(rows=[
       {"user_guid": "u1", "display_name": "U1", "path": "", "name": "a.txt", "url": "u/a.txt", "content_type": "text/plain"},
       {"user_guid": "u2", "display_name": "U2", "path": "", "name": "b.txt", "url": "u/b.txt", "content_type": "text/plain"},
     ], rowcount=2)
 
-  monkeypatch.setattr(mssql_provider, "fetch_json", fake_fetch_json)
+  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
   mod = StorageModule(app)
   mod.db = provider
@@ -92,6 +93,34 @@ def test_list_public_files(monkeypatch):
     {"user_guid": "u1", "display_name": "U1", "path": "", "name": "a.txt", "url": "u/a.txt", "content_type": "text/plain"},
     {"user_guid": "u2", "display_name": "U2", "path": "", "name": "b.txt", "url": "u/b.txt", "content_type": "text/plain"},
   ]
+
+
+def test_set_gallery_sends_numeric_flag_to_db():
+  app = FastAPI()
+  mod = StorageModule(app)
+
+  class CaptureDb:
+    def __init__(self):
+      self.calls = []
+
+    async def run(self, op, args):
+      self.calls.append((op, args))
+      return DBResult(rowcount=1)
+
+  db = CaptureDb()
+  mod.db = db
+
+  asyncio.run(mod.set_gallery("u1", "docs/a.txt", True))
+  asyncio.run(mod.set_gallery("u1", "a.txt", False))
+
+  assert db.calls[0] == (
+    "db:storage:files:set_gallery:1",
+    {"user_guid": "u1", "name": "docs/a.txt", "gallery": 1},
+  )
+  assert db.calls[1] == (
+    "db:storage:files:set_gallery:1",
+    {"user_guid": "u1", "name": "a.txt", "gallery": 0},
+  )
 
 
 def test_list_files_by_user():


### PR DESCRIPTION
## Summary
- extract a shared helper in the MSSQL registry for public storage toggle/list queries
- update public/gellery operations to rely on the helper while keeping SQL the same
- expand storage module and RPC service tests to verify the shared helper behaviour

## Testing
- `pytest tests/test_db_provider_contract.py tests/test_storage_module.py tests/test_storage_files_services.py`


------
https://chatgpt.com/codex/tasks/task_e_68db2f4b4f248325bf19591d91f689fe