### PR TITLE
Refactor MSSQL helpers to return DBResponse

### DIFF
--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -7,8 +7,14 @@ from ... import DbProviderBase, DBResult
 from .logic import init_pool, close_pool
 from .db_helpers import Operation, execute_operation
 
-from server.registry.providers.mssql import PROVIDER_QUERIES
+from importlib import import_module
+
 from server.registry.types import DBRequest, DBResponse
+
+
+def _get_provider_queries():
+  module = import_module("server.registry.providers.mssql")
+  return getattr(module, "PROVIDER_QUERIES")
 
 
 class MssqlProvider(DbProviderBase):
@@ -28,7 +34,8 @@ class MssqlProvider(DbProviderBase):
     except ValueError as exc:
       raise KeyError(f"Invalid operation version for '{op}'") from exc
     provider_map = f"{domain}.{subdomain}.{name}"
-    entry = PROVIDER_QUERIES.get(provider_map)
+    provider_queries = _get_provider_queries()
+    entry = provider_queries.get(provider_map)
     if entry is None:
       raise KeyError(f"No MSSQL handler for '{op}'")
     if isinstance(entry, Mapping):

--- a/server/registry/account/users/mssql.py
+++ b/server/registry/account/users/mssql.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from server.registry.support.users.mssql import set_credits_v1 as _support_set_credits_v1
+from server.registry.types import DBResponse
 
 __all__ = [
   "set_credits_v1",
@@ -12,5 +13,5 @@ __all__ = [
 
 
 # Delegate to the support-domain implementation to avoid duplication.
-def set_credits_v1(args: dict[str, Any]):
-  return _support_set_credits_v1(args)
+async def set_credits_v1(args: dict[str, Any]) -> DBResponse:
+  return await _support_set_credits_v1(args)

--- a/server/registry/assistant/conversations/mssql.py
+++ b/server/registry/assistant/conversations/mssql.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from server.modules.providers import DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation, json_one
+from server.registry.providers.mssql import run_exec, run_json_many, run_json_one
+from server.registry.types import DBResponse
 
 __all__ = [
   "find_recent_v1",
@@ -16,7 +16,7 @@ __all__ = [
 ]
 
 
-def insert_conversation_v1(args: dict[str, Any]) -> Operation:
+async def insert_conversation_v1(args: dict[str, Any]) -> DBResponse:
   personas_recid = args["personas_recid"]
   models_recid = args["models_recid"]
   guild_id = args.get("guild_id")
@@ -39,8 +39,7 @@ def insert_conversation_v1(args: dict[str, Any]) -> Operation:
     SELECT SCOPE_IDENTITY() AS recid
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(
-    DbRunMode.JSON_ONE,
+  return await run_json_one(
     sql,
     (
       personas_recid,
@@ -55,7 +54,7 @@ def insert_conversation_v1(args: dict[str, Any]) -> Operation:
   )
 
 
-def find_recent_v1(args: dict[str, Any]):
+async def find_recent_v1(args: dict[str, Any]) -> DBResponse:
   personas_recid = args["personas_recid"]
   models_recid = args["models_recid"]
   guild_id = args.get("guild_id")
@@ -84,7 +83,7 @@ def find_recent_v1(args: dict[str, Any]):
     ORDER BY element_created_on DESC
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return json_one(
+  return await run_json_one(
     sql,
     (
       personas_recid,
@@ -101,7 +100,7 @@ def find_recent_v1(args: dict[str, Any]):
   )
 
 
-def update_output_v1(args: dict[str, Any]) -> Operation:
+async def update_output_v1(args: dict[str, Any]) -> DBResponse:
   recid = args["recid"]
   output_data = args.get("output_data")
   tokens = args.get("tokens")
@@ -111,10 +110,10 @@ def update_output_v1(args: dict[str, Any]) -> Operation:
         element_tokens = ?
     WHERE recid = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (output_data, tokens, recid))
+  return await run_exec(sql, (output_data, tokens, recid))
 
 
-def list_by_time_v1(args: dict[str, Any]) -> Operation:
+async def list_by_time_v1(args: dict[str, Any]) -> DBResponse:
   personas_recid = args["personas_recid"]
   start = args["start"]
   end = args["end"]
@@ -134,10 +133,10 @@ def list_by_time_v1(args: dict[str, Any]) -> Operation:
     ORDER BY element_created_on
     FOR JSON PATH, INCLUDE_NULL_VALUES;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, (personas_recid, start, end))
+  return await run_json_many(sql, (personas_recid, start, end))
 
 
-def list_recent_v1(_: dict[str, Any]) -> Operation:
+async def list_recent_v1(_: dict[str, Any]) -> DBResponse:
   sql = """
     SELECT TOP (2)
            recid,
@@ -153,4 +152,4 @@ def list_recent_v1(_: dict[str, Any]) -> Operation:
     ORDER BY element_created_on DESC
     FOR JSON PATH, INCLUDE_NULL_VALUES;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, ())
+  return await run_json_many(sql)

--- a/server/registry/assistant/models/mssql.py
+++ b/server/registry/assistant/models/mssql.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from server.modules.providers import DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation
+from server.registry.providers.mssql import run_json_many, run_json_one
+from server.registry.types import DBResponse
 
 __all__ = [
   "get_by_name_v1",
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-def list_models_v1(_: dict[str, Any]) -> Operation:
+async def list_models_v1(_: dict[str, Any]) -> DBResponse:
   sql = """
     SELECT
       recid,
@@ -22,13 +22,13 @@ def list_models_v1(_: dict[str, Any]) -> Operation:
     ORDER BY element_name
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, ())
+  return await run_json_many(sql)
 
 
-def get_by_name_v1(args: dict[str, Any]) -> Operation:
+async def get_by_name_v1(args: dict[str, Any]) -> DBResponse:
   name = args["name"]
   sql = """
     SELECT recid FROM assistant_models WHERE element_name = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, (name,))
+  return await run_json_one(sql, (name,))

--- a/server/registry/assistant/personas/mssql.py
+++ b/server/registry/assistant/personas/mssql.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from server.modules.providers import DBResult, DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation, exec_op, exec_query
+from server.registry.providers.mssql import run_exec, run_json_many, run_json_one
+from server.registry.types import DBResponse
 
 __all__ = [
   "delete_persona_v1",
@@ -15,7 +15,7 @@ __all__ = [
 ]
 
 
-def get_by_name_v1(args: dict[str, Any]) -> Operation:
+async def get_by_name_v1(args: dict[str, Any]) -> DBResponse:
   name = args["name"]
   sql = """
     SELECT
@@ -39,10 +39,10 @@ def get_by_name_v1(args: dict[str, Any]) -> Operation:
     WHERE vp.persona_name = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, (name,))
+  return await run_json_one(sql, (name,))
 
 
-def list_personas_v1(_: dict[str, Any]) -> Operation:
+async def list_personas_v1(_: dict[str, Any]) -> DBResponse:
   sql = """
     SELECT
       ap.recid,
@@ -65,17 +65,17 @@ def list_personas_v1(_: dict[str, Any]) -> Operation:
     ORDER BY vp.persona_name
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, ())
+  return await run_json_many(sql)
 
 
-async def upsert_persona_v1(args: dict[str, Any]) -> DBResult:
+async def upsert_persona_v1(args: dict[str, Any]) -> DBResponse:
   recid = args.get("recid")
   name = args["name"]
   prompt = args["prompt"]
   tokens = int(args["tokens"])
   models_recid = int(args["models_recid"])
   if recid is not None:
-    rc = await exec_query(exec_op(
+    rc = await run_exec(
       """
         UPDATE assistant_personas
         SET element_name = ?,
@@ -86,10 +86,10 @@ async def upsert_persona_v1(args: dict[str, Any]) -> DBResult:
         WHERE recid = ?;
       """,
       (name, prompt, tokens, models_recid, recid),
-    ))
+    )
     if rc.rowcount:
       return rc
-  rc = await exec_query(exec_op(
+  rc = await run_exec(
     """
       UPDATE assistant_personas
       SET element_prompt = ?,
@@ -99,10 +99,10 @@ async def upsert_persona_v1(args: dict[str, Any]) -> DBResult:
       WHERE element_name = ?;
     """,
     (prompt, tokens, models_recid, name),
-  ))
+  )
   if rc.rowcount:
     return rc
-  return await exec_query(exec_op(
+  return await run_exec(
     """
       INSERT INTO assistant_personas (
         element_name,
@@ -112,10 +112,10 @@ async def upsert_persona_v1(args: dict[str, Any]) -> DBResult:
       ) VALUES (?, ?, ?, ?);
     """,
     (name, prompt, tokens, models_recid),
-  ))
+  )
 
 
-def delete_persona_v1(args: dict[str, Any]) -> Operation:
+async def delete_persona_v1(args: dict[str, Any]) -> DBResponse:
   recid = args.get("recid")
   name = args.get("name")
   if recid is not None:
@@ -126,4 +126,4 @@ def delete_persona_v1(args: dict[str, Any]) -> Operation:
     params = (name,)
   else:
     raise ValueError("Missing identifier for persona delete")
-  return Operation(DbRunMode.EXEC, sql, params)
+  return await run_exec(sql, params)

--- a/server/registry/content/cache/mssql.py
+++ b/server/registry/content/cache/mssql.py
@@ -7,14 +7,8 @@ import logging
 from typing import Any, Dict
 from uuid import UUID
 
-from server.modules.providers import DBResult, DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import (
-  Operation,
-  exec_op,
-  exec_query,
-  fetch_json,
-  json_one,
-)
+from server.registry.providers.mssql import run_exec, run_json_many, run_json_one
+from server.registry.types import DBResponse
 from server.modules.providers.database.mssql_provider.logic import transaction
 
 __all__ = [
@@ -30,11 +24,11 @@ __all__ = [
 
 
 async def _get_storage_type_recid(mimetype: str, *, allow_folder: bool) -> int:
-  async def _fetch_type(target: str):
-    return await fetch_json(json_one(
+  async def _fetch_type(target: str) -> DBResponse:
+    return await run_json_one(
       "SELECT recid FROM storage_types WHERE element_mimetype = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
       (target,),
-    ))
+    )
 
   res = await _fetch_type(mimetype)
   if res.rows:
@@ -44,7 +38,7 @@ async def _get_storage_type_recid(mimetype: str, *, allow_folder: bool) -> int:
     raise ValueError(f"Unknown storage mimetype: {mimetype}")
 
   if mimetype == "path/folder":
-    await exec_query(exec_op(
+    await run_exec(
       """
       MERGE storage_types AS target
       USING (SELECT 16 AS recid, 'path/folder' AS element_mimetype, 'Folder' AS element_displaytype) AS src
@@ -53,8 +47,7 @@ async def _get_storage_type_recid(mimetype: str, *, allow_folder: bool) -> int:
         INSERT (recid, element_mimetype, element_displaytype)
         VALUES (src.recid, src.element_mimetype, src.element_displaytype);
       """,
-      (),
-    ))
+    )
     res = await _fetch_type(mimetype)
     if res.rows:
       return res.rows[0]["recid"]
@@ -66,7 +59,7 @@ async def _get_storage_type_recid(mimetype: str, *, allow_folder: bool) -> int:
   return 1
 
 
-def list_v1(args: Dict[str, Any]) -> Operation:
+async def list_v1(args: Dict[str, Any]) -> DBResponse:
   user_guid = args["user_guid"]
   sql = """
     SELECT
@@ -81,10 +74,10 @@ def list_v1(args: Dict[str, Any]) -> Operation:
     ORDER BY usc.element_path, usc.element_filename
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, (user_guid,))
+  return await run_json_many(sql, (user_guid,))
 
 
-async def replace_user_v1(args: Dict[str, Any]) -> DBResult:
+async def replace_user_v1(args: Dict[str, Any]) -> DBResponse:
   user_guid = args["user_guid"]
   items: list[Dict[str, Any]] = args.get("items", [])
   async with transaction() as cur:
@@ -100,10 +93,10 @@ async def replace_user_v1(args: Dict[str, Any]) -> DBResult:
           VALUES (?, ?, ?, ?, ?, NULL, 0);""",
         (user_guid, type_recid, path, filename, item.get("public", 0)),
       )
-  return DBResult(rows=[], rowcount=len(items))
+  return DBResponse(rows=[], rowcount=len(items))
 
 
-async def upsert_v1(args: Dict[str, Any]):
+async def upsert_v1(args: Dict[str, Any]) -> DBResponse:
   user_guid = args["user_guid"]
   path = args.get("path", "")
   filename = args.get("filename", "")
@@ -153,7 +146,7 @@ async def upsert_v1(args: Dict[str, Any]):
     reported,
     moderation_recid,
   )
-  rc = await exec_query(exec_op(sql, params))
+  rc = await run_exec(sql, params)
   if rc.rowcount == 0:
     logging.error(
       "[MSSQL] storage_cache_upsert affected 0 rows for %s/%s",
@@ -163,7 +156,7 @@ async def upsert_v1(args: Dict[str, Any]):
   return rc
 
 
-def delete_v1(args: Dict[str, Any]) -> Operation:
+async def delete_v1(args: Dict[str, Any]) -> DBResponse:
   user_guid = args["user_guid"]
   path = args.get("path", "")
   filename = args.get("filename", "")
@@ -171,10 +164,10 @@ def delete_v1(args: Dict[str, Any]) -> Operation:
     DELETE FROM users_storage_cache
     WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (user_guid, path, filename))
+  return await run_exec(sql, (user_guid, path, filename))
 
 
-def delete_folder_v1(args: Dict[str, Any]) -> Operation:
+async def delete_folder_v1(args: Dict[str, Any]) -> DBResponse:
   user_guid = args["user_guid"]
   path = args.get("path", "").lstrip("/")
   parent, name = path.rsplit("/", 1) if "/" in path else ("", path)
@@ -187,10 +180,10 @@ def delete_folder_v1(args: Dict[str, Any]) -> Operation:
       OR element_path LIKE ?
     );
   """
-  return Operation(DbRunMode.EXEC, sql, (user_guid, parent, name, path, like))
+  return await run_exec(sql, (user_guid, parent, name, path, like))
 
 
-def set_public_v1(args: Dict[str, Any]) -> Operation:
+async def set_public_v1(args: Dict[str, Any]) -> DBResponse:
   guid = str(UUID(args["user_guid"]))
   name = args.get("name")
   if name:
@@ -204,10 +197,10 @@ def set_public_v1(args: Dict[str, Any]) -> Operation:
     SET element_public = ?
     WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (flag_value, guid, path, filename))
+  return await run_exec(sql, (flag_value, guid, path, filename))
 
 
-def set_reported_v1(args: Dict[str, Any]) -> Operation:
+async def set_reported_v1(args: Dict[str, Any]) -> DBResponse:
   guid = str(UUID(args["user_guid"]))
   path = args.get("path", "")
   filename = args.get("filename", "")
@@ -217,14 +210,14 @@ def set_reported_v1(args: Dict[str, Any]) -> Operation:
     SET element_reported = ?
     WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (reported, guid, path, filename))
