### PR TITLE
Migrate storage helpers to content registry URNs

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -20,6 +20,19 @@ def _current_dbresult_cls():
   return ProvidersDBResult
 
 
+def _normalize_cache_item_payload(item: Dict[str, Any]) -> Dict[str, Any]:
+  normalized = dict(item)
+  name = normalized.get("filename") or normalized.get("name")
+  if name is not None:
+    normalized["filename"] = name
+  if "path" not in normalized or normalized["path"] is None:
+    normalized["path"] = ""
+  for flag in ("public", "reported"):
+    if flag in normalized and normalized[flag] is not None:
+      normalized[flag] = 1 if normalized[flag] else 0
+  return normalized
+
+
 class DbModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
@@ -57,11 +70,16 @@ class DbModule(BaseModule):
   def set_registry(self, registry: RegistryDispatcher) -> None:
     self._registry = registry
 
-  async def run(self, op: str, args: Dict[str, Any]) -> DBResult:
+  async def run(self, op: str | DBRequest, args: Dict[str, Any] | None = None) -> DBResult:
     assert self._provider, "db_module not initialized"
     if not self._registry:
       raise RuntimeError("registry dispatcher not configured")
-    request = DBRequest(op=op, params=args)
+    if isinstance(op, DBRequest):
+      if args is not None:
+        raise ValueError("Arguments are not supported when passing a DBRequest")
+      request = op
+    else:
+      request = DBRequest(op=op, params=args or {})
     response = await self._registry.execute(request)
     DBResultCls = _current_dbresult_cls()
     if isinstance(response, DBResponse):
@@ -143,13 +161,24 @@ class DbModule(BaseModule):
     return int(value)
 
   async def list_storage_cache(self, user_guid: str) -> list[Dict[str, Any]]:
-    res = await self.run("db:storage:cache:list:1", {"user_guid": user_guid})
+    request = DBRequest(
+      op="db:content:cache:list:1",
+      params={"user_guid": user_guid},
+    )
+    res = await self.run(request)
     return res.rows
 
   async def replace_storage_cache(self, user_guid: str, items: list[Dict[str, Any]]):
+    normalized_items = [_normalize_cache_item_payload(item) for item in items]
+    payload = {
+      "user_guid": user_guid,
+      "items": normalized_items,
+    }
     await self.run(
-      "db:storage:cache:replace_user:1",
-      {"user_guid": user_guid, "items": items},
+      DBRequest(
+        op="db:content:cache:replace_user:1",
+        params=payload,
+      )
     )
 
   async def user_exists(self, user_guid: str) -> bool:
@@ -157,17 +186,19 @@ class DbModule(BaseModule):
     return bool(res.rows)
 
   async def upsert_storage_cache(self, item: Dict[str, Any]) -> DBResult:
-    return await self.run("db:storage:cache:upsert:1", item)
+    normalized_item = _normalize_cache_item_payload(item)
+    request = DBRequest(op="db:content:cache:upsert:1", params=normalized_item)
+    return await self.run(request)
 
   async def delete_storage_cache(self, user_guid: str, path: str, filename: str):
-    await self.run(
-      "db:storage:cache:delete:1",
-      {"user_guid": user_guid, "path": path, "filename": filename},
-    )
+    await self.run(DBRequest(
+      op="db:content:cache:delete:1",
+      params={"user_guid": user_guid, "path": path, "filename": filename},
+    ))
 
   async def delete_storage_cache_folder(self, user_guid: str, path: str):
-    await self.run(
-      "db:storage:cache:delete_folder:1",
-      {"user_guid": user_guid, "path": path},
-    )
+    await self.run(DBRequest(
+      op="db:content:cache:delete_folder:1",
+      params={"user_guid": user_guid, "path": path},
+    ))
 

--- a/server/modules/public_gallery_module.py
+++ b/server/modules/public_gallery_module.py
@@ -22,5 +22,5 @@ class PublicGalleryModule(BaseModule):
 
   async def list_public_files(self):
     assert self.db
