### PR TITLE
Add registry router scaffolding and migrate storage cache handlers

### DIFF
--- a/server/modules/__init__.py
+++ b/server/modules/__init__.py
@@ -31,6 +31,7 @@ class ModuleManager:
     self.app = app
     self.instances: Dict[str, BaseModule] = {}
     self.registry = RegistryDispatcher()
+    self.registry.initialise()
     setattr(app.state, "registry", self.registry)
 
     for fname in os.listdir(MODULES_FOLDER):

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -5,7 +5,9 @@ from ... import DBResult, DbRunMode
 from .logic import transaction
 from .db_helpers import Operation, exec_op, fetch_json, exec_query, json_many, json_one, row_many, row_one
 from server.registry.accounts.security.mssql import get_security_profile_v1
-import logging
+from server.registry.content.cache import mssql as content_cache_mssql
+from server.registry.content.files import mssql as content_files_mssql
+from server.registry.content.public import mssql as content_public_mssql
 
 # handler can be:
 #  - sync: Operation(kind=..., sql=..., params=...) -> provider will run it
@@ -24,42 +26,6 @@ def get_handler(op: str):
         return _REG[op]
     except KeyError:
         raise KeyError(f"No MSSQL handler for '{op}'")
-
-async def _get_storage_type_recid(mimetype: str, *, allow_folder: bool) -> int:
-  async def _fetch_type(target: str):
-    return await fetch_json(json_one(
-      "SELECT recid FROM storage_types WHERE element_mimetype = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
-      (target,),
-    ))
-
-  res = await _fetch_type(mimetype)
-  if res.rows:
-    return res.rows[0]["recid"]
-
-  if not allow_folder:
-    raise ValueError(f"Unknown storage mimetype: {mimetype}")
-
-  if mimetype == "path/folder":
-    await exec_query(exec_op(
-      """
-      MERGE storage_types AS target
-      USING (SELECT 16 AS recid, 'path/folder' AS element_mimetype, 'Folder' AS element_displaytype) AS src
-      ON target.element_mimetype = src.element_mimetype
-      WHEN NOT MATCHED THEN
-        INSERT (recid, element_mimetype, element_displaytype)
-        VALUES (src.recid, src.element_mimetype, src.element_displaytype);
-      """,
-      (),
-    ))
-    res = await _fetch_type(mimetype)
-    if res.rows:
-      return res.rows[0]["recid"]
-    return 16
-
-  fallback = await _fetch_type("application/octet-stream")
-  if fallback.rows:
-    return fallback.rows[0]["recid"]
-  return 1
 
 async def get_auth_provider_recid(provider: str, *, cursor=None) -> int:
   """Return the auth provider recid for ``provider`` or raise a uniform error."""
@@ -380,238 +346,76 @@ def _support_users_set_credits(args: Dict[str, Any]):
 
 # -------------------- STORAGE CACHE --------------------
 
