### PR TITLE
Add registry helpers for storage toggles

### DIFF
--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -12,11 +12,14 @@ from .env_module import EnvModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
 from server.registry.content.cache import (
+  count_rows_request,
   delete_cache_folder_request,
   delete_cache_item_request,
   list_cache_request,
+  set_reported_request,
   upsert_cache_item_request,
 )
+from server.registry.content.files import set_gallery_request
 from server.registry.content.public import (
   list_public_request,
   list_reported_request,
@@ -481,18 +484,12 @@ class StorageModule(BaseModule):
 
   async def set_gallery(self, user_guid: str, name: str, gallery: bool):
     assert self.db
-    await self.db.run(
-      "db:content:files:set_gallery:1",
-      {"user_guid": user_guid, "name": name, "gallery": bool(gallery)},
-    )
+    await self.db.run(set_gallery_request(user_guid, name, bool(gallery)))
 
   async def report_file(self, user_guid: str, name: str):
     assert self.db
     path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
-    await self.db.run(
-      "db:content:cache:set_reported:1",
-      {"user_guid": user_guid, "path": path, "filename": filename, "reported": True},
-    )
+    await self.db.run(set_reported_request(user_guid, path=path, filename=filename, reported=True))
 
   async def create_folder(self, user_guid: str, path: str):
     if not self.connection_string or not self.db:
@@ -907,7 +904,7 @@ class StorageModule(BaseModule):
 
   async def get_storage_stats(self):
     assert self.db
-    db_res = await self.db.run("db:content:cache:count_rows:1", {})
+    db_res = await self.db.run(count_rows_request())
     db_rows = db_res.rows[0]["count"] if db_res.rows else 0
     if not self.connection_string:
       return {

--- a/server/registry/content/cache/__init__.py
+++ b/server/registry/content/cache/__init__.py
@@ -11,9 +11,12 @@ __all__ = [
   "register",
   "delete_cache_folder_request",
   "delete_cache_item_request",
+  "set_public_request",
+  "set_reported_request",
   "list_cache_request",
   "replace_user_cache_request",
   "upsert_cache_item_request",
+  "count_rows_request",
 ]
 
 
@@ -68,6 +71,49 @@ def delete_cache_folder_request(user_guid: str, path: str):
     "user_guid": user_guid,
     "path": path,
   })
+
+
+def set_public_request(
+  user_guid: str,
+  *,
+  public: bool,
+  name: str | None = None,
+  path: str | None = None,
+  filename: str | None = None,
+):
+  from server.registry.types import DBRequest
+  params = {
+    "user_guid": user_guid,
+    "public": bool(public),
+  }
+  if name is not None:
+    params["name"] = name
+  if path is not None:
+    params["path"] = path
+  if filename is not None:
+    params["filename"] = filename
+  return DBRequest(op="db:content:cache:set_public:1", params=params)
+
+
+def set_reported_request(
+  user_guid: str,
+  *,
+  path: str,
+  filename: str,
+  reported: bool = True,
+):
+  from server.registry.types import DBRequest
+  return DBRequest(op="db:content:cache:set_reported:1", params={
+    "user_guid": user_guid,
+    "path": path,
+    "filename": filename,
+    "reported": bool(reported),
+  })
+
+
+def count_rows_request():
+  from server.registry.types import DBRequest
+  return DBRequest(op="db:content:cache:count_rows:1", params={})
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/content/files/__init__.py
+++ b/server/registry/content/files/__init__.py
@@ -4,12 +4,26 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from server.registry.types import DBRequest
+
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
 __all__ = [
+  "set_gallery_request",
   "register",
 ]
+
+
+def set_gallery_request(user_guid: str, name: str, gallery: bool) -> DBRequest:
+  return DBRequest(
+    op="db:content:files:set_gallery:1",
+    params={
+      "user_guid": user_guid,
+      "name": name,
+      "gallery": bool(gallery),
+    },
+  )
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -6,6 +6,8 @@ from server.modules.providers import DBResult, DbRunMode
 from server.modules.providers.database.mssql_provider import MssqlProvider
 from server.registry.providers import mssql as registry_mssql
 from server.registry.types import DBResponse
+from server.registry.content.files import set_gallery_request
+from server.registry.content.cache import set_public_request
 
 
 def _set_provider_callable(monkeypatch, provider_map: str, handler):
@@ -145,11 +147,9 @@ def test_storage_files_set_gallery(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
-  res = asyncio.run(provider.run("db:content:files:set_gallery:1", {
-    "user_guid": guid,
-    "name": "file.txt",
-    "gallery": True,
-  }))
+  request = set_gallery_request(guid, "file.txt", True)
+
+  res = asyncio.run(provider.run(request.op, request.params))
 
   assert isinstance(res, DBResult)
   assert res.rowcount == 1
@@ -169,12 +169,14 @@ def test_storage_cache_set_public(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
 
-  res = asyncio.run(provider.run("db:content:cache:set_public:1", {
-    "user_guid": guid,
-    "path": "docs",
-    "filename": "file.txt",
-    "public": False,
-  }))
+  request = set_public_request(
+    guid,
+    public=False,
+    path="docs",
+    filename="file.txt",
+  )
+
+  res = asyncio.run(provider.run(request.op, request.params))
 
   assert isinstance(res, DBResult)
   assert res.rowcount == 1

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -9,6 +9,7 @@ from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.modules.providers.database.mssql_provider as mssql_provider
 from server.modules.providers import DBResult, DbRunMode
 from server.registry.types import DBRequest
+from server.registry.content.files import set_gallery_request
 
 
 def _extract_request(request, args=None):
@@ -149,8 +150,11 @@ def test_set_gallery_sends_numeric_flag_to_db():
       self.calls = []
 
     async def run(self, request, args=None):
-      op, params = _extract_request(request, args)
-      self.calls.append((op, params))
+      if isinstance(request, DBRequest):
+        req = request
+      else:
+        req = DBRequest(op=request, params=args or {})
+      self.calls.append(req)
       return DBResult(rowcount=1)
 
   db = CaptureDb()
@@ -159,14 +163,10 @@ def test_set_gallery_sends_numeric_flag_to_db():
   asyncio.run(mod.set_gallery("u1", "docs/a.txt", True))
   asyncio.run(mod.set_gallery("u1", "a.txt", False))
 
-  assert db.calls[0] == (
-    "db:content:files:set_gallery:1",
-    {"user_guid": "u1", "name": "docs/a.txt", "gallery": True},
-  )
-  assert db.calls[1] == (
-    "db:content:files:set_gallery:1",
-    {"user_guid": "u1", "name": "a.txt", "gallery": False},
-  )
+  assert isinstance(db.calls[0], DBRequest)
+  assert isinstance(db.calls[1], DBRequest)
+  assert db.calls[0] == set_gallery_request("u1", "docs/a.txt", True)
+  assert db.calls[1] == set_gallery_request("u1", "a.txt", False)
 
 
 def test_list_files_by_user():


### PR DESCRIPTION
## Summary
- add DBRequest helpers for content file gallery and cache state updates
- update the storage module to call the shared helpers instead of inline URNs
- adjust unit tests to validate the new helper usage

## Testing
- pytest tests/test_storage_module.py tests/test_db_provider_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68ded88fa0608325aa5bcd60489fe34c