### PR TITLE
Add registry request helpers for public domain

### DIFF
--- a/server/modules/public_gallery_module.py
+++ b/server/modules/public_gallery_module.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
+from server.registry.content.public import get_public_files_request
 
 class PublicGalleryModule(BaseModule):
   def __init__(self, app: FastAPI):
@@ -22,5 +23,6 @@ class PublicGalleryModule(BaseModule):
 
   async def list_public_files(self):
     assert self.db
-    res = await self.db.run("db:content:public:get_public_files:1", {})
+    request = get_public_files_request()
+    res = await self.db.run(request.op, request.params)
     return res.rows

--- a/server/modules/public_links_module.py
+++ b/server/modules/public_links_module.py
@@ -3,6 +3,10 @@ from fastapi import FastAPI
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
+from server.registry.public.links import (
+  get_home_links_request,
+  get_navbar_routes_request,
+)
 
 class PublicLinksModule(BaseModule):
   def __init__(self, app: FastAPI):
@@ -22,9 +26,13 @@ class PublicLinksModule(BaseModule):
     self.db = None
 
   async def get_home_links(self):
-    res = await self.db.run("db:public:links:get_home_links:1", {})
+    assert self.db
+    request = get_home_links_request()
+    res = await self.db.run(request.op, request.params)
     return res.rows
 
   async def get_navbar_routes(self, role_mask: int):
-    res = await self.db.run("db:public:links:get_navbar_routes:1", {"role_mask": role_mask})
+    assert self.db
+    request = get_navbar_routes_request(role_mask=role_mask)
+    res = await self.db.run(request.op, request.params)
     return res.rows

--- a/server/modules/public_users_module.py
+++ b/server/modules/public_users_module.py
@@ -3,6 +3,10 @@ from fastapi import FastAPI
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
+from server.registry.public.users import (
+  get_profile_request,
+  get_published_files_request,
+)
 
 class PublicUsersModule(BaseModule):
   def __init__(self, app: FastAPI):
@@ -23,10 +27,12 @@ class PublicUsersModule(BaseModule):
 
   async def get_profile(self, guid: str):
     assert self.db
-    res = await self.db.run("db:public:users:get_profile:1", {"guid": guid})
+    request = get_profile_request(guid=guid)
+    res = await self.db.run(request.op, request.params)
     return res.rows[0] if res.rows else None
 
   async def get_published_files(self, guid: str):
     assert self.db
-    res = await self.db.run("db:public:users:get_published_files:1", {"guid": guid})
+    request = get_published_files_request(guid=guid)
+    res = await self.db.run(request.op, request.params)
     return res.rows

--- a/server/modules/public_vars_module.py
+++ b/server/modules/public_vars_module.py
@@ -5,6 +5,11 @@ from . import BaseModule
 from .db_module import DbModule
 from .auth_module import AuthModule
 from .discord_bot_module import DiscordBotModule
+from server.registry.public.vars import (
+  get_hostname_request,
+  get_repo_request,
+  get_version_request,
+)
 
 class PublicVarsModule(BaseModule):
   def __init__(self, app: FastAPI):
@@ -40,15 +45,21 @@ class PublicVarsModule(BaseModule):
       return result.stdout, result.stderr
 
   async def get_version(self) -> str:
-    res = await self.db.run("db:public:vars:get_version:1", {})
+    assert self.db
+    request = get_version_request()
+    res = await self.db.run(request.op, request.params)
     return res.rows[0].get("version") if res.rows else ""
 
   async def get_hostname(self) -> str:
-    res = await self.db.run("db:public:vars:get_hostname:1", {})
+    assert self.db
+    request = get_hostname_request()
+    res = await self.db.run(request.op, request.params)
     return res.rows[0].get("hostname") if res.rows else ""
 
   async def get_repo(self) -> str:
-    res = await self.db.run("db:public:vars:get_repo:1", {})
+    assert self.db
+    request = get_repo_request()
+    res = await self.db.run(request.op, request.params)
     return res.rows[0].get("repo") if res.rows else ""
 
   async def get_ffmpeg_version(self) -> str:

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -17,6 +17,10 @@ from server.registry.content.cache import (
   list_cache_request,
   upsert_cache_item_request,
 )
+from server.registry.content.public import (
+  list_public_request,
+  list_reported_request,
+)
 from server.registry.system.config import get_config_request
 
 
@@ -368,13 +372,15 @@ class StorageModule(BaseModule):
   async def list_public_files(self):
     """Return files marked as publicly accessible."""
     assert self.db
-    res = await self.db.run("db:content:public:list_public:1", {})
+    request = list_public_request()
+    res = await self.db.run(request.op, request.params)
     return res.rows
 
   async def list_flagged_for_moderation(self):
     """Return files that have been reported for moderation review."""
     assert self.db
-    res = await self.db.run("db:content:public:list_reported:1", {})
+    request = list_reported_request()
+    res = await self.db.run(request.op, request.params)
     return res.rows
 
   async def upload_files(self, user_guid: str, files):

--- a/server/registry/content/public/__init__.py
+++ b/server/registry/content/public/__init__.py
@@ -2,30 +2,53 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from server.registry.types import DBRequest
 
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
 __all__ = [
+  "get_public_files_request",
+  "list_public_request",
+  "list_reported_request",
   "register",
 ]