-    res = await self.db.run("db:public:gallery:get_public_files:1", {})
+    res = await self.db.run("db:content:public:get_public_files:1", {})
     return res.rows

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -356,13 +356,13 @@ class StorageModule(BaseModule):
   async def list_public_files(self):
     """Return files marked as publicly accessible."""
     assert self.db
-    res = await self.db.run("db:storage:cache:list_public:1", {})
+    res = await self.db.run("db:content:public:list_public:1", {})
     return res.rows
 
   async def list_flagged_for_moderation(self):
     """Return files that have been reported for moderation review."""
     assert self.db
-    res = await self.db.run("db:storage:cache:list_reported:1", {})
+    res = await self.db.run("db:content:public:list_reported:1", {})
     return res.rows
 
   async def upload_files(self, user_guid: str, files):
@@ -462,16 +462,16 @@ class StorageModule(BaseModule):
   async def set_gallery(self, user_guid: str, name: str, gallery: bool):
     assert self.db
     await self.db.run(
-      "db:storage:files:set_gallery:1",
-      {"user_guid": user_guid, "name": name, "gallery": 1 if gallery else 0},
+      "db:content:files:set_gallery:1",
+      {"user_guid": user_guid, "name": name, "gallery": bool(gallery)},
     )
 
   async def report_file(self, user_guid: str, name: str):
     assert self.db
     path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
     await self.db.run(
-      "db:storage:cache:set_reported:1",
-      {"user_guid": user_guid, "path": path, "filename": filename, "reported": 1},
+      "db:content:cache:set_reported:1",
+      {"user_guid": user_guid, "path": path, "filename": filename, "reported": True},
     )
 
   async def create_folder(self, user_guid: str, path: str):
@@ -882,7 +882,7 @@ class StorageModule(BaseModule):
 
   async def get_storage_stats(self):
     assert self.db
