### PR TITLE
Implement provider routing in registry

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -67,12 +67,14 @@ class DbModule(BaseModule):
       request = DBRequest(op=op, params=args or {})
     response = await self._registry.execute(request)
     DBResultCls = _current_dbresult_cls()
-    if isinstance(response, DBResponse):
-      return response.to_result()
-    if isinstance(response, DBResultCls):
-      return response
-    payload = response.model_dump() if hasattr(response, "model_dump") else response
-    return DBResultCls(**payload)
+    if not isinstance(response, DBResponse):
+      if isinstance(response, DBResultCls):
+        response = DBResponse.from_result(response)
+      else:
+        payload = response.model_dump() if hasattr(response, "model_dump") else response
+        validated = DBResultCls.model_validate(payload)
+        response = DBResponse.from_result(validated)
+    return response.to_result()
 
   async def startup(self):
     env: EnvModule = self.app.state.env
@@ -85,7 +87,7 @@ class DbModule(BaseModule):
     assert self._provider
     await self._provider.startup()
     if self._registry:
-      self._registry.bind_provider(self._provider)
+      self._registry.bind_provider(self._provider, provider_name=self.provider)
     res = await self.run("db:system:config:get_config:1", {"key": "LoggingLevel"})
     val = res.rows[0]["value"] if res.rows else "0"
     try:

--- a/server/registry/__init__.py
+++ b/server/registry/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import importlib
 import pkgutil
-from typing import Awaitable, Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 
 from server.modules.providers import DBResult, DbProviderBase
 
@@ -46,11 +46,15 @@ class FunctionRoute:
 class RegistryRouter:
   """Hierarchical router that registers domain and subdomain functions."""
 
-  def __init__(self):
+  def __init__(self, *, default_provider: str | None = None):
     self._domains: dict[str, DomainRouter] = {}
     self._routes: dict[str, FunctionRoute] = {}
     self._aliases: dict[str, str] = {}
     self._initialised = False
+    self._provider_name = default_provider
+    self._provider_module = None
+    self._provider_queries: dict[str, Mapping[int, Executor] | Executor] = {}
+    self._provider_executors: dict[str, Executor] = {}
 
   def domain(self, name: str) -> "DomainRouter":
     if name not in self._domains:
@@ -62,6 +66,7 @@ class RegistryRouter:
     if key in self._routes:
       raise ValueError(f"Duplicate registry route registered: {key}")
     self._routes[key] = route
+    self._attach_provider_callable(route)
 
   def add_alias(self, alias: str, target: str) -> None:
     if alias in self._routes or alias in self._aliases:
@@ -88,6 +93,61 @@ class RegistryRouter:
       if callable(register):
         register(self)
     self._initialised = True
+
+  @property
+  def provider_name(self) -> str | None:
+    return self._provider_name
+
+  def set_provider(self, name: str) -> None:
+    if not name:
+      raise ValueError("Provider name cannot be empty")
+    if name != self._provider_name:
+      self._provider_name = name
+      self._provider_module = None
+      self._provider_queries = {}
+      self._provider_executors.clear()
+
+  def load_provider(self, provider: str | None = None) -> None:
+    name = provider or self._provider_name
+    if not name:
+      raise ValueError("Registry provider is not configured")
+    if self._provider_module and name == self._provider_name and self._provider_queries:
+      return
+    module = importlib.import_module(f"server.registry.providers.{name}")
+    queries = getattr(module, "PROVIDER_QUERIES", None)
+    if not isinstance(queries, dict):
+      raise ValueError(f"Provider module '{name}' missing PROVIDER_QUERIES mapping")
+    self._provider_name = name
+    self._provider_module = module
+    self._provider_queries = queries
+    self._provider_executors.clear()
+    for route in self._routes.values():
+      self._attach_provider_callable(route)
+
+  def get_executor(self, route: FunctionRoute) -> Executor | None:
+    executor = self._provider_executors.get(route.key)
+    if executor:
+      return executor
+    self._attach_provider_callable(route)
+    return self._provider_executors.get(route.key)
+
+  def _attach_provider_callable(self, route: FunctionRoute) -> None:
+    if not self._provider_queries:
+      return
+    entry = self._provider_queries.get(route.provider_map)
+    if entry is None:
+      return
+    if isinstance(entry, Mapping):
+      provider_callable = entry.get(route.version)
+    else:
+      provider_callable = entry
+    if provider_callable is None:
+      return
+    if not callable(provider_callable):
+      raise TypeError(
+        f"Provider mapping for '{route.provider_map}' version {route.version} is not callable"
+      )
+    self._provider_executors[route.key] = provider_callable
 
 
 class DomainRouter:
