### PR TITLE
Refactor MSSQL provider bindings to use shared metadata

### DIFF
--- a/server/modules/providers/__init__.py
+++ b/server/modules/providers/__init__.py
@@ -6,6 +6,8 @@ from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict
 from enum import Enum
+import sys
+from types import SimpleNamespace
 
 import aiohttp
 from fastapi import HTTPException, status
@@ -31,8 +33,18 @@ class DBResult(BaseModel):
   rowcount: int = 0
 
 
+_CANONICAL = sys.modules.setdefault(
+  "server.modules.providers._canonical",
+  SimpleNamespace(DBResult=None),
+)
+if _CANONICAL.DBResult is None:
+  _CANONICAL.DBResult = DBResult
+else:
+  DBResult = _CANONICAL.DBResult
+
+
 def get_dbresult_cls() -> type[DBResult]:
-  return DBResult
+  return _CANONICAL.DBResult
 
 
 class DbRunMode(str, Enum):

--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -25,6 +25,7 @@ class MssqlProvider(DbProviderBase):
     await close_pool()
 
   def _resolve_provider_callable(self, op: str):
+    provider_queries = _get_provider_queries()
     parts = op.split(":")
     if len(parts) != 5 or parts[0] != "db":
       raise KeyError(f"Unsupported operation key: {op}")
@@ -34,7 +35,6 @@ class MssqlProvider(DbProviderBase):
     except ValueError as exc:
       raise KeyError(f"Invalid operation version for '{op}'") from exc
     provider_map = f"{domain}.{subdomain}.{name}"
-    provider_queries = _get_provider_queries()
     entry = provider_queries.get(provider_map)
     if entry is None:
       raise KeyError(f"No MSSQL handler for '{op}'")

--- a/server/registry/__init__.py
+++ b/server/registry/__init__.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable, Iterable, Mapping
 
 from server.modules.providers import DBResult, DbProviderBase, get_dbresult_cls
 
+from .providers import ProviderDescriptor
 from .types import DBRequest, DBResponse
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
   "DBResponse",
   "DBResult",
   "DomainRouter",
+  "ProviderBinding",
   "RegistryDispatcher",
   "RegistryRouter",
   "SubdomainRouter",
@@ -36,6 +38,14 @@ class FunctionRoute:
     return f"db:{self.domain}:{self.subdomain}:{self.name}:{self.version}"
 
 
+@dataclass(slots=True)
+class ProviderBinding:
+  canonical: str
+  provider_map: str
+  version: int
+  descriptor: ProviderDescriptor | None
+
+
 class RegistryRouter:
   """Hierarchical router that registers domain and subdomain functions."""
 
@@ -48,6 +58,7 @@ class RegistryRouter:
     self._provider_module = None
     self._provider_queries: dict[str, Mapping[int, Executor] | Executor] = {}
     self._provider_executors: dict[str, Executor] = {}
+    self._provider_bindings: dict[str, ProviderBinding] = {}
 
   def domain(self, name: str) -> "DomainRouter":
     if name not in self._domains:
@@ -107,7 +118,11 @@ class RegistryRouter:
     if self._provider_module and name == self._provider_name and self._provider_queries:
       return
     module = importlib.import_module(f"server.registry.providers.{name}")
-    queries = getattr(module, "PROVIDER_QUERIES", None)
+    build = getattr(module, "build_provider_queries", None)
+    if callable(build):
+      queries = build(self._provider_bindings.values())
+    else:
+      queries = getattr(module, "PROVIDER_QUERIES", None)
     if not isinstance(queries, dict):
       raise ValueError(f"Provider module '{name}' missing PROVIDER_QUERIES mapping")
     self._provider_name = name
@@ -116,6 +131,22 @@ class RegistryRouter:
     self._provider_executors.clear()
     for route in self._routes.values():
       self._attach_provider_callable(route)
+
+  @property
+  def provider_bindings(self) -> Mapping[str, ProviderBinding]:
+    return self._provider_bindings
+
+  def register_provider_binding(
+    self,
+    route: FunctionRoute,
+    provider: ProviderDescriptor | None,
+  ) -> None:
+    self._provider_bindings[route.key] = ProviderBinding(
+      canonical=route.key,
+      provider_map=route.provider_map,
+      version=route.version,
+      descriptor=provider,
+    )
 
   def get_executor(self, route: FunctionRoute) -> Executor | None:
     executor = self._provider_executors.get(route.key)
