### PR TITLE
Simplify DbModule operation dispatch

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -19,8 +19,6 @@ class DbModule(BaseModule):
     self.provider: str = "mssql"
     self.logging_level: int = 0
     self._provider: DbProviderBase | None = None
-    # allow URN operations to map to provider specific keys
-    self._op_aliases: dict[str, str] = {}
 
   async def init(self, provider: str | None = None, **cfg):
     """Initialize database provider.
@@ -48,30 +46,9 @@ class DbModule(BaseModule):
 
     self._provider = provider_cls(**cfg)
 
-  def register_alias(self, urn: str, provider_key: str):
-    """Register a custom mapping from a URN to a provider specific key."""
-    self._op_aliases[urn] = provider_key
-
-  def _resolve_provider_op(self, op: str) -> str:
-    """Translate URN style operations to provider specific keys."""
-    if op in self._op_aliases:
-      return self._op_aliases[op]
-    if op.startswith("urn:"):
-      parts = op.split(":")
-      if len(parts) < 3:
-        raise ValueError(f"Invalid database URN: {op}")
-      namespace = parts[1]
-      if namespace != "db":
-        raise ValueError(f"Unsupported database namespace: {namespace}")
-      provider_op = ":".join(parts[1:])
-      self._op_aliases[op] = provider_op
-      return provider_op
-    return op
-
   async def run(self, op: str, args: Dict[str, Any]) -> DBResult:
     assert self._provider, "db_module not initialized"
-    provider_op = self._resolve_provider_op(op)
-    out = await self._provider.run(provider_op, args)
+    out = await self._provider.run(op, args)
     # normalize to DBResult
     if isinstance(out, DBResult):
       return out

--- a/tests/test_db_module_init.py
+++ b/tests/test_db_module_init.py
@@ -42,7 +42,7 @@ def test_db_module_run_propagates_query_error():
   assert exc.value.detail == detail
 
 
-def test_db_module_accepts_urn_operations():
+def test_db_module_forwards_operations_verbatim():
   app = FastAPI()
   db = DbModule(app)
   captured: dict[str, Any] = {}
@@ -64,7 +64,7 @@ def test_db_module_accepts_urn_operations():
 
   db._provider = RecordingProvider()
 
-  result = asyncio.run(db.run("urn:db:test:urn-op:1", {"foo": "bar"}))
+  result = asyncio.run(db.run("db:test:urn-op:1", {"foo": "bar"}))
   assert captured["op"] == "db:test:urn-op:1"
   assert captured["args"] == {"foo": "bar"}
   assert isinstance(result, DBResult)


### PR DESCRIPTION
## Summary
- remove the DbModule operation alias registry and forward operation strings directly to providers
- update database module tests to expect canonical db: operation names and confirm the verbatim forwarding
- verify no callers rely on urn:db aliases

## Testing
- pytest tests/test_db_module_init.py
- rg "urn:db" -n

------
https://chatgpt.com/codex/tasks/task_e_68dbec4d89108325b739961d25d95263