-    db_res = await self.db.run("db:storage:cache:count_rows:1", {})
+    db_res = await self.db.run("db:content:cache:count_rows:1", {})
     db_rows = db_res.rows[0]["count"] if db_res.rows else 0
     if not self.connection_string:
       return {

--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -142,7 +142,7 @@ def test_storage_files_set_gallery(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
-  res = asyncio.run(provider.run("db:storage:files:set_gallery:1", {"user_guid": guid, "name": "file.txt", "gallery": True}))
+  res = asyncio.run(provider.run("db:content:files:set_gallery:1", {"user_guid": guid, "name": "file.txt", "gallery": True}))
   assert isinstance(res, DBResult)
   assert res.rowcount == 1
 
@@ -161,7 +161,7 @@ def test_storage_cache_set_public(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
-  res = asyncio.run(provider.run("db:storage:cache:set_public:1", {
+  res = asyncio.run(provider.run("db:content:cache:set_public:1", {
     "user_guid": guid,
     "path": "docs",
     "filename": "file.txt",
@@ -184,8 +184,8 @@ def test_storage_public_lists_share_query(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
-  asyncio.run(provider.run("db:storage:cache:list_public:1", {}))
-  asyncio.run(provider.run("db:public:gallery:get_public_files:1", {}))
+  asyncio.run(provider.run("db:content:public:list_public:1", {}))
+  asyncio.run(provider.run("db:content:public:get_public_files:1", {}))
 
   assert len(seen) == 2
   assert seen[0].sql == seen[1].sql

--- a/tests/test_storage_cache_upsert.py
+++ b/tests/test_storage_cache_upsert.py
@@ -31,6 +31,7 @@ logic_mod.close_pool = lambda *args, **kwargs: None
 async def _dummy_tx():
   yield
 logic_mod.transaction = lambda: _dummy_tx()
+logic_mod._pool = object()
 sys.modules['server.modules.providers.database.mssql_provider.logic'] = logic_mod
 
 
@@ -80,18 +81,12 @@ async def execute_operation(operation: Operation):
   return await dummy_fetch_json(operation)
 
 
-helpers_mod = types.ModuleType('server.modules.providers.database.mssql_provider.db_helpers')
-helpers_mod.Operation = Operation
-helpers_mod.json_one = json_one
-helpers_mod.json_many = json_many
-helpers_mod.row_one = row_one
-helpers_mod.row_many = row_many
-helpers_mod.exec_op = exec_op
+helpers_mod = sys.modules['server.modules.providers.database.mssql_provider.db_helpers']
 helpers_mod.fetch_rows = dummy_fetch_rows
 helpers_mod.fetch_json = dummy_fetch_json
 helpers_mod.exec_query = dummy_exec_query
 helpers_mod.execute_operation = execute_operation
-sys.modules['server.modules.providers.database.mssql_provider.db_helpers'] = helpers_mod
+helpers_mod.logic._pool = True
 
 spec = importlib.util.spec_from_file_location(
   'server.modules.providers.database.mssql_provider.registry',
@@ -101,14 +96,18 @@ registry_mod = importlib.util.module_from_spec(spec)
 sys.modules['server.modules.providers.database.mssql_provider.registry'] = registry_mod
 spec.loader.exec_module(registry_mod)
 
+cache_mod = sys.modules['server.registry.content.cache.mssql']
+cache_mod.fetch_json = dummy_fetch_json
+cache_mod.exec_query = dummy_exec_query
+
 
 def test_storage_cache_upsert_sets_created_on(monkeypatch):
   captured = []
   async def fake_exec_query(operation):
     captured.append(operation.params)
     return DBResult(rowcount=1)
-  monkeypatch.setattr(registry_mod, 'exec_query', fake_exec_query)
-  handler = registry_mod.get_handler('db:storage:cache:upsert:1')
+  monkeypatch.setattr(cache_mod, 'exec_query', fake_exec_query)
+  handler = registry_mod.get_handler('db:content:cache:upsert:1')
   args = {
   'user_guid': 'u',
   'path': '',

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -114,12 +114,12 @@ def test_set_gallery_sends_numeric_flag_to_db():
   asyncio.run(mod.set_gallery("u1", "a.txt", False))
 
   assert db.calls[0] == (
-    "db:storage:files:set_gallery:1",
-    {"user_guid": "u1", "name": "docs/a.txt", "gallery": 1},
+    "db:content:files:set_gallery:1",
+    {"user_guid": "u1", "name": "docs/a.txt", "gallery": True},
   )
   assert db.calls[1] == (
-    "db:storage:files:set_gallery:1",
-    {"user_guid": "u1", "name": "a.txt", "gallery": 0},
+    "db:content:files:set_gallery:1",
+    {"user_guid": "u1", "name": "a.txt", "gallery": False},
   )
 
 
@@ -708,7 +708,7 @@ def test_get_storage_stats_counts_all_folders(monkeypatch):
       class Res:
         def __init__(self, rows):
           self.rows = rows
-      if op == "db:storage:cache:count_rows:1":
+      if op == "db:content:cache:count_rows:1":
         return Res([{ "count": 10 }])
       if op == "db:system:config:get_config:1" and args.get("key") == "AzureBlobContainerName":
         return Res([{ "value": "container" }])
@@ -912,7 +912,7 @@ def test_get_storage_stats_counts_user_folders(monkeypatch):
       class Res:
         def __init__(self, rows):
           self.rows = rows
-      if op == "db:storage:cache:count_rows:1":
+      if op == "db:content:cache:count_rows:1":
         return Res([{ "count": 0 }])
       if op == "db:system:config:get_config:1" and args.get("key") == "AzureBlobContainerName":
         return Res([{ "value": "container" }])


### PR DESCRIPTION
## Summary
- update DbModule storage helpers to target db:content:* operations and normalize cache payloads
- switch storage and public gallery modules to the new content URNs
- refresh provider and storage tests to cover the updated identifiers and payload expectations

## Testing
- pytest tests/test_db_provider_contract.py tests/test_storage_module.py tests/test_storage_cache_upsert.py

------
https://chatgpt.com/codex/tasks/task_e_68dd581526648325b5a52b5f3516d69d