### PR TITLE
Refactor MSSQL provider contract to use DBResponse

### DIFF
--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -5,7 +5,7 @@ import inspect
 
 from ... import DbProviderBase, DBResult
 from .logic import init_pool, close_pool
-from .db_helpers import Operation, execute_operation
+from .db_helpers import run_operation
 
 from importlib import import_module
 

--- a/server/modules/providers/database/mssql_provider/db_helpers.py
+++ b/server/modules/providers/database/mssql_provider/db_helpers.py
@@ -1,7 +1,7 @@
 import importlib
 import json, logging
 from dataclasses import dataclass
-from typing import Any, Iterable, AsyncIterator, Awaitable, Callable, Dict
+from typing import Any, Iterable, AsyncIterator, Callable
 from . import logic
 from ... import DBResult, DbRunMode
 
@@ -11,52 +11,18 @@ def _current_run_mode():
   return getattr(providers_mod, "DbRunMode")
 
 
-@dataclass(slots=True)
-class Operation:
-  kind: DbRunMode
-  sql: str
-  params: tuple[Any, ...] = ()
-  postprocess: Callable[[DBResult], DBResult] | None = None
-
-  def __post_init__(self):
-    run_mode_cls = _current_run_mode()
-    if not isinstance(self.kind, run_mode_cls):
-      value = getattr(self.kind, "value", self.kind)
-      try:
-        coerced = run_mode_cls(value)
-      except Exception as exc:
-        try:
-          coerced = run_mode_cls(str(value))
-        except Exception as inner_exc:
-          raise TypeError(f"Unsupported run mode value: {value!r}") from inner_exc
-      object.__setattr__(self, "kind", coerced)
-    if not isinstance(self.params, tuple):
-      object.__setattr__(self, "params", tuple(self.params))
-
-  def __iter__(self):
-    yield self.kind
-    yield self.sql
-    yield self.params
-
-
-def row_one(sql: str, params: Iterable[Any] = (), *, postprocess: Callable[[DBResult], DBResult] | None = None) -> Operation:
-  return Operation(DbRunMode.ROW_ONE, sql, tuple(params), postprocess)
-
-
-def row_many(sql: str, params: Iterable[Any] = (), *, postprocess: Callable[[DBResult], DBResult] | None = None) -> Operation:
-  return Operation(DbRunMode.ROW_MANY, sql, tuple(params), postprocess)
-
-
-def json_one(sql: str, params: Iterable[Any] = (), *, postprocess: Callable[[DBResult], DBResult] | None = None) -> Operation:
-  return Operation(DbRunMode.JSON_ONE, sql, tuple(params), postprocess)
-
-
-def json_many(sql: str, params: Iterable[Any] = (), *, postprocess: Callable[[DBResult], DBResult] | None = None) -> Operation:
-  return Operation(DbRunMode.JSON_MANY, sql, tuple(params), postprocess)
-
-
-def exec_op(sql: str, params: Iterable[Any] = (), *, postprocess: Callable[[DBResult], DBResult] | None = None) -> Operation:
-  return Operation(DbRunMode.EXEC, sql, tuple(params), postprocess)
+def _coerce_run_mode(kind: DbRunMode | str) -> DbRunMode:
+  run_mode_cls = _current_run_mode()
+  if isinstance(kind, run_mode_cls):
+    return kind
+  value = getattr(kind, "value", kind)
+  try:
+    return run_mode_cls(value)
+  except Exception as exc:
+    try:
+      return run_mode_cls(str(value))
+    except Exception as inner_exc:
+      raise TypeError(f"Unsupported run mode value: {value!r}") from inner_exc
 
 
 @dataclass(slots=True)
