### PR TITLE
Refactor DbModule to use registry dispatcher

### DIFF
--- a/server/modules/__init__.py
+++ b/server/modules/__init__.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
 from fastapi import FastAPI
-from typing import Type, Dict, List
+from typing import Dict
 from server.helpers.strings import camel_case
 import asyncio, os, importlib
+from server.registry import RegistryDispatcher
 
 MODULES_FOLDER = os.path.dirname(__file__)
 
@@ -29,6 +30,8 @@ class ModuleManager:
   def __init__(self, app: FastAPI):
     self.app = app
     self.instances: Dict[str, BaseModule] = {}
+    self.registry = RegistryDispatcher()
+    setattr(app.state, "registry", self.registry)
 
     for fname in os.listdir(MODULES_FOLDER):
       if not fname.endswith("_module.py") or fname == "__init__.py":
@@ -44,6 +47,9 @@ class ModuleManager:
         raise ImportError(f"Module '{file_name}' missing expected class '{class_name}'")
       cls = getattr(mod, class_name)
       instance = cls(app)
+
+      if hasattr(instance, "set_registry"):
+        instance.set_registry(self.registry)
 
       setattr(app.state, module_name, instance)
       self.instances[module_name] = instance

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -10,7 +10,14 @@ from . import BaseModule
 from .env_module import EnvModule
 from .providers import DbProviderBase
 from .providers import DBResult
+from server.registry import RegistryDispatcher
+from server.registry.types import DBRequest, DBResponse
 from server.helpers.logging import update_logging_level
+
+
+def _current_dbresult_cls():
+  from server.modules.providers import DBResult as ProvidersDBResult
+  return ProvidersDBResult
 
 
 class DbModule(BaseModule):
@@ -19,6 +26,7 @@ class DbModule(BaseModule):
     self.provider: str = "mssql"
     self.logging_level: int = 0
     self._provider: DbProviderBase | None = None
+    self._registry: RegistryDispatcher | None = getattr(app.state, "registry", None)
 
   async def init(self, provider: str | None = None, **cfg):
     """Initialize database provider.
@@ -46,13 +54,22 @@ class DbModule(BaseModule):
 
     self._provider = provider_cls(**cfg)
 
+  def set_registry(self, registry: RegistryDispatcher) -> None:
+    self._registry = registry
+
   async def run(self, op: str, args: Dict[str, Any]) -> DBResult:
     assert self._provider, "db_module not initialized"
-    out = await self._provider.run(op, args)
-    # normalize to DBResult
-    if isinstance(out, DBResult):
-      return out
-    return DBResult(**out)  # expects {"rows":[...], "rowcount":N}
+    if not self._registry:
+      raise RuntimeError("registry dispatcher not configured")
+    request = DBRequest(op=op, params=args)
+    response = await self._registry.execute(request)
+    DBResultCls = _current_dbresult_cls()
+    if isinstance(response, DBResponse):
+      return response.to_result()
+    if isinstance(response, DBResultCls):
+      return response
+    payload = response.model_dump() if hasattr(response, "model_dump") else response
+    return DBResultCls(**payload)
 
   async def startup(self):
     env: EnvModule = self.app.state.env
@@ -64,6 +81,8 @@ class DbModule(BaseModule):
     await self.init(provider=self.provider, **cfg)
     assert self._provider
     await self._provider.startup()
+    if self._registry:
+      self._registry.bind_provider(self._provider)
     res = await self.run("db:system:config:get_config:1", {"key": "LoggingLevel"})
     val = res.rows[0]["value"] if res.rows else "0"
     try:

--- a/server/modules/providers/database/mssql_provider/db_helpers.py
+++ b/server/modules/providers/database/mssql_provider/db_helpers.py
@@ -16,6 +16,11 @@ class Operation:
     if not isinstance(self.params, tuple):
       object.__setattr__(self, "params", tuple(self.params))
 
+  def __iter__(self):
+    yield self.kind
+    yield self.sql
+    yield self.params
+
 
 def row_one(sql: str, params: Iterable[Any] = (), *, postprocess: Callable[[DBResult], DBResult] | None = None) -> Operation:
   return Operation(DbRunMode.ROW_ONE, sql, tuple(params), postprocess)

--- a/server/registry/__init__.py
+++ b/server/registry/__init__.py
@@ -1,0 +1,53 @@
+"""Registry dispatcher bridge."""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from server.modules.providers import DBResult, DbProviderBase
+
+from .types import DBRequest, DBResponse
+
+__all__ = [
+  "DBRequest",
+  "DBResponse",
+  "DBResult",
+  "RegistryDispatcher",
+]
+
+
+Executor = Callable[[DBRequest], Awaitable[DBResponse]]
+
+
+def _current_dbresult_cls():
+  from server.modules.providers import DBResult as ProvidersDBResult
+  return ProvidersDBResult
+
+
+class RegistryDispatcher:
+  """Simple dispatcher that routes :class:`DBRequest` objects."""
+
+  def __init__(self):
+    self._executor: Executor | None = None
+
+  def set_executor(self, executor: Executor) -> None:
+    self._executor = executor
+
+  def bind_provider(self, provider: DbProviderBase) -> None:
+    async def _execute(request: DBRequest) -> DBResponse:
+      result = await provider.run(request.op, request.params)
+      DBResultCls = _current_dbresult_cls()
+      if isinstance(result, DBResponse):
+        return result
+      if isinstance(result, DBResultCls):
+        return result
+      payload = result.model_dump() if hasattr(result, "model_dump") else result
+      validated = DBResultCls.model_validate(payload)
+      return DBResponse.from_result(validated)
+
+    self.set_executor(_execute)
+
+  async def execute(self, request: DBRequest) -> DBResponse:
+    if not self._executor:
+      raise RuntimeError("Registry dispatcher is not configured")
+    return await self._executor(request)

--- a/server/registry/types.py
+++ b/server/registry/types.py
@@ -1,0 +1,42 @@
+"""Common registry request and response models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from server.modules.providers import DBResult
+
+__all__ = [
+  "DBRequest",
+  "DBResponse",
+  "DBResult",
+]
+
+
+class DBRequest(BaseModel):
+  """Payload describing a database registry operation."""
+
+  op: str
+  params: dict[str, Any] = Field(default_factory=dict)
+  metadata: dict[str, Any] | None = None
+
+  class Config:
+    frozen = True
+    arbitrary_types_allowed = True
+
+
+class DBResponse(BaseModel):
+  """Wrapper around :class:`DBResult` used by the registry."""
+
+  rows: list[dict] = Field(default_factory=list)
+  rowcount: int = 0
+  meta: dict[str, Any] | None = None
+
+  @classmethod
+  def from_result(cls, result: DBResult, *, meta: dict[str, Any] | None = None) -> "DBResponse":
+    return cls(rows=list(result.rows), rowcount=result.rowcount, meta=meta)
+
+  def to_result(self) -> DBResult:
+    return DBResult(rows=list(self.rows), rowcount=self.rowcount)

