### PR TITLE
Refactor MSSQL provider to use registry query map

### DIFF
--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -2,23 +2,13 @@
 from typing import Any, Dict
 from collections.abc import Mapping
 import inspect
-import importlib
-
-from pydantic import ValidationError
 
 from ... import DbProviderBase, DBResult
 from .logic import init_pool, close_pool
 from .db_helpers import Operation, execute_operation
-from . import registry as registry
 
-get_handler = registry.get_handler
 from server.registry.providers.mssql import PROVIDER_QUERIES
 from server.registry.types import DBRequest, DBResponse
-
-
-def _current_dbresult_cls():
-  providers_mod = importlib.import_module("server.modules.providers")
-  return getattr(providers_mod, "DBResult")
 
 
 class MssqlProvider(DbProviderBase):
@@ -29,78 +19,39 @@ class MssqlProvider(DbProviderBase):
     await close_pool()
 
   def _resolve_provider_callable(self, op: str):
+    parts = op.split(":")
+    if len(parts) != 5 or parts[0] != "db":
+      raise KeyError(f"Unsupported operation key: {op}")
+    _, domain, subdomain, name, version_str = parts
     try:
-      handler = get_handler(op)
-    except KeyError:
-      parts = op.split(":")
-      if len(parts) != 5 or parts[0] != "db":
-        raise KeyError(f"Unsupported operation key: {op}")
-      _, domain, subdomain, name, version_str = parts
-      try:
-        version = int(version_str)
-      except ValueError as exc:
-        raise KeyError(f"Invalid operation version for '{op}'") from exc
-      provider_map = f"{domain}.{subdomain}.{name}"
-      entry = PROVIDER_QUERIES.get(provider_map)
-      if entry is None:
-        raise KeyError(f"No MSSQL handler for '{op}'")
-      if isinstance(entry, Mapping):
-        handler = entry.get(version)
-      else:
-        handler = entry
-      if handler is None:
-        raise KeyError(f"No MSSQL handler for '{op}' version {version}")
-      return handler
-    expects_dbrequest = False
-    try:
-      signature = inspect.signature(handler)
-    except (TypeError, ValueError):
-      signature = None
-    if signature:
-      params = list(signature.parameters.values())
-      if params and params[0].annotation is DBRequest:
-        expects_dbrequest = True
-
-    if expects_dbrequest:
-      return handler
-
-    async def _wrapped(request: DBRequest):
-      call_arg: Any = request.params
-      result = handler(call_arg)
-      if inspect.isawaitable(result):
-        result = await result
-      return result
-
-    return _wrapped
+      version = int(version_str)
+    except ValueError as exc:
+      raise KeyError(f"Invalid operation version for '{op}'") from exc
+    provider_map = f"{domain}.{subdomain}.{name}"
+    entry = PROVIDER_QUERIES.get(provider_map)
+    if entry is None:
+      raise KeyError(f"No MSSQL handler for '{op}'")
+    if isinstance(entry, Mapping):
+      handler = entry.get(version)
+    else:
+      handler = entry
+    if handler is None:
+      raise KeyError(f"No MSSQL handler for '{op}' version {version}")
+    if not callable(handler):
+      raise TypeError(
+        f"Provider mapping for '{provider_map}' version {version} is not callable"
+      )
+    return handler
 
   async def run(self, op: str, args: Dict[str, Any]) -> DBResult:
     handler = self._resolve_provider_callable(op)
     request = DBRequest(op=op, params=args)
