### PR TITLE
Refactor auth provider lookups into shared helper

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -24,6 +24,25 @@ def get_handler(op: str):
     except KeyError:
         raise KeyError(f"No MSSQL handler for '{op}'")
 
+async def get_auth_provider_recid(provider: str, *, cursor=None) -> int:
+  """Return the auth provider recid for ``provider`` or raise a uniform error."""
+  if cursor is not None:
+    await cursor.execute(
+      "SELECT recid FROM auth_providers WHERE element_name = ?;",
+      (provider,),
+    )
+    row = await cursor.fetchone()
+    if not row:
+      raise ValueError(f"Unknown auth provider: {provider}")
+    return row[0]
+  res = await fetch_json(json_one(
+    "SELECT recid FROM auth_providers WHERE element_name = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
+    (provider,),
+  ))
+  if not res.rows:
+    raise ValueError(f"Unknown auth provider: {provider}")
+  return res.rows[0]["recid"]
+
 # -------------------- MAPPINGS (representative set) --------------------
 
 @register("db:users:providers:get_by_provider_identifier:1")
@@ -76,13 +95,7 @@ async def _users_insert(args: Dict[str, Any]):
     provider_displayname = args["provider_displayname"]
     provider_profileimg = args.get("provider_profile_image", "")
 
-    res = await fetch_json(json_one(
-      "SELECT recid FROM auth_providers WHERE element_name = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
-      (provider,)
-    ))
-    if not res.rows:
-      raise ValueError(f"Unknown auth provider: {provider}")
-    ap_recid = res.rows[0]["recid"]
+    ap_recid = await get_auth_provider_recid(provider)
 
     dup = await fetch_json(json_one(
       "SELECT users_guid FROM users_auth WHERE element_identifier = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
@@ -135,13 +148,7 @@ async def _users_link_provider(args: Dict[str, Any]):
     guid = str(UUID(args["guid"]))
     provider = args["provider"]
     identifier = str(UUID(args["provider_identifier"]))
-    res = await fetch_json(json_one(
-      "SELECT recid FROM auth_providers WHERE element_name = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
-      (provider,)
-    ))
-    if not res.rows:
-      raise ValueError(f"Unknown auth provider: {provider}")
-    ap_recid = res.rows[0]["recid"]
+    ap_recid = await get_auth_provider_recid(provider)
     rc = await exec_query(exec_op(
       """
       MERGE users_auth AS target
@@ -169,12 +176,7 @@ async def _users_unlink_provider(args: Dict[str, Any]):
       )
       row = await cur.fetchone()
       current_recid = row[0] if row else None
-      await cur.execute(
-        "SELECT recid FROM auth_providers WHERE element_name = ?;",
-        (provider,)
-      )
-      row = await cur.fetchone()
-      provider_recid = row[0] if row else None
+      provider_recid = await get_auth_provider_recid(provider, cursor=cur)
       await cur.execute(
         """
         UPDATE ua
@@ -665,15 +667,10 @@ async def _users_update_if_unedited(args: Dict[str, Any]):
 async def _users_set_provider(args: Dict[str, Any]):
   guid = args["guid"]
   provider = args["provider"]
-  res = await fetch_json(json_one(
-    "SELECT recid FROM auth_providers WHERE element_name = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
-    (provider,),
-  ))
-  if not res.rows:
-    raise ValueError(f"Unknown auth provider: {provider}")
+  ap_recid = await get_auth_provider_recid(provider)
   return await exec_query(exec_op(
     "UPDATE account_users SET providers_recid = ? WHERE element_guid = ?;",
-    (res.rows[0]["recid"], guid),
+    (ap_recid, guid),
   ))
 
 @register("db:users:profile:get_roles:1")
@@ -866,13 +863,7 @@ def _public_users_get_published_files(args: Dict[str, Any]):
 async def _users_set_img(args: Dict[str, Any]):
   """Insert or update a user's profile image."""
   guid, image_b64, provider = args["guid"], args["image_b64"], args["provider"]
-  res = await fetch_json(json_one(
-    "SELECT recid FROM auth_providers WHERE element_name = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
-    (provider,),
-  ))
-  if not res.rows:
-    raise ValueError(f"Unknown auth provider: {provider}")
-  ap_recid = res.rows[0]["recid"]
+  ap_recid = await get_auth_provider_recid(provider)
   rc = await exec_query(exec_op(
     "UPDATE users_profileimg SET element_base64 = ?, providers_recid = ? WHERE users_guid = ?;",
     (image_b64, ap_recid, guid),
@@ -899,14 +890,7 @@ async def _auth_session_create_session(args: Dict[str, Any]):
       raise ValueError("Missing device fingerprint")
 
     async with transaction() as cur:
-      await cur.execute(
-        "SELECT recid FROM auth_providers WHERE element_name = ?;",
-        (provider,),
-      )
-      row = await cur.fetchone()
-      if not row:
-        raise ValueError(f"Unknown auth provider: {provider}")
-      provider_recid = row[0]
+      provider_recid = await get_auth_provider_recid(provider, cursor=cur)
 
       await cur.execute(
         "SELECT element_guid FROM users_sessions WHERE users_guid = ?;",

--- a/tests/test_user_creation_profile_img.py
+++ b/tests/test_user_creation_profile_img.py
@@ -17,8 +17,14 @@ def test_create_from_provider_inserts_profile_image(monkeypatch):
   async def dummy_transaction():
     yield DummyCursor()
 
-  async def fake_fetch_json(query, params, many=False):
-    q = query.strip().lower()
+  lookups = []
+
+  async def fake_get_provider(provider, cursor=None):
+    lookups.append((provider, cursor is not None))
+    return 1
+
+  async def fake_fetch_json(operation):
+    q = operation.sql.strip().lower()
     if q.startswith("select recid from auth_providers"):
       return DBResult(rows=[{"recid": 1}], rowcount=1)
     if q.startswith("select users_guid from users_auth"):
@@ -26,6 +32,7 @@ def test_create_from_provider_inserts_profile_image(monkeypatch):
     return DBResult(rows=[{"guid": "gid", "profile_image": args["provider_profile_image"]}], rowcount=1)
 
   monkeypatch.setattr(registry, "transaction", dummy_transaction)
+  monkeypatch.setattr(registry, "get_auth_provider_recid", fake_get_provider)
   monkeypatch.setattr(registry, "fetch_json", fake_fetch_json)
 
   handler = registry.get_handler("db:users:providers:create_from_provider:1")
@@ -42,4 +49,5 @@ def test_create_from_provider_inserts_profile_image(monkeypatch):
   assert any("insert into users_roles" in sql for sql in executed)
   assert res.rows
   assert res.rows[0]["profile_image"] == "img"
+  assert lookups == [("microsoft", False)]
 

--- a/tests/test_users_session_upsert.py
+++ b/tests/test_users_session_upsert.py
@@ -37,6 +37,12 @@ sys.modules["server.modules.providers.database.mssql_provider.db_helpers"] = b
 b.fetch_rows = lambda *args, **kwargs: None
 b.fetch_json = lambda *args, **kwargs: None
 b.exec_query = lambda *args, **kwargs: None
+b.Operation = type("Operation", (), {})
+b.exec_op = lambda *args, **kwargs: None
+b.json_many = lambda *args, **kwargs: None
+b.json_one = lambda *args, **kwargs: None
+b.row_many = lambda *args, **kwargs: None
+b.row_one = lambda *args, **kwargs: None
 
 spec = importlib.util.spec_from_file_location(
   "server.modules.providers.database.mssql_provider.registry",
@@ -50,6 +56,7 @@ spec.loader.exec_module(registry_mod)
 def test_create_session_updates_existing(monkeypatch):
   executed: list[str] = []
   fetch_calls: list[int] = []
+  lookups: list[tuple[str, bool]] = []
 
   class DummyCur:
     async def execute(self, sql, params):
@@ -68,6 +75,13 @@ def test_create_session_updates_existing(monkeypatch):
     yield DummyCur()
 
   monkeypatch.setattr(registry_mod, "transaction", fake_tx)
+  original_lookup = registry_mod.get_auth_provider_recid
+
+  async def fake_lookup(provider, cursor=None):
+    lookups.append((provider, cursor is not None))
+    return await original_lookup(provider, cursor=cursor)
+
+  monkeypatch.setattr(registry_mod, "get_auth_provider_recid", fake_lookup)
   handler = registry_mod.get_handler("db:auth:session:create_session:1")
   args = {
     "access_token": "tok",
@@ -83,3 +97,4 @@ def test_create_session_updates_existing(monkeypatch):
   assert not any("insert into users_sessions" in q for q in executed)
   assert any("update sessions_devices" in q for q in executed)
   assert not any("insert into sessions_devices" in q for q in executed)
+  assert lookups == [("microsoft", True)]


### PR DESCRIPTION
## Summary
- add a shared helper in the MSSQL registry to resolve auth provider recids with consistent errors
- replace inline auth_providers queries in provider handlers with the helper
- update focused tests to stub the helper and validate existing DBResult responses

## Testing
- pytest tests/test_user_creation_profile_img.py tests/test_users_session_upsert.py

------
https://chatgpt.com/codex/tasks/task_e_68db3a4f77488325a10480d784f63545