--- a/tests/test_db_module_init.py
+++ b/tests/test_db_module_init.py
@@ -1,6 +1,5 @@
 import asyncio
 from typing import Any
-
 import pytest
 from fastapi import FastAPI
 
@@ -8,6 +7,8 @@ from server.modules.db_module import DbModule
 from server.modules.providers import DBResult, DbProviderBase
 from server.modules.providers.database.mssql_provider import MssqlProvider
 from server.modules.providers.database.mssql_provider.db_helpers import DBQueryError, QueryErrorDetail
+from server.registry import RegistryDispatcher
+from server.registry.types import DBResponse
 
 
 def test_init_uses_concrete_provider():
@@ -36,6 +37,9 @@ def test_db_module_run_propagates_query_error():
       raise DBQueryError(detail)
 
   db._provider = FailingProvider()
+  registry = RegistryDispatcher()
+  registry.bind_provider(db._provider)
+  db.set_registry(registry)
 
   with pytest.raises(DBQueryError) as exc:
     asyncio.run(db.run("db:test:error", {}))
@@ -63,6 +67,9 @@ def test_db_module_forwards_operations_verbatim():
       return DBResult(rows=[{"ok": True}], rowcount=1)
 
   db._provider = RecordingProvider()
+  registry = RegistryDispatcher()
+  registry.bind_provider(db._provider)
+  db.set_registry(registry)
 
   result = asyncio.run(db.run("db:test:urn-op:1", {"foo": "bar"}))
   assert captured["op"] == "db:test:urn-op:1"
@@ -70,3 +77,41 @@ def test_db_module_forwards_operations_verbatim():
   assert isinstance(result, DBResult)
   assert result.rows == [{"ok": True}]
   assert result.rowcount == 1
+
+
+def test_db_module_run_constructs_registry_request():
+  app = FastAPI()
+  db = DbModule(app)
+
+  class DummyProvider(DbProviderBase):
+    async def startup(self):
+      pass
+
+    async def shutdown(self):
+      pass
+
+    async def run(self, op, args):
+      raise AssertionError("provider should not be invoked in this test")
+
+  class RecordingRegistry(RegistryDispatcher):
+    def __init__(self):
+      super().__init__()
+      self.requests: list = []
+
+    async def execute(self, request):
+      self.requests.append(request)
+      return DBResponse(rows=[{"ok": True}], rowcount=1)
+
+  provider = DummyProvider()
+  db._provider = provider
+  registry = RecordingRegistry()
+  db.set_registry(registry)
+
+  result = asyncio.run(db.run("db:test:op", {"key": "value"}))
+
+  assert result.rows == [{"ok": True}]
+  assert result.rowcount == 1
+  assert len(registry.requests) == 1
+  request = registry.requests[0]
+  assert request.op == "db:test:op"
+  assert request.params == {"key": "value"}


### PR DESCRIPTION
## Summary
- add registry request and response models that wrap the existing DBResult
- introduce a registry dispatcher bridge and wire ModuleManager and DbModule to use it
- update MSSQL operation helpers, DbModule runtime flow, and accompanying unit tests for the new request/response contract

## Testing
- pytest
- pytest tests/test_db_module_init.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dc31b2f0a48325afe713a5bf57c59a