### PR TITLE
Add URN support to DbModule database operations

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -19,6 +19,8 @@ class DbModule(BaseModule):
     self.provider: str = "mssql"
     self.logging_level: int = 0
     self._provider: DbProviderBase | None = None
+    # allow URN operations to map to provider specific keys
+    self._op_aliases: dict[str, str] = {}
 
   async def init(self, provider: str | None = None, **cfg):
     """Initialize database provider.
@@ -46,9 +48,30 @@ class DbModule(BaseModule):
 
     self._provider = provider_cls(**cfg)
 
+  def register_alias(self, urn: str, provider_key: str):
+    """Register a custom mapping from a URN to a provider specific key."""
+    self._op_aliases[urn] = provider_key
+
+  def _resolve_provider_op(self, op: str) -> str:
+    """Translate URN style operations to provider specific keys."""
+    if op in self._op_aliases:
+      return self._op_aliases[op]
+    if op.startswith("urn:"):
+      parts = op.split(":")
+      if len(parts) < 3:
+        raise ValueError(f"Invalid database URN: {op}")
+      namespace = parts[1]
+      if namespace != "db":
+        raise ValueError(f"Unsupported database namespace: {namespace}")
+      provider_op = ":".join(parts[1:])
+      self._op_aliases[op] = provider_op
+      return provider_op
+    return op
+
   async def run(self, op: str, args: Dict[str, Any]) -> DBResult:
     assert self._provider, "db_module not initialized"
-    out = await self._provider.run(op, args)
+    provider_op = self._resolve_provider_op(op)
+    out = await self._provider.run(provider_op, args)
     # normalize to DBResult
     if isinstance(out, DBResult):
       return out

--- a/tests/test_db_module_init.py
+++ b/tests/test_db_module_init.py
@@ -1,9 +1,11 @@
 import asyncio
+from typing import Any
+
 import pytest
 from fastapi import FastAPI
 
 from server.modules.db_module import DbModule
-from server.modules.providers import DbProviderBase
+from server.modules.providers import DBResult, DbProviderBase
 from server.modules.providers.database.mssql_provider import MssqlProvider
 from server.modules.providers.database.mssql_provider.db_helpers import DBQueryError, QueryErrorDetail
 
@@ -38,3 +40,33 @@ def test_db_module_run_propagates_query_error():
   with pytest.raises(DBQueryError) as exc:
     asyncio.run(db.run("db:test:error", {}))
   assert exc.value.detail == detail
+
+
+def test_db_module_accepts_urn_operations():
+  app = FastAPI()
+  db = DbModule(app)
+  captured: dict[str, Any] = {}
+
+  class RecordingProvider(DbProviderBase):
+    def __init__(self):
+      super().__init__()
+
+    async def startup(self):
+      pass
+
+    async def shutdown(self):
+      pass
+
+    async def run(self, op, args):
+      captured["op"] = op
+      captured["args"] = args
+      return DBResult(rows=[{"ok": True}], rowcount=1)
+
+  db._provider = RecordingProvider()
+
+  result = asyncio.run(db.run("urn:db:test:urn-op:1", {"foo": "bar"}))
+  assert captured["op"] == "db:test:urn-op:1"
+  assert captured["args"] == {"foo": "bar"}
+  assert isinstance(result, DBResult)
+  assert result.rows == [{"ok": True}]
+  assert result.rowcount == 1


### PR DESCRIPTION
## Summary
- translate URN-form database operations to provider keys inside `DbModule`
- expose alias registration so providers can override mappings when needed
- extend database module tests to cover URN execution paths

## Testing
- pytest tests/test_db_module_init.py

------
https://chatgpt.com/codex/tasks/task_e_68db3ed28c68832597db0fb5f6085038