-    spec = await handler(request)
-
-    if isinstance(spec, DBResponse):
-      return spec.to_result()
-
-    DBResultCls = _current_dbresult_cls()
-
-    async def _resolve(result: Any) -> DBResult:
-      if isinstance(result, Operation):
-        return await execute_operation(result)
-      if isinstance(result, DBResultCls):
-        return result
-      if isinstance(result, Mapping):
-        validator = getattr(DBResultCls, "model_validate", None)
-        try:
-          if callable(validator):
-            return validator(result)
-          return DBResultCls(**result)
-        except (ValidationError, TypeError, ValueError) as exc:
-          raise TypeError(
-            f"Handler '{op}' returned mapping that cannot be parsed as DBResult"
-          ) from exc
+    response = handler(request)
+    if inspect.isawaitable(response):
+      response = await response
+    if not isinstance(response, DBResponse):
       raise TypeError(
-        f"Handler '{op}' returned unsupported result type: {type(result)!r}."
-        " Expected Operation, DBResult, mapping, or DBResponse."
+        f"Handler '{op}' returned unsupported result type: {type(response)!r}."
+        " Expected DBResponse."
       )
-
-    return await _resolve(spec)
+    return response.to_result()

--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -1,20 +1,24 @@
 import asyncio
 from uuid import UUID
 
-from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.modules.providers.database.mssql_provider as mssql_provider
 from server.modules.providers import DBResult, DbRunMode
+from server.modules.providers.database.mssql_provider import MssqlProvider
+from server.registry.providers import mssql as registry_mssql
+from server.registry.types import DBResponse
+
+
+def _set_provider_callable(monkeypatch, provider_map: str, handler):
+  monkeypatch.setitem(mssql_provider.PROVIDER_QUERIES, provider_map, {1: handler})
 
 
 def test_run_json_one(monkeypatch):
   provider = MssqlProvider()
+  op = "db:test:queries:json_one:1"
 
-  def fake_get_handler(op):
-    assert op == "test:json_one"
-    def handler(args):
-      assert args == {}
-      return mssql_provider.Operation(DbRunMode.JSON_ONE, "select 1", ())
-    return handler
+  def fake_handler(params):
+    assert params == {}
+    return mssql_provider.Operation(DbRunMode.JSON_ONE, "select 1", ())
 
   async def fake_execute_operation(operation):
     assert isinstance(operation, mssql_provider.Operation)