@@ -81,14 +47,15 @@ def _raise_query_error(query: str, params: tuple[Any, ...], error: Exception, *,
 def _rowdict(cols: Iterable[str], row: Iterable[Any]):
   return dict(zip(cols, row))
 
-async def fetch_rows(operation: Operation, *, stream: bool = False) -> DBResult | AsyncIterator[dict]:
+async def fetch_rows(kind: DbRunMode | str, sql: str, params: Iterable[Any] = (), *, stream: bool = False) -> DBResult | AsyncIterator[dict]:
   assert logic._pool, "MSSQL pool not initialized"
   run_mode_cls = _current_run_mode()
-  if operation.kind not in (run_mode_cls.ROW_ONE, run_mode_cls.ROW_MANY):
-    raise ValueError(f"Operation kind '{operation.kind}' is not row fetch capable")
-  query = operation.sql
-  params = operation.params
-  one = operation.kind is run_mode_cls.ROW_ONE
+  mode = _coerce_run_mode(kind)
+  if mode not in (run_mode_cls.ROW_ONE, run_mode_cls.ROW_MANY):
+    raise ValueError(f"Operation kind '{mode}' is not row fetch capable")
+  query = sql
+  params = tuple(params)
+  one = mode is run_mode_cls.ROW_ONE
   async def _ensure_result_set(cur) -> bool:
     if cur.description is not None:
       return True
@@ -131,14 +98,15 @@ async def fetch_rows(operation: Operation, *, stream: bool = False) -> DBResult 
   except Exception as e:
     _raise_query_error(query, params, e, log=logging.debug)
 
-async def fetch_json(operation: Operation) -> DBResult:
+async def fetch_json(kind: DbRunMode | str, sql: str, params: Iterable[Any] = ()) -> DBResult:
   assert logic._pool, "MSSQL pool not initialized"
   run_mode_cls = _current_run_mode()
-  if operation.kind not in (run_mode_cls.JSON_ONE, run_mode_cls.JSON_MANY):
-    raise ValueError(f"Operation kind '{operation.kind}' is not JSON fetch capable")
-  query = operation.sql
-  params = operation.params
-  many = operation.kind is run_mode_cls.JSON_MANY
+  mode = _coerce_run_mode(kind)
+  if mode not in (run_mode_cls.JSON_ONE, run_mode_cls.JSON_MANY):
+    raise ValueError(f"Operation kind '{mode}' is not JSON fetch capable")
+  query = sql
+  params = tuple(params)
+  many = mode is run_mode_cls.JSON_MANY
   try:
     async with logic._pool.acquire() as conn:
       async with conn.cursor() as cur:
@@ -164,13 +132,10 @@ async def fetch_json(operation: Operation) -> DBResult:
   except Exception as e:
     _raise_query_error(query, params, e, log=logging.error)
 
-async def exec_query(operation: Operation) -> DBResult:
+async def exec_query(sql: str, params: Iterable[Any] = ()) -> DBResult:
   assert logic._pool, "MSSQL pool not initialized"
-  run_mode_cls = _current_run_mode()
-  if operation.kind is not run_mode_cls.EXEC:
-    raise ValueError(f"Operation kind '{operation.kind}' is not executable")
-  query = operation.sql
-  params = operation.params
+  query = sql
+  params = tuple(params)
   try:
     async with logic._pool.acquire() as conn:
       async with conn.cursor() as cur:
@@ -180,20 +145,13 @@ async def exec_query(operation: Operation) -> DBResult:
     _raise_query_error(query, params, e, log=logging.error)
 
 
-async def execute_operation(operation: Operation) -> DBResult:
+async def run_operation(kind: DbRunMode | str, sql: str, params: Iterable[Any] = ()) -> DBResult:
   run_mode_cls = _current_run_mode()
-  runners: Dict[DbRunMode, Callable[[Operation], Awaitable[DBResult]]] = {
-    run_mode_cls.ROW_ONE: fetch_rows,
-    run_mode_cls.ROW_MANY: fetch_rows,
-    run_mode_cls.JSON_ONE: fetch_json,
-    run_mode_cls.JSON_MANY: fetch_json,
-    run_mode_cls.EXEC: exec_query,
-  }
-  try:
-    runner = runners[operation.kind]
-  except KeyError:
-    raise ValueError(f"Unknown operation kind: {operation.kind}") from None
-  result = await runner(operation)
-  if operation.postprocess:
-    return operation.postprocess(result)
-  return result
+  mode = _coerce_run_mode(kind)
+  if mode in (run_mode_cls.ROW_ONE, run_mode_cls.ROW_MANY):
+    return await fetch_rows(mode, sql, params)
+  if mode in (run_mode_cls.JSON_ONE, run_mode_cls.JSON_MANY):
+    return await fetch_json(mode, sql, params)
+  if mode is run_mode_cls.EXEC:
+    return await exec_query(sql, params)
+  raise ValueError(f"Unknown operation kind: {mode}")

--- a/server/registry/providers/mssql.py
+++ b/server/registry/providers/mssql.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import importlib
 import inspect
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from typing import Any
 
-from server.modules.providers.database.mssql_provider.db_helpers import Operation
 from server.registry.types import DBRequest, DBResponse
 
 from . import ProviderCallable, ProviderQueryMap
@@ -24,25 +23,10 @@ def _get_provider():
   return importlib.import_module("server.modules.providers.database.mssql_provider")
 
 
-def _response_from_payload(payload: Any, *, meta: dict[str, Any] | None = None) -> DBResponse:
-  rows_attr = getattr(payload, "rows", None)
-  rowcount_attr = getattr(payload, "rowcount", None)
-  if rows_attr is not None or rowcount_attr is not None:
-    rows = list(rows_attr or []) if rows_attr is not None else []
-    rowcount = int(rowcount_attr) if rowcount_attr is not None else len(rows)
-    return DBResponse(rows=rows, rowcount=rowcount, meta=meta)
-  if isinstance(payload, Mapping):
-    return DBResponse(rows=[dict(payload)], rowcount=1, meta=meta)
-  if payload is None:
-    return DBResponse(meta=meta)
-  raise TypeError(f"Unsupported provider specification result: {type(payload)!r}")
-
-
 async def _run_operation(kind: str, sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any] | None = None) -> DBResponse:
-  operation = Operation(kind, sql, tuple(params))
   provider = _get_provider()
-  result = await provider.execute_operation(operation)
-  return _response_from_payload(result, meta=meta)
+  result = await provider.run_operation(kind, sql, tuple(params))
+  return DBResponse.from_result(result, meta=meta)
 
 
 async def run_json_one(sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any] | None = None) -> DBResponse:
@@ -58,18 +42,11 @@ async def run_exec(sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any]
 
 
 async def _coerce_response(spec: Any) -> DBResponse:
-  if isinstance(spec, DBResponse):
-    return spec
   if inspect.isawaitable(spec):
-    return await _coerce_response(await spec)
-  if isinstance(spec, Operation):
-    provider = _get_provider()
-    result = await provider.execute_operation(spec)
-    return _response_from_payload(result)
-  try:
-    return _response_from_payload(spec)
-  except TypeError:
-    raise
+    spec = await spec
+  if not isinstance(spec, DBResponse):
+    raise TypeError(f"Expected DBResponse from provider callable, received {type(spec)!r}")
+  return spec
 
 
 def _wrap(fn: Any) -> ProviderCallable:

--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -3,7 +3,6 @@ import asyncio
 from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.modules.providers.database.mssql_provider as mssql_provider
 from server.modules.providers import DBResult, DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation
 
 
 def test_assistant_conversations_list_by_time(monkeypatch):
@@ -12,11 +11,12 @@ def test_assistant_conversations_list_by_time(monkeypatch):
   start = '2024-01-01'
   end = '2024-01-02'
 
-  async def fake_execute_operation(operation):
-    assert isinstance(operation, Operation)
-    assert operation.kind is DbRunMode.JSON_MANY
-    sql = operation.sql
-    params = operation.params
+  captured: dict[str, object] = {}
+
+  async def fake_run_operation(kind, sql, params):
+    captured["kind"] = kind
+    captured["sql"] = sql
+    captured["params"] = params
     assert "element_modified_on" in sql
     assert "element_user_id" in sql
     assert "element_tokens" in sql
@@ -25,7 +25,7 @@ def test_assistant_conversations_list_by_time(monkeypatch):
     assert params == (personas_recid, start, end)
     return DBResult(rows=[{"recid": 1}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, 'execute_operation', fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, 'run_operation', fake_run_operation)
 
   res = asyncio.run(provider.run(
     'db:assistant:conversations:list_by_time:1',
@@ -33,6 +33,7 @@ def test_assistant_conversations_list_by_time(monkeypatch):
   ))
   assert isinstance(res, DBResult)
   assert res.rows == [{"recid": 1}]
+  assert captured["kind"] in (DbRunMode.JSON_MANY, DbRunMode.JSON_MANY.value)
 
 
 def test_assistant_conversations_insert(monkeypatch):
@@ -48,20 +49,22 @@ def test_assistant_conversations_insert(monkeypatch):
     'tokens': 5,
   }
 