-@register("db:storage:cache:list:1")
-def _storage_cache_list(args: Dict[str, Any]):
-  user_guid = args["user_guid"]
-  sql = """
-    SELECT
-      usc.element_path AS path,
-      usc.element_filename AS filename,
-      st.element_mimetype AS content_type,
-      usc.element_url AS url,
-      usc.element_public AS [public]
-    FROM users_storage_cache usc
-    JOIN storage_types st ON st.recid = usc.types_recid
-    WHERE usc.users_guid = ? AND usc.element_deleted = 0
-    ORDER BY usc.element_path, usc.element_filename
-    FOR JSON PATH;
-  """
-  return Operation(DbRunMode.JSON_MANY, sql, (user_guid,))
+@register("db:content:cache:list:1")
+def _content_cache_list(args: Dict[str, Any]):
+  return content_cache_mssql.list_v1(args)
+register("db:storage:cache:list:1")(_content_cache_list)
 
 
-@register("db:storage:cache:replace_user:1")
-async def _storage_cache_replace_user(args: Dict[str, Any]):
-  user_guid = args["user_guid"]
-  items: list[Dict[str, Any]] = args.get("items", [])
-  async with transaction() as cur:
-    await cur.execute("DELETE FROM users_storage_cache WHERE users_guid = ?;", (user_guid,))
-    for item in items:
-      path = item.get("path", "")
-      filename = item.get("filename", "")
-      mimetype = item.get("content_type", "application/octet-stream")
-      type_recid = await _get_storage_type_recid(mimetype, allow_folder=False)
-      await cur.execute(
-        """INSERT INTO users_storage_cache
-          (users_guid, types_recid, element_path, element_filename, element_public, element_modified_on, element_deleted)
-          VALUES (?, ?, ?, ?, ?, NULL, 0);""",
-        (user_guid, type_recid, path, filename, item.get("public", 0)),
-      )
-  return DBResult(rows=[], rowcount=len(items))
+@register("db:content:cache:replace_user:1")
+async def _content_cache_replace_user(args: Dict[str, Any]):
+  return await content_cache_mssql.replace_user_v1(args)
+register("db:storage:cache:replace_user:1")(_content_cache_replace_user)
 
 
-@register("db:storage:cache:upsert:1")
-async def _storage_cache_upsert(args: Dict[str, Any]):
-  user_guid = args["user_guid"]
-  path = args.get("path", "")
-  filename = args.get("filename", "")
-  mimetype = args.get("content_type", "application/octet-stream")
-  public = args.get("public", 0)
-  from datetime import datetime
-  created_on = args.get("created_on")
-  if created_on is None:
-    created_on = datetime.utcnow()
-  modified_on = args.get("modified_on")
-  url = args.get("url")
-  reported = args.get("reported", 0)
-  moderation_recid = args.get("moderation_recid")
-  type_recid = await _get_storage_type_recid(mimetype, allow_folder=True)
-  sql = """
-    MERGE users_storage_cache AS target
-    USING (SELECT ? AS users_guid, ? AS types_recid, ? AS element_path, ? AS element_filename,
-                  ? AS element_public, ? AS element_created_on, ? AS element_modified_on,
-                  ? AS element_deleted, ? AS element_url, ? AS element_reported, ? AS moderation_recid) AS src
-    ON target.users_guid = src.users_guid AND target.element_path = src.element_path AND target.element_filename = src.element_filename
-    WHEN MATCHED THEN UPDATE SET
-      types_recid = src.types_recid,
-      element_public = src.element_public,
-      element_created_on = src.element_created_on,
-      element_modified_on = src.element_modified_on,
-      element_deleted = src.element_deleted,
-      element_url = src.element_url,
-      element_reported = src.element_reported,
-      moderation_recid = src.moderation_recid
-    WHEN NOT MATCHED THEN
-      INSERT (users_guid, types_recid, element_path, element_filename, element_public,
-              element_created_on, element_modified_on, element_deleted, element_url,
-              element_reported, moderation_recid)
-      VALUES (src.users_guid, src.types_recid, src.element_path, src.element_filename,
-              src.element_public, src.element_created_on, src.element_modified_on,
-              src.element_deleted, src.element_url, src.element_reported, src.moderation_recid);
-  """
-  params = (
-    user_guid,
-    type_recid,
-    path,
-    filename,
-    public,
-    created_on,
-    modified_on,
-    0,
-    url,
-    reported,
-    moderation_recid,
-  )
-  rc = await exec_query(exec_op(sql, params))
-  if rc.rowcount == 0:
-    logging.error(
-      "[MSSQL] storage_cache_upsert affected 0 rows for %s/%s",
-      path or ".",
-      filename,
-    )
-  return rc
+@register("db:content:cache:upsert:1")
+async def _content_cache_upsert(args: Dict[str, Any]):
+  return await content_cache_mssql.upsert_v1(args)
+register("db:storage:cache:upsert:1")(_content_cache_upsert)
 
 
-@register("db:storage:cache:delete:1")
-def _storage_cache_delete(args: Dict[str, Any]):
-  user_guid = args["user_guid"]
-  path = args.get("path", "")
-  filename = args.get("filename", "")
-  sql = """
-    DELETE FROM users_storage_cache
-    WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
-  """
-  return Operation(DbRunMode.EXEC, sql, (user_guid, path, filename))
+@register("db:content:cache:delete:1")
+def _content_cache_delete(args: Dict[str, Any]):
+  return content_cache_mssql.delete_v1(args)
+register("db:storage:cache:delete:1")(_content_cache_delete)
 
 
-@register("db:storage:cache:delete_folder:1")
-def _storage_cache_delete_folder(args: Dict[str, Any]):
-  user_guid = args["user_guid"]
-  path = args.get("path", "").lstrip("/")
-  parent, name = path.rsplit("/", 1) if "/" in path else ("", path)
-  like = f"{path}/%" if path else "%"
-  sql = """
-    DELETE FROM users_storage_cache
-    WHERE users_guid = ? AND (
-      (element_path = ? AND element_filename = ?)
-      OR element_path = ?
-      OR element_path LIKE ?
-    );
-  """
-  return Operation(DbRunMode.EXEC, sql, (user_guid, parent, name, path, like))
+@register("db:content:cache:delete_folder:1")
+def _content_cache_delete_folder(args: Dict[str, Any]):
+  return content_cache_mssql.delete_folder_v1(args)
+register("db:storage:cache:delete_folder:1")(_content_cache_delete_folder)
 
 
-_STORAGE_PUBLIC_TOGGLE_SQL = """
-  UPDATE users_storage_cache
-  SET element_public = ?
-  WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
-"""
+@register("db:content:cache:set_public:1")
+def _content_cache_set_public(args: Dict[str, Any]):
+  return content_cache_mssql.set_public_v1(args)
+register("db:storage:cache:set_public:1")(_content_cache_set_public)
 
 
-_STORAGE_PUBLIC_LIST_SQL = """
-  SELECT usc.users_guid AS user_guid,
-         au.element_display AS display_name,
-         usc.element_path AS path,
-         usc.element_filename AS name,
-         usc.element_url AS url,
-         st.element_mimetype AS content_type
-  FROM users_storage_cache usc
-  JOIN account_users au ON au.element_guid = usc.users_guid
-  JOIN storage_types st ON st.recid = usc.types_recid
-  WHERE usc.element_public = 1 AND usc.element_deleted = 0 AND ISNULL(usc.element_reported,0) = 0
-  ORDER BY usc.element_created_on
-  FOR JSON PATH;
-"""
+@register("db:content:cache:set_reported:1")
+def _content_cache_set_reported(args: Dict[str, Any]):
+  return content_cache_mssql.set_reported_v1(args)
+register("db:storage:cache:set_reported:1")(_content_cache_set_reported)
 
 
-def _storage_public_operation(action: str, *, args: Dict[str, Any] | None = None, flag_key: str = "public") -> Operation:
-  if action == "toggle":
-    if args is None:
-      raise ValueError("toggle action requires args")
-    guid = str(UUID(args["user_guid"]))
-    name = args.get("name")
-    if name:
-      path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
-    else:
-      path = args.get("path", "")
-      filename = args.get("filename", "")
-    flag_value = 1 if args.get(flag_key) else 0
-    return Operation(DbRunMode.EXEC, _STORAGE_PUBLIC_TOGGLE_SQL, (flag_value, guid, path, filename))
-  if action == "list":
-    return Operation(DbRunMode.JSON_MANY, _STORAGE_PUBLIC_LIST_SQL, ())
-  raise ValueError(f"Unknown storage public action: {action}")
+@register("db:content:cache:count_rows:1")
+def _content_cache_count_rows(args: Dict[str, Any]):
+  return content_cache_mssql.count_rows_v1(args)
+register("db:storage:cache:count_rows:1")(_content_cache_count_rows)
 
 
-@register("db:storage:cache:set_public:1")
-def _storage_cache_set_public(args: Dict[str, Any]):
-  return _storage_public_operation("toggle", args=args, flag_key="public")
+@register("db:content:public:list_public:1")
+def _content_public_list_public(args: Dict[str, Any]):
+  return content_public_mssql.list_public_v1(args)
+register("db:storage:cache:list_public:1")(_content_public_list_public)
 
 
-@register("db:storage:files:set_gallery:1")
-def _storage_files_set_gallery(args: Dict[str, Any]):
-  return _storage_public_operation("toggle", args=args, flag_key="gallery")
+@register("db:content:public:get_public_files:1")
+def _content_public_get_public_files(args: Dict[str, Any]):
+  return content_public_mssql.get_public_files_v1(args)
+register("db:public:gallery:get_public_files:1")(_content_public_get_public_files)
 
 
-@register("db:storage:cache:set_reported:1")
-def _storage_cache_set_reported(args: Dict[str, Any]):
-  guid = str(UUID(args["user_guid"]))
-  path = args.get("path", "")
-  filename = args.get("filename", "")
-  reported = 1 if args.get("reported") else 0
-  sql = """
-    UPDATE users_storage_cache
-    SET element_reported = ?
-    WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
-  """
-  return Operation(DbRunMode.EXEC, sql, (reported, guid, path, filename))
+@register("db:content:public:list_reported:1")
+def _content_public_list_reported(args: Dict[str, Any]):
+  return content_public_mssql.list_reported_v1(args)
+register("db:storage:cache:list_reported:1")(_content_public_list_reported)
 
 
-@register("db:storage:cache:list_public:1")
-def _storage_cache_list_public(_: Dict[str, Any]):
-  return _storage_public_operation("list")
-
-
-@register("db:public:gallery:get_public_files:1")
-def _public_gallery_get_public_files(_: Dict[str, Any]):
-  return _storage_public_operation("list")
-
-
-@register("db:storage:cache:list_reported:1")
-def _storage_cache_list_reported(_: Dict[str, Any]):
-  sql = """
-    SELECT usc.users_guid AS user_guid,
-           usc.element_path AS path,
-           usc.element_filename AS name,
-           usc.element_url AS url,
-           st.element_mimetype AS content_type
-    FROM users_storage_cache usc
-    JOIN storage_types st ON st.recid = usc.types_recid
-    WHERE usc.element_reported = 1 AND usc.element_deleted = 0
-    ORDER BY usc.element_created_on
-    FOR JSON PATH;
-  """
-  return Operation(DbRunMode.JSON_MANY, sql, ())
-
-
-@register("db:storage:cache:count_rows:1")
-def _storage_cache_count_rows(_: Dict[str, Any]):
-  sql = """
-    SELECT COUNT(*) AS count
-    FROM users_storage_cache
-    WHERE element_deleted = 0
-    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
-  """
-  return Operation(DbRunMode.JSON_ONE, sql, ())
-
+@register("db:content:files:set_gallery:1")
+def _content_files_set_gallery(args: Dict[str, Any]):
+  return content_files_mssql.set_gallery_v1(args)
+register("db:storage:files:set_gallery:1")(_content_files_set_gallery)
 
 @register("db:users:profile:set_optin:1")
 def _users_set_optin(args: Dict[str, Any]):