+  return await run_exec(sql, (reported, guid, path, filename))
 
 
-def count_rows_v1(_: Dict[str, Any]) -> Operation:
+async def count_rows_v1(_: Dict[str, Any]) -> DBResponse:
   sql = """
     SELECT COUNT(*) AS count
     FROM users_storage_cache
     WHERE element_deleted = 0
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, ())
+  return await run_json_one(sql)

--- a/server/registry/content/files/mssql.py
+++ b/server/registry/content/files/mssql.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 from typing import Any, Dict
 from uuid import UUID
 
-from server.modules.providers import DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation
+from server.registry.providers.mssql import run_exec
+from server.registry.types import DBResponse
 
 __all__ = [
   "set_gallery_v1",
 ]
 
 
-def set_gallery_v1(args: Dict[str, Any]) -> Operation:
+async def set_gallery_v1(args: Dict[str, Any]) -> DBResponse:
   guid = str(UUID(args["user_guid"]))
   name = args.get("name")
   if name:
@@ -27,4 +27,4 @@ def set_gallery_v1(args: Dict[str, Any]) -> Operation:
     SET element_public = ?
     WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (gallery, guid, path, filename))
+  return await run_exec(sql, (gallery, guid, path, filename))

--- a/server/registry/content/public/mssql.py
+++ b/server/registry/content/public/mssql.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from server.modules.providers import DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation
+from server.registry.providers.mssql import run_json_many
+from server.registry.types import DBResponse
 
 __all__ = [
   "get_public_files_v1",
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-def list_public_v1(_: Dict[str, Any]) -> Operation:
+async def list_public_v1(_: Dict[str, Any]) -> DBResponse:
   sql = """
     SELECT usc.users_guid AS user_guid,
            au.element_display AS display_name,
