### PR TITLE
Remove storage registry aliases in favor of db:content helpers

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -18,21 +18,6 @@ from server.helpers.logging import update_logging_level
 def _current_dbresult_cls():
   from server.modules.providers import DBResult as ProvidersDBResult
   return ProvidersDBResult
-
-
-def _normalize_cache_item_payload(item: Dict[str, Any]) -> Dict[str, Any]:
-  normalized = dict(item)
-  name = normalized.get("filename") or normalized.get("name")
-  if name is not None:
-    normalized["filename"] = name
-  if "path" not in normalized or normalized["path"] is None:
-    normalized["path"] = ""
-  for flag in ("public", "reported"):
-    if flag in normalized and normalized[flag] is not None:
-      normalized[flag] = 1 if normalized[flag] else 0
-  return normalized
-
-
 class DbModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
@@ -160,45 +145,7 @@ class DbModule(BaseModule):
       raise ValueError("Missing config value for key: JwksCacheTime")
     return int(value)
 
-  async def list_storage_cache(self, user_guid: str) -> list[Dict[str, Any]]:
-    request = DBRequest(
-      op="db:content:cache:list:1",
-      params={"user_guid": user_guid},
-    )
-    res = await self.run(request)
-    return res.rows
-
-  async def replace_storage_cache(self, user_guid: str, items: list[Dict[str, Any]]):
-    normalized_items = [_normalize_cache_item_payload(item) for item in items]
-    payload = {
-      "user_guid": user_guid,
-      "items": normalized_items,
-    }
-    await self.run(
-      DBRequest(
-        op="db:content:cache:replace_user:1",
-        params=payload,
-      )
-    )
-
   async def user_exists(self, user_guid: str) -> bool:
     res = await self.run("db:users:account:exists:1", {"user_guid": user_guid})
     return bool(res.rows)
-
-  async def upsert_storage_cache(self, item: Dict[str, Any]) -> DBResult:
-    normalized_item = _normalize_cache_item_payload(item)
-    request = DBRequest(op="db:content:cache:upsert:1", params=normalized_item)
-    return await self.run(request)
-
-  async def delete_storage_cache(self, user_guid: str, path: str, filename: str):
-    await self.run(DBRequest(
-      op="db:content:cache:delete:1",
-      params={"user_guid": user_guid, "path": path, "filename": filename},
-    ))
-
-  async def delete_storage_cache_folder(self, user_guid: str, path: str):
-    await self.run(DBRequest(
-      op="db:content:cache:delete_folder:1",
-      params={"user_guid": user_guid, "path": path},
-    ))
 

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -349,55 +349,46 @@ def _support_users_set_credits(args: Dict[str, Any]):
 @register("db:content:cache:list:1")
 def _content_cache_list(args: Dict[str, Any]):
   return content_cache_mssql.list_v1(args)
-register("db:storage:cache:list:1")(_content_cache_list)
 
 
 @register("db:content:cache:replace_user:1")
 async def _content_cache_replace_user(args: Dict[str, Any]):
   return await content_cache_mssql.replace_user_v1(args)
-register("db:storage:cache:replace_user:1")(_content_cache_replace_user)
 
 
 @register("db:content:cache:upsert:1")
 async def _content_cache_upsert(args: Dict[str, Any]):
   return await content_cache_mssql.upsert_v1(args)
-register("db:storage:cache:upsert:1")(_content_cache_upsert)
 
 
 @register("db:content:cache:delete:1")
 def _content_cache_delete(args: Dict[str, Any]):
   return content_cache_mssql.delete_v1(args)
-register("db:storage:cache:delete:1")(_content_cache_delete)
 
 
 @register("db:content:cache:delete_folder:1")
 def _content_cache_delete_folder(args: Dict[str, Any]):
   return content_cache_mssql.delete_folder_v1(args)
-register("db:storage:cache:delete_folder:1")(_content_cache_delete_folder)
 
 
 @register("db:content:cache:set_public:1")
 def _content_cache_set_public(args: Dict[str, Any]):
   return content_cache_mssql.set_public_v1(args)
-register("db:storage:cache:set_public:1")(_content_cache_set_public)
 
 
 @register("db:content:cache:set_reported:1")
 def _content_cache_set_reported(args: Dict[str, Any]):
   return content_cache_mssql.set_reported_v1(args)
