### PR TITLE
Refactor profile registry requests

### DIFF
--- a/rpc/auth/discord/services.py
+++ b/rpc/auth/discord/services.py
@@ -11,6 +11,10 @@ from server.modules.env_module import EnvModule
 from server.modules.auth_module import AuthModule
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
+from server.registry.accounts.profile import (
+  set_profile_image_request,
+  update_if_unedited_request,
+)
 from .models import AuthDiscordOauthLogin1, AuthDiscordOauthLoginPayload1
 
 
@@ -87,20 +91,20 @@ async def auth_discord_oauth_login_v1(request: Request):
   user_guid = user["guid"]
   new_img = profile.get("profilePicture")
   if new_img and new_img != user.get("profile_image"):
-    await db.run(
-      "db:users:profile:set_profile_image:1",
-      {"guid": user_guid, "image_b64": new_img, "provider": provider},
+    image_request = set_profile_image_request(
+      guid=user_guid,
+      provider=provider,
+      image_b64=new_img,
     )
+    await db.run(image_request)
     user["profile_image"] = new_img
   if user.get("provider_name") == "discord":
-    res_prof = await db.run(
-      "db:users:profile:update_if_unedited:1",
-      {
-        "guid": user_guid,
-        "email": profile["email"],
-        "display_name": profile["username"],
-      },
+    update_request = update_if_unedited_request(
+      guid=user_guid,
+      email=profile["email"],
+      display_name=profile["username"],
     )
+    res_prof = await db.run(update_request)
     if res_prof.rows:
       updated = res_prof.rows[0]
       if updated.get("display_name"):

--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -9,6 +9,10 @@ from server.modules.env_module import EnvModule
 from server.modules.auth_module import AuthModule
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
+from server.registry.accounts.profile import (
+  set_profile_image_request,
+  update_if_unedited_request,
+)
 from .models import AuthGoogleOauthLogin1, AuthGoogleOauthLoginPayload1
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
@@ -93,20 +97,20 @@ async def auth_google_oauth_login_v1(request: Request):
   user_guid = user["guid"]
   new_img = profile.get("profilePicture")
   if new_img and new_img != user.get("profile_image"):
-    await db.run(
-      "db:users:profile:set_profile_image:1",
-      {"guid": user_guid, "image_b64": new_img, "provider": provider},
+    image_request = set_profile_image_request(
+      guid=user_guid,
+      provider=provider,
+      image_b64=new_img,
     )
+    await db.run(image_request)
     user["profile_image"] = new_img
   if user.get("provider_name") == "google":
-    res_prof = await db.run(
-      "db:users:profile:update_if_unedited:1",
-      {
-        "guid": user_guid,
-        "email": profile["email"],
-        "display_name": profile["username"],
-      },
+    update_request = update_if_unedited_request(
+      guid=user_guid,
+      email=profile["email"],
+      display_name=profile["username"],
     )
+    res_prof = await db.run(update_request)
     if res_prof.rows:
       updated = res_prof.rows[0]
       if updated.get("display_name"):

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -9,6 +9,10 @@ from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
+from server.registry.accounts.profile import (
+  set_profile_image_request,
+  update_if_unedited_request,
+)
 from .models import AuthMicrosoftOauthLogin1
 
 
@@ -67,20 +71,20 @@ async def auth_microsoft_oauth_login_v1(request: Request):
   user_guid = user["guid"]
   new_img = profile.get("profilePicture")
   if new_img != user.get("profile_image"):
-    await db.run(
-      "db:users:profile:set_profile_image:1",
-      {"guid": user_guid, "image_b64": new_img, "provider": provider},
+    image_request = set_profile_image_request(
+      guid=user_guid,
+      provider=provider,
+      image_b64=new_img,
     )
+    await db.run(image_request)
     user["profile_image"] = new_img
   if user.get("provider_name") == "microsoft":
-    res_prof = await db.run(
-      "db:users:profile:update_if_unedited:1",
-      {
-        "guid": user_guid,
-        "email": profile["email"],
-        "display_name": profile["username"],
-      },
+    update_request = update_if_unedited_request(
+      guid=user_guid,
+      email=profile["email"],
+      display_name=profile["username"],
     )
+    res_prof = await db.run(update_request)
     if res_prof.rows:
       updated = res_prof.rows[0]
       if updated.get("display_name"):

--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -3,6 +3,12 @@ from fastapi import HTTPException, Request
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.db_module import DbModule
+from server.registry.accounts.profile import (
+  get_profile_request,
+  set_display_request,
+  set_optin_request,
+  set_profile_image_request,
+)
 from server.registry.security.accounts import get_security_profile_request
 from .models import (
   UsersProfileProfile1,
@@ -28,7 +34,8 @@ async def users_profile_get_profile_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   db: DbModule = request.app.state.db
-  res = await db.run("db:users:profile:get_profile:1", {"guid": user_guid})
+  request_db = get_profile_request(guid=user_guid)
+  res = await db.run(request_db)
   if not res.rows:
     raise HTTPException(status_code=404, detail="Profile not found")
   row = res.rows[0]
@@ -52,10 +59,8 @@ async def users_profile_set_display_v1(request: Request):
 
   payload = UsersProfileSetDisplay1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run("db:users:profile:set_display:1", {
-    "guid": user_guid,
-    "display_name": payload.display_name,
-  })
+  request_db = set_display_request(guid=user_guid, display_name=payload.display_name)
+  await db.run(request_db)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -70,10 +75,8 @@ async def users_profile_set_optin_v1(request: Request):
 
   payload = UsersProfileSetOptin1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run("db:users:profile:set_optin:1", {
-    "guid": user_guid,
-    "display_email": payload.display_email,
-  })
+  request_db = set_optin_request(guid=user_guid, display_email=payload.display_email)
+  await db.run(request_db)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -106,11 +109,12 @@ async def users_profile_set_profile_image_v1(request: Request):
 
   payload = UsersProfileSetProfileImage1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run("db:users:profile:set_profile_image:1", {
-    "guid": user_guid,
-    "image_b64": payload.image_b64,
-    "provider": payload.provider,
-  })
+  request_db = set_profile_image_request(
+    guid=user_guid,
+    image_b64=payload.image_b64,
+    provider=payload.provider,
+  )
+  await db.run(request_db)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -14,6 +14,10 @@ from .models import (
   UsersProvidersCreateFromProvider1,
 )
 from server.modules.oauth_module import OauthModule
+from server.registry.accounts.profile import (
+  get_profile_request,
+  update_if_unedited_request,
+)
 from server.registry.security.identities import (
   create_from_provider_request,
   get_by_provider_identifier_request,
@@ -130,14 +134,12 @@ async def users_providers_set_provider_v1(request: Request):
     raw_name = (profile.get("username") or "").strip()
     email = raw_email
     display_name = raw_name or (raw_email.split("@")[0] if raw_email else "User")
-    await db.run(
-      "db:users:profile:update_if_unedited:1",
-      {
-        "guid": auth_ctx.user_guid,
-        "email": email,
-        "display_name": display_name,
-      },
+    update_request = update_if_unedited_request(
+      guid=auth_ctx.user_guid,
+      email=email,
+      display_name=display_name,
     )
+    await db.run(update_request)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -257,10 +259,8 @@ async def users_providers_unlink_provider_v1(request: Request):
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
   db: DbModule = request.app.state.db
-  res_prof = await db.run(
-    "db:users:profile:get_profile:1",
-    {"guid": auth_ctx.user_guid},
-  )
+  profile_request = get_profile_request(guid=auth_ctx.user_guid)
+  res_prof = await db.run(profile_request)
   default_provider = res_prof.rows[0].get("default_provider") if res_prof.rows else None
   unlink_request = unlink_provider_request(
     guid=auth_ctx.user_guid,

--- a/server/modules/session_module.py
+++ b/server/modules/session_module.py
@@ -8,6 +8,7 @@ from server.modules.auth_module import AuthModule, DEFAULT_SESSION_TOKEN_EXPIRY
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
 from server.modules.discord_bot_module import DiscordBotModule
+from server.registry.accounts.profile import set_profile_image_request
 from server.registry.security.accounts import get_security_profile_request
 from server.registry.security.sessions import (
   create_session_request,
@@ -72,10 +73,12 @@ class SessionModule(BaseModule):
 
     new_img = provider_profile.get("profilePicture")
     if new_img and new_img != user.get("profile_image"):
-      await self.db.run(
-        "urn:users:profile:set_profile_image:1",
-        {"guid": user["guid"], "image_b64": new_img, "provider": provider},
+      request = set_profile_image_request(
+        guid=user["guid"],
+        provider=provider,
+        image_b64=new_img,
       )
+      await self.db.run(request)
       user["profile_image"] = new_img
 
     user_guid = user["guid"]

--- a/server/modules/user_admin_module.py
+++ b/server/modules/user_admin_module.py
@@ -2,6 +2,10 @@ from fastapi import FastAPI, HTTPException
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
+from server.registry.accounts.profile import (
+  get_profile_request,
+  set_display_request,
+)
 
 
 class UserAdminModule(BaseModule):
@@ -21,14 +25,16 @@ class UserAdminModule(BaseModule):
     pass
 
   async def get_displayname(self, guid: str) -> str:
-    res = await self.db.run("db:users:profile:get_profile:1", {"guid": guid})
+    request = get_profile_request(guid=guid)
+    res = await self.db.run(request)
     if not res.rows:
       raise HTTPException(status_code=404, detail="Profile not found")
     row = res.rows[0]
     return row.get("display_name", "")
 
   async def get_credits(self, guid: str) -> int:
-    res = await self.db.run("db:users:profile:get_profile:1", {"guid": guid})
+    request = get_profile_request(guid=guid)
+    res = await self.db.run(request)
     if not res.rows:
       raise HTTPException(status_code=404, detail="Profile not found")
     row = res.rows[0]
@@ -44,7 +50,5 @@ class UserAdminModule(BaseModule):
     )
 
   async def reset_display(self, guid: str) -> None:
-    await self.db.run(
-      "db:users:profile:set_display:1",
-      {"guid": guid, "display_name": "Default User"},
-    )
+    request = set_display_request(guid=guid, display_name="Default User")
+    await self.db.run(request)

--- a/server/registry/accounts/__init__.py
+++ b/server/registry/accounts/__init__.py
@@ -1,0 +1,21 @@
+"""Accounts domain registry bindings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from . import profile
+
+if TYPE_CHECKING:
+  from server.registry import RegistryRouter
+
+__all__ = [
+  "profile",
+  "register",
+]
+
+
+def register(router: "RegistryRouter") -> None:
+  """Register accounts domain routes."""
+  domain = router.domain("accounts")
+  profile.register(domain.subdomain("profile"))

--- a/server/registry/accounts/profile/__init__.py
+++ b/server/registry/accounts/profile/__init__.py
@@ -1,0 +1,104 @@
+"""Account profile registry helpers."""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from server.registry.types import DBRequest
+from server.registry.users.profile import mssql as _mssql  # noqa: F401 - ensure provider import
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "get_profile_request",
+  "set_display_request",
+  "set_optin_request",
+  "set_profile_image_request",
+  "set_roles_request",
+  "update_if_unedited_request",
+  "register",
+]
+
+_DEF_PROVIDER = "users.profile"
+
+
+def _request(name: str, params: dict[str, Any]) -> DBRequest:
+  return DBRequest(op=f"db:accounts:profile:{name}:1", params=params)
+
+
+def get_profile_request(*, guid: str) -> DBRequest:
+  return _request("get_profile", {"guid": guid})
+
+
+def set_display_request(*, guid: str, display_name: str) -> DBRequest:
+  return _request("set_display", {"guid": guid, "display_name": display_name})
+
+
+def set_optin_request(*, guid: str, display_email: bool) -> DBRequest:
+  return _request("set_optin", {"guid": guid, "display_email": display_email})
+
+
+def set_profile_image_request(
+  *,
+  guid: str,
+  provider: str,
+  image_b64: str | None,
+) -> DBRequest:
+  params: dict[str, Any] = {
+    "guid": guid,
+    "provider": provider,
+    "image_b64": image_b64,
+  }
+  return _request("set_profile_image", params)
+
+
+def set_roles_request(*, guid: str, roles: int) -> DBRequest:
+  return _request("set_roles", {"guid": guid, "roles": roles})
+
+
+def update_if_unedited_request(
+  *,
+  guid: str,
+  display_name: str | None = None,
+  email: str | None = None,
+) -> DBRequest:
+  params: dict[str, Any] = {"guid": guid}
+  if display_name is not None:
+    params["display_name"] = display_name
+  if email is not None:
+    params["email"] = email
+  return _request("update_if_unedited", params)
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function(
+    "get_profile",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.get_profile",
+  )
+  router.add_function(
+    "set_display",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.set_display",
+  )
+  router.add_function(
+    "set_optin",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.set_optin",
+  )
+  router.add_function(
+    "set_profile_image",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.set_profile_image",
+  )
+  router.add_function(
+    "set_roles",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.set_roles",
+  )
+  router.add_function(
+    "update_if_unedited",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.update_if_unedited",
+  )

--- a/tests/test_auth_google_profile_image_update.py
+++ b/tests/test_auth_google_profile_image_update.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.oauth_module import OauthModule
+from server.registry.accounts.profile import set_profile_image_request
 
 
 class DummyAuth:
@@ -35,22 +36,31 @@ class DBRes:
     self.rowcount = rowcount
 
 
+PROFILE_IMAGE_OP = set_profile_image_request(guid="", provider="", image_b64=None).op
+
+
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
-    self.calls.append((op, args))
-    if op == "db:security:identities:get_by_provider_identifier:1":
+  async def run(self, op, args=None):
+    if hasattr(op, "op") and hasattr(op, "params"):
+      key = op.op
+      params = op.params
+    else:
+      key = op
+      params = args
+    self.calls.append((key, params))
+    if key == "db:security:identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
-    if op == "db:security:sessions:set_rotkey:1" or op == "db:users:profile:set_profile_image:1":
+    if key == "db:security:sessions:set_rotkey:1" or key == PROFILE_IMAGE_OP:
       return DBRes([], 1)
-    if op == "db:security:sessions:create_session:1":
+    if key == "db:security:sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:security:sessions:update_device_token:1":
+    if key == "db:security:sessions:update_device_token:1":
       return DBRes([], 1)
-    if op == "db:system:config:get_config:1":
-      key = args.get("key")
-      if key == "Hostname":
+    if key == "db:system:config:get_config:1":
+      config_key = params.get("key") if isinstance(params, dict) else None
+      if config_key == "Hostname":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
     return DBRes()
 
@@ -147,5 +157,5 @@ def test_updates_profile_image(monkeypatch):
   req = DummyRequest()
   req.app.state.oauth.exchange_code_for_tokens = fake_exchange
   asyncio.run(auth_google_oauth_login_v1(req))
-  assert any(op == "db:users:profile:set_profile_image:1" for op, _ in req.app.state.db.calls)
+  assert any(op == PROFILE_IMAGE_OP for op, _ in req.app.state.db.calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_profile_refresh.py
+++ b/tests/test_auth_google_profile_refresh.py
@@ -5,6 +5,7 @@ import json
 from fastapi import FastAPI
 
 from server.modules.oauth_module import OauthModule
+from server.registry.accounts.profile import update_if_unedited_request
 
 class DummyAuth:
   def __init__(self, profile):
@@ -24,26 +25,35 @@ class DBRes:
     self.rows = rows or []
     self.rowcount = rowcount
 
+UPDATE_IF_UNEDITED_OP = update_if_unedited_request(guid="", email=None, display_name=None).op
+
+
 class DummyDb:
   def __init__(self, allow_update):
     self.calls = []
     self.allow_update = allow_update
-  async def run(self, op, args):
-    self.calls.append((op, args))
-    if op == "db:security:identities:get_by_provider_identifier:1":
+  async def run(self, op, args=None):
+    if hasattr(op, "op") and hasattr(op, "params"):
+      key = op.op
+      params = op.params
+    else:
+      key = op
+      params = args
+    self.calls.append((key, params))
+    if key == "db:security:identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "provider_name": "google" }], 1)
-    if op == "db:users:profile:update_if_unedited:1":
-      if self.allow_update:
-        return DBRes([{ "display_name": args["display_name"], "email": args["email"] }], 1)
+    if key == UPDATE_IF_UNEDITED_OP:
+      if self.allow_update and isinstance(params, dict):
+        return DBRes([{ "display_name": params.get("display_name"), "email": params.get("email") }], 1)
       return DBRes([], 0)
-    if op == "db:security:sessions:set_rotkey:1":
+    if key == "db:security:sessions:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:security:sessions:create_session:1":
+    if key == "db:security:sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:security:sessions:update_device_token:1":
+    if key == "db:security:sessions:update_device_token:1":
       return DBRes([], 1)
-    if op == "db:system:config:get_config:1":
-      if args.get("key") == "Hostname":
+    if key == "db:system:config:get_config:1":
+      if isinstance(params, dict) and params.get("key") == "Hostname":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
     return DBRes()
 
@@ -139,7 +149,7 @@ def test_updates_profile_if_unedited():
   state.oauth.exchange_code_for_tokens = fake_exchange
   req = DummyRequest(state)
   resp = asyncio.run(auth_google_oauth_login_v1(req))
-  assert any(op == "db:users:profile:update_if_unedited:1" for op, _ in db.calls)
+  assert any(op == UPDATE_IF_UNEDITED_OP for op, _ in db.calls)
   data = json.loads(resp.body)
   assert data["payload"]["display_name"] == "New"
 
@@ -151,7 +161,7 @@ def test_leaves_profile_if_edited():
   state.oauth.exchange_code_for_tokens = fake_exchange
   req = DummyRequest(state)
   resp = asyncio.run(auth_google_oauth_login_v1(req))
-  assert any(op == "db:users:profile:update_if_unedited:1" for op, _ in db.calls)
+  assert any(op == UPDATE_IF_UNEDITED_OP for op, _ in db.calls)
   data = json.loads(resp.body)
   assert data["payload"]["display_name"] == "User"
 

--- a/tests/test_auth_microsoft_profile_image_clear.py
+++ b/tests/test_auth_microsoft_profile_image_clear.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
 
 from server.modules.oauth_module import OauthModule
+from server.registry.accounts.profile import set_profile_image_request
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -21,18 +22,27 @@ class DBRes:
     self.rows = rows or []
     self.rowcount = rowcount
 
+PROFILE_IMAGE_OP = set_profile_image_request(guid="", provider="", image_b64=None).op
+
+
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
-    self.calls.append((op, args))
-    if op == "db:security:identities:get_by_provider_identifier:1":
+  async def run(self, op, args=None):
+    if hasattr(op, "op") and hasattr(op, "params"):
+      key = op.op
+      params = op.params
+    else:
+      key = op
+      params = args
+    self.calls.append((key, params))
+    if key == "db:security:identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
-    if op == "db:security:sessions:set_rotkey:1" or op == "db:users:profile:set_profile_image:1":
+    if key == "db:security:sessions:set_rotkey:1" or key == PROFILE_IMAGE_OP:
       return DBRes([], 1)
-    if op == "db:security:sessions:create_session:1":
+    if key == "db:security:sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:security:sessions:update_device_token:1":
+    if key == "db:security:sessions:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 
@@ -102,6 +112,6 @@ def test_clears_profile_image(monkeypatch):
   req = DummyRequest()
   asyncio.run(auth_microsoft_oauth_login_v1(req))
   assert any(
-    op == "db:users:profile:set_profile_image:1" and args.get("image_b64") is None
+    op == PROFILE_IMAGE_OP and args.get("image_b64") is None
     for op, args in req.app.state.db.calls
   )

--- a/tests/test_auth_microsoft_profile_image_update.py
+++ b/tests/test_auth_microsoft_profile_image_update.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
 
 from server.modules.oauth_module import OauthModule
+from server.registry.accounts.profile import set_profile_image_request
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -21,18 +22,27 @@ class DBRes:
     self.rows = rows or []
     self.rowcount = rowcount
 
+PROFILE_IMAGE_OP = set_profile_image_request(guid="", provider="", image_b64=None).op
+
+
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
-    self.calls.append((op, args))
-    if op == "db:security:identities:get_by_provider_identifier:1":
+  async def run(self, op, args=None):
+    if hasattr(op, "op") and hasattr(op, "params"):
+      key = op.op
+      params = op.params
+    else:
+      key = op
+      params = args
+    self.calls.append((key, params))
+    if key == "db:security:identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
-    if op == "db:security:sessions:set_rotkey:1" or op == "db:users:profile:set_profile_image:1":
+    if key == "db:security:sessions:set_rotkey:1" or key == PROFILE_IMAGE_OP:
       return DBRes([], 1)
-    if op == "db:security:sessions:create_session:1":
+    if key == "db:security:sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:security:sessions:update_device_token:1":
+    if key == "db:security:sessions:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 
@@ -101,4 +111,4 @@ def test_updates_profile_image(monkeypatch):
 
   req = DummyRequest()
   asyncio.run(auth_microsoft_oauth_login_v1(req))
-  assert any(op == "db:users:profile:set_profile_image:1" for op, _ in req.app.state.db.calls)
+  assert any(op == PROFILE_IMAGE_OP for op, _ in req.app.state.db.calls)

--- a/tests/test_auth_microsoft_profile_refresh.py
+++ b/tests/test_auth_microsoft_profile_refresh.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
 
 from server.modules.oauth_module import OauthModule
+from server.registry.accounts.profile import update_if_unedited_request
 import json
 
 
@@ -26,23 +27,32 @@ class DBRes:
     self.rowcount = rowcount
 
 
+UPDATE_IF_UNEDITED_OP = update_if_unedited_request(guid="", email=None, display_name=None).op
+
+
 class DummyDb:
   def __init__(self, allow_update):
     self.calls = []
     self.allow_update = allow_update
-  async def run(self, op, args):
-    self.calls.append((op, args))
-    if op == "db:security:identities:get_by_provider_identifier:1":
+  async def run(self, op, args=None):
+    if hasattr(op, "op") and hasattr(op, "params"):
+      key = op.op
+      params = op.params
+    else:
+      key = op
+      params = args
+    self.calls.append((key, params))
+    if key == "db:security:identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "provider_name": "microsoft" }], 1)
-    if op == "db:users:profile:update_if_unedited:1":
-      if self.allow_update:
-        return DBRes([{ "display_name": args["display_name"], "email": args["email"] }], 1)
+    if key == UPDATE_IF_UNEDITED_OP:
+      if self.allow_update and isinstance(params, dict):
+        return DBRes([{ "display_name": params.get("display_name"), "email": params.get("email") }], 1)
       return DBRes([], 0)
-    if op == "db:security:sessions:set_rotkey:1":
+    if key == "db:security:sessions:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:security:sessions:create_session:1":
+    if key == "db:security:sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:security:sessions:update_device_token:1":
+    if key == "db:security:sessions:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 
@@ -120,7 +130,7 @@ def test_updates_profile_if_unedited():
   state = DummyState(auth, db)
   req = DummyRequest(state)
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
-  assert any(op == "db:users:profile:update_if_unedited:1" for op, _ in db.calls)
+  assert any(op == UPDATE_IF_UNEDITED_OP for op, _ in db.calls)
   data = json.loads(resp.body)
   assert data["payload"]["display_name"] == "New"
 
@@ -131,7 +141,7 @@ def test_leaves_profile_if_edited():
   state = DummyState(auth, db)
   req = DummyRequest(state)
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
-  assert any(op == "db:users:profile:update_if_unedited:1" for op, _ in db.calls)
+  assert any(op == UPDATE_IF_UNEDITED_OP for op, _ in db.calls)
   data = json.loads(resp.body)
   assert data["payload"]["display_name"] == "User"
 

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
+from server.registry.accounts.profile import set_profile_image_request
 
 # stub rpc package
 pkg = types.ModuleType("rpc")
@@ -68,23 +69,32 @@ class DBRes:
     self.rows = rows or []
     self.rowcount = rowcount
 
+PROFILE_IMAGE_REQUEST = set_profile_image_request(guid="", provider="", image_b64=None)
+
+
 class DummyDb:
   def __init__(self, roles=0):
     self.calls = []
     self.roles = roles
-  async def run(self, op, args):
-    self.calls.append((op, args))
-    if op == "db:security:accounts:get_security_profile:1":
+  async def run(self, op, args=None):
+    if hasattr(op, "op") and hasattr(op, "params"):
+      key = op.op
+      params = op.params
+    else:
+      key = op
+      params = args
+    self.calls.append((key, params))
+    if key == "db:security:accounts:get_security_profile:1":
       return DBRes([
         {
-          "guid": args.get("guid"),
-          "user_guid": args.get("guid"),
+          "guid": params.get("guid"),
+          "user_guid": params.get("guid"),
           "user_roles": self.roles,
           "provider_name": "microsoft",
           "provider_display": "Microsoft",
         }
       ], 1)
-    if op == "db:users:profile:set_profile_image:1":
+    if key == PROFILE_IMAGE_REQUEST.op:
       return DBRes([], 1)
     return DBRes()
 
@@ -121,7 +131,8 @@ def test_set_profile_image_calls_db():
   db = DummyDb()
   req = DummyRequest(DummyState(db))
   resp = asyncio.run(users_profile_set_profile_image_v1(req))
-  assert ("db:users:profile:set_profile_image:1", {"guid": "u1", "image_b64": "abc", "provider": "microsoft"}) in db.calls
+  expected_request = set_profile_image_request(guid="u1", image_b64="abc", provider="microsoft")
+  assert (expected_request.op, expected_request.params) in db.calls
   assert resp.payload["image_b64"] == "abc"
 
 

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -14,6 +14,25 @@ from server.modules.oauth_module import OauthModule
 
 import pytest
 from fastapi import HTTPException
+from server.registry.accounts.profile import (
+  get_profile_request,
+  set_profile_image_request,
+  update_if_unedited_request,
+)
+
+PROFILE_GET_REQUEST = get_profile_request(guid="")
+PROFILE_IMAGE_REQUEST = set_profile_image_request(guid="", provider="", image_b64=None)
+UPDATE_IF_UNEDITED_REQUEST = update_if_unedited_request(
+  guid="",
+  email=None,
+  display_name=None,
+)
+
+
+def _normalize_db_call(op, args=None):
+  if hasattr(op, "op") and hasattr(op, "params"):
+    return op.op, op.params
+  return op, args
 
 # stub rpc package
 pkg = types.ModuleType("rpc")
@@ -79,8 +98,9 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
-    self.calls.append((op, args))
+  async def run(self, op, args=None):
+    key, params = _normalize_db_call(op, args)
+    self.calls.append((key, params))
     return DBRes()
 
 class DummyState:
@@ -123,10 +143,12 @@ def test_set_provider_calls_db():
   req = DummyRequest(DummyState(db, auth=DummyAuth()))
   resp = asyncio.run(users_providers_set_provider_v1(req))
   assert ("db:security:identities:set_provider:1", {"guid": "u1", "provider": "microsoft"}) in db.calls
-  assert (
-    "db:users:profile:update_if_unedited:1",
-    {"guid": "u1", "email": "e", "display_name": "n"},
-  ) in db.calls
+  expected_update = update_if_unedited_request(
+    guid="u1",
+    email="e",
+    display_name="n",
+  )
+  assert (expected_update.op, expected_update.params) in db.calls
   assert isinstance(resp, RPCResponse)
   assert resp.payload["provider"] == "microsoft"
 
@@ -160,10 +182,12 @@ def test_set_provider_defaults_blank_profile():
       return "pid", {"email": "", "username": ""}, {}
   req = DummyRequest(DummyState(db, auth=DummyAuth()))
   asyncio.run(users_providers_set_provider_v1(req))
-  assert (
-    "db:users:profile:update_if_unedited:1",
-    {"guid": "u1", "email": "", "display_name": "User"},
-  ) in db.calls
+  expected_update = update_if_unedited_request(
+    guid="u1",
+    email="",
+    display_name="User",
+  )
+  assert (expected_update.op, expected_update.params) in db.calls
 
 
 def test_link_provider_google_normalizes_identifier():
@@ -198,11 +222,12 @@ def test_link_provider_google_normalizes_identifier():
   class DummyDb:
     def __init__(self):
       self.calls = []
-    async def run(self, op, args):
-      self.calls.append((op, args))
-      if op == "db:system:config:get_config:1":
-        key = args["key"]
-        if key == "Hostname":
+    async def run(self, op, args=None):
+      key, params = _normalize_db_call(op, args)
+      self.calls.append((key, params))
+      if key == "db:system:config:get_config:1":
+        config_key = params.get("key") if isinstance(params, dict) else None
+        if config_key == "Hostname":
           return DBRes(rows=[{"value": "redirect"}])
       return DBRes()
 
@@ -310,8 +335,9 @@ def test_link_provider_microsoft_normalizes_identifier():
   class DummyDb:
     def __init__(self):
       self.calls = []
-    async def run(self, op, args):
-      self.calls.append((op, args))
+    async def run(self, op, args=None):
+      key, params = _normalize_db_call(op, args)
+      self.calls.append((key, params))
       return DBRes()
 
   db = DummyDb()
@@ -330,11 +356,12 @@ def test_unlink_non_default_provider_retains_tokens():
   svc_mod.unbox_request = fake_get
 
   class LocalDb(DummyDb):
-    async def run(self, op, args):
-      self.calls.append((op, args))
-      if op == "db:users:profile:get_profile:1":
+    async def run(self, op, args=None):
+      key, params = _normalize_db_call(op, args)
+      self.calls.append((key, params))
+      if key == PROFILE_GET_REQUEST.op:
         return DBRes(rows=[{"default_provider": "microsoft"}])
-      if op == "db:security:identities:unlink_provider:1":
+      if key == "db:security:identities:unlink_provider:1":
         return DBRes(rows=[{"providers_remaining": 1}], rowcount=1)
       return DBRes()
 
@@ -354,11 +381,12 @@ def test_unlink_default_provider_without_new_default_raises():
   svc_mod.unbox_request = fake_get
 
   class LocalDb(DummyDb):
-    async def run(self, op, args):
-      self.calls.append((op, args))
-      if op == "db:users:profile:get_profile:1":
+    async def run(self, op, args=None):
+      key, params = _normalize_db_call(op, args)
+      self.calls.append((key, params))
+      if key == PROFILE_GET_REQUEST.op:
         return DBRes(rows=[{"default_provider": "google"}])
-      if op == "db:security:identities:unlink_provider:1":
+      if key == "db:security:identities:unlink_provider:1":
         return DBRes(rows=[{"providers_remaining": 1}], rowcount=1)
       return DBRes()
 
@@ -377,11 +405,12 @@ def test_unlink_default_provider_sets_new_default_and_revokes_tokens():
   svc_mod.unbox_request = fake_get
 
   class LocalDb(DummyDb):
-    async def run(self, op, args):
-      self.calls.append((op, args))
-      if op == "db:users:profile:get_profile:1":
+    async def run(self, op, args=None):
+      key, params = _normalize_db_call(op, args)
+      self.calls.append((key, params))
+      if key == PROFILE_GET_REQUEST.op:
         return DBRes(rows=[{"default_provider": "google"}])
-      if op == "db:security:identities:unlink_provider:1":
+      if key == "db:security:identities:unlink_provider:1":
         return DBRes(rows=[{"providers_remaining": 1}], rowcount=1)
       return DBRes()
 
@@ -401,13 +430,14 @@ def test_unlink_last_provider_soft_deletes_and_revokes():
   svc_mod.unbox_request = fake_get
 
   class LocalDb(DummyDb):
-    async def run(self, op, args):
-      self.calls.append((op, args))
-      if op == "db:users:profile:get_profile:1":
+    async def run(self, op, args=None):
+      key, params = _normalize_db_call(op, args)
+      self.calls.append((key, params))
+      if key == PROFILE_GET_REQUEST.op:
         return DBRes(rows=[{"default_provider": "google"}])
-      if op == "db:security:identities:unlink_provider:1":
+      if key == "db:security:identities:unlink_provider:1":
         return DBRes(rows=[{"providers_remaining": 0}], rowcount=1)
-      if op == "db:security:identities:unlink_last_provider:1":
+      if key == "db:security:identities:unlink_last_provider:1":
         return DBRes([], 1)
       return DBRes()
 


### PR DESCRIPTION
## Summary
- add an accounts.profile registry package with typed DBRequest helpers and router registration
- update modules and RPC services to call the new helpers instead of hard-coded profile URNs
- adjust unit tests to consume DBRequest instances and expect the canonical accounts profile operations

## Testing
- pytest tests/test_auth_microsoft_profile_image_update.py tests/test_auth_microsoft_profile_image_clear.py tests/test_auth_google_profile_image_update.py tests/test_auth_google_profile_refresh.py tests/test_auth_microsoft_profile_refresh.py tests/test_users_profile_services.py tests/test_users_providers_services.py

------
https://chatgpt.com/codex/tasks/task_e_68de9a51b384832594bdf6cf9f3abd41