@@ -29,14 +29,14 @@ def list_public_v1(_: Dict[str, Any]) -> Operation:
     ORDER BY usc.element_created_on
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, ())
+  return await run_json_many(sql)
 
 
-def get_public_files_v1(params: Dict[str, Any]) -> Operation:
-  return list_public_v1(params)
+async def get_public_files_v1(params: Dict[str, Any]) -> DBResponse:
+  return await list_public_v1(params)
 
 
-def list_reported_v1(_: Dict[str, Any]) -> Operation:
+async def list_reported_v1(_: Dict[str, Any]) -> DBResponse:
   sql = """
     SELECT usc.users_guid AS user_guid,
            usc.element_path AS path,
@@ -49,4 +49,4 @@ def list_reported_v1(_: Dict[str, Any]) -> Operation:
     ORDER BY usc.element_created_on
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, ())
+  return await run_json_many(sql)

--- a/server/registry/providers/mssql.py
+++ b/server/registry/providers/mssql.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 import importlib
 import inspect
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Any
 
-from server.modules.providers import DBResult
-import server.modules.providers.database.mssql_provider as mssql_provider
 from server.modules.providers.database.mssql_provider.db_helpers import Operation
 from server.registry.types import DBRequest, DBResponse
 
@@ -16,7 +14,47 @@ from . import ProviderCallable, ProviderQueryMap
 
 __all__ = [
   "PROVIDER_QUERIES",
+  "run_exec",
+  "run_json_many",
+  "run_json_one",
 ]
+
+
+def _get_provider():
+  return importlib.import_module("server.modules.providers.database.mssql_provider")
+
+
+def _response_from_payload(payload: Any, *, meta: dict[str, Any] | None = None) -> DBResponse:
+  rows_attr = getattr(payload, "rows", None)
+  rowcount_attr = getattr(payload, "rowcount", None)
+  if rows_attr is not None or rowcount_attr is not None:
+    rows = list(rows_attr or []) if rows_attr is not None else []
+    rowcount = int(rowcount_attr) if rowcount_attr is not None else len(rows)
+    return DBResponse(rows=rows, rowcount=rowcount, meta=meta)
+  if isinstance(payload, Mapping):
+    return DBResponse(rows=[dict(payload)], rowcount=1, meta=meta)
+  if payload is None:
+    return DBResponse(meta=meta)
+  raise TypeError(f"Unsupported provider specification result: {type(payload)!r}")
+
+
+async def _run_operation(kind: str, sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any] | None = None) -> DBResponse:
+  operation = Operation(kind, sql, tuple(params))
+  provider = _get_provider()
+  result = await provider.execute_operation(operation)
+  return _response_from_payload(result, meta=meta)
+
+
+async def run_json_one(sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any] | None = None) -> DBResponse:
+  return await _run_operation("json_one", sql, params, meta=meta)
+
+
+async def run_json_many(sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any] | None = None) -> DBResponse:
+  return await _run_operation("json_many", sql, params, meta=meta)
+
+
+async def run_exec(sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any] | None = None) -> DBResponse:
+  return await _run_operation("exec", sql, params, meta=meta)
 
 
 async def _coerce_response(spec: Any) -> DBResponse:
@@ -25,18 +63,13 @@ async def _coerce_response(spec: Any) -> DBResponse:
   if inspect.isawaitable(spec):
     return await _coerce_response(await spec)
   if isinstance(spec, Operation):
-    result = await mssql_provider.execute_operation(spec)
-    return DBResponse.from_result(result)
-  if isinstance(spec, DBResult):
-    return DBResponse.from_result(spec)
-  if isinstance(spec, Mapping):
-    validator = getattr(DBResult, "model_validate", None)
-    if callable(validator):
-      return DBResponse.from_result(validator(spec))
-    return DBResponse.from_result(DBResult(**spec))
-  if spec is None:
-    return DBResponse()
-  raise TypeError(f"Unsupported provider specification result: {type(spec)!r}")
+    provider = _get_provider()
+    result = await provider.execute_operation(spec)
+    return _response_from_payload(result)
+  try:
+    return _response_from_payload(spec)
+  except TypeError:
+    raise
 
 
 def _wrap(fn: Any) -> ProviderCallable:

--- a/server/registry/public/links/mssql.py
+++ b/server/registry/public/links/mssql.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from server.modules.providers import DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation
+from server.registry.providers.mssql import run_json_many
+from server.registry.types import DBResponse
 
 __all__ = [
   "get_home_links_v1",
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-def get_home_links_v1(_: dict[str, Any]) -> Operation:
+async def get_home_links_v1(_: dict[str, Any]) -> DBResponse:
   sql = """
     SELECT
       element_title AS title,
@@ -22,10 +22,10 @@ def get_home_links_v1(_: dict[str, Any]) -> Operation:
     ORDER BY element_sequence
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, ())
+  return await run_json_many(sql)
 
 
-def get_navbar_routes_v1(args: dict[str, Any]) -> Operation:
+async def get_navbar_routes_v1(args: dict[str, Any]) -> DBResponse:
   mask = int(args.get("role_mask", 0))
   sql = """
     SELECT
@@ -38,4 +38,4 @@ def get_navbar_routes_v1(args: dict[str, Any]) -> Operation:
     ORDER BY element_sequence
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, (mask,))
+  return await run_json_many(sql, (mask,))

--- a/server/registry/public/users/mssql.py
+++ b/server/registry/public/users/mssql.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
-from server.modules.providers import DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation
+from server.registry.providers.mssql import run_json_many, run_json_one
+from server.registry.types import DBResponse
 
 __all__ = [
   "get_profile_v1",
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-def get_profile_v1(args: dict[str, Any]) -> Operation:
+async def get_profile_v1(args: dict[str, Any]) -> DBResponse:
   guid = str(UUID(args["guid"]))
   sql = """
     SELECT TOP 1
@@ -26,10 +26,10 @@ def get_profile_v1(args: dict[str, Any]) -> Operation:
     WHERE au.element_guid = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, (guid,))
