### PR TITLE
Add shared DBResult helper for registry conversions

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -8,18 +8,12 @@ import logging
 
 from . import BaseModule
 from .env_module import EnvModule
-from .providers import DbProviderBase
-from .providers import DBResult
+from .providers import DBResult, DbProviderBase, get_dbresult_cls
 from server.registry import RegistryDispatcher
 from server.registry.types import DBRequest, DBResponse
 from server.helpers.logging import update_logging_level
 from server.registry.security.accounts import account_exists_request
 from server.registry.system.config import get_config_request
-
-
-def _current_dbresult_cls():
-  from server.modules.providers import DBResult as ProvidersDBResult
-  return ProvidersDBResult
 class DbModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
@@ -68,7 +62,7 @@ class DbModule(BaseModule):
     else:
       request = DBRequest(op=op, params=args or {})
     response = await self._registry.execute(request)
-    DBResultCls = _current_dbresult_cls()
+    DBResultCls = get_dbresult_cls()
     if not isinstance(response, DBResponse):
       if isinstance(response, DBResultCls):
         response = DBResponse.from_result(response)

--- a/server/modules/providers/__init__.py
+++ b/server/modules/providers/__init__.py
@@ -22,12 +22,17 @@ __all__ = [
   "DbProviderBase",
   "DBResult",
   "DbRunMode",
+  "get_dbresult_cls",
 ]
 
 
 class DBResult(BaseModel):
   rows: list[dict] = Field(default_factory=list)
   rowcount: int = 0
+
+
+def get_dbresult_cls() -> type[DBResult]:
+  return DBResult
 
 
 class DbRunMode(str, Enum):

--- a/server/registry/__init__.py
+++ b/server/registry/__init__.py
@@ -7,7 +7,7 @@ import importlib
 import pkgutil
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 
-from server.modules.providers import DBResult, DbProviderBase
+from server.modules.providers import DBResult, DbProviderBase, get_dbresult_cls
 
 from .types import DBRequest, DBResponse
 
@@ -23,13 +23,6 @@ __all__ = [
 
 
 Executor = Callable[[DBRequest], Awaitable[DBResponse]]
-
-
-def _current_dbresult_cls():
-  from server.modules.providers import DBResult as ProvidersDBResult
-  return ProvidersDBResult
-
-
 @dataclass(slots=True)
 class FunctionRoute:
   domain: str
@@ -223,7 +216,7 @@ class RegistryDispatcher:
     if provider_key:
       self.router.set_provider(provider_key)
       self.router.load_provider(provider_key)
-    DBResultCls = _current_dbresult_cls()
+    DBResultCls = get_dbresult_cls()
 
     def _ensure_response(result: DBResponse | DBResult | object) -> DBResponse:
       if isinstance(result, DBResponse):

--- a/server/registry/types.py
+++ b/server/registry/types.py
@@ -3,23 +3,16 @@
 from __future__ import annotations
 
 from typing import Any
-import importlib
 
 from pydantic import BaseModel, Field
 
-from server.modules.providers import DBResult
+from server.modules.providers import DBResult, get_dbresult_cls
 
 __all__ = [
   "DBRequest",
   "DBResponse",
   "DBResult",
 ]
-
-
-def _current_dbresult_cls():
-  providers_mod = importlib.import_module("server.modules.providers")
-  return getattr(providers_mod, "DBResult")
-
 
 class DBRequest(BaseModel):
   """Payload describing a database registry operation."""
@@ -45,5 +38,5 @@ class DBResponse(BaseModel):
     return cls(rows=list(result.rows), rowcount=result.rowcount, meta=meta)
 
   def to_result(self) -> DBResult:
-    DBResultCls = _current_dbresult_cls()
+    DBResultCls = get_dbresult_cls()
     return DBResultCls(rows=list(self.rows), rowcount=self.rowcount)


### PR DESCRIPTION
## Summary
- add a shared `get_dbresult_cls` helper in the providers package to surface the canonical `DBResult`
- update registry and database modules to use the helper, ensuring `DBResponse.to_result` also leverages it for consistent conversions

## Testing
- pytest tests/test_db_provider_contract.py tests/test_db_module_init.py

------
https://chatgpt.com/codex/tasks/task_e_68df01a2ce688325975a58c90ec5a0f1