--- a/server/registry/__init__.py
+++ b/server/registry/__init__.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Awaitable, Callable
+from dataclasses import dataclass
+import importlib
+import pkgutil
+from typing import Awaitable, Callable, Iterable
 
 from server.modules.providers import DBResult, DbProviderBase
 
@@ -12,7 +15,10 @@ __all__ = [
   "DBRequest",
   "DBResponse",
   "DBResult",
+  "DomainRouter",
   "RegistryDispatcher",
+  "RegistryRouter",
+  "SubdomainRouter",
 ]
 
 
@@ -24,17 +30,139 @@ def _current_dbresult_cls():
   return ProvidersDBResult
 
 
+@dataclass(slots=True)
+class FunctionRoute:
+  domain: str
+  subdomain: str
+  name: str
+  version: int
+  provider_map: str
+
+  @property
+  def key(self) -> str:
+    return f"db:{self.domain}:{self.subdomain}:{self.name}:{self.version}"
+
+
+class RegistryRouter:
+  """Hierarchical router that registers domain and subdomain functions."""
+
+  def __init__(self):
+    self._domains: dict[str, DomainRouter] = {}
+    self._routes: dict[str, FunctionRoute] = {}
+    self._aliases: dict[str, str] = {}
+    self._initialised = False
+
+  def domain(self, name: str) -> "DomainRouter":
+    if name not in self._domains:
+      self._domains[name] = DomainRouter(self, name)
+    return self._domains[name]
+
+  def add_route(self, route: FunctionRoute) -> None:
+    key = route.key
+    if key in self._routes:
+      raise ValueError(f"Duplicate registry route registered: {key}")
+    self._routes[key] = route
+
+  def add_alias(self, alias: str, target: str) -> None:
+    if alias in self._routes or alias in self._aliases:
+      raise ValueError(f"Duplicate registry alias registered: {alias}")
+    self._aliases[alias] = target
+
+  def resolve(self, op: str) -> FunctionRoute | None:
+    if op in self._routes:
+      return self._routes[op]
+    target = self._aliases.get(op)
+    if target:
+      return self._routes.get(target)
+    return None
+
+  def register_domains(self) -> None:
+    if self._initialised:
+      return
+    package = importlib.import_module("server.registry")
+    for _, name, ispkg in pkgutil.iter_modules(package.__path__):
+      if not ispkg or name.startswith("_"):
+        continue
+      module = importlib.import_module(f"{package.__name__}.{name}")
+      register = getattr(module, "register", None)
+      if callable(register):
+        register(self)
+    self._initialised = True
+
+
+class DomainRouter:
+  """Routes functions for a specific domain."""
+
+  def __init__(self, registry: RegistryRouter, name: str):
+    self._registry = registry
+    self._name = name
+    self._subdomains: dict[str, SubdomainRouter] = {}
+
+  @property
+  def name(self) -> str:
+    return self._name
+
+  def subdomain(self, name: str) -> "SubdomainRouter":
+    if name not in self._subdomains:
+      self._subdomains[name] = SubdomainRouter(self._registry, self, name)
+    return self._subdomains[name]
+
+
+class SubdomainRouter:
+  """Registers concrete registry functions for a subdomain."""
+
+  def __init__(self, registry: RegistryRouter, domain: DomainRouter, name: str):
+    self._registry = registry
+    self._domain = domain
+    self._name = name
+
+  @property
+  def domain(self) -> DomainRouter:
+    return self._domain
+
+  @property
+  def name(self) -> str:
+    return self._name
+
+  def add_function(
+    self,
+    name: str,
+    *,
+    version: int,
+    provider_map: str,
+    aliases: Iterable[str] | None = None,
+  ) -> None:
+    route = FunctionRoute(
+      domain=self._domain.name,
+      subdomain=self._name,
+      name=name,
+      version=version,
+      provider_map=provider_map,
+    )
+    self._registry.add_route(route)
+    for alias in aliases or []:
+      self._registry.add_alias(alias, route.key)
+
+
 class RegistryDispatcher:
   """Simple dispatcher that routes :class:`DBRequest` objects."""
 