+  return await run_json_one(sql, (guid,))
 
 
-def get_published_files_v1(args: dict[str, Any]) -> Operation:
+async def get_published_files_v1(args: dict[str, Any]) -> DBResponse:
   guid = str(UUID(args["guid"]))
   sql = """
     SELECT
@@ -43,4 +43,4 @@ def get_published_files_v1(args: dict[str, Any]) -> Operation:
     ORDER BY usc.element_created_on
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, (guid,))
+  return await run_json_many(sql, (guid,))

--- a/server/registry/public/vars/mssql.py
+++ b/server/registry/public/vars/mssql.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from server.modules.providers import DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation
+from server.registry.providers.mssql import run_json_one
+from server.registry.types import DBResponse
 
 __all__ = [
   "get_hostname_v1",
@@ -14,31 +14,31 @@ __all__ = [
 ]
 
 
-def get_hostname_v1(_: dict[str, Any]) -> Operation:
+async def get_hostname_v1(_: dict[str, Any]) -> DBResponse:
   sql = """
     SELECT element_value AS hostname
     FROM system_config
     WHERE element_key = 'hostname'
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, ())
+  return await run_json_one(sql)
 
 
-def get_version_v1(_: dict[str, Any]) -> Operation:
+async def get_version_v1(_: dict[str, Any]) -> DBResponse:
   sql = """
     SELECT element_value AS version
     FROM system_config
     WHERE element_key = 'version'
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, ())
+  return await run_json_one(sql)
 
 
-def get_repo_v1(_: dict[str, Any]) -> Operation:
+async def get_repo_v1(_: dict[str, Any]) -> DBResponse:
   sql = """
     SELECT element_value AS repo
     FROM system_config
     WHERE element_key = 'repo'
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, ())
+  return await run_json_one(sql)

--- a/server/registry/security/accounts/mssql.py
+++ b/server/registry/security/accounts/mssql.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from typing import Any, Iterable
 from uuid import UUID
 
-from server.modules.providers import DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation
+from server.registry.providers.mssql import run_json_one
+from server.registry.types import DBResponse
 
 __all__ = [
   "account_exists_v1",
@@ -83,29 +82,7 @@ def _unique(sequence: Iterable[str]) -> list[str]:
   return items
 
 
-def _make_operation(sql: str, params: Iterable[Any]) -> Operation:
-  db_helpers = import_module("server.modules.providers.database.mssql_provider.db_helpers")
-  json_one = getattr(db_helpers, "json_one", None)
-  payload = tuple(params)
-  if callable(json_one):
-    op = json_one(sql, payload)
-    if op is not None:
-      return op
-  operation_cls = getattr(db_helpers, "Operation")
-  providers_mod = import_module("server.modules.providers")
-  db_run_mode = getattr(providers_mod, "DbRunMode")
-  try:
-    return operation_cls(db_run_mode.JSON_ONE, sql, payload)
-  except TypeError:
-    op = operation_cls()
-    setattr(op, "kind", db_run_mode.JSON_ONE)
-    setattr(op, "sql", sql)
-    setattr(op, "params", payload)
-    setattr(op, "postprocess", None)
-    return op
-
-
-def get_security_profile_v1(params: dict[str, Any]) -> Operation:
+async def get_security_profile_v1(params: dict[str, Any]) -> DBResponse:
   """Return an operation that fetches security metadata for a user context."""
 
   filters: list[str] = []
@@ -146,10 +123,10 @@ def get_security_profile_v1(params: dict[str, Any]) -> Operation:
   join_sql = "".join(_unique(joins))
   where_sql = " AND\n    ".join(filters)
   sql = f"{_BASE_QUERY}{join_sql}  WHERE {where_sql}\n  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;"
-  return _make_operation(sql, args)
+  return await run_json_one(sql, args)
 
 
-def account_exists_v1(args: dict[str, Any]) -> Operation:
+async def account_exists_v1(args: dict[str, Any]) -> DBResponse:
   guid = str(UUID(args["user_guid"]))
   sql = """
     SELECT 1 AS exists_flag
@@ -157,4 +134,4 @@ def account_exists_v1(args: dict[str, Any]) -> Operation:
     WHERE element_guid = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, (guid,))
+  return await run_json_one(sql, (guid,))

--- a/server/registry/security/identities/mssql.py
+++ b/server/registry/security/identities/mssql.py
@@ -5,14 +5,8 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
-from server.modules.providers import DBResult, DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import (
-  Operation,
-  exec_op,
-  exec_query,
-  fetch_json,
-  json_one,
-)
+from server.registry.providers.mssql import run_exec, run_json_one
+from server.registry.types import DBResponse
 from server.modules.providers.database.mssql_provider.logic import transaction
 
 __all__ = [
@@ -40,16 +34,16 @@ async def get_auth_provider_recid(provider: str, *, cursor=None) -> int:
     if not row:
       raise ValueError(f"Unknown auth provider: {provider}")
     return row[0]
-  res = await fetch_json(json_one(
+  res = await run_json_one(
     "SELECT recid FROM auth_providers WHERE element_name = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
     (provider,),
-  ))
+  )
   if not res.rows:
     raise ValueError(f"Unknown auth provider: {provider}")
   return res.rows[0]["recid"]
 
 
-def get_by_provider_identifier_v1(args: dict[str, Any]) -> Operation:
+async def get_by_provider_identifier_v1(args: dict[str, Any]) -> DBResponse:
   provider = args["provider"]
   identifier = str(UUID(args["provider_identifier"]))
   sql = """
@@ -67,10 +61,10 @@ def get_by_provider_identifier_v1(args: dict[str, Any]) -> Operation:
     WHERE ap.element_name = ? AND ua.element_identifier = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, (provider, identifier))
+  return await run_json_one(sql, (provider, identifier))
 
 
-def get_any_by_provider_identifier_v1(args: dict[str, Any]) -> Operation:
+async def get_any_by_provider_identifier_v1(args: dict[str, Any]) -> DBResponse:
   identifier = str(UUID(args["provider_identifier"]))
   sql = """
     SELECT TOP 1
@@ -81,10 +75,10 @@ def get_any_by_provider_identifier_v1(args: dict[str, Any]) -> Operation:
     WHERE ua.element_identifier = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, (identifier,))
+  return await run_json_one(sql, (identifier,))
 
 
-async def create_from_provider_v1(args: dict[str, Any]) -> DBResult:
+async def create_from_provider_v1(args: dict[str, Any]) -> DBResponse:
   from datetime import datetime, timezone
   from uuid import uuid4
 
@@ -100,25 +94,24 @@ async def create_from_provider_v1(args: dict[str, Any]) -> DBResult:
 
   ap_recid = await get_auth_provider_recid(provider)
 
-  dup = await fetch_json(json_one(
+  dup = await run_json_one(
     "SELECT users_guid FROM users_auth WHERE element_identifier = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
     (identifier,),
-  ))
+  )
   if dup.rows:
     existing_guid = dup.rows[0]["users_guid"]
-    await exec_query(exec_op(
+    await run_exec(
       "UPDATE users_auth SET element_linked = 1, providers_recid = ? WHERE element_identifier = ?;",
       (ap_recid, identifier),
-    ))
-    await exec_query(exec_op(
+    )
+    await run_exec(
       "UPDATE account_users SET providers_recid = ? WHERE element_guid = ?;",
       (ap_recid, existing_guid),
-    ))
-    sel = get_by_provider_identifier_v1({
+    )
+    return await get_by_provider_identifier_v1({
       "provider": provider,
       "provider_identifier": identifier,
     })
-    return await fetch_json(sel)
 
   async with transaction() as cur:
     await cur.execute(
@@ -145,19 +138,18 @@ async def create_from_provider_v1(args: dict[str, Any]) -> DBResult:
       (new_guid, 1),
     )
 
-  sel = get_by_provider_identifier_v1({
+  return await get_by_provider_identifier_v1({
     "provider": provider,
     "provider_identifier": identifier,
   })
-  return await fetch_json(sel)
 
 
-async def link_provider_v1(args: dict[str, Any]) -> DBResult:
+async def link_provider_v1(args: dict[str, Any]) -> DBResponse:
   guid = str(UUID(args["guid"]))
   provider = args["provider"]
   identifier = str(UUID(args["provider_identifier"]))
   ap_recid = await get_auth_provider_recid(provider)
-  return await exec_query(exec_op(
+  return await run_exec(
     """
     MERGE users_auth AS target
     USING (SELECT ? AS users_guid, ? AS providers_recid, ? AS element_identifier) AS source