@@ -184,6 +215,7 @@ class SubdomainRouter:
     version: int,
     provider_map: str,
     aliases: Iterable[str] | None = None,
+    provider: ProviderDescriptor | None = None,
   ) -> None:
     route = FunctionRoute(
       domain=self._domain.name,
@@ -193,6 +225,7 @@ class SubdomainRouter:
       provider_map=provider_map,
     )
     self._registry.add_route(route)
+    self._registry.register_provider_binding(route, provider)
     for alias in aliases or []:
       self._registry.add_alias(alias, route.key)
 

--- a/server/registry/account/users/__init__.py
+++ b/server/registry/account/users/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 
 from server.registry.types import DBRequest
-from . import mssql  # noqa: F401 - ensure provider import
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -16,6 +14,7 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "account.users"
+_PROVIDER_DESCRIPTOR = ("server.registry.account.users.mssql", "set_credits_v1")
 
 
 def _request(name: str, params: dict[str, Any]) -> DBRequest:
@@ -31,4 +30,5 @@ def register(router: "SubdomainRouter") -> None:
     "set_credits",
     version=1,
     provider_map=f"{_DEF_PROVIDER}.set_credits",
+    provider=_PROVIDER_DESCRIPTOR,
   )

--- a/server/registry/accounts/profile/__init__.py
+++ b/server/registry/accounts/profile/__init__.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 
 from server.registry.types import DBRequest
-from server.registry.users.profile import mssql as _mssql  # noqa: F401 - ensure provider import
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -21,6 +19,15 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "users.profile"
+_PROVIDER_MODULE = "server.registry.users.profile.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "get_profile": "get_profile_v1",
+  "set_display": "set_display_v1",
+  "set_optin": "set_optin_v1",
+  "set_profile_image": "set_profile_image_v1",
+  "set_roles": "set_roles_v1",
+  "update_if_unedited": "update_if_unedited_v1",
+}
 
 
 def _request(name: str, params: dict[str, Any]) -> DBRequest:
@@ -72,33 +79,10 @@ def update_if_unedited_request(
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "get_profile",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_profile",
-  )
-  router.add_function(
-    "set_display",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.set_display",
-  )
-  router.add_function(
-    "set_optin",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.set_optin",
-  )
-  router.add_function(
-    "set_profile_image",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.set_profile_image",
-  )
-  router.add_function(
-    "set_roles",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.set_roles",
-  )
-  router.add_function(
-    "update_if_unedited",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.update_if_unedited",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/assistant/conversations/__init__.py
+++ b/server/registry/assistant/conversations/__init__.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Any
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401 - ensure provider imports are discoverable
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -22,6 +20,14 @@ __all__ = [
 
 _OP_PREFIX = "db:assistant:conversations"
 _PROVIDER_MAP = "assistant.conversations"
+_PROVIDER_MODULE = "server.registry.assistant.conversations.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "find_recent": "find_recent_v1",
+  "insert": "insert_conversation_v1",
+  "list_by_time": "list_by_time_v1",
+  "list_recent": "list_recent_v1",
+  "update_output": "update_output_v1",
+}
 
 
 def _op(name: str) -> str:
@@ -115,28 +121,10 @@ def list_recent_request() -> DBRequest:
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "find_recent",
-    version=1,
-    provider_map=f"{_PROVIDER_MAP}.find_recent",
-  )
-  router.add_function(
-    "insert",
-    version=1,
-    provider_map=f"{_PROVIDER_MAP}.insert",
-  )
-  router.add_function(
-    "list_by_time",
-    version=1,
-    provider_map=f"{_PROVIDER_MAP}.list_by_time",
-  )
-  router.add_function(
-    "list_recent",
-    version=1,
-    provider_map=f"{_PROVIDER_MAP}.list_recent",
-  )
-  router.add_function(
-    "update_output",
-    version=1,
-    provider_map=f"{_PROVIDER_MAP}.update_output",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_PROVIDER_MAP}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/assistant/models/__init__.py
+++ b/server/registry/assistant/models/__init__.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401 - ensure provider imports are discoverable
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -19,6 +17,11 @@ __all__ = [
 
 _OP_PREFIX = "db:assistant:models"
 _PROVIDER_MAP = "assistant.models"
+_PROVIDER_MODULE = "server.registry.assistant.models.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "get_by_name": "get_by_name_v1",
+  "list": "list_models_v1",
+}
 
 
 def _op(name: str) -> str:
@@ -34,13 +37,10 @@ def get_model_by_name_request(name: str) -> DBRequest:
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "get_by_name",
-    version=1,
-    provider_map=f"{_PROVIDER_MAP}.get_by_name",
-  )
-  router.add_function(
-    "list",
-    version=1,
-    provider_map=f"{_PROVIDER_MAP}.list",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_PROVIDER_MAP}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/assistant/personas/__init__.py
+++ b/server/registry/assistant/personas/__init__.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401 - ensure provider imports are discoverable
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -21,6 +19,13 @@ __all__ = [
 
 _OP_PREFIX = "db:assistant:personas"
 _PROVIDER_MAP = "assistant.personas"
+_PROVIDER_MODULE = "server.registry.assistant.personas.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "delete": "delete_persona_v1",
+  "get_by_name": "get_by_name_v1",
+  "list": "list_personas_v1",
+  "upsert": "upsert_persona_v1",
+}
 
 
 def _op(name: str) -> str:
@@ -66,23 +71,10 @@ def delete_persona_request(*, recid: int | None = None, name: str | None = None)
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "delete",
-    version=1,
-    provider_map=f"{_PROVIDER_MAP}.delete",
-  )
-  router.add_function(
-    "get_by_name",
-    version=1,
-    provider_map=f"{_PROVIDER_MAP}.get_by_name",
-  )
-  router.add_function(
-    "list",
-    version=1,
-    provider_map=f"{_PROVIDER_MAP}.list",
-  )
-  router.add_function(
-    "upsert",
-    version=1,
-    provider_map=f"{_PROVIDER_MAP}.upsert",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_PROVIDER_MAP}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/content/cache/__init__.py
+++ b/server/registry/content/cache/__init__.py
@@ -21,6 +21,17 @@ __all__ = [
 
 
 _DEF_PROVIDER = "content.cache"
+_PROVIDER_MODULE = "server.registry.content.cache.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "list": "list_v1",
+  "replace_user": "replace_user_v1",
+  "upsert": "upsert_v1",
+  "delete": "delete_v1",
+  "delete_folder": "delete_folder_v1",
+  "set_public": "set_public_v1",
+  "set_reported": "set_reported_v1",
+  "count_rows": "count_rows_v1",
+}
 
 
 def _normalize_cache_item_payload(item: Dict[str, Any]) -> Dict[str, Any]:
@@ -117,43 +128,10 @@ def count_rows_request():
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "list",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.list",
-  )
-  router.add_function(
-    "replace_user",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.replace_user",
-  )
-  router.add_function(
-    "upsert",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.upsert",
-  )
-  router.add_function(
-    "delete",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.delete",
-  )
-  router.add_function(
-    "delete_folder",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.delete_folder",
-  )
-  router.add_function(
-    "set_public",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.set_public",
-  )
-  router.add_function(
-    "set_reported",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.set_reported",
-  )
-  router.add_function(
-    "count_rows",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.count_rows",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/content/files/__init__.py
+++ b/server/registry/content/files/__init__.py
@@ -31,4 +31,5 @@ def register(router: "SubdomainRouter") -> None:
     "set_gallery",
     version=1,
     provider_map="content.files.set_gallery",
+    provider=("server.registry.content.files.mssql", "set_gallery_v1"),
   )

--- a/server/registry/content/public/__init__.py
+++ b/server/registry/content/public/__init__.py
@@ -17,6 +17,12 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "content.public"
+_PROVIDER_MODULE = "server.registry.content.public.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "list_public": "list_public_v1",
+  "list_reported": "list_reported_v1",
+  "get_public_files": "get_public_files_v1",
+}
 
 
 def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
