### PR TITLE
Add account users registry helper for credit updates

### DIFF
--- a/server/modules/user_admin_module.py
+++ b/server/modules/user_admin_module.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
+from server.registry.account.users import set_credits_request
 from server.registry.accounts.profile import (
   get_profile_request,
   set_display_request,
@@ -44,10 +45,8 @@ class UserAdminModule(BaseModule):
     return credits
 
   async def set_credits(self, guid: str, credits: int) -> None:
-    await self.db.run(
-      "db:support:users:set_credits:1",
-      {"guid": guid, "credits": credits},
-    )
+    request = set_credits_request(guid=guid, credits=credits)
+    await self.db.run(request)
 
   async def reset_display(self, guid: str) -> None:
     request = set_display_request(guid=guid, display_name="Default User")

--- a/server/registry/account/__init__.py
+++ b/server/registry/account/__init__.py
@@ -1,0 +1,21 @@
+"""Account domain registry bindings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from . import users
+
+if TYPE_CHECKING:
+  from server.registry import RegistryRouter
+
+__all__ = [
+  "users",
+  "register",
+]
+
+
+def register(router: "RegistryRouter") -> None:
+  """Register account domain routes."""
+  domain = router.domain("account")
+  users.register(domain.subdomain("users"))

--- a/server/registry/account/users/__init__.py
+++ b/server/registry/account/users/__init__.py
@@ -1,0 +1,34 @@
+"""Account user registry helpers."""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from server.registry.types import DBRequest
+from . import mssql  # noqa: F401 - ensure provider import
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "set_credits_request",
+  "register",
+]
+
+_DEF_PROVIDER = "account.users"
+
+
+def _request(name: str, params: dict[str, Any]) -> DBRequest:
+  return DBRequest(op=f"db:account:users:{name}:1", params=params)
+
+
+def set_credits_request(*, guid: str, credits: int) -> DBRequest:
+  return _request("set_credits", {"guid": guid, "credits": credits})
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function(
+    "set_credits",
+    version=1,
+    provider_map=f"{_DEF_PROVIDER}.set_credits",
+  )

--- a/server/registry/account/users/mssql.py
+++ b/server/registry/account/users/mssql.py
@@ -1,0 +1,16 @@
+"""Account-domain MSSQL helpers for user records."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from server.registry.support.users.mssql import set_credits_v1 as _support_set_credits_v1
+
+__all__ = [
+  "set_credits_v1",
+]
+
+
+# Delegate to the support-domain implementation to avoid duplication.
+def set_credits_v1(args: dict[str, Any]):
+  return _support_set_credits_v1(args)

--- a/server/registry/providers/mssql.py
+++ b/server/registry/providers/mssql.py
@@ -107,6 +107,7 @@ _PROVIDER_SPECS: dict[str, tuple[str, str]] = {
   "public.vars.get_hostname": ("server.registry.public.vars.mssql", "get_hostname_v1"),
   "public.vars.get_repo": ("server.registry.public.vars.mssql", "get_repo_v1"),
   "public.vars.get_version": ("server.registry.public.vars.mssql", "get_version_v1"),
+  "account.users.set_credits": ("server.registry.account.users.mssql", "set_credits_v1"),
   "support.users.set_credits": ("server.registry.support.users.mssql", "set_credits_v1"),
   "system.config.delete_config": ("server.registry.system.config.mssql", "delete_config_v1"),
   "system.config.get_config": ("server.registry.system.config.mssql", "get_config_v1"),


### PR DESCRIPTION
## Summary
- add a new account domain registry with a users helper that returns the db:account:users:set_credits:1 request
- wire UserAdminModule through the helper and expose the account users mapping in the MSSQL provider
- reuse the support-domain implementation for the account users provider binding

## Testing
- pytest tests/test_support_services.py tests/test_account_user_services.py

------
https://chatgpt.com/codex/tasks/task_e_68deb56800b083259a941f7f048a8a64