@@ -169,10 +161,10 @@ async def link_provider_v1(args: dict[str, Any]) -> DBResult:
       VALUES (source.users_guid, source.providers_recid, source.element_identifier, 1);
     """,
     (guid, ap_recid, identifier),
-  ))
+  )
 
 
-async def unlink_provider_v1(args: dict[str, Any]) -> DBResult:
+async def unlink_provider_v1(args: dict[str, Any]) -> DBResponse:
   guid = str(UUID(args["guid"]))
   provider = args["provider"]
   new_recid = args.get("new_provider_recid")
@@ -220,20 +212,20 @@ async def unlink_provider_v1(args: dict[str, Any]) -> DBResult:
           "UPDATE account_users SET providers_recid = NULL WHERE element_guid = ?;",
           (guid,),
         )
-  return DBResult(rows=[{"providers_remaining": cnt}], rowcount=1)
+  return DBResponse(rows=[{"providers_remaining": cnt}], rowcount=1)
 
 
-def soft_delete_account_v1(args: dict[str, Any]) -> Operation:
+async def soft_delete_account_v1(args: dict[str, Any]) -> DBResponse:
   guid = str(UUID(args["guid"]))
   sql = """
     UPDATE account_users
     SET element_soft_deleted_at = SYSDATETIMEOFFSET()
     WHERE element_guid = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (guid,))
+  return await run_exec(sql, (guid,))
 
 
-def get_user_by_email_v1(args: dict[str, Any]) -> Operation:
+async def get_user_by_email_v1(args: dict[str, Any]) -> DBResponse:
   email = args["email"]
   sql = """
     SELECT TOP 1
@@ -242,21 +234,21 @@ def get_user_by_email_v1(args: dict[str, Any]) -> Operation:
     WHERE element_email = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, (email,))
+  return await run_json_one(sql, (email,))
 
 
-async def set_provider_v1(args: dict[str, Any]) -> DBResult:
+async def set_provider_v1(args: dict[str, Any]) -> DBResponse:
   guid = args["guid"]
   provider = args["provider"]
   ap_recid = await get_auth_provider_recid(provider)
-  return await exec_query(exec_op(
+  return await run_exec(
     "UPDATE account_users SET providers_recid = ? WHERE element_guid = ?;",
     (ap_recid, guid),
-  ))
+  )
 
 
-def unlink_last_provider_v1(args: dict[str, Any]) -> Operation:
+async def unlink_last_provider_v1(args: dict[str, Any]) -> DBResponse:
   guid = args["guid"]
   provider = args["provider"]
   sql = "EXEC auth_unlink_last_provider @guid=?, @provider=?;"
-  return Operation(DbRunMode.EXEC, sql, (guid, provider))
+  return await run_exec(sql, (guid, provider))

--- a/server/registry/security/oauth/mssql.py
+++ b/server/registry/security/oauth/mssql.py
@@ -5,11 +5,8 @@ from __future__ import annotations
 from typing import Any
 from uuid import NAMESPACE_URL, UUID, uuid5
 
-from server.modules.providers.database.mssql_provider.db_helpers import (
-  exec_op,
-  exec_query,
-  fetch_json,
-)
+from server.registry.providers.mssql import run_exec
+from server.registry.types import DBResponse
 
 from server.registry.security.identities import mssql as identities_mssql
 
@@ -20,44 +17,41 @@ __all__ = [
 ]
 
 
-async def relink_discord_v1(args: dict[str, Any]):
+async def relink_discord_v1(args: dict[str, Any]) -> DBResponse:
   raw_id = args["provider_identifier"]
   identifier = str(UUID(str(uuid5(NAMESPACE_URL, f"discord:{raw_id}"))))
   email = args.get("email")
   display = args.get("display_name")
   img = args.get("profile_image", "")
   sql = "EXEC auth_oauth_relink @provider='discord', @identifier=?, @email=?, @display=?, @image=?;"
-  await exec_query(exec_op(sql, (identifier, email, display, img)))
-  sel = identities_mssql.get_by_provider_identifier_v1({
+  await run_exec(sql, (identifier, email, display, img))
+  return await identities_mssql.get_by_provider_identifier_v1({
     "provider": "discord",
     "provider_identifier": identifier,
   })
-  return await fetch_json(sel)
 
 
-async def relink_google_v1(args: dict[str, Any]):
+async def relink_google_v1(args: dict[str, Any]) -> DBResponse:
   identifier = str(UUID(args["provider_identifier"]))
   email = args.get("email")
   display = args.get("display_name")
   img = args.get("profile_image", "")
   sql = "EXEC auth_oauth_relink @provider='google', @identifier=?, @email=?, @display=?, @image=?;"
-  await exec_query(exec_op(sql, (identifier, email, display, img)))
-  sel = identities_mssql.get_by_provider_identifier_v1({
+  await run_exec(sql, (identifier, email, display, img))
+  return await identities_mssql.get_by_provider_identifier_v1({
     "provider": "google",
     "provider_identifier": identifier,
   })
-  return await fetch_json(sel)
 
 
-async def relink_microsoft_v1(args: dict[str, Any]):
+async def relink_microsoft_v1(args: dict[str, Any]) -> DBResponse:
   identifier = str(UUID(args["provider_identifier"]))
   email = args.get("email")
   display = args.get("display_name")
   img = args.get("profile_image", "")
   sql = "EXEC auth_oauth_relink @provider='microsoft', @identifier=?, @email=?, @display=?, @image=?;"
-  await exec_query(exec_op(sql, (identifier, email, display, img)))
-  sel = identities_mssql.get_by_provider_identifier_v1({
+  await run_exec(sql, (identifier, email, display, img))
+  return await identities_mssql.get_by_provider_identifier_v1({
     "provider": "microsoft",
     "provider_identifier": identifier,
   })
-  return await fetch_json(sel)

--- a/server/registry/security/sessions/mssql.py
+++ b/server/registry/security/sessions/mssql.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID, uuid4
 
-from server.modules.providers import DBResult, DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation, exec_op, exec_query
+from server.registry.providers.mssql import run_exec
+from server.registry.types import DBResponse
 from server.modules.providers.database.mssql_provider.logic import transaction
 
 from server.registry.security.identities.mssql import get_auth_provider_recid
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 
-async def create_session_v1(args: dict[str, Any]) -> DBResult:
+async def create_session_v1(args: dict[str, Any]) -> DBResponse:
   access_token = args["access_token"]
   expires = args["expires"]
   fingerprint = args.get("fingerprint")
@@ -95,10 +95,10 @@ async def create_session_v1(args: dict[str, Any]) -> DBResult:
         ),
       )
 
-  return DBResult(rows=[{"session_guid": session_guid, "device_guid": device_guid}], rowcount=1)
+  return DBResponse(rows=[{"session_guid": session_guid, "device_guid": device_guid}], rowcount=1)
 
 
-def update_session_v1(args: dict[str, Any]) -> Operation:
+async def update_session_v1(args: dict[str, Any]) -> DBResponse:
   token = args["access_token"]
   ip_address = args.get("ip_address")
   user_agent = args.get("user_agent")
@@ -107,10 +107,10 @@ def update_session_v1(args: dict[str, Any]) -> Operation:
       SET element_ip_last_seen = ?, element_user_agent = ?
       WHERE element_token = ?;
     """
