### PR TITLE
Refactor auth modules to use unified security profile query

### DIFF
--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -86,8 +86,9 @@ async def users_profile_get_roles_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   db: DbModule = request.app.state.db
-  res = await db.run("db:users:profile:get_roles:1", {"guid": user_guid})
-  roles = int(res.rows[0].get("element_roles", 0)) if res.rows else 0
+  res = await db.run("db:accounts:security:get_security_profile:1", {"guid": user_guid})
+  row = res.rows[0] if res.rows else {}
+  roles = int(row.get("user_roles") or row.get("element_roles") or 0)
   payload = UsersProfileRoles1(roles=roles)
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -4,7 +4,7 @@ import base64, logging, uuid
 from datetime import datetime, timedelta, timezone
 from fastapi import FastAPI, HTTPException, status
 from jose import jwt, JWTError, ExpiredSignatureError
-from typing import Dict
+from typing import Any, Dict
 
 from server.modules import BaseModule
 from server.modules.env_module import EnvModule
@@ -26,6 +26,7 @@ class RoleCache:
     self.role_names: list[str] = []
     self.role_registered: int = 0
     self._user_roles: dict[str, tuple[list[str], int]] = {}
+    self._user_security: dict[str, dict[str, Any]] = {}
 
   async def load_roles(self):
     logging.debug("[RoleCache] Loading roles from database")
@@ -44,6 +45,7 @@ class RoleCache:
     self.role_registered = self.roles.get("ROLE_REGISTERED", 0)
     self.role_names = [n for n in self.roles.keys() if n != "ROLE_REGISTERED"]
     self._user_roles.clear()
+    self._user_security.clear()
     logging.debug("[RoleCache] Loaded roles: %s", self.roles)
 
   async def refresh_role_cache(self):
@@ -78,16 +80,53 @@ class RoleCache:
       return [n for n in self.role_names]
     return list(self.roles.keys())
 
-  async def get_user_roles(self, guid: str, refresh: bool = False) -> tuple[list[str], int]:
-    if not refresh and guid in self._user_roles:
-      logging.debug("[RoleCache] Returning cached roles for %s", guid)
-      return self._user_roles[guid]
-    logging.debug("[RoleCache] Fetching roles for %s", guid)
-    res = await self.db.run("db:users:profile:get_roles:1", {"guid": guid})
-    mask = int(res.rows[0].get("element_roles", 0)) if res.rows else 0
+  def _hydrate_security_profile(self, guid: str, row: dict[str, Any] | None) -> dict[str, Any]:
+    if not guid:
+      return {}
+    if not row:
+      self._user_security.pop(guid, None)
+      self._user_roles.pop(guid, None)
+      return {}
+    profile = dict(row)
+    mask = int(profile.get("user_roles") or profile.get("element_roles") or 0)
     names = self.mask_to_names(mask)
+    profile["user_roles"] = mask
+    profile["element_roles"] = mask
+    profile["role_mask"] = mask
+    profile["roles"] = names
+    self._user_security[guid] = profile
     self._user_roles[guid] = (names, mask)
-    logging.debug("[RoleCache] Roles for %s: %s (mask=%#018x)", guid, names, mask)
+    logging.debug(
+      "[RoleCache] Cached security profile for %s: roles=%s mask=%#018x",
+      guid,
+      names,
+      mask,
+    )
+    return profile
+
+  async def get_user_security_profile(self, guid: str, refresh: bool = False) -> dict[str, Any]:
+    if not guid:
+      return {}
+    if not refresh and guid in self._user_security:
+      logging.debug("[RoleCache] Returning cached security profile for %s", guid)
+      return self._user_security[guid]
+    logging.debug("[RoleCache] Fetching security profile for %s", guid)
+    res = await self.db.run("db:accounts:security:get_security_profile:1", {"guid": guid})
+    row = res.rows[0] if res.rows else None
+    return self._hydrate_security_profile(str(guid), row)
+
+  def cache_security_profile(self, row: dict[str, Any] | None) -> dict[str, Any]:
+    if not row:
+      return {}
+    guid = str(row.get("user_guid") or row.get("guid") or "")
+    return self._hydrate_security_profile(guid, row)
+
+  async def get_user_roles(self, guid: str, refresh: bool = False) -> tuple[list[str], int]:
+    profile = await self.get_user_security_profile(guid, refresh)
+    if not profile:
+      return [], 0
+    names = profile.get("roles", [])
+    mask = int(profile.get("role_mask", 0))
     return names, mask
 
   async def user_has_role(self, guid: str, required_mask: int) -> bool:
@@ -100,7 +139,7 @@ class RoleCache:
 
   async def refresh_user_roles(self, guid: str):
     logging.debug("[RoleCache] Refreshing user roles for %s", guid)
-    await self.get_user_roles(guid, refresh=True)
+    await self.get_user_security_profile(guid, refresh=True)
 
 
 class AuthModule(BaseModule):
@@ -128,6 +167,10 @@ class AuthModule(BaseModule):
   @property
   def _user_roles(self) -> dict[str, tuple[list[str], int]]:
     return self.role_cache._user_roles
+
+  @property
+  def _user_security(self) -> dict[str, dict[str, Any]]:
+    return self.role_cache._user_security
 
   async def startup(self):
     self.env: EnvModule = self.app.state.env
@@ -254,8 +297,8 @@ class AuthModule(BaseModule):
     if not guid or not session_guid or not device_guid:
       raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Subject not found", headers={"WWW-Authenticate": "Bearer"})
 
-    res = await self.db.run("db:users:session:get_rotkey:1", {"guid": guid})
-    rotkey = res.rows[0].get("rotkey") if res.rows else None
+    security = await self.role_cache.get_user_security_profile(guid, refresh=True)
+    rotkey = security.get("rotkey") or security.get("element_rotkey")
     derived_secret = f"{self.jwt_secret}:{rotkey}:{guid}:{session_guid}:{device_guid}" if rotkey else None
     try:
       if not derived_secret:
@@ -325,17 +368,20 @@ class AuthModule(BaseModule):
     return self.role_cache.get_role_names(exclude_registered)
 
   async def get_discord_user_security(self, discord_id: str) -> tuple[str, list[str], int]:
-    res = await self.db.run("db:auth:discord:get_security:1", {"discord_id": discord_id})
+    res = await self.db.run("db:accounts:security:get_security_profile:1", {"discord_id": discord_id})
     if not res.rows:
       return "", [], 0
-    row = res.rows[0]
-    guid = row.get("user_guid")
-    mask = int(row.get("user_roles", 0) or 0)
-    names = self.role_cache.mask_to_names(mask)
+    profile = self.role_cache.cache_security_profile(res.rows[0])
+    guid = str(profile.get("user_guid") or profile.get("guid") or "")
+    mask = int(profile.get("role_mask", 0))
+    names = profile.get("roles", self.role_cache.mask_to_names(mask))
     return guid, names, mask
 
   async def get_user_roles(self, guid: str, refresh: bool = False) -> tuple[list[str], int]:
     return await self.role_cache.get_user_roles(guid, refresh)
+
+  async def get_security_profile(self, guid: str, refresh: bool = False) -> dict[str, Any]:
+    return await self.role_cache.get_user_security_profile(guid, refresh)
 
   async def user_has_role(self, guid: str, required_mask: int) -> bool:
     return await self.role_cache.user_has_role(guid, required_mask)

--- a/server/modules/session_module.py
+++ b/server/modules/session_module.py
@@ -92,12 +92,14 @@ class SessionModule(BaseModule):
   ) -> str:
     data = self.auth.decode_rotation_token(rotation_token)
     user_guid = data["guid"]
-    stored = await self.db.run("db:users:session:get_rotkey:1", {"guid": user_guid})
-    row = stored.rows[0] if stored.rows else None
-    if not row or row.get("rotkey") != rotation_token:
+    security = await self.auth.get_security_profile(user_guid, refresh=True)
+    rotkey = security.get("rotkey") or security.get("element_rotkey")
+    if not security or rotkey != rotation_token:
       raise HTTPException(status_code=401, detail="Invalid rotation token")
-    provider = row.get("provider_name") or "microsoft"
-    roles, _ = await self.auth.get_user_roles(user_guid)
+    provider = security.get("provider_name") or "microsoft"
+    roles = security.get("roles") or []
+    if not roles:
+      roles, _ = await self.auth.get_user_roles(user_guid)
     session_exp = datetime.now(timezone.utc) + timedelta(
       minutes=DEFAULT_SESSION_TOKEN_EXPIRY
     )
@@ -146,16 +148,20 @@ class SessionModule(BaseModule):
     user_agent: str | None,
   ) -> dict:
     res = await self.db.run(
-      "db:auth:session:get_by_access_token:1", {"access_token": token}
+      "db:accounts:security:get_security_profile:1", {"access_token": token}
     )
     session = res.rows[0] if res.rows else None
     if not session:
       raise HTTPException(status_code=401, detail="Invalid session token")
 