+
+_DEF_PROVIDER = "content.public"
+
+
+def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
+  return DBRequest(op=op, params=params or {})
+
+
+def list_public_request() -> DBRequest:
+  return _request("db:content:public:list_public:1")
+
+
+def list_reported_request() -> DBRequest:
+  return _request("db:content:public:list_reported:1")
+
+
+def get_public_files_request() -> DBRequest:
+  return _request("db:content:public:get_public_files:1")
 
 
 def register(router: "SubdomainRouter") -> None:
   router.add_function(
     "list_public",
     version=1,
-    provider_map="content.public.list_public",
+    provider_map=f"{_DEF_PROVIDER}.list_public",
   )
   router.add_function(
     "list_reported",
     version=1,
-    provider_map="content.public.list_reported",
+    provider_map=f"{_DEF_PROVIDER}.list_reported",
   )
   router.add_function(
     "get_public_files",
     version=1,
-    provider_map="content.public.get_public_files",
+    provider_map=f"{_DEF_PROVIDER}.get_public_files",
     aliases=["db:public:gallery:get_public_files:1"],
   )

--- a/server/registry/public/__init__.py
+++ b/server/registry/public/__init__.py
@@ -1,0 +1,27 @@
+"""Public domain registry bindings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from . import links, users, vars as _vars
+
+if TYPE_CHECKING:
+  from server.registry import RegistryRouter
+
+__all__ = [
+  "links",
+  "users",
+  "vars",
+  "register",
+]
+
+# expose module under original name while avoiding shadowing built-in ``vars``
+vars = _vars
+
+
+def register(router: "RegistryRouter") -> None:
+  domain = router.domain("public")
+  links.register(domain.subdomain("links"))
+  users.register(domain.subdomain("users"))
+  vars.register(domain.subdomain("vars"))

--- a/server/registry/public/links/__init__.py
+++ b/server/registry/public/links/__init__.py
@@ -1,0 +1,45 @@
+"""Public links registry bindings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from server.registry.types import DBRequest
+
+from . import mssql  # noqa: F401
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "get_home_links_request",
+  "get_navbar_routes_request",
+  "register",
+]
+
+_DEF_PROVIDER = "public.links"
+
+
+def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
+  return DBRequest(op=op, params=params or {})
+
+
+def get_home_links_request() -> DBRequest:
+  return _request("db:public:links:get_home_links:1")
+
+
+def get_navbar_routes_request(*, role_mask: int) -> DBRequest:
+  return _request("db:public:links:get_navbar_routes:1", {"role_mask": role_mask})
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function(
+    "get_home_links",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.get_home_links",
+  )
+  router.add_function(
+    "get_navbar_routes",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.get_navbar_routes",
+  )

--- a/server/registry/public/users/__init__.py
+++ b/server/registry/public/users/__init__.py
@@ -1,0 +1,45 @@
+"""Public users registry bindings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from server.registry.types import DBRequest
+
+from . import mssql  # noqa: F401
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "get_profile_request",
+  "get_published_files_request",
+  "register",
+]
+
+_DEF_PROVIDER = "public.users"
+
+
+def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
+  return DBRequest(op=op, params=params or {})
+
+
+def get_profile_request(*, guid: str) -> DBRequest:
+  return _request("db:public:users:get_profile:1", {"guid": guid})
+
+
+def get_published_files_request(*, guid: str) -> DBRequest:
+  return _request("db:public:users:get_published_files:1", {"guid": guid})
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function(
+    "get_profile",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.get_profile",
+  )
+  router.add_function(
+    "get_published_files",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.get_published_files",
+  )

--- a/server/registry/public/vars/__init__.py
+++ b/server/registry/public/vars/__init__.py
@@ -1,0 +1,55 @@
+"""Public vars registry bindings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from server.registry.types import DBRequest
+
+from . import mssql  # noqa: F401
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "get_hostname_request",
+  "get_repo_request",
+  "get_version_request",
+  "register",
+]
+
+_DEF_PROVIDER = "public.vars"
+
+
+def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
+  return DBRequest(op=op, params=params or {})
+
+
+def get_version_request() -> DBRequest:
+  return _request("db:public:vars:get_version:1")
+
+
+def get_hostname_request() -> DBRequest:
+  return _request("db:public:vars:get_hostname:1")
+
+
+def get_repo_request() -> DBRequest:
+  return _request("db:public:vars:get_repo:1")
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function(
+    "get_version",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.get_version",
+  )
+  router.add_function(
+    "get_hostname",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.get_hostname",
+  )
+  router.add_function(
+    "get_repo",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.get_repo",
+  )


### PR DESCRIPTION
## Summary
- add request helper factories for the public registry subdomains and wire them into the router
- expose matching helpers for the content.public bindings and migrate public modules to use them
- switch storage and gallery module calls to the new helpers for consistent DBRequest usage

## Testing
- pytest tests/test_public_links_service.py tests/test_public_users_service.py tests/test_public_vars_service.py

------
https://chatgpt.com/codex/tasks/task_e_68de8f8070388325ab6b028780a0098a