-  return Operation(DbRunMode.EXEC, sql, (ip_address, user_agent, token))
+  return await run_exec(sql, (ip_address, user_agent, token))
 
 
-def update_device_token_v1(args: dict[str, Any]) -> Operation:
+async def update_device_token_v1(args: dict[str, Any]) -> DBResponse:
   device_guid = str(UUID(args["device_guid"]))
   token = args["access_token"]
   sql = """
@@ -118,20 +118,20 @@ def update_device_token_v1(args: dict[str, Any]) -> Operation:
     SET element_token = ?
     WHERE element_guid = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (token, device_guid))
+  return await run_exec(sql, (token, device_guid))
 
 
-def revoke_device_token_v1(args: dict[str, Any]) -> Operation:
+async def revoke_device_token_v1(args: dict[str, Any]) -> DBResponse:
   token = args["access_token"]
   sql = """
     UPDATE sessions_devices
     SET element_revoked_at = SYSDATETIMEOFFSET()
     WHERE element_token = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (token,))
+  return await run_exec(sql, (token,))
 
 
-def revoke_all_device_tokens_v1(args: dict[str, Any]) -> Operation:
+async def revoke_all_device_tokens_v1(args: dict[str, Any]) -> DBResponse:
   guid = str(UUID(args["guid"]))
   sql = """
     UPDATE sd
@@ -140,10 +140,10 @@ def revoke_all_device_tokens_v1(args: dict[str, Any]) -> Operation:
     JOIN users_sessions us ON us.element_guid = sd.sessions_guid
     WHERE us.users_guid = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (guid,))
+  return await run_exec(sql, (guid,))
 
 
-def revoke_provider_tokens_v1(args: dict[str, Any]) -> Operation:
+async def revoke_provider_tokens_v1(args: dict[str, Any]) -> DBResponse:
   guid = str(UUID(args["guid"]))
   provider = args["provider"]
   sql = """
@@ -154,10 +154,10 @@ def revoke_provider_tokens_v1(args: dict[str, Any]) -> Operation:
     JOIN auth_providers ap ON ap.recid = sd.providers_recid
     WHERE us.users_guid = ? AND ap.element_name = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (guid, provider))
+  return await run_exec(sql, (guid, provider))
 
 
-def set_rotkey_v1(args: dict[str, Any]) -> Operation:
+async def set_rotkey_v1(args: dict[str, Any]) -> DBResponse:
   guid = args["guid"]
   rotkey = args["rotkey"]
   iat = args["iat"]
@@ -167,4 +167,4 @@ def set_rotkey_v1(args: dict[str, Any]) -> Operation:
     SET element_rotkey = ?, element_rotkey_iat = ?, element_rotkey_exp = ?
     WHERE element_guid = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (rotkey, iat, exp, guid))
+  return await run_exec(sql, (rotkey, iat, exp, guid))

--- a/server/registry/support/users/mssql.py
+++ b/server/registry/support/users/mssql.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from server.modules.providers import DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation
+from server.registry.providers.mssql import run_exec
+from server.registry.types import DBResponse
 
 __all__ = [
   "set_credits_v1",
 ]
 
 
-def set_credits_v1(args: dict[str, Any]) -> Operation:
+async def set_credits_v1(args: dict[str, Any]) -> DBResponse:
   guid = args["guid"]
   credits = args["credits"]
   sql = """
@@ -20,4 +20,4 @@ def set_credits_v1(args: dict[str, Any]) -> Operation:
     SET element_credits = ?
     WHERE users_guid = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (credits, guid))
+  return await run_exec(sql, (credits, guid))

--- a/server/registry/system/config/mssql.py
+++ b/server/registry/system/config/mssql.py
@@ -4,12 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from server.modules.providers import DBResult, DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import (
-  Operation,
-  exec_op,
-  exec_query,
-)
+from server.registry.providers.mssql import run_exec, run_json_many, run_json_one
+from server.registry.types import DBResponse
 
 __all__ = [
   "delete_config_v1",
@@ -19,7 +15,7 @@ __all__ = [
 ]
 
 
-def get_config_v1(args: dict[str, Any]) -> Operation:
+async def get_config_v1(args: dict[str, Any]) -> DBResponse:
   key = args["key"]
   sql = """
     SELECT element_value AS value
@@ -27,35 +23,32 @@ def get_config_v1(args: dict[str, Any]) -> Operation:
     WHERE element_key = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, (key,))
+  return await run_json_one(sql, (key,))
 
 
-async def upsert_config_v1(args: dict[str, Any]) -> DBResult:
+async def upsert_config_v1(args: dict[str, Any]) -> DBResponse:
   key = args["key"]
   value = args["value"]
-  rc = await exec_query(exec_op(
-    "UPDATE system_config SET element_value = ? WHERE element_key = ?;",
-    (value, key),
-  ))
+  rc = await run_exec("UPDATE system_config SET element_value = ? WHERE element_key = ?;", (value, key))
   if rc.rowcount == 0:
-    rc = await exec_query(exec_op(
+    rc = await run_exec(
       "INSERT INTO system_config (element_key, element_value) VALUES (?, ?);",
       (key, value),
-    ))
+    )
   return rc
 
 
-def get_configs_v1(_: dict[str, Any]) -> Operation:
+async def get_configs_v1(_: dict[str, Any]) -> DBResponse:
   sql = """
     SELECT element_key AS [key], element_value AS value
     FROM system_config
     ORDER BY element_key
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, ())
+  return await run_json_many(sql)
 
 
-def delete_config_v1(args: dict[str, Any]) -> Operation:
+async def delete_config_v1(args: dict[str, Any]) -> DBResponse:
   key = args["key"]
   sql = "DELETE FROM system_config WHERE element_key = ?;"
-  return Operation(DbRunMode.EXEC, sql, (key,))
+  return await run_exec(sql, (key,))

--- a/server/registry/system/roles/mssql.py
+++ b/server/registry/system/roles/mssql.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from server.modules.providers import DBResult, DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation, exec_op, exec_query
+from server.registry.providers.mssql import run_exec, run_json_many
+from server.registry.types import DBResponse
 
 __all__ = [
   "add_role_member_v1",
@@ -18,17 +18,17 @@ __all__ = [
 ]
 
 
-def list_roles_v1(_: dict[str, Any]) -> Operation:
+async def list_roles_v1(_: dict[str, Any]) -> DBResponse:
   sql = """
     SELECT element_name AS name, element_mask AS mask, element_display AS display
     FROM system_roles
     ORDER BY element_mask
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, ())
+  return await run_json_many(sql)
 
 
-def get_role_members_v1(args: dict[str, Any]) -> Operation:
+async def get_role_members_v1(args: dict[str, Any]) -> DBResponse:
   role = args["role"]
   sql = """
     SELECT au.element_guid AS guid, au.element_display AS display_name
@@ -39,10 +39,10 @@ def get_role_members_v1(args: dict[str, Any]) -> Operation:
     ORDER BY au.element_display
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, (role,))
+  return await run_json_many(sql, (role,))
 
 
-def get_role_non_members_v1(args: dict[str, Any]) -> Operation:
+async def get_role_non_members_v1(args: dict[str, Any]) -> DBResponse:
   role = args["role"]
   sql = """
     SELECT au.element_guid AS guid, au.element_display AS display_name