-  def __init__(self):
+  def __init__(self, *, router: RegistryRouter | None = None):
+    self.router = router or RegistryRouter()
     self._executor: Executor | None = None
+
+  def initialise(self) -> None:
+    self.router.register_domains()
 
   def set_executor(self, executor: Executor) -> None:
     self._executor = executor
 
   def bind_provider(self, provider: DbProviderBase) -> None:
+    self.initialise()
     async def _execute(request: DBRequest) -> DBResponse:
+      route = self.router.resolve(request.op)
+      if route and route.key != request.op:
+        request = request.model_copy(update={"op": route.key})
       result = await provider.run(request.op, request.params)
       DBResultCls = _current_dbresult_cls()
       if isinstance(result, DBResponse):
@@ -50,4 +178,8 @@ class RegistryDispatcher:
   async def execute(self, request: DBRequest) -> DBResponse:
     if not self._executor:
       raise RuntimeError("Registry dispatcher is not configured")
+    self.initialise()
+    route = self.router.resolve(request.op)
+    if route and route.key != request.op:
+      request = request.model_copy(update={"op": route.key})
     return await self._executor(request)

--- a/server/registry/content/__init__.py
+++ b/server/registry/content/__init__.py
@@ -1,0 +1,24 @@
+"""Content domain registry bindings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from . import cache, files, public
+
+if TYPE_CHECKING:
+  from server.registry import RegistryRouter
+
+__all__ = [
+  "cache",
+  "files",
+  "public",
+  "register",
+]
+
+
+def register(router: "RegistryRouter") -> None:
+  domain = router.domain("content")
+  cache.register(domain.subdomain("cache"))
+  files.register(domain.subdomain("files"))
+  public.register(domain.subdomain("public"))

--- a/server/registry/content/cache/__init__.py
+++ b/server/registry/content/cache/__init__.py
@@ -1,0 +1,70 @@
+"""Content cache registry bindings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "register",
+]
+
+
+_DEF_PROVIDER = "content.cache"
+
+
+def _alias(key: str) -> str:
+  return f"db:storage:cache:{key}:1"
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function(
+    "list",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.list",
+    aliases=[_alias("list")],
+  )
+  router.add_function(
+    "replace_user",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.replace_user",
+    aliases=[_alias("replace_user")],
+  )
+  router.add_function(
+    "upsert",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.upsert",
+    aliases=[_alias("upsert")],
+  )
+  router.add_function(
+    "delete",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.delete",
+    aliases=[_alias("delete")],
+  )
+  router.add_function(
+    "delete_folder",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.delete_folder",
+    aliases=[_alias("delete_folder")],
+  )
+  router.add_function(
+    "set_public",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.set_public",
+    aliases=[_alias("set_public")],
+  )
+  router.add_function(
+    "set_reported",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.set_reported",
+    aliases=[_alias("set_reported")],
+  )
+  router.add_function(
+    "count_rows",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.count_rows",
+    aliases=[_alias("count_rows")],
+  )