@@ -157,21 +217,37 @@ class RegistryDispatcher:
   def set_executor(self, executor: Executor) -> None:
     self._executor = executor
 
-  def bind_provider(self, provider: DbProviderBase) -> None:
+  def bind_provider(self, provider: DbProviderBase, *, provider_name: str | None = None) -> None:
     self.initialise()
-    async def _execute(request: DBRequest) -> DBResponse:
-      route = self.router.resolve(request.op)
-      if route and route.key != request.op:
-        request = request.model_copy(update={"op": route.key})
-      result = await provider.run(request.op, request.params)
-      DBResultCls = _current_dbresult_cls()
+    provider_key = provider_name or self.router.provider_name
+    if provider_key:
+      self.router.set_provider(provider_key)
+      self.router.load_provider(provider_key)
+    DBResultCls = _current_dbresult_cls()
+
+    def _ensure_response(result: DBResponse | DBResult | object) -> DBResponse:
       if isinstance(result, DBResponse):
         return result
       if isinstance(result, DBResultCls):
-        return result
+        return DBResponse.from_result(result)
       payload = result.model_dump() if hasattr(result, "model_dump") else result
       validated = DBResultCls.model_validate(payload)
       return DBResponse.from_result(validated)
+
+    async def _execute(request: DBRequest) -> DBResponse:
+      route = self.router.resolve(request.op)
+      if not route:
+        result = await provider.run(request.op, request.params)
+        return _ensure_response(result)
+      if route.key != request.op:
+        request = request.model_copy(update={"op": route.key})
+      executor = self.router.get_executor(route)
+      if not executor:
+        raise KeyError(
+          f"No provider callable registered for '{route.provider_map}' version {route.version}"
+        )
+      result = await executor(request)
+      return _ensure_response(result)
 
     self.set_executor(_execute)
 

--- a/server/registry/providers/__init__.py
+++ b/server/registry/providers/__init__.py
@@ -1,0 +1,15 @@
+"""Provider dispatch helpers for the registry."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+
+from server.registry.types import DBRequest, DBResponse
+
+ProviderCallable = Callable[[DBRequest], Awaitable[DBResponse]]
+ProviderQueryMap = Mapping[str, Mapping[int, ProviderCallable] | ProviderCallable]
+
+__all__ = [
+  "ProviderCallable",
+  "ProviderQueryMap",
+]

--- a/server/registry/providers/mssql.py
+++ b/server/registry/providers/mssql.py
@@ -1,0 +1,87 @@
+"""MSSQL provider callable bindings."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Mapping
+from typing import Any
+
+from server.modules.providers import DBResult
+from server.modules.providers.database.mssql_provider.db_helpers import Operation, execute_operation
+from server.registry.content.cache import mssql as content_cache
+from server.registry.content.files import mssql as content_files
+from server.registry.content.public import mssql as content_public
+from server.registry.types import DBRequest, DBResponse
+
+from . import ProviderCallable, ProviderQueryMap
+
+__all__ = [
+  "PROVIDER_QUERIES",
+]
+
+
+async def _coerce_response(spec: Any) -> DBResponse:
+  if isinstance(spec, DBResponse):
+    return spec
+  if inspect.isawaitable(spec):
+    return await _coerce_response(await spec)
+  if isinstance(spec, Operation):
+    result = await execute_operation(spec)
+    return DBResponse.from_result(result)
+  if isinstance(spec, DBResult):
+    return DBResponse.from_result(spec)
+  if isinstance(spec, Mapping):
+    validator = getattr(DBResult, "model_validate", None)
+    if callable(validator):
+      return DBResponse.from_result(validator(spec))
+    return DBResponse.from_result(DBResult(**spec))
+  if spec is None:
+    return DBResponse()
+  raise TypeError(f"Unsupported provider specification result: {type(spec)!r}")
+
+
+def _wrap(fn: Any) -> ProviderCallable:
+  async def _executor(request: DBRequest) -> DBResponse:
+    spec = fn(request.params)
+    return await _coerce_response(spec)
+  return _executor
+
+
+PROVIDER_QUERIES: ProviderQueryMap = {
+  "content.cache.list": {
+    1: _wrap(content_cache.list_v1),
+  },
+  "content.cache.replace_user": {
+    1: _wrap(content_cache.replace_user_v1),
+  },
+  "content.cache.upsert": {
+    1: _wrap(content_cache.upsert_v1),
+  },
+  "content.cache.delete": {
+    1: _wrap(content_cache.delete_v1),
+  },
+  "content.cache.delete_folder": {
+    1: _wrap(content_cache.delete_folder_v1),
+  },
+  "content.cache.set_public": {
+    1: _wrap(content_cache.set_public_v1),
+  },
+  "content.cache.set_reported": {
+    1: _wrap(content_cache.set_reported_v1),
+  },
+  "content.cache.count_rows": {
+    1: _wrap(content_cache.count_rows_v1),
+  },
+  "content.public.list_public": {
+    1: _wrap(content_public.list_public_v1),
+  },
+  "content.public.list_reported": {
+    1: _wrap(content_public.list_reported_v1),
+  },
+  "content.public.get_public_files": {
+    1: _wrap(content_public.get_public_files_v1),
+  },
+  "content.files.set_gallery": {
+    1: _wrap(content_files.set_gallery_v1),
+  },
+}