@@ -53,10 +53,10 @@ def get_role_non_members_v1(args: dict[str, Any]) -> Operation:
     ORDER BY au.element_display
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, (role,))
+  return await run_json_many(sql, (role,))
 
 
-def add_role_member_v1(args: dict[str, Any]) -> Operation:
+async def add_role_member_v1(args: dict[str, Any]) -> DBResponse:
   role = args["role"]
   user_guid = args["user_guid"]
   sql = """
@@ -66,10 +66,10 @@ def add_role_member_v1(args: dict[str, Any]) -> Operation:
     WHEN MATCHED THEN UPDATE SET element_roles = ur.element_roles | src.element_mask
     WHEN NOT MATCHED THEN INSERT (users_guid, element_roles) VALUES (src.users_guid, src.element_mask);
   """
-  return Operation(DbRunMode.EXEC, sql, (user_guid, role))
+  return await run_exec(sql, (user_guid, role))
 
 
-def remove_role_member_v1(args: dict[str, Any]) -> Operation:
+async def remove_role_member_v1(args: dict[str, Any]) -> DBResponse:
   role = args["role"]
   user_guid = args["user_guid"]
   sql = """
@@ -78,26 +78,26 @@ def remove_role_member_v1(args: dict[str, Any]) -> Operation:
     UPDATE users_roles SET element_roles = element_roles & ~@mask WHERE users_guid = ?;
     DELETE FROM users_roles WHERE users_guid = ? AND element_roles = 0;
   """
-  return Operation(DbRunMode.EXEC, sql, (role, user_guid, user_guid))
+  return await run_exec(sql, (role, user_guid, user_guid))
 
 
-async def upsert_role_v1(args: dict[str, Any]) -> DBResult:
+async def upsert_role_v1(args: dict[str, Any]) -> DBResponse:
   name = args["name"]
   mask = int(args["mask"])
   display = args.get("display")
-  rc = await exec_query(exec_op(
+  rc = await run_exec(
     "UPDATE system_roles SET element_mask = ?, element_display = ? WHERE element_name = ?;",
     (mask, display, name),
-  ))
+  )
   if rc.rowcount == 0:
-    rc = await exec_query(exec_op(
+    rc = await run_exec(
       "INSERT INTO system_roles (element_name, element_mask, element_display) VALUES (?, ?, ?);",
       (name, mask, display),
-    ))
+    )
   return rc
 
 
-async def delete_role_v1(args: dict[str, Any]) -> DBResult:
+async def delete_role_v1(args: dict[str, Any]) -> DBResponse:
   name = args["name"]
   sql = """
     DECLARE @mask BIGINT;
@@ -105,4 +105,4 @@ async def delete_role_v1(args: dict[str, Any]) -> DBResult:
     UPDATE users_roles SET element_roles = element_roles & ~@mask;
     DELETE FROM system_roles WHERE element_name = ?;
   """
-  return await exec_query(exec_op(sql, (name, name)))
+  return await run_exec(sql, (name, name))

--- a/server/registry/system/routes/mssql.py
+++ b/server/registry/system/routes/mssql.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from server.modules.providers import DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation, exec_op, exec_query
+from server.registry.providers.mssql import run_exec, run_json_many
+from server.registry.types import DBResponse
 
 __all__ = [
   "delete_route_v1",
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-def get_routes_v1(_: dict[str, Any]) -> Operation:
+async def get_routes_v1(_: dict[str, Any]) -> DBResponse:
   sql = """
     SELECT
       element_path,
@@ -26,28 +26,28 @@ def get_routes_v1(_: dict[str, Any]) -> Operation:
     ORDER BY element_sequence
     FOR JSON PATH;
   """
-  return Operation(DbRunMode.JSON_MANY, sql, ())
+  return await run_json_many(sql)
 
 
-async def upsert_route_v1(args: dict[str, Any]):
+async def upsert_route_v1(args: dict[str, Any]) -> DBResponse:
   path = args["path"]
   name = args["name"]
   icon = args.get("icon")
   sequence = int(args["sequence"])
   roles = int(args["roles"])
-  rc = await exec_query(exec_op(
+  rc = await run_exec(
     "UPDATE frontend_routes SET element_name = ?, element_icon = ?, element_sequence = ?, element_roles = ? WHERE element_path = ?;",
     (name, icon, sequence, roles, path),
-  ))
+  )
   if rc.rowcount == 0:
-    rc = await exec_query(exec_op(
+    rc = await run_exec(
       "INSERT INTO frontend_routes (element_path, element_name, element_icon, element_sequence, element_roles) VALUES (?, ?, ?, ?, ?);",
       (path, name, icon, sequence, roles),
-    ))
+    )
   return rc
 
 
-def delete_route_v1(args: dict[str, Any]) -> Operation:
+async def delete_route_v1(args: dict[str, Any]) -> DBResponse:
   path = args["path"]
   sql = "DELETE FROM frontend_routes WHERE element_path = ?;"
-  return Operation(DbRunMode.EXEC, sql, (path,))
+  return await run_exec(sql, (path,))

--- a/server/registry/users/profile/mssql.py
+++ b/server/registry/users/profile/mssql.py
@@ -5,14 +5,8 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
-from server.modules.providers import DBResult, DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import (
-  Operation,
-  exec_op,
-  exec_query,
-  fetch_json,
-  json_one,
-)
+from server.registry.providers.mssql import run_exec, run_json_one
+from server.registry.types import DBResponse
 
 from server.registry.security.identities.mssql import get_auth_provider_recid
 
@@ -26,7 +20,7 @@ __all__ = [
 ]
 
 
-def get_profile_v1(args: dict[str, Any]) -> Operation:
+async def get_profile_v1(args: dict[str, Any]) -> DBResponse:
   guid = str(args["guid"])
   sql = """
     SELECT TOP 1
@@ -50,10 +44,10 @@ def get_profile_v1(args: dict[str, Any]) -> Operation:
     WHERE v.user_guid = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return Operation(DbRunMode.JSON_ONE, sql, (guid,))
+  return await run_json_one(sql, (guid,))
 
 
-def set_display_v1(args: dict[str, Any]) -> Operation:
+async def set_display_v1(args: dict[str, Any]) -> DBResponse:
   guid = args["guid"]
   display_name = args["display_name"]
   sql = """
@@ -61,10 +55,10 @@ def set_display_v1(args: dict[str, Any]) -> Operation:
     SET element_display = ?
     WHERE element_guid = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (display_name, guid))
+  return await run_exec(sql, (display_name, guid))
 
 
-def set_optin_v1(args: dict[str, Any]) -> Operation:
+async def set_optin_v1(args: dict[str, Any]) -> DBResponse:
   guid = args["guid"]
   display_email = args["display_email"]
   sql = """
@@ -72,23 +66,23 @@ def set_optin_v1(args: dict[str, Any]) -> Operation:
     SET element_optin = ?
     WHERE element_guid = ?;
   """
-  return Operation(DbRunMode.EXEC, sql, (display_email, guid))
+  return await run_exec(sql, (display_email, guid))
 
 
-async def update_if_unedited_v1(args: dict[str, Any]) -> DBResult:
+async def update_if_unedited_v1(args: dict[str, Any]) -> DBResponse:
   guid = str(UUID(args["guid"]))
   email = args.get("email")
   display = args.get("display_name")
-  res = await exec_query(exec_op(
+  res = await run_exec(
     """
     UPDATE account_users
     SET element_email = ?, element_display = ?
     WHERE element_guid = ? AND (element_email <> ? OR element_display <> ?);
     """,
     (email, display, guid, email, display),
-  ))
+  )
   if res.rowcount > 0:
-    return await fetch_json(json_one(
+    return await run_json_one(
       """
       SELECT element_display AS display_name, element_email AS email
       FROM account_users
@@ -96,39 +90,39 @@ async def update_if_unedited_v1(args: dict[str, Any]) -> DBResult:
       FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
       """,
       (guid,),
-    ))
-  return DBResult()
+    )
+  return DBResponse()
 
 
-async def set_roles_v1(args: dict[str, Any]) -> DBResult:
+async def set_roles_v1(args: dict[str, Any]) -> DBResponse:
   guid = args["guid"]
   roles = int(args["roles"])
   if roles == 0:
-    return await exec_query(exec_op("DELETE FROM users_roles WHERE users_guid = ?;", (guid,)))
-  res = await exec_query(exec_op(
+    return await run_exec("DELETE FROM users_roles WHERE users_guid = ?;", (guid,))
+  res = await run_exec(
     "UPDATE users_roles SET element_roles = ? WHERE users_guid = ?;",
     (roles, guid),
-  ))
+  )
   if res.rowcount == 0:
-    res = await exec_query(exec_op(
+    res = await run_exec(
       "INSERT INTO users_roles (users_guid, element_roles) VALUES (?, ?);",
       (guid, roles),
-    ))
+    )
   return res
 
 
-async def set_profile_image_v1(args: dict[str, Any]) -> DBResult:
+async def set_profile_image_v1(args: dict[str, Any]) -> DBResponse:
   guid = args["guid"]
   image_b64 = args["image_b64"]
   provider = args["provider"]
   ap_recid = await get_auth_provider_recid(provider)
-  rc = await exec_query(exec_op(
+  rc = await run_exec(
     "UPDATE users_profileimg SET element_base64 = ?, providers_recid = ? WHERE users_guid = ?;",
     (image_b64, ap_recid, guid),
-  ))
+  )
   if rc.rowcount == 0:
-    rc = await exec_query(exec_op(
+    rc = await run_exec(
       "INSERT INTO users_profileimg (users_guid, element_base64, providers_recid) VALUES (?, ?, ?);",
       (guid, image_b64, ap_recid),
-    ))
+    )
   return rc

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -1,15 +1,16 @@
 import asyncio
+from typing import Any
 from uuid import uuid4
 
 import pytest
 
-from server.modules.providers import DbRunMode
 from server.modules.providers.database.mssql_provider import db_helpers
 from server.registry.security.accounts import mssql as security_accounts
 from server.registry.providers.mssql import PROVIDER_QUERIES
 from server.registry.support.users import mssql as support_users
 from server.registry.users.profile import mssql as users_profile
 from server.registry.security.identities import mssql as security_identities
+from server.registry.types import DBResponse
 
 
 def _provider_map_for(urn: str) -> str:
@@ -19,20 +20,36 @@ def _provider_map_for(urn: str) -> str:
   return f"{parts[1]}.{parts[2]}.{parts[3]}"
 
 
-def test_mssql_get_by_provider_identifier_uses_user_view():
-  op = security_identities.get_by_provider_identifier_v1({
+def test_mssql_get_by_provider_identifier_uses_user_view(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_json_one(sql, params=(), *, meta=None):
+    captured["sql"] = sql
+    captured["params"] = params
+    return DBResponse()
+
+  monkeypatch.setattr(security_identities, "run_json_one", fake_run_json_one)
+  asyncio.run(security_identities.get_by_provider_identifier_v1({
     "provider": "microsoft",
     "provider_identifier": str(uuid4()),
-  })
-  sql = op.sql.lower()
+  }))
+  sql = captured["sql"].lower()
   assert "vw_account_user_profile" in sql
   assert "v.credits" in sql
   assert "users_credits" not in sql
 
 
-def test_mssql_get_profile_uses_profile_view():
-  op = users_profile.get_profile_v1({"guid": "gid"})
-  sql = op.sql.lower()
+def test_mssql_get_profile_uses_profile_view(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_json_one(sql, params=(), *, meta=None):
+    captured["sql"] = sql
+    captured["params"] = params
+    return DBResponse()
+
+  monkeypatch.setattr(users_profile, "run_json_one", fake_run_json_one)
+  asyncio.run(users_profile.get_profile_v1({"guid": "gid"}))
+  sql = captured["sql"].lower()
   assert "vw_account_user_profile" in sql
   assert "v.credits" in sql
   assert "users_credits" not in sql
@@ -59,10 +76,21 @@ _SECURITY_PROFILE_CASES = [
   _SECURITY_PROFILE_CASES,
 )
 def test_mssql_accounts_security_profile_routes_through_security_view(
-  args, expected_fragments, joins_users_auth
+  monkeypatch,
+  args,
+  expected_fragments,
+  joins_users_auth,
 ):
-  op = security_accounts.get_security_profile_v1(args)
-  sql = op.sql.lower()
+  captured: dict[str, Any] = {}
+
+  async def fake_run_json_one(sql, params=(), *, meta=None):
+    captured["sql"] = sql
+    captured["params"] = params
+    return DBResponse()
+
+  monkeypatch.setattr(security_accounts, "run_json_one", fake_run_json_one)
+  asyncio.run(security_accounts.get_security_profile_v1(args))
+  sql = captured["sql"].lower()
   for fragment in expected_fragments:
     assert fragment in sql
   assert ("join users_auth" in sql) is joins_users_auth
@@ -82,11 +110,18 @@ def test_removed_security_aliases_are_not_registered(urn):
   assert provider_map not in PROVIDER_QUERIES
 
 
-def test_mssql_support_users_set_credits_updates_table():
-  op = support_users.set_credits_v1({"guid": "gid", "credits": 10})
-  assert op.kind is DbRunMode.EXEC
-  assert "update users_credits" in op.sql.lower()
-  assert op.params == (10, "gid")
+def test_mssql_support_users_set_credits_updates_table(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_exec(sql, params, *, meta=None):
+    captured["sql"] = sql
+    captured["params"] = params
+    return DBResponse()
+
+  monkeypatch.setattr(support_users, "run_exec", fake_run_exec)
+  asyncio.run(support_users.set_credits_v1({"guid": "gid", "credits": 10}))
+  assert "update users_credits" in captured["sql"].lower()
+  assert captured["params"] == (10, "gid")
 
 
 def test_fetch_rows_raises_structured_error(monkeypatch):

--- a/tests/test_storage_cache_upsert.py
+++ b/tests/test_storage_cache_upsert.py
@@ -1,20 +1,20 @@
 import asyncio
 
-from server.modules.providers import DBResult
 from server.registry.content.cache import mssql as content_cache
+from server.registry.types import DBResponse
 
 
 def test_storage_cache_upsert_sets_created_on(monkeypatch):
   captured = []
 
-  async def fake_exec_query(operation):
-    captured.append(operation.params)
-    return DBResult(rowcount=1)
+  async def fake_run_exec(sql, params):
+    captured.append(params)
+    return DBResponse(rowcount=1)
 
   async def fake_get_storage_type_recid(*_args, **_kwargs):
     return 1
 
-  monkeypatch.setattr(content_cache, "exec_query", fake_exec_query)
+  monkeypatch.setattr(content_cache, "run_exec", fake_run_exec)
   monkeypatch.setattr(content_cache, "_get_storage_type_recid", fake_get_storage_type_recid)
 
   args = {


### PR DESCRIPTION
## Summary
- add async `run_exec`/`run_json_*` helpers in the MSSQL provider that always yield `DBResponse` and lazily load the database executor
- refactor each MSSQL registry module to call the new helpers, returning `DBResponse` instead of `Operation`/`DBResult`
- update MSSQL-focused unit tests to stub the new helpers and assert query shapes while continuing to drive the dispatcher

## Testing
- `pytest tests/test_storage_cache_upsert.py tests/test_provider_queries.py`


------
https://chatgpt.com/codex/tasks/task_e_68df143e672c8325b9ce3a4a1ac0c561