-  async def fake_execute_operation(operation):
-    assert isinstance(operation, Operation)
-    assert operation.kind is DbRunMode.JSON_ONE
-    sql = operation.sql
-    params = operation.params
+  captured: dict[str, object] = {}
+
+  async def fake_run_operation(kind, sql, params):
+    captured["kind"] = kind
+    captured["sql"] = sql
+    captured["params"] = params
     assert "INSERT INTO assistant_conversations" in sql
     assert "FOR JSON PATH" in sql
     assert params == (1, 2, '1', '2', '3', 'hi', '', 5)
     return DBResult(rows=[{'recid': 9}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, 'execute_operation', fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, 'run_operation', fake_run_operation)
 
   res = asyncio.run(provider.run('db:assistant:conversations:insert:1', args))
   assert res.rows == [{'recid': 9}]
+  assert captured["kind"] in (DbRunMode.JSON_ONE, DbRunMode.JSON_ONE.value)
 
 
 def test_assistant_conversations_find_recent(monkeypatch):
@@ -76,51 +79,56 @@ def test_assistant_conversations_find_recent(monkeypatch):
     'window_seconds': 120,
   }
 
-  async def fake_execute_operation(operation):
-    assert isinstance(operation, Operation)
-    assert operation.kind is DbRunMode.JSON_ONE
-    sql = operation.sql
-    params = operation.params
+  captured: dict[str, object] = {}
+
+  async def fake_run_operation(kind, sql, params):
+    captured["kind"] = kind
+    captured["sql"] = sql
+    captured["params"] = params
     assert "SELECT TOP 1 recid" in sql
     assert "DATEADD" in sql
     assert "FOR JSON PATH" in sql
     assert params == (1, 2, 'hi', '1', '1', '2', '2', '3', '3', 120)
     return DBResult(rows=[{'recid': 5}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, 'execute_operation', fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, 'run_operation', fake_run_operation)
 
   res = asyncio.run(provider.run('db:assistant:conversations:find_recent:1', args))
   assert res.rows == [{'recid': 5}]
+  assert captured["kind"] in (DbRunMode.JSON_ONE, DbRunMode.JSON_ONE.value)
 
 
 def test_assistant_conversations_update_output(monkeypatch):
   provider = MssqlProvider()
   args = {'recid': 9, 'output_data': 'out', 'tokens': 12}
 
-  async def fake_execute_operation(operation):
-    assert isinstance(operation, Operation)
-    assert operation.kind is DbRunMode.EXEC
-    sql = operation.sql
-    params = operation.params
+  captured: dict[str, object] = {}
+
+  async def fake_run_operation(kind, sql, params):
+    captured["kind"] = kind
+    captured["sql"] = sql
+    captured["params"] = params
     assert "element_modified_on" not in sql
     assert "element_tokens" in sql
     assert params == ('out', 12, 9)
     return DBResult(rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, 'execute_operation', fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, 'run_operation', fake_run_operation)
 
   res = asyncio.run(provider.run('db:assistant:conversations:update_output:1', args))
   assert res.rowcount == 1
+  assert captured["kind"] in (DbRunMode.EXEC, DbRunMode.EXEC.value)
 
 
 def test_assistant_conversations_list_recent(monkeypatch):
   provider = MssqlProvider()
 
-  async def fake_execute_operation(operation):
-    assert isinstance(operation, Operation)
-    assert operation.kind is DbRunMode.JSON_MANY
-    sql = operation.sql
-    params = operation.params
+  captured: dict[str, object] = {}
+
+  async def fake_run_operation(kind, sql, params):
+    captured["kind"] = kind
+    captured["sql"] = sql
+    captured["params"] = params
     assert "SELECT TOP (2)" in sql
     assert "element_output" in sql
     assert "ORDER BY element_created_on DESC" in sql
@@ -129,9 +137,10 @@ def test_assistant_conversations_list_recent(monkeypatch):
     assert params == ()
     return DBResult(rows=[{"recid": 2}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, 'execute_operation', fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, 'run_operation', fake_run_operation)
 
   res = asyncio.run(provider.run('db:assistant:conversations:list_recent:1', {}))
   assert isinstance(res, DBResult)
   assert res.rows == [{"recid": 2}]
+  assert captured["kind"] in (DbRunMode.JSON_MANY, DbRunMode.JSON_MANY.value)
 

--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -11,25 +11,26 @@ from server.registry.content.cache import set_public_request
 
 
 def _set_provider_callable(monkeypatch, provider_map: str, handler):
-  monkeypatch.setitem(mssql_provider.PROVIDER_QUERIES, provider_map, {1: handler})
+  monkeypatch.setitem(registry_mssql.PROVIDER_QUERIES, provider_map, {1: handler})
 
 
 def test_run_json_one(monkeypatch):
   provider = MssqlProvider()
   op = "db:test:queries:json_one:1"
 
+  captured: dict[str, object] = {}
+
   def fake_handler(params):
     assert params == {}
-    return mssql_provider.Operation(DbRunMode.JSON_ONE, "select 1", ())
+    return registry_mssql.run_json_one("select 1")
 
-  async def fake_execute_operation(operation):
-    assert isinstance(operation, mssql_provider.Operation)
-    assert operation.kind is DbRunMode.JSON_ONE
-    assert operation.sql == "select 1"
-    assert operation.params == ()
+  async def fake_run_operation(kind, sql, params):
+    captured["kind"] = kind
+    captured["sql"] = sql
+    captured["params"] = params
     return DBResult(rows=[{"v": 1}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, "run_operation", fake_run_operation)
   _set_provider_callable(monkeypatch, "test.queries.json_one", registry_mssql._wrap(fake_handler))
 
   res = asyncio.run(provider.run(op, {}))
@@ -37,24 +38,28 @@ def test_run_json_one(monkeypatch):
   assert isinstance(res, DBResult)
   assert res.rows == [{"v": 1}]
   assert res.rowcount == 1
+  assert captured["kind"] in (DbRunMode.JSON_ONE, DbRunMode.JSON_ONE.value)
+  assert captured["sql"] == "select 1"
+  assert captured["params"] == ()
 
 
 def test_run_row_one(monkeypatch):
   provider = MssqlProvider()
   op = "db:test:queries:row_one:1"
 
+  captured: dict[str, object] = {}
+
   def fake_handler(params):
     assert params == {}
-    return mssql_provider.Operation(DbRunMode.ROW_ONE, "select 1", ())
+    return registry_mssql._run_operation("row_one", "select 1")
 
-  async def fake_execute_operation(operation):
-    assert isinstance(operation, mssql_provider.Operation)
-    assert operation.kind is DbRunMode.ROW_ONE
-    assert operation.sql == "select 1"
-    assert operation.params == ()
+  async def fake_run_operation(kind, sql, params):
+    captured["kind"] = kind
+    captured["sql"] = sql
+    captured["params"] = params
     return DBResult(rows=[{"v": 1}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, "run_operation", fake_run_operation)
   _set_provider_callable(monkeypatch, "test.queries.row_one", registry_mssql._wrap(fake_handler))
 
   res = asyncio.run(provider.run(op, {}))
@@ -62,6 +67,9 @@ def test_run_row_one(monkeypatch):
   assert isinstance(res, DBResult)
   assert res.rows == [{"v": 1}]
   assert res.rowcount == 1
+  assert captured["kind"] in (DbRunMode.ROW_ONE, DbRunMode.ROW_ONE.value)
+  assert captured["sql"] == "select 1"
+  assert captured["params"] == ()
 
 
 def test_run_row_many(monkeypatch):
@@ -69,36 +77,43 @@ def test_run_row_many(monkeypatch):
   guid = "00000000-0000-0000-0000-000000000000"
   expected_guid = str(UUID(guid))
 
-  async def fake_execute_operation(operation):
-    assert isinstance(operation, mssql_provider.Operation)
-    assert operation.kind is DbRunMode.JSON_MANY
-    assert "FOR JSON PATH" in operation.sql
-    assert operation.params == (expected_guid,)
+  captured: dict[str, object] = {}
+
+  async def fake_run_operation(kind, sql, params):
+    captured["kind"] = kind
+    captured["sql"] = sql
+    captured["params"] = params
     return DBResult(rows=[{"path": "a"}, {"path": "b"}], rowcount=2)
 
-  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, "run_operation", fake_run_operation)
 
   res = asyncio.run(provider.run("db:public:users:get_published_files:1", {"guid": guid}))
 
   assert isinstance(res, DBResult)
   assert res.rows == [{"path": "a"}, {"path": "b"}]
   assert res.rowcount == 2
+  assert captured["kind"] in (DbRunMode.JSON_MANY, DbRunMode.JSON_MANY.value)
+  assert "FOR JSON PATH" in str(captured["sql"]).upper()
+  assert captured["params"] == (expected_guid,)
 
 
 def test_run_json_many(monkeypatch):
   provider = MssqlProvider()
   op = "db:test:queries:json_many:1"
 
+  captured: dict[str, object] = {}
+
   def fake_handler(params):
     assert params == {}
-    return mssql_provider.Operation(DbRunMode.JSON_MANY, "select", ())
+    return registry_mssql.run_json_many("select")
 
-  async def fake_execute_operation(operation):
-    assert isinstance(operation, mssql_provider.Operation)
-    assert operation.kind is DbRunMode.JSON_MANY
+  async def fake_run_operation(kind, sql, params):
+    captured["kind"] = kind
+    captured["sql"] = sql
+    captured["params"] = params
     return DBResult(rows=[{"v": 1}, {"v": 2}], rowcount=2)
 
-  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, "run_operation", fake_run_operation)
   _set_provider_callable(monkeypatch, "test.queries.json_many", registry_mssql._wrap(fake_handler))
 
   res = asyncio.run(provider.run(op, {}))
@@ -106,24 +121,28 @@ def test_run_json_many(monkeypatch):
   assert isinstance(res, DBResult)
   assert res.rows == [{"v": 1}, {"v": 2}]
   assert res.rowcount == 2
+  assert captured["kind"] in (DbRunMode.JSON_MANY, DbRunMode.JSON_MANY.value)
+  assert captured["sql"] == "select"
+  assert captured["params"] == ()
 
 
 def test_run_exec(monkeypatch):
   provider = MssqlProvider()
   op = "db:test:queries:exec:1"
 
+  captured: dict[str, object] = {}
+
   def fake_handler(params):
     assert params == {}
-    return mssql_provider.Operation(DbRunMode.EXEC, "update", (1,))
+    return registry_mssql.run_exec("update", (1,))
 
-  async def fake_execute_operation(operation):
-    assert isinstance(operation, mssql_provider.Operation)
-    assert operation.kind is DbRunMode.EXEC
-    assert operation.sql == "update"
-    assert operation.params == (1,)
+  async def fake_run_operation(kind, sql, params):
+    captured["kind"] = kind
+    captured["sql"] = sql
+    captured["params"] = params
     return DBResult(rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, "run_operation", fake_run_operation)
   _set_provider_callable(monkeypatch, "test.queries.exec", registry_mssql._wrap(fake_handler))
 
   res = asyncio.run(provider.run(op, {}))
@@ -131,6 +150,9 @@ def test_run_exec(monkeypatch):
   assert isinstance(res, DBResult)
   assert res.rows == []
   assert res.rowcount == 1
+  assert captured["kind"] in (DbRunMode.EXEC, DbRunMode.EXEC.value)
+  assert captured["sql"] == "update"
+  assert captured["params"] == (1,)
 
 
 def test_storage_files_set_gallery(monkeypatch):
@@ -138,14 +160,15 @@ def test_storage_files_set_gallery(monkeypatch):
   guid = "00000000-0000-0000-0000-000000000000"
   expected_guid = str(UUID(guid))
 
-  async def fake_execute_operation(operation):
-    assert isinstance(operation, mssql_provider.Operation)
-    assert operation.kind is DbRunMode.EXEC
-    assert "UPDATE users_storage_cache" in operation.sql
-    assert operation.params == (1, expected_guid, "", "file.txt")
+  captured: dict[str, object] = {}
+
+  async def fake_run_operation(kind, sql, params):
+    captured["kind"] = kind
+    captured["sql"] = sql
+    captured["params"] = params
     return DBResult(rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, "run_operation", fake_run_operation)
 
   request = set_gallery_request(guid, "file.txt", True)
 
@@ -153,6 +176,9 @@ def test_storage_files_set_gallery(monkeypatch):
 
   assert isinstance(res, DBResult)
   assert res.rowcount == 1
+  assert captured["kind"] in (DbRunMode.EXEC, DbRunMode.EXEC.value)
+  assert "UPDATE USERS_STORAGE_CACHE" in str(captured["sql"]).upper()
+  assert captured["params"] == (1, expected_guid, "", "file.txt")
 
 
 def test_storage_cache_set_public(monkeypatch):
@@ -160,14 +186,15 @@ def test_storage_cache_set_public(monkeypatch):
   guid = "00000000-0000-0000-0000-000000000001"
   expected_guid = str(UUID(guid))
 
-  async def fake_execute_operation(operation):
-    assert isinstance(operation, mssql_provider.Operation)
-    assert operation.kind is DbRunMode.EXEC
-    assert operation.params == (0, expected_guid, "docs", "file.txt")
-    assert "UPDATE users_storage_cache" in operation.sql
+  captured: dict[str, object] = {}
+
+  async def fake_run_operation(kind, sql, params):
+    captured["kind"] = kind
+    captured["sql"] = sql
+    captured["params"] = params
     return DBResult(rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, "run_operation", fake_run_operation)
 
   request = set_public_request(
     guid,
@@ -180,26 +207,28 @@ def test_storage_cache_set_public(monkeypatch):
 
   assert isinstance(res, DBResult)
   assert res.rowcount == 1
+  assert captured["kind"] in (DbRunMode.EXEC, DbRunMode.EXEC.value)
+  assert captured["params"] == (0, expected_guid, "docs", "file.txt")
+  assert "UPDATE USERS_STORAGE_CACHE" in str(captured["sql"]).upper()
 
 
 def test_storage_public_lists_share_query(monkeypatch):
   provider = MssqlProvider()
-  seen = []
+  seen: list[tuple[object, str, tuple]] = []
 
-  async def fake_execute_operation(operation):
-    seen.append(operation)
-    assert isinstance(operation, mssql_provider.Operation)
-    assert operation.kind is DbRunMode.JSON_MANY
-    assert operation.params == ()
+  async def fake_run_operation(kind, sql, params):
+    seen.append((kind, sql, params))
+    assert kind in (DbRunMode.JSON_MANY, DbRunMode.JSON_MANY.value)
+    assert params == ()
     return DBResult(rows=[], rowcount=0)
 
-  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, "run_operation", fake_run_operation)
 
   asyncio.run(provider.run("db:content:public:list_public:1", {}))
   asyncio.run(provider.run("db:content:public:get_public_files:1", {}))
 
   assert len(seen) == 2
-  assert seen[0].sql == seen[1].sql
+  assert seen[0][1] == seen[1][1]
 
 
 def test_unlink_provider_dict_result(monkeypatch):

--- a/tests/test_mssql_personas_registry.py
+++ b/tests/test_mssql_personas_registry.py
@@ -1,16 +1,25 @@
-from server.modules.providers import DbRunMode
-from server.modules.providers.database.mssql_provider.db_helpers import Operation
+import asyncio
+
 from server.registry.assistant.personas import mssql as personas_mssql
+from server.registry.types import DBResponse
 
 
-def test_persona_lookup_query_targets_element_name():
-  op = personas_mssql.get_by_name_v1({"name": "stark"})
+def test_persona_lookup_query_targets_element_name(monkeypatch):
+  captured: dict[str, object] = {}
 
-  assert isinstance(op, Operation)
-  assert op.kind is DbRunMode.JSON_ONE
-  assert "FROM vw_personas vp" in op.sql
-  assert "JOIN assistant_personas ap ON ap.element_name = vp.persona_name" in op.sql
-  assert "WHERE vp.persona_name = ?" in op.sql
-  assert "FOR JSON PATH" in op.sql
-  assert "vp.model_name AS element_model" in op.sql
-  assert op.params == ("stark",)
+  async def fake_run_json_one(sql, params=(), *, meta=None):
+    captured["sql"] = sql
+    captured["params"] = params
+    return DBResponse()
+
+  monkeypatch.setattr(personas_mssql, "run_json_one", fake_run_json_one)
+
+  asyncio.run(personas_mssql.get_by_name_v1({"name": "stark"}))
+
+  sql = captured["sql"].lower()
+  assert "from vw_personas vp" in sql
+  assert "join assistant_personas ap on ap.element_name = vp.persona_name" in sql
+  assert "where vp.persona_name = ?" in sql
+  assert "for json path" in sql
+  assert "vp.model_name as element_model" in sql
+  assert captured["params"] == ("stark",)

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 
 from server.modules.providers.database.mssql_provider import db_helpers
+from server.modules.providers import DbRunMode
 from server.registry.security.accounts import mssql as security_accounts
 from server.registry.providers.mssql import PROVIDER_QUERIES
 from server.registry.support.users import mssql as support_users
@@ -154,7 +155,7 @@ def test_fetch_rows_raises_structured_error(monkeypatch):
 
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
   with pytest.raises(db_helpers.DBQueryError) as exc:
-    asyncio.run(db_helpers.fetch_rows(db_helpers.row_one("SELECT 1")))
+    asyncio.run(db_helpers.fetch_rows(DbRunMode.ROW_ONE, "SELECT 1"))
   assert exc.value.detail.query == "SELECT 1"
   assert exc.value.detail.params == ()
 
@@ -189,7 +190,7 @@ def test_fetch_json_raises_structured_error(monkeypatch):
 
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
   with pytest.raises(db_helpers.DBQueryError) as exc:
-    asyncio.run(db_helpers.fetch_json(db_helpers.json_one("SELECT 1")))
+    asyncio.run(db_helpers.fetch_json(DbRunMode.JSON_ONE, "SELECT 1"))
   assert exc.value.detail.query == "SELECT 1"
 
 
@@ -229,11 +230,11 @@ def test_fetch_json_handles_multiple_rows(monkeypatch):
       return _Ctx()
 
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
-  result = asyncio.run(db_helpers.fetch_json(db_helpers.json_many("SELECT 1")))
+  result = asyncio.run(db_helpers.fetch_json(DbRunMode.JSON_MANY, "SELECT 1"))
   assert result.rows == [{"a": 1, "b": "two"}]
 
 
-def test_execute_operation_handles_exec(monkeypatch):
+def test_run_operation_handles_exec(monkeypatch):
   class Cur:
     async def __aenter__(self):
       return self
@@ -263,5 +264,5 @@ def test_execute_operation_handles_exec(monkeypatch):
       return _Ctx()
 
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
-  result = asyncio.run(db_helpers.exec_query(db_helpers.exec_op("UPDATE")))
+  result = asyncio.run(db_helpers.run_operation(DbRunMode.EXEC, "UPDATE"))
   assert result.rowcount == 3

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -121,16 +121,16 @@ def test_list_public_files(monkeypatch):
   app = FastAPI()
   provider = MssqlProvider()
 
-  async def fake_execute_operation(operation):
-    assert operation.kind is DbRunMode.JSON_MANY
-    assert "FOR JSON PATH" in operation.sql
-    assert operation.params == ()
+  async def fake_run_operation(kind, sql, params):
+    assert kind in (DbRunMode.JSON_MANY, DbRunMode.JSON_MANY.value)
+    assert "FOR JSON PATH" in sql
+    assert params == ()
     return DBResult(rows=[
       {"user_guid": "u1", "display_name": "U1", "path": "", "name": "a.txt", "url": "u/a.txt", "content_type": "text/plain"},
       {"user_guid": "u2", "display_name": "U2", "path": "", "name": "b.txt", "url": "u/b.txt", "content_type": "text/plain"},
     ], rowcount=2)
 
-  monkeypatch.setattr(mssql_provider, "execute_operation", fake_execute_operation)
+  monkeypatch.setattr(mssql_provider, "run_operation", fake_run_operation)
 
   mod = StorageModule(app)
   mod.db = provider


### PR DESCRIPTION
## Summary
- standardize MSSQL registry helpers to invoke the provider run_operation API and always yield DBResponse payloads
- replace the Operation wrapper in db_helpers with direct DbRunMode handling and expose run_operation for callers
- update MSSQL-related tests to monkeypatch run_operation and expect DBResponse-based flows

## Testing
- pytest tests/test_db_provider_contract.py tests/test_provider_queries.py tests/test_db_assistant_conversations.py tests/test_storage_module.py tests/test_mssql_personas_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68df18eac3008325ba591eba0b8b7643