### PR TITLE
Remove MSSQL security alias handlers

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -354,12 +354,6 @@ async def _auth_discord_oauth_relink(args: Dict[str, Any]):
     sel = _users_select({"provider": "discord", "provider_identifier": identifier})
     return await fetch_json(sel)
 
-@register("db:auth:discord:get_security:1")
-def _auth_discord_get_security(args: Dict[str, Any]):
-  raw_id = args["discord_id"]
-  return get_security_profile_v1({"discord_id": raw_id})
-
-
 @register("db:users:profile:set_display:1")
 def _users_set_display(args: Dict[str, Any]):
     guid = args["guid"]
@@ -672,11 +666,6 @@ def _accounts_security_get_security_profile(args: Dict[str, Any]):
   return get_security_profile_v1(args)
 
 
-@register("db:users:profile:get_roles:1")
-def _users_get_roles(args: Dict[str, Any]):
-  guid = args["guid"]
-  return get_security_profile_v1({"guid": guid})
-
 @register("db:users:profile:set_roles:1")
 async def _users_set_roles(args: Dict[str, Any]):
   """Upsert a user's role mask."""
@@ -706,11 +695,6 @@ def _users_session_set_rotkey(args: Dict[str, Any]):
       WHERE element_guid = ?;
     """
     return Operation(DbRunMode.EXEC, sql, (rotkey, iat, exp, guid))
-
-@register("db:users:session:get_rotkey:1")
-def _users_session_get_rotkey(args: Dict[str, Any]):
-  guid = args["guid"]
-  return get_security_profile_v1({"guid": guid})
 
 @register("db:public:links:get_home_links:1")
 def _public_links_get_home_links(args: Dict[str, Any]):
@@ -935,11 +919,6 @@ async def _auth_session_create_session(args: Dict[str, Any]):
         )
 
     return {"rows": [{"session_guid": session_guid, "device_guid": device_guid}], "rowcount": 1}
-
-@register("db:auth:session:get_by_access_token:1")
-def _auth_session_get_by_access_token(args: Dict[str, Any]):
-  token = args["access_token"]
-  return get_security_profile_v1({"access_token": token})
 
 @register("db:auth:session:update_session:1")
 def _auth_session_update_session(args: Dict[str, Any]):

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -70,24 +70,17 @@ def test_mssql_get_profile_uses_profile_view():
   assert "v.credits" in sql
   assert "users_credits" not in sql
 
-def test_mssql_get_rotkey_queries_users_and_providers():
-  handler = get_mssql_handler("db:users:session:get_rotkey:1")
+def test_mssql_accounts_security_profile_by_guid_uses_security_view():
+  handler = get_mssql_handler("db:accounts:security:get_security_profile:1")
   op = handler({"guid": "gid"})
   assert hasattr(op, "sql")
   sql = op.sql.lower()
   assert "vw_user_session_security" in sql
   assert "auth_providers" in sql
 
-def test_mssql_get_roles_uses_security_view():
-  handler = get_mssql_handler("db:users:profile:get_roles:1")
-  op = handler({"guid": "gid"})
-  assert hasattr(op, "sql")
-  sql = op.sql.lower()
-  assert "vw_user_session_security" in sql
-  assert "auth_providers" in sql
 
-def test_mssql_get_by_access_token_uses_security_view():
-  handler = get_mssql_handler("db:auth:session:get_by_access_token:1")
+def test_mssql_accounts_security_profile_by_access_token_uses_security_view():
+  handler = get_mssql_handler("db:accounts:security:get_security_profile:1")
   op = handler({"access_token": "tok"})
   assert hasattr(op, "sql")
   sql = op.sql.lower()
@@ -95,8 +88,9 @@ def test_mssql_get_by_access_token_uses_security_view():
   assert "user_roles" in sql
   assert "auth_providers" in sql
 
-def test_mssql_discord_get_security_uses_security_view():
-  handler = get_mssql_handler("db:auth:discord:get_security:1")
+
+def test_mssql_accounts_security_profile_by_discord_id_joins_users_auth():
+  handler = get_mssql_handler("db:accounts:security:get_security_profile:1")
   op = handler({"discord_id": "42"})
   assert hasattr(op, "sql")
   sql = op.sql.lower()
@@ -105,13 +99,14 @@ def test_mssql_discord_get_security_uses_security_view():
   assert "join users_auth" in sql
 
 
-def test_mssql_accounts_security_profile_uses_security_view():
+def test_mssql_accounts_security_profile_by_provider_identifier_joins_users_auth():
   handler = get_mssql_handler("db:accounts:security:get_security_profile:1")
-  op = handler({"guid": "gid"})
+  op = handler({"provider": "discord", "provider_identifier": str(uuid4())})
   assert hasattr(op, "sql")
   sql = op.sql.lower()
   assert "vw_user_session_security" in sql
   assert "auth_providers" in sql
+  assert "join users_auth" in sql
 
 
 def test_mssql_support_users_set_credits_updates_table():


### PR DESCRIPTION
## Summary
- remove redundant MSSQL registry handlers so security metadata routes through db:accounts:security:get_security_profile:1
- refresh provider query tests to cover the unified security profile lookups across guid, access token, discord, and provider filters

## Testing
- pytest tests/test_provider_queries.py

------
https://chatgpt.com/codex/tasks/task_e_68dc688320088325b5fe42096b881fea