### PR TITLE
Add assistant generation registry helpers and update consumers

### DIFF
--- a/rpc/discord/chat/services.py
+++ b/rpc/discord/chat/services.py
@@ -8,6 +8,11 @@ from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.discord_chat_module import DiscordChatModule
 from server.modules.openai_module import OpenaiModule
+from server.registry.generation.conversations import (
+  insert_conversation_request,
+  list_by_time_request,
+  update_output_request,
+)
 
 from .models import (
   DiscordChatPersonaRequest1,
@@ -314,12 +319,11 @@ async def discord_chat_get_conversation_history_v1(request: Request):
   start = now - timedelta(days=30)
   try:
     history_res = await db_module.run(
-      "db:assistant:conversations:list_by_time:1",
-      {
-        "personas_recid": personas_recid,
-        "start": start.isoformat(),
-        "end": now.isoformat(),
-      },
+      list_by_time_request(
+        personas_recid=personas_recid,
+        start=start.isoformat(),
+        end=now.isoformat(),
+      )
     )
   except Exception:
     logging.exception("[discord_chat_get_conversation_history_v1] db query failed")
@@ -531,19 +535,18 @@ async def discord_chat_insert_conversation_input_v1(request: Request):
   channel_id = payload.get("channel_id")
   user_id = payload.get("user_id")
 
-  args = {
-    "personas_recid": personas_recid,
-    "models_recid": models_recid,
-    "guild_id": str(guild_id) if guild_id is not None else None,
-    "channel_id": str(channel_id) if channel_id is not None else None,
-    "user_id": str(user_id) if user_id is not None else None,
-    "input_data": message,
-    "output_data": "",
-    "tokens": None,
-  }
-
   try:
-    insert_res = await db_module.run("db:assistant:conversations:insert:1", args)
+    insert_res = await db_module.run(
+      insert_conversation_request(
+        personas_recid=personas_recid,
+        models_recid=models_recid,
+        guild_id=guild_id,
+        channel_id=channel_id,
+        user_id=user_id,
+        input_data=message,
+        output_data="",
+      )
+    )
   except Exception:
     logging.exception("[discord_chat_insert_conversation_input_v1] insert failed", extra={"persona": persona})
     return RPCResponse(
@@ -696,12 +699,11 @@ async def discord_chat_generate_persona_response_v1(request: Request):
     await db_module.on_ready()
     try:
       await db_module.run(
-        "db:assistant:conversations:update_output:1",
-        {
-          "recid": conversation_reference,
-          "output_data": content or "",
-          "tokens": total_tokens,
-        },
+        update_output_request(
+          recid=conversation_reference,
+          output_data=content or "",
+          tokens=total_tokens,
+        )
       )
     except Exception:
       logging.exception(

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -8,6 +8,18 @@ from openai import AsyncOpenAI
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
+from server.registry.generation.conversations import (
+  find_recent_request,
+  insert_conversation_request,
+  update_output_request,
+)
+from server.registry.generation.models import list_models_request
+from server.registry.generation.personas import (
+  delete_persona_request,
+  get_persona_by_name_request,
+  list_personas_request,
+  upsert_persona_request,
+)
 from server.registry.system.config import get_config_request
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -106,7 +118,8 @@ class OpenaiModule(BaseModule):
     if not self.db:
       return None
     try:
-      res = await self.db.run("db:assistant:personas:get_by_name:1", {"name": name})
+      request = get_persona_by_name_request(name)
+      res = await self.db.run(request)
       if res.rows:
         return res.rows[0]
     except Exception:
@@ -136,12 +149,12 @@ class OpenaiModule(BaseModule):
 
   async def list_models(self) -> List[Dict[str, Any]]:
     assert self.db
-    res = await self.db.run("db:assistant:models:list:1", {})
+    res = await self.db.run(list_models_request())
     return list(res.rows or [])
 
   async def list_personas(self) -> List[Dict[str, Any]]:
     assert self.db
-    res = await self.db.run("db:assistant:personas:list:1", {})
+    res = await self.db.run(list_personas_request())
     personas: List[Dict[str, Any]] = []
     for row in res.rows or []:
       personas.append({
@@ -170,14 +183,18 @@ class OpenaiModule(BaseModule):
     }
     if not payload["name"]:
       raise ValueError("name required")
-    await self.db.run("db:assistant:personas:upsert:1", payload)
+    request = upsert_persona_request(
+      recid=payload["recid"],
+      name=payload["name"],
+      prompt=payload["prompt"],
+      tokens=payload["tokens"],
+      models_recid=payload["models_recid"],
+    )
+    await self.db.run(request)
 
   async def delete_persona(self, recid: int | None = None, name: str | None = None) -> None:
     assert self.db
-    await self.db.run(
-      "db:assistant:personas:delete:1",
-      {"recid": recid, "name": name},
-    )
+    await self.db.run(delete_persona_request(recid=recid, name=name))
 
   async def _log_conversation_start(
     self,
@@ -192,37 +209,30 @@ class OpenaiModule(BaseModule):
     if not self.db or personas_recid is None or models_recid is None:
       return None
     try:
-      guild_id_str = str(guild_id) if guild_id is not None else None
-      channel_id_str = str(channel_id) if channel_id is not None else None
-      user_id_str = str(user_id) if user_id is not None else None
-      existing = await self.db.run(
-        "db:assistant:conversations:find_recent:1",
-        {
-          "personas_recid": personas_recid,
-          "models_recid": models_recid,
-          "guild_id": guild_id_str,
-          "channel_id": channel_id_str,
-          "user_id": user_id_str,
-          "input_data": input_data,
-        },
+      request = find_recent_request(
+        personas_recid=personas_recid,
+        models_recid=models_recid,
+        guild_id=guild_id,
+        channel_id=channel_id,
+        user_id=user_id,
+        input_data=input_data,
       )
+      existing = await self.db.run(request)
       if existing.rows:
         recid = existing.rows[0].get("recid")
         if recid is not None:
           return recid
-      res = await self.db.run(
-        "db:assistant:conversations:insert:1",
-        {
-          "personas_recid": personas_recid,
-          "models_recid": models_recid,
-          "guild_id": guild_id_str,
-          "channel_id": channel_id_str,
-          "user_id": user_id_str,
-          "input_data": input_data,
-          "output_data": "",
-          "tokens": tokens,
-        },
+      insert_request = insert_conversation_request(
+        personas_recid=personas_recid,
+        models_recid=models_recid,
+        guild_id=guild_id,
+        channel_id=channel_id,
+        user_id=user_id,
+        input_data=input_data,
+        output_data="",
+        tokens=tokens,
       )
+      res = await self.db.run(insert_request)
       if res.rows:
         return res.rows[0].get("recid")
     except Exception:
@@ -239,8 +249,7 @@ class OpenaiModule(BaseModule):
       return
     try:
       res = await self.db.run(
-        "db:assistant:conversations:update_output:1",
-        {"recid": recid, "output_data": output_data, "tokens": tokens},
+        update_output_request(recid=recid, output_data=output_data, tokens=tokens)
       )
       if res.rowcount == 0:
         logging.warning(

--- a/server/registry/assistant/conversations/__init__.py
+++ b/server/registry/assistant/conversations/__init__.py
@@ -1,0 +1,142 @@
+"""Assistant conversation registry helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from server.registry.types import DBRequest
+
+from . import mssql  # noqa: F401 - ensure provider imports are discoverable
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "find_recent_request",
+  "insert_conversation_request",
+  "list_by_time_request",
+  "list_recent_request",
+  "register",
+  "update_output_request",
+]
+
+_OP_PREFIX = "db:assistant:conversations"
+_PROVIDER_MAP = "assistant.conversations"
+
+
+def _op(name: str) -> str:
+  return f"{_OP_PREFIX}:{name}:1"
+
+
+def _normalize_identifier(value: Any) -> str | None:
+  if value is None:
+    return None
+  return str(value)
+
+
+def insert_conversation_request(
+  *,
+  personas_recid: int,
+  models_recid: int,
+  guild_id: str | int | None,
+  channel_id: str | int | None,
+  user_id: str | int | None,
+  input_data: str,
+  output_data: str | None = None,
+  tokens: int | None = None,
+) -> DBRequest:
+  return DBRequest(
+    op=_op("insert"),
+    params={
+      "personas_recid": personas_recid,
+      "models_recid": models_recid,
+      "guild_id": _normalize_identifier(guild_id),
+      "channel_id": _normalize_identifier(channel_id),
+      "user_id": _normalize_identifier(user_id),
+      "input_data": input_data,
+      "output_data": output_data,
+      "tokens": tokens,
+    },
+  )
+
+
+def find_recent_request(
+  *,
+  personas_recid: int,
+  models_recid: int,
+  guild_id: str | int | None,
+  channel_id: str | int | None,
+  user_id: str | int | None,
+  input_data: str,
+  window_seconds: int | None = None,
+) -> DBRequest:
+  params = {
+    "personas_recid": personas_recid,
+    "models_recid": models_recid,
+    "guild_id": _normalize_identifier(guild_id),
+    "channel_id": _normalize_identifier(channel_id),
+    "user_id": _normalize_identifier(user_id),
+    "input_data": input_data,
+  }
+  if window_seconds is not None:
+    params["window_seconds"] = window_seconds
+  return DBRequest(op=_op("find_recent"), params=params)
+
+
+def update_output_request(
+  *,
+  recid: int,
+  output_data: str | None,
+  tokens: int | None,
+) -> DBRequest:
+  return DBRequest(
+    op=_op("update_output"),
+    params={
+      "recid": recid,
+      "output_data": output_data,
+      "tokens": tokens,
+    },
+  )
+
+
+def list_by_time_request(*, personas_recid: int, start: str, end: str) -> DBRequest:
+  return DBRequest(
+    op=_op("list_by_time"),
+    params={
+      "personas_recid": personas_recid,
+      "start": start,
+      "end": end,
+    },
+  )
+
+
+def list_recent_request() -> DBRequest:
+  return DBRequest(op=_op("list_recent"), params={})
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function(
+    "find_recent",
+    version=1,
+    provider_map=f"{_PROVIDER_MAP}.find_recent",
+  )
+  router.add_function(
+    "insert",
+    version=1,
+    provider_map=f"{_PROVIDER_MAP}.insert",
+  )
+  router.add_function(
+    "list_by_time",
+    version=1,
+    provider_map=f"{_PROVIDER_MAP}.list_by_time",
+  )
+  router.add_function(
+    "list_recent",
+    version=1,
+    provider_map=f"{_PROVIDER_MAP}.list_recent",
+  )
+  router.add_function(
+    "update_output",
+    version=1,
+    provider_map=f"{_PROVIDER_MAP}.update_output",
+  )

--- a/server/registry/assistant/models/__init__.py
+++ b/server/registry/assistant/models/__init__.py
@@ -1,0 +1,46 @@
+"""Assistant model registry helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from server.registry.types import DBRequest
+
+from . import mssql  # noqa: F401 - ensure provider imports are discoverable
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "get_model_by_name_request",
+  "list_models_request",
+  "register",
+]
+
+_OP_PREFIX = "db:assistant:models"
+_PROVIDER_MAP = "assistant.models"
+
+
+def _op(name: str) -> str:
+  return f"{_OP_PREFIX}:{name}:1"
+
+
+def list_models_request() -> DBRequest:
+  return DBRequest(op=_op("list"), params={})
+
+
+def get_model_by_name_request(name: str) -> DBRequest:
+  return DBRequest(op=_op("get_by_name"), params={"name": name})
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function(
+    "get_by_name",
+    version=1,
+    provider_map=f"{_PROVIDER_MAP}.get_by_name",
+  )
+  router.add_function(
+    "list",
+    version=1,
+    provider_map=f"{_PROVIDER_MAP}.list",
+  )

--- a/server/registry/assistant/personas/__init__.py
+++ b/server/registry/assistant/personas/__init__.py
@@ -1,0 +1,88 @@
+"""Assistant persona registry helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from server.registry.types import DBRequest
+
+from . import mssql  # noqa: F401 - ensure provider imports are discoverable
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "delete_persona_request",
+  "get_persona_by_name_request",
+  "list_personas_request",
+  "register",
+  "upsert_persona_request",
+]
+
+_OP_PREFIX = "db:assistant:personas"
+_PROVIDER_MAP = "assistant.personas"
+
+
+def _op(name: str) -> str:
+  return f"{_OP_PREFIX}:{name}:1"
+
+
+def get_persona_by_name_request(name: str) -> DBRequest:
+  return DBRequest(op=_op("get_by_name"), params={"name": name})
+
+
+def list_personas_request() -> DBRequest:
+  return DBRequest(op=_op("list"), params={})
+
+
+def upsert_persona_request(
+  *,
+  recid: int | None,
+  name: str,
+  prompt: str,
+  tokens: int,
+  models_recid: int,
+) -> DBRequest:
+  return DBRequest(
+    op=_op("upsert"),
+    params={
+      "recid": recid,
+      "name": name,
+      "prompt": prompt,
+      "tokens": tokens,
+      "models_recid": models_recid,
+    },
+  )
+
+
+def delete_persona_request(*, recid: int | None = None, name: str | None = None) -> DBRequest:
+  return DBRequest(
+    op=_op("delete"),
+    params={
+      "recid": recid,
+      "name": name,
+    },
+  )
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function(
+    "delete",
+    version=1,
+    provider_map=f"{_PROVIDER_MAP}.delete",
+  )
+  router.add_function(
+    "get_by_name",
+    version=1,
+    provider_map=f"{_PROVIDER_MAP}.get_by_name",
+  )
+  router.add_function(
+    "list",
+    version=1,
+    provider_map=f"{_PROVIDER_MAP}.list",
+  )
+  router.add_function(
+    "upsert",
+    version=1,
+    provider_map=f"{_PROVIDER_MAP}.upsert",
+  )

--- a/server/registry/generation/__init__.py
+++ b/server/registry/generation/__init__.py
@@ -1,0 +1,24 @@
+"""Generation domain registry bindings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from server.registry.assistant import conversations, models, personas
+
+if TYPE_CHECKING:
+  from server.registry import RegistryRouter
+
+__all__ = [
+  "conversations",
+  "models",
+  "personas",
+  "register",
+]
+
+
+def register(router: "RegistryRouter") -> None:
+  domain = router.domain("assistant")
+  conversations.register(domain.subdomain("conversations"))
+  models.register(domain.subdomain("models"))
+  personas.register(domain.subdomain("personas"))

--- a/server/registry/generation/conversations/__init__.py
+++ b/server/registry/generation/conversations/__init__.py
@@ -1,0 +1,19 @@
+"""Generation conversation helpers."""
+
+from server.registry.assistant.conversations import (
+  find_recent_request,
+  insert_conversation_request,
+  list_by_time_request,
+  list_recent_request,
+  register,
+  update_output_request,
+)
+
+__all__ = [
+  "find_recent_request",
+  "insert_conversation_request",
+  "list_by_time_request",
+  "list_recent_request",
+  "register",
+  "update_output_request",
+]

--- a/server/registry/generation/models/__init__.py
+++ b/server/registry/generation/models/__init__.py
@@ -1,0 +1,13 @@
+"""Generation model helpers."""
+
+from server.registry.assistant.models import (
+  get_model_by_name_request,
+  list_models_request,
+  register,
+)
+
+__all__ = [
+  "get_model_by_name_request",
+  "list_models_request",
+  "register",
+]

--- a/server/registry/generation/personas/__init__.py
+++ b/server/registry/generation/personas/__init__.py
@@ -1,0 +1,17 @@
+"""Generation persona helpers."""
+
+from server.registry.assistant.personas import (
+  delete_persona_request,
+  get_persona_by_name_request,
+  list_personas_request,
+  register,
+  upsert_persona_request,
+)
+
+__all__ = [
+  "delete_persona_request",
+  "get_persona_by_name_request",
+  "list_personas_request",
+  "register",
+  "upsert_persona_request",
+]

--- a/tests/test_openai_module.py
+++ b/tests/test_openai_module.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 
 from server.modules.openai_module import OpenaiModule, SummaryQueue
 from server.modules.providers import DBResult
+from server.registry.types import DBRequest
 
 
 def test_fetch_chat_message_order_and_return():
@@ -96,10 +97,13 @@ def test_fetch_chat_logs_conversation():
 
   class DummyDB:
     def __init__(self):
-      self.calls = []
+      self.calls: list[DBRequest] = []
 
-    async def run(self, op, args):
-      self.calls.append((op, args))
+    async def run(self, request):
+      assert isinstance(request, DBRequest)
+      self.calls.append(request)
+      op = request.op
+      params = request.params
       if op == "db:assistant:personas:get_by_name:1":
         return DBResult(
           rows=[
@@ -113,24 +117,24 @@ def test_fetch_chat_logs_conversation():
           rowcount=1,
         )
       if op == "db:assistant:conversations:find_recent:1":
-        assert args["personas_recid"] == 1
-        assert args["models_recid"] == 2
-        assert args["guild_id"] == "1"
-        assert args["channel_id"] == "2"
-        assert args["user_id"] == "3"
-        assert args["input_data"] == "hello"
+        assert params["personas_recid"] == 1
+        assert params["models_recid"] == 2
+        assert params["guild_id"] == "1"
+        assert params["channel_id"] == "2"
+        assert params["user_id"] == "3"
+        assert params["input_data"] == "hello"
         return DBResult(rows=[], rowcount=0)
       if op == "db:assistant:conversations:insert:1":
-        assert args["personas_recid"] == 1
-        assert args["models_recid"] == 2
-        assert args["guild_id"] == "1"
-        assert args["channel_id"] == "2"
-        assert args["user_id"] == "3"
-        assert args["input_data"] == "hello"
-        assert args["tokens"] == 7
+        assert params["personas_recid"] == 1
+        assert params["models_recid"] == 2
+        assert params["guild_id"] == "1"
+        assert params["channel_id"] == "2"
+        assert params["user_id"] == "3"
+        assert params["input_data"] == "hello"
+        assert params["tokens"] == 7
         return DBResult(rows=[{"recid": 99}], rowcount=1)
       if op == "db:assistant:conversations:update_output:1":
-        assert args == {"recid": 99, "output_data": "hi", "tokens": 42}
+        assert params == {"recid": 99, "output_data": "hi", "tokens": 42}
         return DBResult(rowcount=1)
       return DBResult()
 
@@ -153,7 +157,7 @@ def test_fetch_chat_logs_conversation():
   assert res["content"] == "hi"
   assert dummy_create.kwargs["max_tokens"] == 5
   assert "tools" not in dummy_create.kwargs
-  calls = [c[0] for c in module.db.calls]
+  calls = [request.op for request in module.db.calls]
   assert calls == [
     "db:assistant:personas:get_by_name:1",
     "db:assistant:conversations:find_recent:1",
@@ -167,9 +171,10 @@ def test_log_conversation_end_warns_when_no_rows_updated(caplog):
   module = OpenaiModule(app)
 
   class DummyDB:
-    async def run(self, op, args):
-      assert op == "db:assistant:conversations:update_output:1"
-      assert args == {"recid": 99, "output_data": "done", "tokens": 3}
+    async def run(self, request):
+      assert isinstance(request, DBRequest)
+      assert request.op == "db:assistant:conversations:update_output:1"
+      assert request.params == {"recid": 99, "output_data": "done", "tokens": 3}
       return DBResult(rowcount=0)
 
   module.db = DummyDB()
@@ -198,11 +203,13 @@ def test_fetch_chat_reuses_existing_conversation():
 
   class DummyDB:
     def __init__(self):
-      self.calls: list[tuple[str, dict]] = []
+      self.calls: list[DBRequest] = []
       self.insert_count = 0
 
-    async def run(self, op, args):
-      self.calls.append((op, args))
+    async def run(self, request):
+      assert isinstance(request, DBRequest)
+      self.calls.append(request)
+      op = request.op
       if op == "db:assistant:personas:get_by_name:1":
         return DBResult(
           rows=[
@@ -245,7 +252,7 @@ def test_fetch_chat_reuses_existing_conversation():
   asyncio.run(module.fetch_chat(**args))
 
   assert module.db.insert_count == 1
-  call_ops = [op for op, _ in module.db.calls]
+  call_ops = [request.op for request in module.db.calls]
   assert call_ops == [
     "db:assistant:personas:get_by_name:1",
     "db:assistant:conversations:find_recent:1",
@@ -275,10 +282,13 @@ def test_persona_response_calls_openai():
 
   class DummyDB:
     def __init__(self):
-      self.calls = []
+      self.calls: list[DBRequest] = []
 
-    async def run(self, op, args):
-      self.calls.append((op, args))
+    async def run(self, request):
+      assert isinstance(request, DBRequest)
+      self.calls.append(request)
+      op = request.op
+      params = request.params
       if op == "db:assistant:personas:get_by_name:1":
         return DBResult(
           rows=[{
@@ -292,19 +302,19 @@ def test_persona_response_calls_openai():
           rowcount=1,
         )
       if op == "db:assistant:conversations:find_recent:1":
-        assert args["input_data"] == "Tell me"
+        assert params["input_data"] == "Tell me"
         return DBResult(rows=[], rowcount=0)
       if op == "db:assistant:conversations:insert:1":
-        assert args["personas_recid"] == 1
-        assert args["models_recid"] == 2
-        assert args["guild_id"] == "1"
-        assert args["channel_id"] == "2"
-        assert args["user_id"] == "3"
-        assert args["input_data"] == "Tell me"
-        assert args["tokens"] is None
+        assert params["personas_recid"] == 1
+        assert params["models_recid"] == 2
+        assert params["guild_id"] == "1"
+        assert params["channel_id"] == "2"
+        assert params["user_id"] == "3"
+        assert params["input_data"] == "Tell me"
+        assert params["tokens"] is None
         return DBResult(rows=[{"recid": 77}], rowcount=1)
       if op == "db:assistant:conversations:update_output:1":
-        assert args == {"recid": 77, "output_data": "Response", "tokens": 11}
+        assert params == {"recid": 77, "output_data": "Response", "tokens": 11}
         return DBResult(rowcount=1)
       return DBResult()
 
@@ -332,7 +342,7 @@ def test_persona_response_calls_openai():
     {"role": "system", "content": "be stark"},
     {"role": "user", "content": "Tell me"},
   ]
-  assert [op for op, _ in module.db.calls] == [
+  assert [request.op for request in module.db.calls] == [
     "db:assistant:personas:get_by_name:1",
     "db:assistant:conversations:find_recent:1",
     "db:assistant:conversations:insert:1",
@@ -345,8 +355,9 @@ def test_persona_response_missing_persona():
   module = OpenaiModule(app)
 
   class DummyDB:
-    async def run(self, op, args):
-      if op == "db:assistant:personas:get_by_name:1":
+    async def run(self, request):
+      assert isinstance(request, DBRequest)
+      if request.op == "db:assistant:personas:get_by_name:1":
         return DBResult(rows=[], rowcount=0)
       return DBResult()
 
@@ -362,8 +373,9 @@ def test_persona_response_stub_without_client():
   module = OpenaiModule(app)
 
   class DummyDB:
-    async def run(self, op, args):
-      if op == "db:assistant:personas:get_by_name:1":
+    async def run(self, request):
+      assert isinstance(request, DBRequest)
+      if request.op == "db:assistant:personas:get_by_name:1":
         return DBResult(
           rows=[{
             "recid": 1,


### PR DESCRIPTION
## Summary
- add generation registry package that wires assistant conversations, models, and personas helpers
- provide DBRequest helper constructors for assistant registry operations and re-export them through the generation namespace
- refactor OpenAI and Discord chat modules plus tests to rely on the new helpers instead of hard-coded registry strings

## Testing
- `pytest tests/test_openai_module.py tests/test_discord_chat_services.py`


------
https://chatgpt.com/codex/tasks/task_e_68deadd5cb5483259a8aaa0590b5768d