@@ -23,10 +27,11 @@ def test_run_json_one(monkeypatch):
     assert operation.params == ()
     return DBResult(rows=[{"v": 1}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
   monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  _set_provider_callable(monkeypatch, "test.queries.json_one", registry_mssql._wrap(fake_handler))
 
-  res = asyncio.run(provider.run("test:json_one", {}))
+  res = asyncio.run(provider.run(op, {}))
+
   assert isinstance(res, DBResult)
   assert res.rows == [{"v": 1}]
   assert res.rowcount == 1
@@ -34,13 +39,11 @@ def test_run_json_one(monkeypatch):
 
 def test_run_row_one(monkeypatch):
   provider = MssqlProvider()
+  op = "db:test:queries:row_one:1"
 
-  def fake_get_handler(op):
-    assert op == "test:row_one"
-    def handler(args):
-      assert args == {}
-      return mssql_provider.Operation(DbRunMode.ROW_ONE, "select 1", ())
-    return handler
+  def fake_handler(params):
+    assert params == {}
+    return mssql_provider.Operation(DbRunMode.ROW_ONE, "select 1", ())
 
   async def fake_execute_operation(operation):
     assert isinstance(operation, mssql_provider.Operation)
@@ -49,10 +52,11 @@ def test_run_row_one(monkeypatch):
     assert operation.params == ()
     return DBResult(rows=[{"v": 1}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
   monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  _set_provider_callable(monkeypatch, "test.queries.row_one", registry_mssql._wrap(fake_handler))
 
-  res = asyncio.run(provider.run("test:row_one", {}))
+  res = asyncio.run(provider.run(op, {}))
+
   assert isinstance(res, DBResult)
   assert res.rows == [{"v": 1}]
   assert res.rowcount == 1
@@ -73,6 +77,7 @@ def test_run_row_many(monkeypatch):
   monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
   res = asyncio.run(provider.run("db:public:users:get_published_files:1", {"guid": guid}))
+
   assert isinstance(res, DBResult)
   assert res.rows == [{"path": "a"}, {"path": "b"}]
   assert res.rowcount == 2
@@ -80,23 +85,22 @@ def test_run_row_many(monkeypatch):
 
 def test_run_json_many(monkeypatch):
   provider = MssqlProvider()
+  op = "db:test:queries:json_many:1"
 
-  def fake_get_handler(op):
-    assert op == "test:json_many"
-    def handler(args):
-      assert args == {}
-      return mssql_provider.Operation(DbRunMode.JSON_MANY, "select", ())
-    return handler
+  def fake_handler(params):
+    assert params == {}
+    return mssql_provider.Operation(DbRunMode.JSON_MANY, "select", ())
 
   async def fake_execute_operation(operation):
     assert isinstance(operation, mssql_provider.Operation)
     assert operation.kind is DbRunMode.JSON_MANY
     return DBResult(rows=[{"v": 1}, {"v": 2}], rowcount=2)
 
-  monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
   monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  _set_provider_callable(monkeypatch, "test.queries.json_many", registry_mssql._wrap(fake_handler))
 
-  res = asyncio.run(provider.run("test:json_many", {}))
+  res = asyncio.run(provider.run(op, {}))
+
   assert isinstance(res, DBResult)
   assert res.rows == [{"v": 1}, {"v": 2}]
   assert res.rowcount == 2
@@ -104,13 +108,11 @@ def test_run_json_many(monkeypatch):
 
 def test_run_exec(monkeypatch):
   provider = MssqlProvider()
+  op = "db:test:queries:exec:1"
 
-  def fake_get_handler(op):
-    assert op == "test:exec"
-    def handler(args):
-      assert args == {}
-      return mssql_provider.Operation(DbRunMode.EXEC, "update", (1,))
-    return handler
+  def fake_handler(params):
+    assert params == {}
+    return mssql_provider.Operation(DbRunMode.EXEC, "update", (1,))
 
   async def fake_execute_operation(operation):
     assert isinstance(operation, mssql_provider.Operation)
@@ -119,10 +121,11 @@ def test_run_exec(monkeypatch):
     assert operation.params == (1,)
     return DBResult(rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
   monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  _set_provider_callable(monkeypatch, "test.queries.exec", registry_mssql._wrap(fake_handler))
 
-  res = asyncio.run(provider.run("test:exec", {}))
+  res = asyncio.run(provider.run(op, {}))
+
   assert isinstance(res, DBResult)
   assert res.rows == []
   assert res.rowcount == 1
@@ -142,7 +145,12 @@ def test_storage_files_set_gallery(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
-  res = asyncio.run(provider.run("db:content:files:set_gallery:1", {"user_guid": guid, "name": "file.txt", "gallery": True}))
+  res = asyncio.run(provider.run("db:content:files:set_gallery:1", {
+    "user_guid": guid,
+    "name": "file.txt",
+    "gallery": True,
+  }))
+
   assert isinstance(res, DBResult)
   assert res.rowcount == 1
 
@@ -167,6 +175,7 @@ def test_storage_cache_set_public(monkeypatch):
     "filename": "file.txt",
     "public": False,
   }))
+
   assert isinstance(res, DBResult)
   assert res.rowcount == 1
 
@@ -195,20 +204,20 @@ def test_unlink_provider_dict_result(monkeypatch):
   provider = MssqlProvider()
   guid = "00000000-0000-0000-0000-000000000002"
 
-  def fake_get_handler(op):
-    assert op == "db:security:identities:unlink_provider:1"
+  async def fake_callable(request):
+    assert request.op == "db:security:identities:unlink_provider:1"
+    assert request.params == {
+      "guid": guid,
+      "provider": "google",
+      "new_provider_recid": 123,
+    }
+    return DBResponse(rows=[{"providers_remaining": 1}], rowcount=1)
 
-    async def handler(args):
-      assert args == {
-        "guid": guid,
-        "provider": "google",
-        "new_provider_recid": 123,
-      }
-      return {"rows": [{"providers_remaining": 1}], "rowcount": 1}
-
-    return handler
-
-  monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
+  _set_provider_callable(
+    monkeypatch,
+    "security.identities.unlink_provider",
+    fake_callable,
+  )
 
   res = asyncio.run(provider.run("db:security:identities:unlink_provider:1", {
     "guid": guid,
@@ -225,27 +234,24 @@ def test_create_session_dict_result(monkeypatch):
   provider = MssqlProvider()
   guid = "00000000-0000-0000-0000-000000000003"
 
-  def fake_get_handler(op):
-    assert op == "db:security:sessions:create_session:1"
+  async def fake_callable(request):
+    assert request.op == "db:security:sessions:create_session:1"
+    assert request.params == {
+      "access_token": "token",
+      "expires": "2024-01-01T00:00:00Z",
+      "fingerprint": "fingerprint",
+      "user_agent": "pytest",
+      "ip_address": "127.0.0.1",
+      "user_guid": guid,
+      "provider": "google",
+    }
+    return DBResponse(rows=[{"session_guid": "sess", "device_guid": "device"}], rowcount=1)
 
-    async def handler(args):
-      assert args == {
-        "access_token": "token",
-        "expires": "2024-01-01T00:00:00Z",
-        "fingerprint": "fingerprint",
-        "user_agent": "pytest",
-        "ip_address": "127.0.0.1",
-        "user_guid": guid,
-        "provider": "google",
-      }
-      return {
-        "rows": [{"session_guid": "sess", "device_guid": "device"}],
-        "rowcount": 1,
-      }
-
-    return handler
-
-  monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
+  _set_provider_callable(
+    monkeypatch,
+    "security.sessions.create_session",
+    fake_callable,
+  )
 
   res = asyncio.run(provider.run("db:security:sessions:create_session:1", {
     "access_token": "token",

--- a/tests/test_mssql_personas_registry.py
+++ b/tests/test_mssql_personas_registry.py
@@ -1,15 +1,16 @@
 from server.modules.providers import DbRunMode
-from server.modules.providers.database.mssql_provider import registry
+from server.modules.providers.database.mssql_provider.db_helpers import Operation
+from server.registry.assistant.personas import mssql as personas_mssql
 
 
 def test_persona_lookup_query_targets_element_name():
-  handler = registry.get_handler("db:assistant:personas:get_by_name:1")
-  mode, sql, params = handler({"name": "stark"})
+  op = personas_mssql.get_by_name_v1({"name": "stark"})
 
-  assert mode is DbRunMode.JSON_ONE
-  assert "FROM vw_personas vp" in sql
-  assert "JOIN assistant_personas ap ON ap.element_name = vp.persona_name" in sql
-  assert "WHERE vp.persona_name = ?" in sql
-  assert "FOR JSON PATH" in sql
-  assert "vp.model_name AS element_model" in sql
-  assert params == ("stark",)
+  assert isinstance(op, Operation)
+  assert op.kind is DbRunMode.JSON_ONE
+  assert "FROM vw_personas vp" in op.sql
+  assert "JOIN assistant_personas ap ON ap.element_name = vp.persona_name" in op.sql
+  assert "WHERE vp.persona_name = ?" in op.sql
+  assert "FOR JSON PATH" in op.sql
+  assert "vp.model_name AS element_model" in op.sql
+  assert op.params == ("stark",)


### PR DESCRIPTION
## Summary
- resolve MSSQL provider callables directly from the registry-provided PROVIDER_QUERIES map and expect DBResponse results from handlers
- update database provider contract tests to exercise the registry wrappers instead of the legacy compatibility layer
- adjust the personas registry test to target the current MSSQL query implementation

## Testing
- pytest tests/test_provider_queries.py tests/test_db_provider_contract.py tests/test_mssql_personas_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68decb9b0b388325b412cc12169fe141