+    cached = self.auth.role_cache.cache_security_profile(session)
+    if cached:
+      session = cached
+
     if session.get("revoked_at"):
       raise HTTPException(status_code=401, detail="Session revoked")
 
-    expires_at = session.get("expires_at")
+    expires_at = session.get("expires_at") or session.get("element_token_exp")
     if expires_at:
       try:
         exp_dt = datetime.fromisoformat(expires_at)
@@ -176,10 +182,17 @@ class SessionModule(BaseModule):
       "session_guid": session.get("session_guid"),
       "device_guid": session.get("device_guid"),
       "user_guid": session.get("user_guid"),
-      "issued_at": session.get("issued_at"),
-      "expires_at": session.get("expires_at"),
+      "issued_at": session.get("issued_at") or session.get("element_token_iat"),
+      "expires_at": session.get("expires_at") or session.get("element_token_exp"),
+      "revoked_at": session.get("revoked_at") or session.get("element_revoked_at"),
       "device_fingerprint": session.get("device_fingerprint"),
       "user_agent": session.get("user_agent"),
       "ip_last_seen": session.get("ip_last_seen"),
+      "provider_name": session.get("provider_name"),
+      "provider_display": session.get("provider_display"),
+      "session_created_at": session.get("session_created_at") or session.get("session_created_on"),
+      "session_modified_at": session.get("session_modified_on"),
+      "device_created_at": session.get("device_created_on"),
+      "device_modified_at": session.get("device_modified_on"),
     }
     return payload

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -52,8 +52,15 @@ class DummyDb:
       return DBRes([], 1)
     if op == "db:users:session:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:users:profile:get_roles:1":
-      return DBRes([{ "element_roles": 0 }], 1)
+    if op == "db:accounts:security:get_security_profile:1":
+      return DBRes([
+        {
+          "guid": args.get("guid"),
+          "user_guid": args.get("guid"),
+          "user_roles": 0,
+          "provider_name": args.get("provider") if "provider" in args else "google",
+        }
+      ], 1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":

--- a/tests/test_auth_microsoft_oauth_login_creation.py
+++ b/tests/test_auth_microsoft_oauth_login_creation.py
@@ -34,8 +34,15 @@ class DummyDb:
       return DBRes([], 1)
     if op == "db:users:session:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:users:profile:get_roles:1":
-      return DBRes([{ "element_roles": 0 }], 1)
+    if op == "db:accounts:security:get_security_profile:1":
+      return DBRes([
+        {
+          "guid": args.get("guid"),
+          "user_guid": args.get("guid"),
+          "user_roles": 0,
+          "provider_name": args.get("provider") if "provider" in args else "microsoft",
+        }
+      ], 1)
     if op == "db:auth:session:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
     if op == "db:auth:session:update_device_token:1":

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -74,8 +74,16 @@ class DummyDb:
     self.roles = roles
   async def run(self, op, args):
     self.calls.append((op, args))
-    if op == "db:users:profile:get_roles:1":
-      return DBRes([{"element_roles": self.roles}], 1)
+    if op == "db:accounts:security:get_security_profile:1":
+      return DBRes([
+        {
+          "guid": args.get("guid"),
+          "user_guid": args.get("guid"),
+          "user_roles": self.roles,
+          "provider_name": "microsoft",
+          "provider_display": "Microsoft",
+        }
+      ], 1)
     if op == "db:users:profile:set_profile_image:1":
       return DBRes([], 1)
     return DBRes()
@@ -103,7 +111,7 @@ def test_get_roles_service_returns_mask():
   resp = asyncio.run(users_profile_get_roles_v1(req))
   assert isinstance(resp, RPCResponse)
   assert resp.payload["roles"] == 5
-  assert ("db:users:profile:get_roles:1", {"guid": "u1"}) in db.calls
+  assert ("db:accounts:security:get_security_profile:1", {"guid": "u1"}) in db.calls
 
 def test_set_profile_image_calls_db():
   async def fake_img(request):


### PR DESCRIPTION
## Summary
- hydrate the auth role cache and session flows from the new db:accounts:security:get_security_profile:1 request
- expose provider metadata and timing fields when serializing session payloads
- update RPC helpers and tests to cover the revised security profile contract

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc4411ae148325b345fc71c84cf1df