--- a/server/registry/content/cache/mssql.py
+++ b/server/registry/content/cache/mssql.py
@@ -1,0 +1,230 @@
+"""MSSQL implementations for content cache registry functions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+from typing import Any, Dict
+from uuid import UUID
+
+from server.modules.providers import DBResult, DbRunMode
+from server.modules.providers.database.mssql_provider.db_helpers import (
+  Operation,
+  exec_op,
+  exec_query,
+  fetch_json,
+  json_one,
+)
+from server.modules.providers.database.mssql_provider.logic import transaction
+
+__all__ = [
+  "count_rows_v1",
+  "delete_folder_v1",
+  "delete_v1",
+  "list_v1",
+  "replace_user_v1",
+  "set_public_v1",
+  "set_reported_v1",
+  "upsert_v1",
+]
+
+
+async def _get_storage_type_recid(mimetype: str, *, allow_folder: bool) -> int:
+  async def _fetch_type(target: str):
+    return await fetch_json(json_one(
+      "SELECT recid FROM storage_types WHERE element_mimetype = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
+      (target,),
+    ))
+
+  res = await _fetch_type(mimetype)
+  if res.rows:
+    return res.rows[0]["recid"]
+
+  if not allow_folder:
+    raise ValueError(f"Unknown storage mimetype: {mimetype}")
+
+  if mimetype == "path/folder":
+    await exec_query(exec_op(
+      """
+      MERGE storage_types AS target
+      USING (SELECT 16 AS recid, 'path/folder' AS element_mimetype, 'Folder' AS element_displaytype) AS src
+      ON target.element_mimetype = src.element_mimetype
+      WHEN NOT MATCHED THEN
+        INSERT (recid, element_mimetype, element_displaytype)
+        VALUES (src.recid, src.element_mimetype, src.element_displaytype);
+      """,
+      (),
+    ))
+    res = await _fetch_type(mimetype)
+    if res.rows:
+      return res.rows[0]["recid"]
+    return 16
+
+  fallback = await _fetch_type("application/octet-stream")
+  if fallback.rows:
+    return fallback.rows[0]["recid"]
+  return 1
+
+
+def list_v1(args: Dict[str, Any]) -> Operation:
+  user_guid = args["user_guid"]
+  sql = """
+    SELECT
+      usc.element_path AS path,
+      usc.element_filename AS filename,
+      st.element_mimetype AS content_type,
+      usc.element_url AS url,
+      usc.element_public AS [public]
+    FROM users_storage_cache usc
+    JOIN storage_types st ON st.recid = usc.types_recid
+    WHERE usc.users_guid = ? AND usc.element_deleted = 0
+    ORDER BY usc.element_path, usc.element_filename
+    FOR JSON PATH;
+  """
+  return Operation(DbRunMode.JSON_MANY, sql, (user_guid,))
+
+
+async def replace_user_v1(args: Dict[str, Any]) -> DBResult:
+  user_guid = args["user_guid"]
+  items: list[Dict[str, Any]] = args.get("items", [])
+  async with transaction() as cur:
+    await cur.execute("DELETE FROM users_storage_cache WHERE users_guid = ?;", (user_guid,))
+    for item in items:
+      path = item.get("path", "")
+      filename = item.get("filename", "")
+      mimetype = item.get("content_type", "application/octet-stream")
+      type_recid = await _get_storage_type_recid(mimetype, allow_folder=False)
+      await cur.execute(
+        """INSERT INTO users_storage_cache
+          (users_guid, types_recid, element_path, element_filename, element_public, element_modified_on, element_deleted)
+          VALUES (?, ?, ?, ?, ?, NULL, 0);""",
+        (user_guid, type_recid, path, filename, item.get("public", 0)),
+      )
+  return DBResult(rows=[], rowcount=len(items))
+
+
+async def upsert_v1(args: Dict[str, Any]):
+  user_guid = args["user_guid"]
+  path = args.get("path", "")
+  filename = args.get("filename", "")
+  mimetype = args.get("content_type", "application/octet-stream")
+  public = args.get("public", 0)
+  created_on = args.get("created_on")
+  if created_on is None:
+    created_on = datetime.utcnow()
+  modified_on = args.get("modified_on")
+  url = args.get("url")
+  reported = args.get("reported", 0)
+  moderation_recid = args.get("moderation_recid")
+  type_recid = await _get_storage_type_recid(mimetype, allow_folder=True)
+  sql = """
+    MERGE users_storage_cache AS target
+    USING (SELECT ? AS users_guid, ? AS types_recid, ? AS element_path, ? AS element_filename,
+                  ? AS element_public, ? AS element_created_on, ? AS element_modified_on,
+                  ? AS element_deleted, ? AS element_url, ? AS element_reported, ? AS moderation_recid) AS src
+    ON target.users_guid = src.users_guid AND target.element_path = src.element_path AND target.element_filename = src.element_filename
+    WHEN MATCHED THEN UPDATE SET
+      types_recid = src.types_recid,
+      element_public = src.element_public,
+      element_created_on = src.element_created_on,
+      element_modified_on = src.element_modified_on,
+      element_deleted = src.element_deleted,
+      element_url = src.element_url,
+      element_reported = src.element_reported,
+      moderation_recid = src.moderation_recid
+    WHEN NOT MATCHED THEN
+      INSERT (users_guid, types_recid, element_path, element_filename, element_public,
+              element_created_on, element_modified_on, element_deleted, element_url,
+              element_reported, moderation_recid)
+      VALUES (src.users_guid, src.types_recid, src.element_path, src.element_filename,
+              src.element_public, src.element_created_on, src.element_modified_on,
+              src.element_deleted, src.element_url, src.element_reported, src.moderation_recid);
+  """
+  params = (
+    user_guid,
+    type_recid,
+    path,
+    filename,
+    public,
+    created_on,
+    modified_on,
+    0,
+    url,
+    reported,
+    moderation_recid,
+  )
+  rc = await exec_query(exec_op(sql, params))
+  if rc.rowcount == 0:
+    logging.error(
+      "[MSSQL] storage_cache_upsert affected 0 rows for %s/%s",
+      path or ".",
+      filename,
+    )
+  return rc
+
+
+def delete_v1(args: Dict[str, Any]) -> Operation:
+  user_guid = args["user_guid"]
+  path = args.get("path", "")
+  filename = args.get("filename", "")
+  sql = """
+    DELETE FROM users_storage_cache
+    WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
+  """
+  return Operation(DbRunMode.EXEC, sql, (user_guid, path, filename))
+
+
+def delete_folder_v1(args: Dict[str, Any]) -> Operation:
+  user_guid = args["user_guid"]
+  path = args.get("path", "").lstrip("/")
+  parent, name = path.rsplit("/", 1) if "/" in path else ("", path)
+  like = f"{path}/%" if path else "%"
+  sql = """
+    DELETE FROM users_storage_cache
+    WHERE users_guid = ? AND (
+      (element_path = ? AND element_filename = ?)
+      OR element_path = ?
+      OR element_path LIKE ?
+    );
+  """
+  return Operation(DbRunMode.EXEC, sql, (user_guid, parent, name, path, like))
+
+
+def set_public_v1(args: Dict[str, Any]) -> Operation:
+  guid = str(UUID(args["user_guid"]))
+  name = args.get("name")
+  if name:
+    path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
+  else:
+    path = args.get("path", "")
+    filename = args.get("filename", "")
+  flag_value = 1 if args.get("public") else 0
+  sql = """
+    UPDATE users_storage_cache
+    SET element_public = ?
+    WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
+  """
+  return Operation(DbRunMode.EXEC, sql, (flag_value, guid, path, filename))
+
+
+def set_reported_v1(args: Dict[str, Any]) -> Operation:
+  guid = str(UUID(args["user_guid"]))
+  path = args.get("path", "")
+  filename = args.get("filename", "")
+  reported = 1 if args.get("reported") else 0
+  sql = """
+    UPDATE users_storage_cache
+    SET element_reported = ?
+    WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
+  """
+  return Operation(DbRunMode.EXEC, sql, (reported, guid, path, filename))
+
+
+def count_rows_v1(_: Dict[str, Any]) -> Operation:
+  sql = """
+    SELECT COUNT(*) AS count
+    FROM users_storage_cache
+    WHERE element_deleted = 0
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return Operation(DbRunMode.JSON_ONE, sql, ())