@@ -36,18 +42,10 @@ def get_public_files_request() -> DBRequest:
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "list_public",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.list_public",
-  )
-  router.add_function(
-    "list_reported",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.list_reported",
-  )
-  router.add_function(
-    "get_public_files",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_public_files",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/providers/__init__.py
+++ b/server/registry/providers/__init__.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
 
 from server.registry.types import DBRequest, DBResponse
 
 ProviderCallable = Callable[[DBRequest], Awaitable[DBResponse]]
 ProviderQueryMap = Mapping[str, Mapping[int, ProviderCallable] | ProviderCallable]
+RawProvider = Callable[[dict[str, Any]], Awaitable[DBResponse] | DBResponse]
+ProviderDescriptor = RawProvider | tuple[str, str]
 
 __all__ = [
   "ProviderCallable",
   "ProviderQueryMap",
+  "ProviderDescriptor",
+  "RawProvider",
 ]

--- a/server/registry/providers/mssql.py
+++ b/server/registry/providers/mssql.py
@@ -7,9 +7,10 @@ import inspect
 from collections.abc import Iterable
 from typing import Any
 
+from server.registry import ProviderBinding, RegistryRouter
 from server.registry.types import DBRequest, DBResponse
 
-from . import ProviderCallable, ProviderQueryMap
+from . import ProviderCallable, ProviderDescriptor, ProviderQueryMap, RawProvider
 
 __all__ = [
   "PROVIDER_QUERIES",
@@ -49,99 +50,59 @@ async def _coerce_response(spec: Any) -> DBResponse:
   return spec
 
 
-def _wrap(fn: Any) -> ProviderCallable:
+def _wrap(fn: RawProvider) -> ProviderCallable:
   async def _executor(request: DBRequest) -> DBResponse:
     spec = fn(request.params)
     return await _coerce_response(spec)
   return _executor
 
 
-def _wrap_lazy(module_path: str, attr_name: str) -> ProviderCallable:
+def _resolve_descriptor(descriptor: ProviderDescriptor) -> RawProvider:
+  if callable(descriptor):
+    return descriptor
+  module_path, attr_name = descriptor
+
   def _invoke(params: dict[str, Any]) -> Any:
     module = importlib.import_module(module_path)
     fn = getattr(module, attr_name)
     return fn(params)
-  return _wrap(_invoke)
+
+  return _invoke
 
 
-_PROVIDER_SPECS: dict[str, tuple[str, str]] = {
-  "security.accounts.get_security_profile": ("server.registry.security.accounts.mssql", "get_security_profile_v1"),
-  "security.accounts.account_exists": ("server.registry.security.accounts.mssql", "account_exists_v1"),
-  "assistant.conversations.find_recent": ("server.registry.assistant.conversations.mssql", "find_recent_v1"),
-  "assistant.conversations.insert": ("server.registry.assistant.conversations.mssql", "insert_conversation_v1"),
-  "assistant.conversations.list_by_time": ("server.registry.assistant.conversations.mssql", "list_by_time_v1"),
-  "assistant.conversations.list_recent": ("server.registry.assistant.conversations.mssql", "list_recent_v1"),
-  "assistant.conversations.update_output": ("server.registry.assistant.conversations.mssql", "update_output_v1"),
-  "assistant.models.get_by_name": ("server.registry.assistant.models.mssql", "get_by_name_v1"),
-  "assistant.models.list": ("server.registry.assistant.models.mssql", "list_models_v1"),
-  "assistant.personas.delete": ("server.registry.assistant.personas.mssql", "delete_persona_v1"),
-  "assistant.personas.get_by_name": ("server.registry.assistant.personas.mssql", "get_by_name_v1"),
-  "assistant.personas.list": ("server.registry.assistant.personas.mssql", "list_personas_v1"),
-  "assistant.personas.upsert": ("server.registry.assistant.personas.mssql", "upsert_persona_v1"),
-  "security.oauth.relink_discord": ("server.registry.security.oauth.mssql", "relink_discord_v1"),
-  "security.oauth.relink_google": ("server.registry.security.oauth.mssql", "relink_google_v1"),
-  "security.oauth.relink_microsoft": ("server.registry.security.oauth.mssql", "relink_microsoft_v1"),
-  "security.identities.unlink_last_provider": ("server.registry.security.identities.mssql", "unlink_last_provider_v1"),
-  "security.identities.create_from_provider": ("server.registry.security.identities.mssql", "create_from_provider_v1"),
-  "security.identities.get_any_by_provider_identifier": ("server.registry.security.identities.mssql", "get_any_by_provider_identifier_v1"),
-  "security.identities.get_by_provider_identifier": ("server.registry.security.identities.mssql", "get_by_provider_identifier_v1"),
-  "security.identities.get_user_by_email": ("server.registry.security.identities.mssql", "get_user_by_email_v1"),
-  "security.identities.link_provider": ("server.registry.security.identities.mssql", "link_provider_v1"),
-  "security.identities.set_provider": ("server.registry.security.identities.mssql", "set_provider_v1"),
-  "security.identities.soft_delete_account": ("server.registry.security.identities.mssql", "soft_delete_account_v1"),
-  "security.identities.unlink_provider": ("server.registry.security.identities.mssql", "unlink_provider_v1"),
-  "security.sessions.create_session": ("server.registry.security.sessions.mssql", "create_session_v1"),
-  "security.sessions.revoke_all_device_tokens": ("server.registry.security.sessions.mssql", "revoke_all_device_tokens_v1"),
-  "security.sessions.revoke_device_token": ("server.registry.security.sessions.mssql", "revoke_device_token_v1"),
-  "security.sessions.revoke_provider_tokens": ("server.registry.security.sessions.mssql", "revoke_provider_tokens_v1"),
-  "security.sessions.update_device_token": ("server.registry.security.sessions.mssql", "update_device_token_v1"),
-  "security.sessions.update_session": ("server.registry.security.sessions.mssql", "update_session_v1"),
-  "security.sessions.set_rotkey": ("server.registry.security.sessions.mssql", "set_rotkey_v1"),
-  "content.cache.count_rows": ("server.registry.content.cache.mssql", "count_rows_v1"),
-  "content.cache.delete": ("server.registry.content.cache.mssql", "delete_v1"),
-  "content.cache.delete_folder": ("server.registry.content.cache.mssql", "delete_folder_v1"),
-  "content.cache.list": ("server.registry.content.cache.mssql", "list_v1"),
-  "content.cache.replace_user": ("server.registry.content.cache.mssql", "replace_user_v1"),
-  "content.cache.set_public": ("server.registry.content.cache.mssql", "set_public_v1"),
-  "content.cache.set_reported": ("server.registry.content.cache.mssql", "set_reported_v1"),
-  "content.cache.upsert": ("server.registry.content.cache.mssql", "upsert_v1"),
-  "content.files.set_gallery": ("server.registry.content.files.mssql", "set_gallery_v1"),
-  "content.public.get_public_files": ("server.registry.content.public.mssql", "get_public_files_v1"),
-  "content.public.list_public": ("server.registry.content.public.mssql", "list_public_v1"),
-  "content.public.list_reported": ("server.registry.content.public.mssql", "list_reported_v1"),
-  "public.links.get_home_links": ("server.registry.public.links.mssql", "get_home_links_v1"),
-  "public.links.get_navbar_routes": ("server.registry.public.links.mssql", "get_navbar_routes_v1"),
-  "public.users.get_profile": ("server.registry.public.users.mssql", "get_profile_v1"),
-  "public.users.get_published_files": ("server.registry.public.users.mssql", "get_published_files_v1"),
-  "public.vars.get_hostname": ("server.registry.public.vars.mssql", "get_hostname_v1"),
-  "public.vars.get_repo": ("server.registry.public.vars.mssql", "get_repo_v1"),
-  "public.vars.get_version": ("server.registry.public.vars.mssql", "get_version_v1"),
-  "account.users.set_credits": ("server.registry.account.users.mssql", "set_credits_v1"),
-  "support.users.set_credits": ("server.registry.support.users.mssql", "set_credits_v1"),
-  "system.config.delete_config": ("server.registry.system.config.mssql", "delete_config_v1"),
-  "system.config.get_config": ("server.registry.system.config.mssql", "get_config_v1"),
-  "system.config.get_configs": ("server.registry.system.config.mssql", "get_configs_v1"),
-  "system.config.upsert_config": ("server.registry.system.config.mssql", "upsert_config_v1"),
-  "system.roles.add_role_member": ("server.registry.system.roles.mssql", "add_role_member_v1"),
-  "system.roles.delete_role": ("server.registry.system.roles.mssql", "delete_role_v1"),
-  "system.roles.get_role_members": ("server.registry.system.roles.mssql", "get_role_members_v1"),
-  "system.roles.get_role_non_members": ("server.registry.system.roles.mssql", "get_role_non_members_v1"),
-  "system.roles.list": ("server.registry.system.roles.mssql", "list_roles_v1"),
-  "system.roles.remove_role_member": ("server.registry.system.roles.mssql", "remove_role_member_v1"),
-  "system.roles.upsert_role": ("server.registry.system.roles.mssql", "upsert_role_v1"),
-  "system.routes.delete_route": ("server.registry.system.routes.mssql", "delete_route_v1"),
-  "system.routes.get_routes": ("server.registry.system.routes.mssql", "get_routes_v1"),
-  "system.routes.upsert_route": ("server.registry.system.routes.mssql", "upsert_route_v1"),
-  "users.profile.get_profile": ("server.registry.users.profile.mssql", "get_profile_v1"),
-  "users.profile.set_display": ("server.registry.users.profile.mssql", "set_display_v1"),
-  "users.profile.set_optin": ("server.registry.users.profile.mssql", "set_optin_v1"),
-  "users.profile.set_profile_image": ("server.registry.users.profile.mssql", "set_profile_image_v1"),
-  "users.profile.set_roles": ("server.registry.users.profile.mssql", "set_roles_v1"),
-  "users.profile.update_if_unedited": ("server.registry.users.profile.mssql", "update_if_unedited_v1"),
-}
+def _wrap_descriptor(descriptor: ProviderDescriptor) -> ProviderCallable:
+  raw = _resolve_descriptor(descriptor)
+  return _wrap(raw)
 
 
-PROVIDER_QUERIES: ProviderQueryMap = {
-  key: {1: _wrap_lazy(module, attr)}
-  for key, (module, attr) in _PROVIDER_SPECS.items()
-}
+def _collect_bindings(
+  bindings: Iterable[ProviderBinding] | None,
+) -> list[ProviderBinding]:
+  if bindings is not None:
+    return list(bindings)
+  router = RegistryRouter()
+  router.register_domains()
+  return list(router.provider_bindings.values())
+
+
+def build_provider_queries(
+  bindings: Iterable[ProviderBinding] | None = None,
+) -> dict[str, dict[int, ProviderCallable]]:
+  collected = _collect_bindings(bindings)
+  queries: dict[str, dict[int, ProviderCallable]] = {}
+  for binding in collected:
+    descriptor = binding.descriptor
+    if descriptor is None:
+      raise ValueError(
+        f"Route '{binding.canonical}' does not declare a provider binding for MSSQL",
+      )
+    versions = queries.setdefault(binding.provider_map, {})
+    if binding.version in versions:
+      raise ValueError(
+        f"Duplicate MSSQL provider binding for '{binding.provider_map}' version {binding.version}",
+      )
+    versions[binding.version] = _wrap_descriptor(descriptor)
+  return {key: value.copy() for key, value in queries.items()}
+
+
+PROVIDER_QUERIES: ProviderQueryMap = build_provider_queries()

--- a/server/registry/public/links/__init__.py
+++ b/server/registry/public/links/__init__.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Any
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -18,6 +16,11 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "public.links"
+_PROVIDER_MODULE = "server.registry.public.links.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "get_home_links": "get_home_links_v1",
+  "get_navbar_routes": "get_navbar_routes_v1",
+}
 
 
 def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
@@ -33,13 +36,10 @@ def get_navbar_routes_request(*, role_mask: int) -> DBRequest:
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "get_home_links",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_home_links",
-  )
-  router.add_function(
-    "get_navbar_routes",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_navbar_routes",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/public/users/__init__.py
+++ b/server/registry/public/users/__init__.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Any
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -18,6 +16,11 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "public.users"
+_PROVIDER_MODULE = "server.registry.public.users.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "get_profile": "get_profile_v1",
+  "get_published_files": "get_published_files_v1",
+}
 
 
 def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