--- a/tests/test_db_module_init.py
+++ b/tests/test_db_module_init.py
@@ -1,4 +1,6 @@
 import asyncio
+import sys
+from types import ModuleType
 from typing import Any
 import pytest
 from fastapi import FastAPI
@@ -7,8 +9,8 @@ from server.modules.db_module import DbModule
 from server.modules.providers import DBResult, DbProviderBase
 from server.modules.providers.database.mssql_provider import MssqlProvider
 from server.modules.providers.database.mssql_provider.db_helpers import DBQueryError, QueryErrorDetail
-from server.registry import RegistryDispatcher
-from server.registry.types import DBResponse
+from server.registry import RegistryDispatcher, RegistryRouter
+from server.registry.types import DBRequest, DBResponse
 
 
 def test_init_uses_concrete_provider():
@@ -115,3 +117,46 @@ def test_db_module_run_constructs_registry_request():
   request = registry.requests[0]
   assert request.op == "db:test:op"
   assert request.params == {"key": "value"}
+
+
+def test_registry_dispatcher_executes_provider_callable(monkeypatch):
+  router = RegistryRouter()
+  router.domain("demo").subdomain("ops").add_function(
+    "test",
+    version=1,
+    provider_map="demo.ops.test",
+  )
+
+  calls: dict[str, Any] = {}
+
+  async def stub_callable(request: DBRequest) -> DBResponse:
+    calls["op"] = request.op
+    calls["params"] = request.params
+    value = request.params.get("value")
+    return DBResponse(rows=[{"value": value}], rowcount=1)
+
+  module = ModuleType("server.registry.providers.stub")
+  module.PROVIDER_QUERIES = {
+    "demo.ops.test": {1: stub_callable},
+  }
+  monkeypatch.setitem(sys.modules, module.__name__, module)
+
+  class DummyProvider(DbProviderBase):
+    async def startup(self):
+      pass
+
+    async def shutdown(self):
+      pass
+
+    async def run(self, op, args):
+      raise AssertionError("provider.run should not be used when route is registered")
+
+  dispatcher = RegistryDispatcher(router=router)
+  dispatcher.bind_provider(DummyProvider(), provider_name="stub")
+
+  response = asyncio.run(dispatcher.execute(DBRequest(op="db:demo:ops:test:1", params={"value": 7})))
+
+  assert response.rows == [{"value": 7}]
+  assert response.rowcount == 1
+  assert calls["op"] == "db:demo:ops:test:1"
+  assert calls["params"] == {"value": 7}


### PR DESCRIPTION
## Summary
- load provider-specific callable maps in the registry router and dispatch to them when routes are registered
- add MSSQL provider bindings that wrap existing query helpers with DBResponse conversion
- adjust the DB module and registry tests to expect DBResponse results from dispatcher execution

## Testing
- pytest tests/test_db_module_init.py

------
https://chatgpt.com/codex/tasks/task_e_68dd709c55bc83259690ad134497c957