--- a/server/registry/content/files/__init__.py
+++ b/server/registry/content/files/__init__.py
@@ -1,0 +1,21 @@
+"""Content files registry bindings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "register",
+]
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function(
+    "set_gallery",
+    version=1,
+    provider_map="content.files.set_gallery",
+    aliases=["db:storage:files:set_gallery:1"],
+  )

--- a/server/registry/content/files/mssql.py
+++ b/server/registry/content/files/mssql.py
@@ -1,0 +1,30 @@
+"""MSSQL implementations for content files registry functions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from uuid import UUID
+
+from server.modules.providers import DbRunMode
+from server.modules.providers.database.mssql_provider.db_helpers import Operation
+
+__all__ = [
+  "set_gallery_v1",
+]
+
+
+def set_gallery_v1(args: Dict[str, Any]) -> Operation:
+  guid = str(UUID(args["user_guid"]))
+  name = args.get("name")
+  if name:
+    path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
+  else:
+    path = args.get("path", "")
+    filename = args.get("filename", "")
+  gallery = 1 if args.get("gallery") else 0
+  sql = """
+    UPDATE users_storage_cache
+    SET element_public = ?
+    WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
+  """
+  return Operation(DbRunMode.EXEC, sql, (gallery, guid, path, filename))

--- a/server/registry/content/public/__init__.py
+++ b/server/registry/content/public/__init__.py
@@ -1,0 +1,33 @@
+"""Content public registry bindings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "register",
+]
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function(
+    "list_public",
+    version=1,
+    provider_map="content.public.list_public",
+    aliases=["db:storage:cache:list_public:1"],
+  )
+  router.add_function(
+    "list_reported",
+    version=1,
+    provider_map="content.public.list_reported",
+    aliases=["db:storage:cache:list_reported:1"],
+  )
+  router.add_function(
+    "get_public_files",
+    version=1,
+    provider_map="content.public.get_public_files",
+    aliases=["db:public:gallery:get_public_files:1"],
+  )

--- a/server/registry/content/public/mssql.py
+++ b/server/registry/content/public/mssql.py
@@ -1,0 +1,52 @@
+"""MSSQL implementations for content public registry functions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from server.modules.providers import DbRunMode
+from server.modules.providers.database.mssql_provider.db_helpers import Operation
+
+__all__ = [
+  "get_public_files_v1",
+  "list_public_v1",
+  "list_reported_v1",
+]
+
+
+def list_public_v1(_: Dict[str, Any]) -> Operation:
+  sql = """
+    SELECT usc.users_guid AS user_guid,
+           au.element_display AS display_name,
+           usc.element_path AS path,
+           usc.element_filename AS name,
+           usc.element_url AS url,
+           st.element_mimetype AS content_type
+    FROM users_storage_cache usc
+    JOIN account_users au ON au.element_guid = usc.users_guid
+    JOIN storage_types st ON st.recid = usc.types_recid
+    WHERE usc.element_public = 1 AND usc.element_deleted = 0 AND ISNULL(usc.element_reported,0) = 0
+    ORDER BY usc.element_created_on
+    FOR JSON PATH;
+  """
+  return Operation(DbRunMode.JSON_MANY, sql, ())
+
+
+def get_public_files_v1(params: Dict[str, Any]) -> Operation:
+  return list_public_v1(params)
+
+
+def list_reported_v1(_: Dict[str, Any]) -> Operation:
+  sql = """
+    SELECT usc.users_guid AS user_guid,
+           usc.element_path AS path,
+           usc.element_filename AS name,
+           usc.element_url AS url,
+           st.element_mimetype AS content_type
+    FROM users_storage_cache usc
+    JOIN storage_types st ON st.recid = usc.types_recid
+    WHERE usc.element_reported = 1 AND usc.element_deleted = 0
+    ORDER BY usc.element_created_on
+    FOR JSON PATH;
+  """
+  return Operation(DbRunMode.JSON_MANY, sql, ())


### PR DESCRIPTION
## Summary
- add router scaffolding in the registry to register domain and subdomain functions and initialise it from the module manager
- scaffold the content domain packages with canonical storage cache, files, and public routes plus legacy aliases
- move the MSSQL storage cache handlers into the new registry packages and update the provider registry to forward to them

## Testing
- pytest tests/test_db_module_init.py

------
https://chatgpt.com/codex/tasks/task_e_68dd525ff46083259eb0e9124ee831c5