-register("db:storage:cache:set_reported:1")(_content_cache_set_reported)
 
 
 @register("db:content:cache:count_rows:1")
 def _content_cache_count_rows(args: Dict[str, Any]):
   return content_cache_mssql.count_rows_v1(args)
-register("db:storage:cache:count_rows:1")(_content_cache_count_rows)
 
 
 @register("db:content:public:list_public:1")
 def _content_public_list_public(args: Dict[str, Any]):
   return content_public_mssql.list_public_v1(args)
-register("db:storage:cache:list_public:1")(_content_public_list_public)
 
 
 @register("db:content:public:get_public_files:1")
@@ -409,13 +400,11 @@ register("db:public:gallery:get_public_files:1")(_content_public_get_public_file
 @register("db:content:public:list_reported:1")
 def _content_public_list_reported(args: Dict[str, Any]):
   return content_public_mssql.list_reported_v1(args)
-register("db:storage:cache:list_reported:1")(_content_public_list_reported)
 
 
 @register("db:content:files:set_gallery:1")
 def _content_files_set_gallery(args: Dict[str, Any]):
   return content_files_mssql.set_gallery_v1(args)
-register("db:storage:files:set_gallery:1")(_content_files_set_gallery)
 
 @register("db:users:profile:set_optin:1")
 def _users_set_optin(args: Dict[str, Any]):

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -11,6 +11,12 @@ from . import BaseModule
 from .env_module import EnvModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
+from server.registry.content.cache import (
+  delete_cache_folder_request,
+  delete_cache_item_request,
+  list_cache_request,
+  upsert_cache_item_request,
+)
 
 
 class StorageModule(BaseModule):
@@ -150,10 +156,11 @@ class StorageModule(BaseModule):
         filename = parts[-1]
         path = "/".join(parts[1:-1])
         if guid not in public_map:
-          rows = await self.db.list_storage_cache(guid)
+          request = list_cache_request(guid)
+          res = await self.db.run(request)
           public_map[guid] = {
             (r.get("path") or "", r.get("filename")): r.get("public", 0)
-            for r in rows
+            for r in res.rows
             if r.get("content_type") != "path/folder"
           }
         # index folders along the path (up to 4 levels)
@@ -165,7 +172,7 @@ class StorageModule(BaseModule):
             logging.debug(
               "[StorageModule] indexing folder %s/%s", parent or ".", folder_name
             )
-            res = await self.db.upsert_storage_cache({
+            res = await self.db.run(upsert_cache_item_request({
               "user_guid": guid,
               "path": parent,
               "filename": folder_name,
@@ -176,7 +183,7 @@ class StorageModule(BaseModule):
               "url": None,
               "reported": 0,
               "moderation_recid": None,
-            })
+            }))
             if res.rowcount == 0:
               logging.error(
                 "[StorageModule] Failed to upsert folder %s/%s",
@@ -194,7 +201,7 @@ class StorageModule(BaseModule):
             logging.debug(
               "[StorageModule] indexing folder %s/%s", path or ".", filename
             )
-            res = await self.db.upsert_storage_cache({
+            res = await self.db.run(upsert_cache_item_request({
               "user_guid": guid,
               "path": path,
               "filename": filename,
@@ -205,7 +212,7 @@ class StorageModule(BaseModule):
               "url": None,
               "reported": 0,
               "moderation_recid": None,
-            })
+            }))
             if res.rowcount == 0:
               logging.error(
                 "[StorageModule] Failed to upsert folder %s/%s",
@@ -229,7 +236,7 @@ class StorageModule(BaseModule):
           "[StorageModule] indexing file %s/%s", path or ".", filename
         )
         public_val = public_map.get(guid, {}).get((path, filename), 0)
-        res = await self.db.upsert_storage_cache({
+        res = await self.db.run(upsert_cache_item_request({
           "user_guid": guid,
           "path": path,
           "filename": filename,
@@ -240,7 +247,7 @@ class StorageModule(BaseModule):
           "url": url,
           "reported": 0,
           "moderation_recid": None,
-        })
+        }))
         if res.rowcount == 0:
           logging.error(
             "[StorageModule] Failed to upsert file %s/%s",
@@ -254,13 +261,13 @@ class StorageModule(BaseModule):
         existing = public_map.get(user_guid, {})
         for key in list(existing.keys()):
           if key not in files_seen.get(user_guid, set()):
-            await self.db.delete_storage_cache(user_guid, key[0], key[1])
+            await self.db.run(delete_cache_item_request(user_guid, key[0], key[1]))
       else:
         for guid, items_seen in files_seen.items():
           existing = public_map.get(guid, {})
           for key in list(existing.keys()):
             if key not in items_seen:
-              await self.db.delete_storage_cache(guid, key[0], key[1])
+              await self.db.run(delete_cache_item_request(guid, key[0], key[1]))
     finally:
       logging.debug(
         "[StorageModule] Reindex found %d files and %d folders%s",
@@ -278,7 +285,7 @@ class StorageModule(BaseModule):
   async def upsert_file_record(self, user_guid: str, path: str, filename: str, file_type: str, **kwargs):
     """Upsert a file record into the ``users_storage_cache`` table."""
     assert self.db
-    res = await self.db.upsert_storage_cache({
+    res = await self.db.run(upsert_cache_item_request({
       "user_guid": user_guid,
       "path": path,
       "filename": filename,
@@ -289,7 +296,7 @@ class StorageModule(BaseModule):
       "url": kwargs.get("url"),
       "reported": kwargs.get("reported", 0),
       "moderation_recid": kwargs.get("moderation_recid"),
-    })
+    }))
     if res.rowcount == 0:
       logging.error(
         "[StorageModule] Failed to upsert file %s/%s",
@@ -300,7 +307,8 @@ class StorageModule(BaseModule):
   async def list_files_by_user(self, user_guid: str):
     """Return files belonging to ``user_guid``."""
     assert self.db
-    rows = await self.db.list_storage_cache(user_guid)
+    res = await self.db.run(list_cache_request(user_guid))
+    rows = res.rows
     out = []
     for row in rows:
       if row.get("content_type") == "path/folder":
@@ -320,7 +328,8 @@ class StorageModule(BaseModule):
   async def list_folder(self, user_guid: str, folder: str):
     """Return files and subfolders under ``folder`` for ``user_guid``."""
     assert self.db
-    rows = await self.db.list_storage_cache(user_guid)
+    res = await self.db.run(list_cache_request(user_guid))
+    rows = res.rows
     folder = folder.strip("/")
     prefix = f"{folder}/" if folder else ""
     files: list[dict[str, str | None]] = []
@@ -406,7 +415,7 @@ class StorageModule(BaseModule):
         filename = name.split("/")[-1]
         url = f"{container.url}/{blob_name}"
         try:
-          res = await self.db.upsert_storage_cache({
+          res = await self.db.run(upsert_cache_item_request({
             "user_guid": user_guid,
             "path": path,
             "filename": filename,
@@ -417,7 +426,7 @@ class StorageModule(BaseModule):
             "url": url,
             "reported": 0,
             "moderation_recid": None,
-          })
+          }))
           if res.rowcount == 0:
             logging.error("[StorageModule] Failed to upsert file %s/%s", path or '.', filename)
         except Exception as e:
@@ -447,7 +456,7 @@ class StorageModule(BaseModule):
         except Exception as e:
           logging.error("[StorageModule] Failed to delete %s: %s", blob_name, e)
         try:
-          await self.db.delete_storage_cache(user_guid, path, filename)
+          await self.db.run(delete_cache_item_request(user_guid, path, filename))
         except Exception as e:
           logging.error(
             "[StorageModule] Failed to delete cache for %s/%s: %s",
@@ -502,7 +511,7 @@ class StorageModule(BaseModule):
         overwrite=True,
       )
       try:
-        await self.db.upsert_storage_cache({
+        await self.db.run(upsert_cache_item_request({
           "user_guid": user_guid,
           "path": parent,
           "filename": folder_name,
@@ -513,7 +522,7 @@ class StorageModule(BaseModule):
           "url": None,
           "reported": 0,
           "moderation_recid": None,
-        })
+        }))
       except Exception as e:
         logging.error(
           "[StorageModule] Failed to update cache for %s/%s: %s",
@@ -549,7 +558,7 @@ class StorageModule(BaseModule):
         file_path = "/".join(parts[1:-1])
         filename = parts[-1]
         try:
-          await self.db.delete_storage_cache(user_guid, file_path, filename)
+          await self.db.run(delete_cache_item_request(user_guid, file_path, filename))
         except Exception as e:
           logging.error(
             "[StorageModule] Failed to delete cache for %s/%s: %s",
@@ -557,7 +566,7 @@ class StorageModule(BaseModule):
             filename,
             e,
           )
-      await self.db.delete_storage_cache_folder(user_guid, path.lstrip('/'))
+      await self.db.run(delete_cache_folder_request(user_guid, path.lstrip('/')))
     finally:
       await container.close()
       await bsc.close()
@@ -586,13 +595,13 @@ class StorageModule(BaseModule):
       props = await src_blob.get_blob_properties()
       await dst_blob.start_copy_from_url(src_blob.url)
       await src_blob.delete_blob()
-      await self.db.delete_storage_cache(user_guid, src_path, src_filename)
+      await self.db.run(delete_cache_item_request(user_guid, src_path, src_filename))
       ct = None
       if getattr(props, "content_settings", None):
         ct = getattr(props.content_settings, "content_type", None)
       created_on = getattr(props, "creation_time", None) or getattr(props, "created_on", None)
       modified_on = getattr(props, "last_modified", None)
-      await self.db.upsert_storage_cache({
+      await self.db.run(upsert_cache_item_request({
         "user_guid": user_guid,
         "path": dst_path,
         "filename": dst_filename,
@@ -603,7 +612,7 @@ class StorageModule(BaseModule):
         "url": dst_blob.url,
         "reported": 0,
         "moderation_recid": None,
-      })
+      }))
     except Exception as e:
       logging.error("[StorageModule] Failed to move %s to %s: %s", src, dst, e)
     finally:
@@ -625,7 +634,7 @@ class StorageModule(BaseModule):
     old_path, old_filename = old_rel.rsplit("/", 1) if "/" in old_rel else ("", old_rel)
     new_path, new_filename = new_rel.rsplit("/", 1) if "/" in new_rel else ("", new_rel)
     try:
-      await self.db.delete_storage_cache(user_guid, old_path, old_filename)
+      await self.db.run(delete_cache_item_request(user_guid, old_path, old_filename))
     except Exception as e:
       logging.error(
         "[StorageModule] Failed to delete cache for %s/%s: %s",
@@ -655,7 +664,7 @@ class StorageModule(BaseModule):
         rel = f"{user_guid}/{new_rel}".lstrip("/")
         url = f"{base}/{rel}" if base else existing
     try:
-      await self.db.upsert_storage_cache({
+      await self.db.run(upsert_cache_item_request({
         "user_guid": user_guid,
         "path": new_path,
         "filename": new_filename,
@@ -666,7 +675,7 @@ class StorageModule(BaseModule):
         "url": url,
         "reported": cache_entry.get("reported", 0),
         "moderation_recid": cache_entry.get("moderation_recid"),
-      })
+      }))
     except Exception as e:
       logging.error(
         "[StorageModule] Failed to update cache for %s/%s: %s",
@@ -830,7 +839,8 @@ class StorageModule(BaseModule):
       return
     bsc = BlobServiceClient.from_connection_string(self.connection_string)
     container = bsc.get_container_client(container_name)
-    cache_rows = await self.db.list_storage_cache(user_guid)
+    res = await self.db.run(list_cache_request(user_guid))
+    cache_rows = res.rows
     cache_map: dict[str, dict[str, Any]] = {}
     for row in cache_rows:
       path = row.get("path") or ""

--- a/server/registry/README.md
+++ b/server/registry/README.md
@@ -87,10 +87,8 @@ content moderation, etc.). Mapping the existing URNs:
 | `db:content:files:set_gallery:1` | `content.files` | Gallery state toggle. |
 | `db:content:public:get_public_files:1` | `content.public` | Public gallery uses the same underlying SQL. |
 
-During the migration the legacy `db:storage:*` keys will continue to exist behind
-temporary aliases so that the DbModule can transition incrementally. Once the
-modules are updated to call the new `db:content:*` operations the old names can
-be dropped.
+The legacy `db:storage:*` keys have been retired; modules now call the
+`db:content:*` namespace exclusively through the registry.
 
 `content.public` exposes the shared public listing helpers that power
 both the content module and the external public gallery without duplicating SQL

--- a/server/registry/content/cache/__init__.py
+++ b/server/registry/content/cache/__init__.py
@@ -2,21 +2,72 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any, Dict, Iterable, TYPE_CHECKING
 
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
 __all__ = [
   "register",
+  "delete_cache_folder_request",
+  "delete_cache_item_request",
+  "list_cache_request",
+  "replace_user_cache_request",
+  "upsert_cache_item_request",
 ]
 
 
 _DEF_PROVIDER = "content.cache"
 
 
-def _alias(key: str) -> str:
-  return f"db:storage:cache:{key}:1"
+def _normalize_cache_item_payload(item: Dict[str, Any]) -> Dict[str, Any]:
+  normalized = dict(item)
+  name = normalized.get("filename") or normalized.get("name")
+  if name is not None:
+    normalized["filename"] = name
+  if "path" not in normalized or normalized["path"] is None:
+    normalized["path"] = ""
+  for flag in ("public", "reported"):
+    if flag in normalized and normalized[flag] is not None:
+      normalized[flag] = 1 if normalized[flag] else 0
+  return normalized
+
+
+def list_cache_request(user_guid: str):
+  from server.registry.types import DBRequest
+  return DBRequest(op="db:content:cache:list:1", params={"user_guid": user_guid})
+
+
+def replace_user_cache_request(user_guid: str, items: Iterable[Dict[str, Any]]):
+  from server.registry.types import DBRequest
+  normalized = [_normalize_cache_item_payload(item) for item in items]
+  return DBRequest(op="db:content:cache:replace_user:1", params={
+    "user_guid": user_guid,
+    "items": normalized,
+  })
+
+
+def upsert_cache_item_request(item: Dict[str, Any]):
+  from server.registry.types import DBRequest
+  normalized = _normalize_cache_item_payload(item)
+  return DBRequest(op="db:content:cache:upsert:1", params=normalized)
+
+
+def delete_cache_item_request(user_guid: str, path: str, filename: str):
+  from server.registry.types import DBRequest
+  return DBRequest(op="db:content:cache:delete:1", params={
+    "user_guid": user_guid,
+    "path": path,
+    "filename": filename,
+  })
+
+
+def delete_cache_folder_request(user_guid: str, path: str):
+  from server.registry.types import DBRequest
+  return DBRequest(op="db:content:cache:delete_folder:1", params={
+    "user_guid": user_guid,
+    "path": path,
+  })
 
 
 def register(router: "SubdomainRouter") -> None:
@@ -24,47 +75,39 @@ def register(router: "SubdomainRouter") -> None:
     "list",
     version=1,
     provider_map=f"{_DEF_PROVIDER}.list",
-    aliases=[_alias("list")],
   )
   router.add_function(
     "replace_user",
     version=1,
     provider_map=f"{_DEF_PROVIDER}.replace_user",
-    aliases=[_alias("replace_user")],
   )
   router.add_function(
     "upsert",
     version=1,
     provider_map=f"{_DEF_PROVIDER}.upsert",
-    aliases=[_alias("upsert")],
   )
   router.add_function(
     "delete",
     version=1,
     provider_map=f"{_DEF_PROVIDER}.delete",
-    aliases=[_alias("delete")],
   )
   router.add_function(
     "delete_folder",
     version=1,
     provider_map=f"{_DEF_PROVIDER}.delete_folder",
-    aliases=[_alias("delete_folder")],
   )
   router.add_function(
     "set_public",
     version=1,
     provider_map=f"{_DEF_PROVIDER}.set_public",
-    aliases=[_alias("set_public")],
   )
   router.add_function(
     "set_reported",
     version=1,
     provider_map=f"{_DEF_PROVIDER}.set_reported",
-    aliases=[_alias("set_reported")],
   )
   router.add_function(
     "count_rows",
     version=1,
     provider_map=f"{_DEF_PROVIDER}.count_rows",
-    aliases=[_alias("count_rows")],
   )

--- a/server/registry/content/files/__init__.py
+++ b/server/registry/content/files/__init__.py
@@ -17,5 +17,4 @@ def register(router: "SubdomainRouter") -> None:
     "set_gallery",
     version=1,
     provider_map="content.files.set_gallery",
-    aliases=["db:storage:files:set_gallery:1"],
   )

--- a/server/registry/content/public/__init__.py
+++ b/server/registry/content/public/__init__.py
@@ -17,13 +17,11 @@ def register(router: "SubdomainRouter") -> None:
     "list_public",
     version=1,
     provider_map="content.public.list_public",
-    aliases=["db:storage:cache:list_public:1"],
   )
   router.add_function(
     "list_reported",
     version=1,
     provider_map="content.public.list_reported",
-    aliases=["db:storage:cache:list_reported:1"],
   )
   router.add_function(
     "get_public_files",

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -8,6 +8,54 @@ from server.modules import BaseModule
 from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.modules.providers.database.mssql_provider as mssql_provider
 from server.modules.providers import DBResult, DbRunMode
+from server.registry.types import DBRequest
+
+
+def _extract_request(request, args=None):
+  if isinstance(request, DBRequest):
+    return request.op, request.params
+  return request, args or {}
+
+
+def _ensure_result(value):
+  if isinstance(value, DBResult):
+    return value
+  if isinstance(value, list):
+    return DBResult(rows=list(value), rowcount=len(value))
+  if hasattr(value, "rows") and hasattr(value, "rowcount"):
+    rows = list(getattr(value, "rows"))
+    return DBResult(rows=rows, rowcount=getattr(value, "rowcount"))
+  if hasattr(value, "rowcount"):
+    return DBResult(rowcount=getattr(value, "rowcount"))
+  return DBResult()
+
+
+class RegistryDispatchMixin:
+  def _config_result(self, key: str | None):
+    return None
+
+  async def run(self, request, args=None):
+    op, params = _extract_request(request, args)
+    if op == "db:system:config:get_config:1":
+      value = self._config_result(params.get("key"))
+      rows = [] if value is None else [{"value": value}]
+      return DBResult(rows=rows, rowcount=len(rows))
+    if op == "db:content:cache:list:1" and hasattr(self, "list_storage_cache"):
+      res = await self.list_storage_cache(params.get("user_guid"))
+      return _ensure_result(res)
+    if op == "db:content:cache:replace_user:1" and hasattr(self, "replace_storage_cache"):
+      res = await self.replace_storage_cache(params.get("user_guid"), params.get("items", []))
+      return _ensure_result(res)
+    if op == "db:content:cache:upsert:1" and hasattr(self, "upsert_storage_cache"):
+      res = await self.upsert_storage_cache(params)
+      return _ensure_result(res)
+    if op == "db:content:cache:delete:1" and hasattr(self, "delete_storage_cache"):
+      await self.delete_storage_cache(params.get("user_guid"), params.get("path", ""), params.get("filename", ""))
+      return DBResult()
+    if op == "db:content:cache:delete_folder:1" and hasattr(self, "delete_storage_cache_folder"):
+      await self.delete_storage_cache_folder(params.get("user_guid"), params.get("path", ""))
+      return DBResult()
+    return DBResult()
 
 
 class DummyEnv(BaseModule):
@@ -25,31 +73,28 @@ class DummyEnv(BaseModule):
     return self._env.get(key)
 
 
-class DummyDb(BaseModule):
+class DummyDb(RegistryDispatchMixin, BaseModule):
   async def startup(self):
     self.mark_ready()
 
   async def shutdown(self):
     pass
 
-  async def run(self, op, args):
-    class Res:
-      def __init__(self, rows):
-        self.rows = rows
-    if op == "db:system:config:get_config:1" and args.get("key") == "StorageCacheTime":
-      return Res([{ "value": "15m" }])
-    return Res([])
+  def _config_result(self, key: str | None):
+    if key == "StorageCacheTime":
+      return "15m"
+    return None
 
   async def user_exists(self, user_guid):
     return True
 
 
-class DummyListDb:
+class DummyListDb(RegistryDispatchMixin):
   def __init__(self, rows):
     self.rows = rows
 
   async def list_storage_cache(self, user_guid):
-    return self.rows
+    return list(self.rows)
 
 
 def test_storage_module_startup_loads_connection_string_and_interval():
@@ -103,8 +148,9 @@ def test_set_gallery_sends_numeric_flag_to_db():
     def __init__(self):
       self.calls = []
 
-    async def run(self, op, args):
-      self.calls.append((op, args))
+    async def run(self, request, args=None):
+      op, params = _extract_request(request, args)
+      self.calls.append((op, params))
       return DBResult(rowcount=1)
 
   db = CaptureDb()
@@ -179,20 +225,17 @@ def test_reindex_indexes_files_and_folders(monkeypatch):
     async def shutdown(self):
       pass
 
-  class DummyDb(BaseModule):
+  class DummyDb(RegistryDispatchMixin, BaseModule):
     def __init__(self, app: FastAPI):
       super().__init__(app)
       self.upserts = []
       self.existing = set()
     async def startup(self):
       self.mark_ready()
-    async def run(self, op, args):
-      class Res:
-        def __init__(self, rows):
-          self.rows = rows
-      if op == "db:system:config:get_config:1" and args.get("key") == "AzureBlobContainerName":
-        return Res([{ "value": "container" }])
-      return Res([])
+    def _config_result(self, key: str | None):
+      if key == "AzureBlobContainerName":
+        return "container"
+      return None
     async def upsert_storage_cache(self, item):
       self.upserts.append(item)
       from types import SimpleNamespace
@@ -277,20 +320,17 @@ def test_reindex_skips_unknown_users(monkeypatch):
     async def shutdown(self):
       pass
 
-  class DummyDb(BaseModule):
+  class DummyDb(RegistryDispatchMixin, BaseModule):
     def __init__(self, app: FastAPI):
       super().__init__(app)
       self.upserts = []
       self.checked = []
     async def startup(self):
       self.mark_ready()
-    async def run(self, op, args):
-      class Res:
-        def __init__(self, rows):
-          self.rows = rows
-      if op == "db:system:config:get_config:1" and args.get("key") == "AzureBlobContainerName":
-        return Res([{ "value": "container" }])
-      return Res([])
+    def _config_result(self, key: str | None):
+      if key == "AzureBlobContainerName":
+        return "container"
+      return None
     async def upsert_storage_cache(self, item):
       self.upserts.append(item)
       from types import SimpleNamespace
@@ -360,20 +400,17 @@ def test_reindex_skips_unknown_users(monkeypatch):
 
 
 def test_move_file_copies_and_updates_cache(monkeypatch):
-  class DummyDb(BaseModule):
+  class DummyDb(RegistryDispatchMixin, BaseModule):
     def __init__(self, app: FastAPI):
       super().__init__(app)
       self.deleted = None
       self.upserted = None
     async def startup(self):
       self.mark_ready()
-    async def run(self, op, args):
-      class Res:
-        def __init__(self, rows):
-          self.rows = rows
-      if op == "db:system:config:get_config:1" and args.get("key") == "AzureBlobContainerName":
-        return Res([{ "value": "container" }])
-      return Res([])
+    def _config_result(self, key: str | None):
+      if key == "AzureBlobContainerName":
+        return "container"
+      return None
     async def delete_storage_cache(self, user_guid, path, filename):
       self.deleted = (user_guid, path, filename)
     async def upsert_storage_cache(self, item):
@@ -441,7 +478,7 @@ def test_move_file_copies_and_updates_cache(monkeypatch):
 
 
 def test_rename_file_preserves_public_flag(monkeypatch):
-  class DummyDb(BaseModule):
+  class DummyDb(RegistryDispatchMixin, BaseModule):
     def __init__(self, app: FastAPI):
       super().__init__(app)
       self.deleted = []
@@ -450,13 +487,10 @@ def test_rename_file_preserves_public_flag(monkeypatch):
     async def startup(self):
       self.mark_ready()
 
-    async def run(self, op, args):
-      class Res:
-        def __init__(self, rows):
-          self.rows = rows
-      if op == "db:system:config:get_config:1" and args.get("key") == "AzureBlobContainerName":
-        return Res([{ "value": "container" }])
-      return Res([])
+    def _config_result(self, key: str | None):
+      if key == "AzureBlobContainerName":
+        return "container"
+      return None
 
     async def delete_storage_cache(self, user_guid, path, filename):
       self.deleted.append((user_guid, path, filename))
@@ -570,7 +604,7 @@ def test_rename_file_preserves_public_flag(monkeypatch):
 
 
 def test_rename_folder_updates_nested_entries(monkeypatch):
-  class DummyDb(BaseModule):
+  class DummyDb(RegistryDispatchMixin, BaseModule):
     def __init__(self, app: FastAPI):
       super().__init__(app)
       self.deleted = []
@@ -579,13 +613,10 @@ def test_rename_folder_updates_nested_entries(monkeypatch):
     async def startup(self):
       self.mark_ready()
 
-    async def run(self, op, args):
-      class Res:
-        def __init__(self, rows):
-          self.rows = rows
-      if op == "db:system:config:get_config:1" and args.get("key") == "AzureBlobContainerName":
-        return Res([{ "value": "container" }])
-      return Res([])
+    def _config_result(self, key: str | None):
+      if key == "AzureBlobContainerName":
+        return "container"
+      return None
 
     async def delete_storage_cache(self, user_guid, path, filename):
       self.deleted.append((user_guid, path, filename))
@@ -704,15 +735,13 @@ def test_rename_folder_updates_nested_entries(monkeypatch):
 
 def test_get_storage_stats_counts_all_folders(monkeypatch):
   class DummyDb:
-    async def run(self, op, args):
-      class Res:
-        def __init__(self, rows):
-          self.rows = rows
+    async def run(self, request, args=None):
+      op, params = _extract_request(request, args)
       if op == "db:content:cache:count_rows:1":
-        return Res([{ "count": 10 }])
-      if op == "db:system:config:get_config:1" and args.get("key") == "AzureBlobContainerName":
-        return Res([{ "value": "container" }])
-      return Res([])
+        return DBResult(rows=[{"count": 10}], rowcount=1)
+      if op == "db:system:config:get_config:1" and params.get("key") == "AzureBlobContainerName":
+        return DBResult(rows=[{"value": "container"}], rowcount=1)
+      return DBResult()
 
   app = FastAPI()
   mod = StorageModule(app)
@@ -770,17 +799,14 @@ def test_upload_files_sets_created_on(monkeypatch):
   mod = StorageModule(app)
   mod.connection_string = "UseDevelopmentStorage=true"
 
-  class DummyDb:
+  class DummyDb(RegistryDispatchMixin):
     def __init__(self):
       self.upserts = []
 
-    async def run(self, op, args):
-      class Res:
-        def __init__(self, rows):
-          self.rows = rows
-      if op == "db:system:config:get_config:1" and args.get("key") == "AzureBlobContainerName":
-        return Res([{ "value": "container" }])
-      return Res([])
+    def _config_result(self, key: str | None):
+      if key == "AzureBlobContainerName":
+        return "container"
+      return None
 
     async def upsert_storage_cache(self, data):
       self.upserts.append(data)
@@ -832,19 +858,16 @@ def test_upload_files_sets_created_on(monkeypatch):
 
 
 def test_create_folder_creates_marker_and_cache(monkeypatch):
-  class DummyDb(BaseModule):
+  class DummyDb(RegistryDispatchMixin, BaseModule):
     def __init__(self, app: FastAPI):
       super().__init__(app)
       self.upserts = []
     async def startup(self):
       self.mark_ready()
-    async def run(self, op, args):
-      class Res:
-        def __init__(self, rows):
-          self.rows = rows
-      if op == "db:system:config:get_config:1" and args.get("key") == "AzureBlobContainerName":
-        return Res([{ "value": "container" }])
-      return Res([])
+    def _config_result(self, key: str | None):
+      if key == "AzureBlobContainerName":
+        return "container"
+      return None
     async def upsert_storage_cache(self, item):
       self.upserts.append(item)
       from types import SimpleNamespace
@@ -908,15 +931,13 @@ def test_create_folder_creates_marker_and_cache(monkeypatch):
 
 def test_get_storage_stats_counts_user_folders(monkeypatch):
   class DummyDb:
-    async def run(self, op, args):
-      class Res:
-        def __init__(self, rows):
-          self.rows = rows
+    async def run(self, request, args=None):
+      op, params = _extract_request(request, args)
       if op == "db:content:cache:count_rows:1":
-        return Res([{ "count": 0 }])
-      if op == "db:system:config:get_config:1" and args.get("key") == "AzureBlobContainerName":
-        return Res([{ "value": "container" }])
-      return Res([])
+        return DBResult(rows=[{"count": 0}], rowcount=1)
+      if op == "db:system:config:get_config:1" and params.get("key") == "AzureBlobContainerName":
+        return DBResult(rows=[{"value": "container"}], rowcount=1)
+      return DBResult()
 
   app = FastAPI()
   mod = StorageModule(app)


### PR DESCRIPTION
## Summary
- add shared registry request builders for content cache operations and remove the DbModule storage helpers
- update storage module flows to issue `db:content:*` requests and drop the legacy `db:storage:*` aliases
- refresh documentation and storage module tests to reflect the new registry helpers

## Testing
- pytest tests/test_storage_module.py tests/test_storage_cache_upsert.py

------
https://chatgpt.com/codex/tasks/task_e_68dd5b977ba88325bce614a7fec1a85f