### PR TITLE
Handle mapping outputs from MSSQL provider handlers

### DIFF
--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -1,6 +1,9 @@
 # providers/database/mssql_provider/__init__.py
 import inspect
 from typing import Any, Dict
+from collections.abc import Mapping
+
+from pydantic import ValidationError
 
 from ... import DbProviderBase, DBResult
 from .logic import init_pool, close_pool
@@ -18,12 +21,29 @@ class MssqlProvider(DbProviderBase):
   async def run(self, op: str, args: Dict[str, Any]) -> DBResult:
     handler = get_handler(op)
     spec = handler(args)
+
     if inspect.isawaitable(spec):
-      result = await spec  # type: ignore[func-returns-value]
+      spec = await spec  # type: ignore[func-returns-value]
+
+    async def _resolve(result: Any) -> DBResult:
+      if isinstance(result, Operation):
+        return await execute_operation(result)
       if isinstance(result, DBResult):
         return result
-      raise TypeError(f"Handler '{op}' returned unexpected awaitable result: {type(result)!r}")
-    if isinstance(spec, Operation):
-      return await execute_operation(spec)
-    raise TypeError(f"Handler '{op}' returned unsupported spec type: {type(spec)!r}")
+      if isinstance(result, Mapping):
+        validator = getattr(DBResult, "model_validate", None)
+        try:
+          if callable(validator):
+            return validator(result)
+          return DBResult(**result)
+        except (ValidationError, TypeError, ValueError) as exc:
+          raise TypeError(
+            f"Handler '{op}' returned mapping that cannot be parsed as DBResult"
+          ) from exc
+      raise TypeError(
+        f"Handler '{op}' returned unsupported result type: {type(result)!r}."
+        " Expected Operation, DBResult, or mapping with rows/rowcount."
+      )
+
+    return await _resolve(spec)
 

--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -189,3 +189,74 @@ def test_storage_public_lists_share_query(monkeypatch):
 
   assert len(seen) == 2
   assert seen[0].sql == seen[1].sql
+
+
+def test_unlink_provider_dict_result(monkeypatch):
+  provider = MssqlProvider()
+  guid = "00000000-0000-0000-0000-000000000002"
+
+  def fake_get_handler(op):
+    assert op == "db:users:providers:unlink_provider:1"
+
+    async def handler(args):
+      assert args == {
+        "guid": guid,
+        "provider": "google",
+        "new_provider_recid": 123,
+      }
+      return {"rows": [{"providers_remaining": 1}], "rowcount": 1}
+
+    return handler
+
+  monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
+
+  res = asyncio.run(provider.run("db:users:providers:unlink_provider:1", {
+    "guid": guid,
+    "provider": "google",
+    "new_provider_recid": 123,
+  }))
+
+  assert isinstance(res, DBResult)
+  assert res.rows == [{"providers_remaining": 1}]
+  assert res.rowcount == 1
+
+
+def test_create_session_dict_result(monkeypatch):
+  provider = MssqlProvider()
+  guid = "00000000-0000-0000-0000-000000000003"
+
+  def fake_get_handler(op):
+    assert op == "db:auth:session:create_session:1"
+
+    async def handler(args):
+      assert args == {
+        "access_token": "token",
+        "expires": "2024-01-01T00:00:00Z",
+        "fingerprint": "fingerprint",
+        "user_agent": "pytest",
+        "ip_address": "127.0.0.1",
+        "user_guid": guid,
+        "provider": "google",
+      }
+      return {
+        "rows": [{"session_guid": "sess", "device_guid": "device"}],
+        "rowcount": 1,
+      }
+
+    return handler
+
+  monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
+
+  res = asyncio.run(provider.run("db:auth:session:create_session:1", {
+    "access_token": "token",
+    "expires": "2024-01-01T00:00:00Z",
+    "fingerprint": "fingerprint",
+    "user_agent": "pytest",
+    "ip_address": "127.0.0.1",
+    "user_guid": guid,
+    "provider": "google",
+  }))
+
+  assert isinstance(res, DBResult)
+  assert res.rows == [{"session_guid": "sess", "device_guid": "device"}]
+  assert res.rowcount == 1


### PR DESCRIPTION
## Summary
- normalize mapping-like results from MSSQL provider handlers into DBResult instances and tighten error messaging
- add regression coverage for unlink_provider and create_session handlers to confirm dict outputs are accepted

## Testing
- pytest tests/test_db_provider_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68dbde0315388325829f09d72346ce92