### PR TITLE
Remove deprecated public gallery alias

### DIFF
--- a/server/registry/content/public/__init__.py
+++ b/server/registry/content/public/__init__.py
@@ -50,5 +50,4 @@ def register(router: "SubdomainRouter") -> None:
     "get_public_files",
     version=1,
     provider_map=f"{_DEF_PROVIDER}.get_public_files",
-    aliases=["db:public:gallery:get_public_files:1"],
   )

--- a/server/registry/providers/mssql.py
+++ b/server/registry/providers/mssql.py
@@ -99,7 +99,6 @@ _PROVIDER_SPECS: dict[str, tuple[str, str]] = {
   "content.public.get_public_files": ("server.registry.content.public.mssql", "get_public_files_v1"),
   "content.public.list_public": ("server.registry.content.public.mssql", "list_public_v1"),
   "content.public.list_reported": ("server.registry.content.public.mssql", "list_reported_v1"),
-  "public.gallery.get_public_files": ("server.registry.content.public.mssql", "get_public_files_v1"),
   "public.links.get_home_links": ("server.registry.public.links.mssql", "get_home_links_v1"),
   "public.links.get_navbar_routes": ("server.registry.public.links.mssql", "get_navbar_routes_v1"),
   "public.users.get_profile": ("server.registry.public.users.mssql", "get_profile_v1"),


### PR DESCRIPTION
## Summary
- drop the deprecated db:public:gallery alias from the content.public registry registration
- remove the legacy public.gallery provider mapping so the canonical content.public key is used exclusively

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deea2db3448325b8e8ab546c01472e