@@ -33,13 +36,10 @@ def get_published_files_request(*, guid: str) -> DBRequest:
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "get_profile",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_profile",
-  )
-  router.add_function(
-    "get_published_files",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_published_files",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/public/vars/__init__.py
+++ b/server/registry/public/vars/__init__.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Any
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -19,6 +17,12 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "public.vars"
+_PROVIDER_MODULE = "server.registry.public.vars.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "get_version": "get_version_v1",
+  "get_hostname": "get_hostname_v1",
+  "get_repo": "get_repo_v1",
+}
 
 
 def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
@@ -38,18 +42,10 @@ def get_repo_request() -> DBRequest:
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "get_version",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_version",
-  )
-  router.add_function(
-    "get_hostname",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_hostname",
-  )
-  router.add_function(
-    "get_repo",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_repo",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/security/accounts/__init__.py
+++ b/server/registry/security/accounts/__init__.py
@@ -6,8 +6,6 @@ from typing import Any, TYPE_CHECKING
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401 - ensure provider modules are discoverable
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -18,6 +16,11 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "security.accounts"
+_PROVIDER_MODULE = "server.registry.security.accounts.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "get_security_profile": "get_security_profile_v1",
+  "account_exists": "account_exists_v1",
+}
 
 
 def get_security_profile_request(
@@ -50,13 +53,10 @@ def account_exists_request(user_guid: str) -> DBRequest:
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "get_security_profile",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_security_profile",
-  )
-  router.add_function(
-    "account_exists",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.account_exists",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/security/identities/__init__.py
+++ b/server/registry/security/identities/__init__.py
@@ -6,8 +6,6 @@ from typing import Any, TYPE_CHECKING
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -25,6 +23,18 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "security.identities"
+_PROVIDER_MODULE = "server.registry.security.identities.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "create_from_provider": "create_from_provider_v1",
+  "get_any_by_provider_identifier": "get_any_by_provider_identifier_v1",
+  "get_by_provider_identifier": "get_by_provider_identifier_v1",
+  "get_user_by_email": "get_user_by_email_v1",
+  "link_provider": "link_provider_v1",
+  "set_provider": "set_provider_v1",
+  "soft_delete_account": "soft_delete_account_v1",
+  "unlink_last_provider": "unlink_last_provider_v1",
+  "unlink_provider": "unlink_provider_v1",
+}
 
 
 def _request(op: str, params: dict[str, Any]) -> DBRequest:
@@ -145,48 +155,10 @@ def unlink_last_provider_request(*, guid: str, provider: str) -> DBRequest:
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "create_from_provider",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.create_from_provider",
-  )
-  router.add_function(
-    "get_by_provider_identifier",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_by_provider_identifier",
-  )
-  router.add_function(
-    "get_any_by_provider_identifier",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_any_by_provider_identifier",
-  )
-  router.add_function(
-    "get_user_by_email",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_user_by_email",
-  )
-  router.add_function(
-    "link_provider",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.link_provider",
-  )
-  router.add_function(
-    "set_provider",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.set_provider",
-  )
-  router.add_function(
-    "soft_delete_account",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.soft_delete_account",
-  )
-  router.add_function(
-    "unlink_provider",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.unlink_provider",
-  )
-  router.add_function(
-    "unlink_last_provider",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.unlink_last_provider",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/security/oauth/__init__.py
+++ b/server/registry/security/oauth/__init__.py
@@ -6,8 +6,6 @@ from typing import Any, TYPE_CHECKING
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -19,6 +17,12 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "security.oauth"
+_PROVIDER_MODULE = "server.registry.security.oauth.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "relink_discord": "relink_discord_v1",
+  "relink_google": "relink_google_v1",
+  "relink_microsoft": "relink_microsoft_v1",
+}
 
 
 def _relink_request(op: str, params: dict[str, Any]) -> DBRequest:
@@ -114,18 +118,10 @@ def relink_microsoft_request(
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "relink_discord",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.relink_discord",
-  )
-  router.add_function(
-    "relink_google",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.relink_google",
-  )
-  router.add_function(
-    "relink_microsoft",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.relink_microsoft",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/security/sessions/__init__.py
+++ b/server/registry/security/sessions/__init__.py
@@ -6,8 +6,6 @@ from typing import Any, TYPE_CHECKING
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -23,6 +21,16 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "security.sessions"
+_PROVIDER_MODULE = "server.registry.security.sessions.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "create_session": "create_session_v1",
+  "update_session": "update_session_v1",
+  "update_device_token": "update_device_token_v1",
+  "revoke_device_token": "revoke_device_token_v1",
+  "revoke_all_device_tokens": "revoke_all_device_tokens_v1",
+  "revoke_provider_tokens": "revoke_provider_tokens_v1",
+  "set_rotkey": "set_rotkey_v1",
+}
 
 
 def _request(name: str, params: dict[str, Any]) -> DBRequest:
@@ -114,38 +122,10 @@ def set_rotkey_request(
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "create_session",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.create_session",
-  )
-  router.add_function(
-    "update_session",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.update_session",
-  )
-  router.add_function(
-    "update_device_token",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.update_device_token",
-  )
-  router.add_function(
-    "revoke_device_token",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.revoke_device_token",
-  )
-  router.add_function(
-    "revoke_all_device_tokens",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.revoke_all_device_tokens",
-  )
-  router.add_function(
-    "revoke_provider_tokens",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.revoke_provider_tokens",
-  )
-  router.add_function(
-    "set_rotkey",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.set_rotkey",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/system/config/__init__.py
+++ b/server/registry/system/config/__init__.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401 - ensure provider modules are discoverable
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -20,6 +18,13 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "system.config"
+_PROVIDER_MODULE = "server.registry.system.config.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "get_config": "get_config_v1",
+  "get_configs": "get_configs_v1",
+  "upsert_config": "upsert_config_v1",
+  "delete_config": "delete_config_v1",
+}
 
 
 def get_config_request(key: str) -> DBRequest:
@@ -42,23 +47,10 @@ def delete_config_request(key: str) -> DBRequest:
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "get_config",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_config",
-  )
-  router.add_function(
-    "get_configs",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_configs",
-  )
-  router.add_function(
-    "upsert_config",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.upsert_config",
-  )
-  router.add_function(
-    "delete_config",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.delete_config",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/system/roles/__init__.py
+++ b/server/registry/system/roles/__init__.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -23,6 +21,16 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "system.roles"
+_PROVIDER_MODULE = "server.registry.system.roles.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "list": "list_roles_v1",
+  "get_role_members": "get_role_members_v1",
+  "get_role_non_members": "get_role_non_members_v1",
+  "add_role_member": "add_role_member_v1",
+  "remove_role_member": "remove_role_member_v1",
+  "upsert_role": "upsert_role_v1",
+  "delete_role": "delete_role_v1",
+}
 
 
 def list_roles_request() -> DBRequest:
@@ -64,38 +72,10 @@ def delete_role_request(name: str) -> DBRequest:
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "list",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.list",
-  )
-  router.add_function(
-    "get_role_members",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_role_members",
-  )
-  router.add_function(
-    "get_role_non_members",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_role_non_members",
-  )
-  router.add_function(
-    "add_role_member",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.add_role_member",
-  )
-  router.add_function(
-    "remove_role_member",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.remove_role_member",
-  )
-  router.add_function(
-    "upsert_role",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.upsert_role",
-  )
-  router.add_function(
-    "delete_role",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.delete_role",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/system/routes/__init__.py
+++ b/server/registry/system/routes/__init__.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING
 
 from server.registry.types import DBRequest
 
-from . import mssql  # noqa: F401
-
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
@@ -19,6 +17,12 @@ __all__ = [
 ]
 
 _DEF_PROVIDER = "system.routes"
+_PROVIDER_MODULE = "server.registry.system.routes.mssql"
+_PROVIDER_ATTRS: dict[str, str] = {
+  "get_routes": "get_routes_v1",
+  "upsert_route": "upsert_route_v1",
+  "delete_route": "delete_route_v1",
+}
 
 
 def get_routes_request() -> DBRequest:
@@ -47,18 +51,10 @@ def delete_route_request(path: str) -> DBRequest:
 
 
 def register(router: "SubdomainRouter") -> None:
-  router.add_function(
-    "get_routes",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.get_routes",
-  )
-  router.add_function(
-    "upsert_route",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.upsert_route",
-  )
-  router.add_function(
-    "delete_route",
-    version=1,
-    provider_map=f"{_DEF_PROVIDER}.delete_route",
-  )
+  for name, attr in _PROVIDER_ATTRS.items():
+    router.add_function(
+      name,
+      version=1,
+      provider_map=f"{_DEF_PROVIDER}.{name}",
+      provider=(_PROVIDER_MODULE, attr),
+    )

--- a/server/registry/types.py
+++ b/server/registry/types.py
@@ -38,5 +38,6 @@ class DBResponse(BaseModel):
     return cls(rows=list(result.rows), rowcount=result.rowcount, meta=meta)
 
   def to_result(self) -> DBResult:
-    DBResultCls = get_dbresult_cls()
+    DBResultCls = _DBRESULT_CLASS or get_dbresult_cls()
     return DBResultCls(rows=list(self.rows), rowcount=self.rowcount)
+_DBRESULT_CLASS = DBResult

--- a/tests/test_db_module_init.py
+++ b/tests/test_db_module_init.py
@@ -160,3 +160,15 @@ def test_registry_dispatcher_executes_provider_callable(monkeypatch):
   assert response.rowcount == 1
   assert calls["op"] == "db:demo:ops:test:1"
   assert calls["params"] == {"value": 7}
+
+
+def test_mssql_provider_requires_binding():
+  router = RegistryRouter()
+  router.domain("demo").subdomain("ops").add_function(
+    "missing",
+    version=1,
+    provider_map="demo.ops.missing",
+  )
+
+  with pytest.raises(ValueError, match="does not declare a provider binding"):
+    router.load_provider("mssql")


### PR DESCRIPTION
## Summary
- propagate provider descriptors from registry route registration so MSSQL bindings can be derived centrally
- build MSSQL provider query map from registry metadata and enforce canonical DBResult resolution across modules
- fail fast when MSSQL routes lack provider bindings and cover the regression with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df2175d4948325822b8a4f9c16ccce