### PR TITLE
Refactor DB run callers to use DBRequest

### DIFF
--- a/rpc/auth/discord/services.py
+++ b/rpc/auth/discord/services.py
@@ -15,6 +15,7 @@ from server.registry.accounts.profile import (
   set_profile_image_request,
   update_if_unedited_request,
 )
+from server.registry.system.config import get_config_request
 from .models import AuthDiscordOauthLogin1, AuthDiscordOauthLoginPayload1
 
 
@@ -56,7 +57,7 @@ async def auth_discord_oauth_login_v1(request: Request):
   if not client_secret:
     raise HTTPException(status_code=500, detail="DISCORD_AUTH_SECRET not configured")
 
-  res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+  res_redirect = await db.run(get_config_request("Hostname"))
   if not res_redirect.rows:
     raise HTTPException(status_code=500, detail="Discord OAuth redirect URI not configured")
   redirect_uri = res_redirect.rows[0]["value"]

--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -13,6 +13,7 @@ from server.registry.accounts.profile import (
   set_profile_image_request,
   update_if_unedited_request,
 )
+from server.registry.system.config import get_config_request
 from .models import AuthGoogleOauthLogin1, AuthGoogleOauthLoginPayload1
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
@@ -60,7 +61,7 @@ async def auth_google_oauth_login_v1(request: Request):
     raise HTTPException(status_code=500, detail="GOOGLE_AUTH_SECRET not configured")
 
   # Require redirect_uri from system config
-  res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+  res_redirect = await db.run(get_config_request("Hostname"))
   if not res_redirect.rows:
       raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
   redirect_uri = res_redirect.rows[0]["value"]

--- a/rpc/auth/providers/services.py
+++ b/rpc/auth/providers/services.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.db_module import DbModule
+from server.registry.security.identities import unlink_last_provider_request
 
 from .models import AuthProvidersUnlinkLastProvider1
 
@@ -16,7 +17,6 @@ async def auth_providers_unlink_last_provider_v1(request: Request):
     raise HTTPException(status_code=400, detail=str(e))
   db: DbModule = request.app.state.db
   await db.run(
-    rpc_request.op,
-    {"guid": payload.guid, "provider": payload.provider},
+    unlink_last_provider_request(guid=payload.guid, provider=payload.provider)
   )
   return RPCResponse(op=rpc_request.op, payload={"ok": True}, version=rpc_request.version)

--- a/rpc/service/routes/services.py
+++ b/rpc/service/routes/services.py
@@ -27,7 +27,7 @@ async def service_routes_get_routes_v1(request: Request):
   db: DbModule = request.app.state.db
   auth: AuthModule = request.app.state.auth
   db_request = get_routes_request()
-  res = await db.run(db_request.op, db_request.params)
+  res = await db.run(db_request)
   routes = []
   for row in res.rows:
     mask = int(row.get("element_roles", 0))
@@ -71,7 +71,7 @@ async def service_routes_upsert_route_v1(request: Request):
     sequence=payload.sequence,
     roles=mask,
   )
-  await db.run(db_request.op, db_request.params)
+  await db.run(db_request)
   logging.debug(
     "[service_routes_upsert_route_v1] upserted route %s",
     payload.path,
@@ -94,7 +94,7 @@ async def service_routes_delete_route_v1(request: Request):
   payload = ServiceRoutesDeleteRoute1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
   db_request = delete_route_request(payload.path)
-  await db.run(db_request.op, db_request.params)
+  await db.run(db_request)
   logging.debug(
     "[service_routes_delete_route_v1] deleted route %s",
     payload.path,

--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -91,7 +91,7 @@ async def users_profile_get_roles_v1(request: Request):
 
   db: DbModule = request.app.state.db
   request_db = get_security_profile_request(guid=user_guid)
-  res = await db.run(request_db.op, request_db.params)
+  res = await db.run(request_db)
   row = res.rows[0] if res.rows else {}
   roles = int(row.get("user_roles") or row.get("element_roles") or 0)
   payload = UsersProfileRoles1(roles=roles)

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -28,6 +28,7 @@ from server.registry.security.identities import (
   unlink_provider_request,
 )
 from server.registry.security.sessions import revoke_provider_tokens_request
+from server.registry.system.config import get_config_request
 
 
 def normalize_provider_identifier(pid: str) -> str:
@@ -57,7 +58,7 @@ async def users_providers_set_provider_v1(request: Request):
         client_secret = env.get("GOOGLE_AUTH_SECRET")
         if not client_secret:
           raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
-        res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+        res_redirect = await db.run(get_config_request("Hostname"))
         if not res_redirect.rows:
           raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
         redirect_uri = res_redirect.rows[0]["value"]
@@ -82,7 +83,7 @@ async def users_providers_set_provider_v1(request: Request):
         client_secret = env.get("DISCORD_AUTH_SECRET")
         if not client_secret:
           raise HTTPException(status_code=500, detail="Discord OAuth client_secret not configured")
-        res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+        res_redirect = await db.run(get_config_request("Hostname"))
         if not res_redirect.rows:
           raise HTTPException(status_code=500, detail="Discord OAuth redirect URI not configured")
         redirect_uri = res_redirect.rows[0]["value"]
@@ -107,7 +108,7 @@ async def users_providers_set_provider_v1(request: Request):
         client_secret = env.get("MICROSOFT_AUTH_SECRET")
         if not client_secret:
           raise HTTPException(status_code=500, detail="Microsoft OAuth client_secret not configured")
-        res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+        res_redirect = await db.run(get_config_request("Hostname"))
         if not res_redirect.rows:
           raise HTTPException(status_code=500, detail="Microsoft OAuth redirect URI not configured")
         redirect_uri = res_redirect.rows[0]["value"]
@@ -128,7 +129,7 @@ async def users_providers_set_provider_v1(request: Request):
       raise HTTPException(status_code=400, detail="Unsupported auth provider")
     _, profile, _ = await auth.handle_auth_login(payload.provider, id_token, access_token)
   set_request = set_provider_request(guid=auth_ctx.user_guid, provider=payload.provider)
-  await db.run(set_request.op, set_request.params)
+  await db.run(set_request)
   if profile:
     raw_email = (profile.get("email") or "").strip()
     raw_name = (profile.get("username") or "").strip()
@@ -166,7 +167,7 @@ async def users_providers_link_provider_v1(request: Request):
     client_secret = env.get("GOOGLE_AUTH_SECRET")
     if not client_secret:
       raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
-    res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+    res_redirect = await db.run(get_config_request("Hostname"))
     if not res_redirect.rows:
       raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
     redirect_uri = res_redirect.rows[0]["value"]
@@ -189,7 +190,7 @@ async def users_providers_link_provider_v1(request: Request):
       client_secret = env.get("DISCORD_AUTH_SECRET")
       if not client_secret:
         raise HTTPException(status_code=500, detail="Discord OAuth client_secret not configured")
-      res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+      res_redirect = await db.run(get_config_request("Hostname"))
       if not res_redirect.rows:
         raise HTTPException(status_code=500, detail="Discord OAuth redirect URI not configured")
       redirect_uri = res_redirect.rows[0]["value"]
@@ -215,7 +216,7 @@ async def users_providers_link_provider_v1(request: Request):
       client_secret = env.get("MICROSOFT_AUTH_SECRET")
       if not client_secret:
         raise HTTPException(status_code=500, detail="Microsoft OAuth client_secret not configured")
-      res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+      res_redirect = await db.run(get_config_request("Hostname"))
       if not res_redirect.rows:
         raise HTTPException(status_code=500, detail="Microsoft OAuth redirect URI not configured")
       redirect_uri = res_redirect.rows[0]["value"]
@@ -241,7 +242,7 @@ async def users_providers_link_provider_v1(request: Request):
     provider=payload.provider,
     provider_identifier=provider_uid,
   )
-  res = await db.run(request_db.op, request_db.params)
+  res = await db.run(request_db)
   if res.rows and res.rows[0].get("guid") != auth_ctx.user_guid:
     raise HTTPException(status_code=409, detail="Provider already linked")
   link_request = link_provider_request(
@@ -249,7 +250,7 @@ async def users_providers_link_provider_v1(request: Request):
     provider=payload.provider,
     provider_identifier=provider_uid,
   )
-  await db.run(link_request.op, link_request.params)
+  await db.run(link_request)
   return RPCResponse(op=rpc_request.op, payload={"provider": payload.provider}, version=rpc_request.version)
 
 async def users_providers_unlink_provider_v1(request: Request):
@@ -266,14 +267,14 @@ async def users_providers_unlink_provider_v1(request: Request):
     guid=auth_ctx.user_guid,
     provider=payload.provider,
   )
-  res = await db.run(unlink_request.op, unlink_request.params)
+  res = await db.run(unlink_request)
   remaining = res.rows[0].get("providers_remaining") if res.rows else 0
   if remaining == 0:
     final_unlink_request = unlink_last_provider_request(
       guid=auth_ctx.user_guid,
       provider=payload.provider,
     )
-    await db.run(final_unlink_request.op, final_unlink_request.params)
+    await db.run(final_unlink_request)
   elif payload.provider == default_provider:
     if not payload.new_default:
       raise HTTPException(status_code=400, detail="new_default required")
@@ -281,12 +282,12 @@ async def users_providers_unlink_provider_v1(request: Request):
       guid=auth_ctx.user_guid,
       provider=payload.new_default,
     )
-    await db.run(set_request.op, set_request.params)
+    await db.run(set_request)
     revoke_request = revoke_provider_tokens_request(
       guid=auth_ctx.user_guid,
       provider=payload.provider,
     )
-    await db.run(revoke_request.op, revoke_request.params)
+    await db.run(revoke_request)
   return RPCResponse(op=rpc_request.op, payload={"provider": payload.provider}, version=rpc_request.version)
 
 async def users_providers_get_by_provider_identifier_v1(request: Request):
@@ -300,7 +301,7 @@ async def users_providers_get_by_provider_identifier_v1(request: Request):
     provider=payload.provider,
     provider_identifier=payload.provider_identifier,
   )
-  res = await db.run(lookup_request.op, lookup_request.params)
+  res = await db.run(lookup_request)
   row = res.rows[0] if res.rows else None
   return RPCResponse(op=rpc_request.op, payload=row, version=rpc_request.version)
 
@@ -312,7 +313,7 @@ async def users_providers_create_from_provider_v1(request: Request):
     raise HTTPException(status_code=400, detail=str(e))
   db: DbModule = request.app.state.db
   email_request = get_user_by_email_request(email=payload.provider_email)
-  res = await db.run(email_request.op, email_request.params)
+  res = await db.run(email_request)
   if res.rows:
     raise HTTPException(status_code=409, detail="Email already registered")
   create_request = create_from_provider_request(
@@ -322,7 +323,7 @@ async def users_providers_create_from_provider_v1(request: Request):
     provider_displayname=payload.provider_displayname,
     provider_profile_image=payload.provider_profile_image,
   )
-  res = await db.run(create_request.op, create_request.params)
+  res = await db.run(create_request)
   row = res.rows[0] if res.rows else None
   return RPCResponse(op=rpc_request.op, payload=row, version=rpc_request.version)
 

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -39,7 +39,7 @@ class RoleCache:
     try:
       assert self.db, "database module not initialised"
       request = list_roles_request()
-      result = await self.db.run(request.op, request.params)
+      result = await self.db.run(request)
     except Exception as e:
       logging.error("[RoleCache] Failed to load roles: %s", e)
       return
@@ -63,13 +63,13 @@ class RoleCache:
   async def upsert_role(self, name: str, mask: int, display: str | None):
     assert self.db, "database module not initialised"
     request = upsert_role_request(name, mask, display)
-    await self.db.run(request.op, request.params)
+    await self.db.run(request)
     await self.refresh_role_cache()
 
   async def delete_role(self, name: str):
     assert self.db, "database module not initialised"
     request = delete_role_request(name)
-    await self.db.run(request.op, request.params)
+    await self.db.run(request)
     await self.refresh_role_cache()
 
   def mask_to_names(self, mask: int) -> list[str]:
@@ -118,7 +118,7 @@ class RoleCache:
       return self._user_security[guid]
     logging.debug("[RoleCache] Fetching security profile for %s", guid)
     request = get_security_profile_request(guid=guid)
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     row = res.rows[0] if res.rows else None
     return self._hydrate_security_profile(str(guid), row)
 
@@ -376,7 +376,7 @@ class AuthModule(BaseModule):
 
   async def get_discord_user_security(self, discord_id: str) -> tuple[str, list[str], int]:
     request = get_security_profile_request(discord_id=discord_id)
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     if not res.rows:
       return "", [], 0
     profile = self.role_cache.cache_security_profile(res.rows[0])

--- a/server/modules/bsky_module.py
+++ b/server/modules/bsky_module.py
@@ -46,7 +46,7 @@ class BskyModule(BaseModule):
       raise RuntimeError("BskyModule requires database module")
     assert self.db, "database module not initialised"
     request = get_config_request(key)
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     if not res.rows:
       return ""
     return res.rows[0].get("value") or ""

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -85,7 +85,7 @@ class DbModule(BaseModule):
     if self._registry:
       self._registry.bind_provider(self._provider, provider_name=self.provider)
     request = get_config_request("LoggingLevel")
-    res = await self.run(request.op, request.params)
+    res = await self.run(request)
     val = res.rows[0]["value"] if res.rows else "0"
     try:
       self.logging_level = int(val)
@@ -101,14 +101,14 @@ class DbModule(BaseModule):
 
   async def get_ms_api_id(self) -> str:
     request = get_config_request("MsApiId")
-    res = await self.run(request.op, request.params)
+    res = await self.run(request)
     if not res.rows:
       raise ValueError("Missing config value for key: MsApiId")
     return res.rows[0]["value"]
 
   async def get_google_client_id(self) -> str:
     request = get_config_request("GoogleClientId")
-    res = await self.run(request.op, request.params)
+    res = await self.run(request)
     value = res.rows[0]["value"] if res.rows else None
     logging.debug("[DbModule] GoogleClientId=%s", value)
     if not value:
@@ -126,7 +126,7 @@ class DbModule(BaseModule):
 
   async def get_discord_client_id(self) -> str:
     request = get_config_request("DiscordClientId")
-    res = await self.run(request.op, request.params)
+    res = await self.run(request)
     value = res.rows[0]["value"] if res.rows else None
     logging.debug("[DbModule] DiscordClientId=%s", value)
     if not value:
@@ -135,7 +135,7 @@ class DbModule(BaseModule):
 
   async def get_auth_providers(self) -> list[str]:
     request = get_config_request("AuthProviders")
-    res = await self.run(request.op, request.params)
+    res = await self.run(request)
     value = res.rows[0]["value"] if res.rows else None
     if value is None:
       raise ValueError("Missing config value for key: AuthProviders")
@@ -143,7 +143,7 @@ class DbModule(BaseModule):
 
   async def get_jwks_cache_time(self) -> int:
     request = get_config_request("JwksCacheTime")
-    res = await self.run(request.op, request.params)
+    res = await self.run(request)
     value = res.rows[0]["value"] if res.rows else None
     if value is None:
       raise ValueError("Missing config value for key: JwksCacheTime")
@@ -151,6 +151,6 @@ class DbModule(BaseModule):
 
   async def user_exists(self, user_guid: str) -> bool:
     request = account_exists_request(user_guid)
-    res = await self.run(request.op, request.params)
+    res = await self.run(request)
     return bool(res.rows)
 

--- a/server/modules/discord_bot_module.py
+++ b/server/modules/discord_bot_module.py
@@ -77,7 +77,7 @@ class DiscordBotModule(BaseModule):
       update_logging_level(self.db.logging_level)
       configure_discord_logging(self)
       request = get_config_request("DiscordSyschan")
-      res = await self.db.run(request.op, request.params)
+      res = await self.db.run(request)
       if not res.rows:
         raise ValueError("Missing config value for key: DiscordSyschan")
       self.syschan = int(res.rows[0]["value"] or 0)

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -181,7 +181,7 @@ class OauthModule(BaseModule):
       checked.add(uid)
       logging.debug(f"[lookup_user] checking identifier={pid[:40]}")
       request = get_by_provider_identifier_request(provider=provider, provider_identifier=uid)
-      res = await self.db.run(request.op, request.params)
+      res = await self.db.run(request)
       if res.rows:
         logging.debug(f"[lookup_user] user found with identifier={pid[:40]}")
         return res.rows[0]
@@ -199,7 +199,7 @@ class OauthModule(BaseModule):
     logging.debug(f"[create_session] rotation_token={rotation_token[:40]}")
     now = datetime.now(timezone.utc)
     request = set_rotkey_request(guid=user_guid, rotkey=rotation_token, iat=now, exp=rot_exp)
-    await self.db.run(request.op, request.params)
+    await self.db.run(request)
     roles, _ = await self.auth.get_user_roles(user_guid)
     session_exp = now + timedelta(minutes=DEFAULT_SESSION_TOKEN_EXPIRY)
     placeholder = uuid.uuid4().hex
@@ -212,7 +212,7 @@ class OauthModule(BaseModule):
       user_agent=user_agent,
       ip_address=ip_address,
     )
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     row = res.rows[0] if res.rows else {}
     session_guid = row.get("session_guid")
     device_guid = row.get("device_guid")
@@ -220,7 +220,7 @@ class OauthModule(BaseModule):
       user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp,
     )
     update_request = update_device_token_request(device_guid=device_guid, access_token=session_token)
-    await self.db.run(update_request.op, update_request.params)
+    await self.db.run(update_request)
     logging.debug(f"[create_session] session_token={session_token[:40]}")
     return session_token, session_exp, rotation_token, rot_exp
 
@@ -243,7 +243,7 @@ class OauthModule(BaseModule):
         provider=provider,
         provider_identifier=provider_uid,
       )
-      await self.db.run(request.op, request.params)
+      await self.db.run(request)
       needs_relink = True
 
     if needs_relink:
@@ -258,7 +258,7 @@ class OauthModule(BaseModule):
         )
       except KeyError as exc:
         raise HTTPException(status_code=400, detail="Unsupported auth provider") from exc
-      res = await self.db.run(relink_request.op, relink_request.params)
+      res = await self.db.run(relink_request)
       user = res.rows[0] if res.rows else None
 
     if not user:
@@ -269,14 +269,14 @@ class OauthModule(BaseModule):
         provider_displayname=profile["username"],
         provider_profile_image=profile.get("profilePicture"),
       )
-      res = await self.db.run(request.op, request.params)
+      res = await self.db.run(request)
       user = res.rows[0] if res.rows else None
       if not user:
         request = get_by_provider_identifier_request(
           provider=provider,
           provider_identifier=provider_uid,
         )
-        res = await self.db.run(request.op, request.params)
+        res = await self.db.run(request)
         user = res.rows[0] if res.rows else None
       if not user:
         logging.debug("[resolve_user] failed to create user")

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -102,7 +102,7 @@ class OpenaiModule(BaseModule):
     assert self.db
     assert self.db, "database module not initialised"
     request = get_config_request("OpenAIApiKey")
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     if res.rows:
       return res.rows[0].get("value", "")
     return ""

--- a/server/modules/public_gallery_module.py
+++ b/server/modules/public_gallery_module.py
@@ -24,5 +24,5 @@ class PublicGalleryModule(BaseModule):
   async def list_public_files(self):
     assert self.db
     request = get_public_files_request()
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     return res.rows

--- a/server/modules/public_links_module.py
+++ b/server/modules/public_links_module.py
@@ -28,11 +28,11 @@ class PublicLinksModule(BaseModule):
   async def get_home_links(self):
     assert self.db
     request = get_home_links_request()
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     return res.rows
 
   async def get_navbar_routes(self, role_mask: int):
     assert self.db
     request = get_navbar_routes_request(role_mask=role_mask)
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     return res.rows

--- a/server/modules/public_users_module.py
+++ b/server/modules/public_users_module.py
@@ -28,11 +28,11 @@ class PublicUsersModule(BaseModule):
   async def get_profile(self, guid: str):
     assert self.db
     request = get_profile_request(guid=guid)
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     return res.rows[0] if res.rows else None
 
   async def get_published_files(self, guid: str):
     assert self.db
     request = get_published_files_request(guid=guid)
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     return res.rows

--- a/server/modules/public_vars_module.py
+++ b/server/modules/public_vars_module.py
@@ -47,19 +47,19 @@ class PublicVarsModule(BaseModule):
   async def get_version(self) -> str:
     assert self.db
     request = get_version_request()
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     return res.rows[0].get("version") if res.rows else ""
 
   async def get_hostname(self) -> str:
     assert self.db
     request = get_hostname_request()
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     return res.rows[0].get("hostname") if res.rows else ""
 
   async def get_repo(self) -> str:
     assert self.db
     request = get_repo_request()
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     return res.rows[0].get("repo") if res.rows else ""
 
   async def get_ffmpeg_version(self) -> str:

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -43,7 +43,7 @@ class RoleAdminModule(BaseModule):
   async def list_roles(self, actor_mask: int | None = None) -> list[dict]:
     assert self.db, "database module not initialised"
     request = list_roles_request()
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     roles = [
       {
         "name": r.get("name", ""),
@@ -62,9 +62,9 @@ class RoleAdminModule(BaseModule):
   async def get_role_members(self, role: str) -> tuple[list[dict], list[dict]]:
     assert self.db, "database module not initialised"
     mem_request = get_role_members_request(role)
-    mem_res = await self.db.run(mem_request.op, mem_request.params)
+    mem_res = await self.db.run(mem_request)
     non_request = get_role_non_members_request(role)
-    non_res = await self.db.run(non_request.op, non_request.params)
+    non_res = await self.db.run(non_request)
     members = [
       {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
       for r in mem_res.rows
@@ -81,7 +81,7 @@ class RoleAdminModule(BaseModule):
       self._ensure_can_manage(actor_mask, role_mask)
     assert self.db, "database module not initialised"
     request = add_role_member_request(role, user_guid)
-    await self.db.run(request.op, request.params)
+    await self.db.run(request)
     await self.auth.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 
@@ -91,7 +91,7 @@ class RoleAdminModule(BaseModule):
       self._ensure_can_manage(actor_mask, role_mask)
     assert self.db, "database module not initialised"
     request = remove_role_member_request(role, user_guid)
-    await self.db.run(request.op, request.params)
+    await self.db.run(request)
     await self.auth.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 

--- a/server/modules/session_module.py
+++ b/server/modules/session_module.py
@@ -124,7 +124,7 @@ class SessionModule(BaseModule):
       user_agent=user_agent,
       ip_address=ip_address,
     )
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     row2 = res.rows[0] if res.rows else {}
     session_guid = row2.get("session_guid")
     device_guid = row2.get("device_guid")
@@ -132,17 +132,17 @@ class SessionModule(BaseModule):
       user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp
     )
     update_request = update_device_token_request(device_guid=device_guid, access_token=session_token)
-    await self.db.run(update_request.op, update_request.params)
+    await self.db.run(update_request)
     return session_token
 
   async def invalidate_token(self, user_guid: str) -> None:
     now = datetime.now(timezone.utc)
     request = set_rotkey_request(guid=user_guid, rotkey="", iat=now, exp=now)
-    await self.db.run(request.op, request.params)
+    await self.db.run(request)
 
   async def logout_device(self, token: str) -> None:
     request = revoke_device_token_request(access_token=token)
-    await self.db.run(request.op, request.params)
+    await self.db.run(request)
 
   async def get_session(
     self,
@@ -151,7 +151,7 @@ class SessionModule(BaseModule):
     user_agent: str | None,
   ) -> dict:
     request = get_security_profile_request(access_token=token)
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     session = res.rows[0] if res.rows else None
     if not session:
       raise HTTPException(status_code=401, detail="Invalid session token")
@@ -178,7 +178,7 @@ class SessionModule(BaseModule):
         ip_address=ip_address,
         user_agent=user_agent,
       )
-      await self.db.run(request.op, request.params)
+      await self.db.run(request)
     except Exception as e:
       logging.error("[SessionModule.get_session] Failed to update session metadata: %s", e)
 

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -70,7 +70,7 @@ class StorageModule(BaseModule):
 
     try:
       request = get_config_request("StorageCacheTime")
-      res = await self.db.run(request.op, request.params)
+      res = await self.db.run(request)
       value = res.rows[0]["value"] if res.rows else "15m"
       try:
         self.reindex_interval = self._parse_duration(value)
@@ -109,7 +109,7 @@ class StorageModule(BaseModule):
       logging.error("[StorageModule] Missing connection string or database module")
       return
     request = get_config_request("AzureBlobContainerName")
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -376,14 +376,14 @@ class StorageModule(BaseModule):
     """Return files marked as publicly accessible."""
     assert self.db
     request = list_public_request()
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     return res.rows
 
   async def list_flagged_for_moderation(self):
     """Return files that have been reported for moderation review."""
     assert self.db
     request = list_reported_request()
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     return res.rows
 
   async def upload_files(self, user_guid: str, files):
@@ -391,7 +391,7 @@ class StorageModule(BaseModule):
       logging.error("[StorageModule] Missing connection string or database module")
       return
     request = get_config_request("AzureBlobContainerName")
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -453,7 +453,7 @@ class StorageModule(BaseModule):
       logging.error("[StorageModule] Missing connection string or database module")
       return
     request = get_config_request("AzureBlobContainerName")
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -496,7 +496,7 @@ class StorageModule(BaseModule):
       logging.error("[StorageModule] Missing connection string or database module")
       return
     request = get_config_request("AzureBlobContainerName")
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -548,7 +548,7 @@ class StorageModule(BaseModule):
       logging.error("[StorageModule] Missing connection string or database module")
       return
     request = get_config_request("AzureBlobContainerName")
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -589,7 +589,7 @@ class StorageModule(BaseModule):
       logging.error("[StorageModule] Missing connection string or database module")
       return
     request = get_config_request("AzureBlobContainerName")
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -837,7 +837,7 @@ class StorageModule(BaseModule):
       logging.error("[StorageModule] Missing connection string or database module")
       return
     request = get_config_request("AzureBlobContainerName")
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -915,7 +915,7 @@ class StorageModule(BaseModule):
         "db_rows": db_rows,
       }
     request = get_config_request("AzureBlobContainerName")
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       return {

--- a/server/modules/system_config_module.py
+++ b/server/modules/system_config_module.py
@@ -36,7 +36,7 @@ class SystemConfigModule(BaseModule):
     logging.debug("[system_config_get_configs_v1] user=%s roles=%s", user_guid, roles)
     assert self.db, "database module not initialised"
     request = get_configs_request()
-    res = await self.db.run(request.op, request.params)
+    res = await self.db.run(request)
     items = [
       SystemConfigConfigItem1(
         key=row.get("element_key", ""),
@@ -60,7 +60,7 @@ class SystemConfigModule(BaseModule):
     )
     assert self.db, "database module not initialised"
     request = upsert_config_request(key, value)
-    await self.db.run(request.op, request.params)
+    await self.db.run(request)
     logging.debug(
       "[system_config_upsert_config_v1] upserted config %s",
       key,
@@ -76,7 +76,7 @@ class SystemConfigModule(BaseModule):
     )
     assert self.db, "database module not initialised"
     request = delete_config_request(key)
-    await self.db.run(request.op, request.params)
+    await self.db.run(request)
     logging.debug(
       "[system_config_delete_config_v1] deleted config %s",
       key,

--- a/server/routers/discord_events.py
+++ b/server/routers/discord_events.py
@@ -27,10 +27,10 @@ def _register_on_ready_handler(bot_module: "DiscordBotModule", bot: commands.Bot
     channel = bot.get_channel(bot_module.syschan)
     if channel:
       request = get_config_request("Version")
-      res = await bot_module.db.run(request.op, request.params)
+      res = await bot_module.db.run(request)
       version = res.rows[0]["value"] if res.rows else None
       name_request = get_config_request("BotName")
-      name_res = await bot_module.db.run(name_request.op, name_request.params)
+      name_res = await bot_module.db.run(name_request)
       bot_name = name_res.rows[0]["value"] if name_res.rows else None
       msg = f"{(bot_name or 'TheOracleGPT-Dev')} Online. Version: {version or 'unknown'}"
       if await bot_module._try_send_channel(channel.id, msg):

--- a/tests/test_account_role_services.py
+++ b/tests/test_account_role_services.py
@@ -1,5 +1,6 @@
 import types, sys, pathlib, asyncio, importlib
 from fastapi import HTTPException
+from server.registry.types import DBRequest
 
 # stub rpc package and load required modules
 root_path = pathlib.Path(__file__).resolve().parent.parent
@@ -41,8 +42,9 @@ class DummyDb:
     self.non_members = non_members or []
     self.roles = roles or []
 
-  async def run(self, op, args):
-    self.calls.append((op, args))
+  async def run(self, request: DBRequest):
+    self.calls.append(request)
+    op = request.op
     if op == "db:system:roles:get_role_members:1":
       return DBRes(self.members, len(self.members))
     if op == "db:system:roles:get_role_non_members:1":
@@ -66,15 +68,17 @@ class RoleCache:
     self.upsert_args = (name, mask, display)
     if self.db:
       await self.db.run(
-        "db:system:roles:upsert_role:1",
-        {"name": name, "mask": mask, "display": display},
+        DBRequest(
+          op="db:system:roles:upsert_role:1",
+          params={"name": name, "mask": mask, "display": display},
+        )
       )
     await self.refresh_role_cache()
 
   async def delete_role(self, name):
     self.delete_args = name
     if self.db:
-      await self.db.run("db:system:roles:delete_role:1", {"name": name})
+      await self.db.run(DBRequest(op="db:system:roles:delete_role:1", params={"name": name}))
     await self.refresh_role_cache()
 
   async def refresh_user_roles(self, guid):
@@ -101,7 +105,7 @@ class DummyRoleAdmin:
       raise HTTPException(status_code=403, detail="Forbidden")
 
   async def list_roles(self, actor_mask: int | None = None):
-    res = await self.db.run("db:system:roles:list:1", {})
+    res = await self.db.run(DBRequest(op="db:system:roles:list:1", params={}))
     roles = [
       {
         "name": r.get("name", ""),
@@ -118,8 +122,8 @@ class DummyRoleAdmin:
     return roles
 
   async def get_role_members(self, role):
-    mem_res = await self.db.run("db:system:roles:get_role_members:1", {"role": role})
-    non_res = await self.db.run("db:system:roles:get_role_non_members:1", {"role": role})
+    mem_res = await self.db.run(DBRequest(op="db:system:roles:get_role_members:1", params={"role": role}))
+    non_res = await self.db.run(DBRequest(op="db:system:roles:get_role_non_members:1", params={"role": role}))
     members = [
       {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
       for r in mem_res.rows
@@ -135,8 +139,10 @@ class DummyRoleAdmin:
       role_mask = self.auth.role_cache.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
     await self.db.run(
-      "db:system:roles:add_role_member:1",
-      {"role": role, "user_guid": user_guid},
+      DBRequest(
+        op="db:system:roles:add_role_member:1",
+        params={"role": role, "user_guid": user_guid},
+      )
     )
     await self.auth.role_cache.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
@@ -146,8 +152,10 @@ class DummyRoleAdmin:
       role_mask = self.auth.role_cache.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
     await self.db.run(
-      "db:system:roles:remove_role_member:1",
-      {"role": role, "user_guid": user_guid},
+      DBRequest(
+        op="db:system:roles:remove_role_member:1",
+        params={"role": role, "user_guid": user_guid},
+      )
     )
     await self.auth.role_cache.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
@@ -207,7 +215,7 @@ def test_add_and_remove_member():
   helpers.unbox_request = fake_get_add
   svc_mod.unbox_request = fake_get_add
   resp = asyncio.run(account_role_add_role_member_v1(req))
-  assert any(op == "db:system:roles:add_role_member:1" for op, _ in db.calls)
+  assert any(c.op == "db:system:roles:add_role_member:1" for c in db.calls)
   assert resp.payload["members"] == [{"guid": "u1", "displayName": "User 1"}]
   assert resp.payload["nonMembers"] == [{"guid": "u2", "displayName": "User 2"}]
 
@@ -230,7 +238,7 @@ def test_add_and_remove_member():
   helpers.unbox_request = fake_get_remove
   svc_mod.unbox_request = fake_get_remove
   resp2 = asyncio.run(account_role_remove_role_member_v1(req))
-  assert any(op == "db:system:roles:remove_role_member:1" for op, _ in db.calls)
+  assert any(c.op == "db:system:roles:remove_role_member:1" for c in db.calls)
   assert resp2.payload["members"] == []
   assert resp2.payload["nonMembers"] == [
     {"guid": "u1", "displayName": "User 1"},
@@ -257,11 +265,12 @@ def test_upsert_and_delete_role():
   svc_mod.unbox_request = fake_upsert
   resp = asyncio.run(account_role_upsert_role_v1(req))
   assert auth.role_cache.upsert_args == ("ROLE_NEW", 8, "New")
-  assert (
-    "db:system:roles:upsert_role:1",
-    {"name": "ROLE_NEW", "mask": 8, "display": "New"},
-  ) in db.calls
-  assert isinstance(resp, models_mod.RPCResponse)
+  assert any(
+    c.op == "db:system:roles:upsert_role:1"
+    and c.params == {"name": "ROLE_NEW", "mask": 8, "display": "New"}
+    for c in db.calls
+  )
+  assert getattr(resp, "op", None) == "urn:account:role:upsert_role:1"
 
   db.calls.clear()
 
@@ -278,8 +287,12 @@ def test_upsert_and_delete_role():
   svc_mod.unbox_request = fake_delete
   resp2 = asyncio.run(account_role_delete_role_v1(req))
   assert auth.role_cache.delete_args == "ROLE_NEW"
-  assert ("db:system:roles:delete_role:1", {"name": "ROLE_NEW"}) in db.calls
-  assert isinstance(resp2, models_mod.RPCResponse)
+  assert any(
+    c.op == "db:system:roles:delete_role:1"
+    and c.params == {"name": "ROLE_NEW"}
+    for c in db.calls
+  )
+  assert getattr(resp2, "op", None) == "urn:account:role:delete_role:1"
 
 
 def test_get_roles_filters_by_mask():

--- a/tests/test_auth_discord_link_by_email.py
+++ b/tests/test_auth_discord_link_by_email.py
@@ -2,6 +2,7 @@ import sys, types, importlib.util, asyncio, json
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.oauth_module import OauthModule
 
@@ -34,7 +35,11 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:identities:get_by_provider_identifier:1":
       return DBRes([], 0)

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -5,6 +5,7 @@ import json
 from fastapi import HTTPException, FastAPI
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.oauth_module import OauthModule
+from server.registry.types import DBRequest
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -36,7 +37,11 @@ class DummyDb:
   def __init__(self):
     self.calls = []
     self.linked = False
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:identities:get_by_provider_identifier:1":
       if self.linked:

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -8,6 +8,7 @@ import uuid
 from fastapi import FastAPI
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.oauth_module import OauthModule
+from server.registry.types import DBRequest
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -38,7 +39,11 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)

--- a/tests/test_auth_google_link_by_email.py
+++ b/tests/test_auth_google_link_by_email.py
@@ -2,6 +2,7 @@ import sys, types, importlib.util, asyncio, json
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.oauth_module import OauthModule
@@ -41,7 +42,11 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:identities:get_by_provider_identifier:1":
       return DBRes([], 0)

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -8,6 +8,7 @@ import uuid
 from fastapi import FastAPI
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.oauth_module import OauthModule
+from server.registry.types import DBRequest
 
 class DummyAuth:
   async def handle_auth_login(self, provider, id_token, access_token):
@@ -38,7 +39,11 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:identities:get_by_provider_identifier:1":
       if len([c for c in self.calls if c[0] == op]) == 1:

--- a/tests/test_auth_google_profile_image_update.py
+++ b/tests/test_auth_google_profile_image_update.py
@@ -2,6 +2,7 @@ import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.oauth_module import OauthModule
@@ -43,6 +44,10 @@ class DummyDb:
   def __init__(self):
     self.calls = []
   async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     if hasattr(op, "op") and hasattr(op, "params"):
       key = op.op
       params = op.params

--- a/tests/test_auth_google_profile_refresh.py
+++ b/tests/test_auth_google_profile_refresh.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 import json
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.oauth_module import OauthModule
 from server.registry.accounts.profile import update_if_unedited_request
@@ -33,6 +34,10 @@ class DummyDb:
     self.calls = []
     self.allow_update = allow_update
   async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     if hasattr(op, "op") and hasattr(op, "params"):
       key = op.op
       params = op.params

--- a/tests/test_auth_google_relink_unlinked.py
+++ b/tests/test_auth_google_relink_unlinked.py
@@ -2,6 +2,7 @@ import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.oauth_module import OauthModule
@@ -35,7 +36,11 @@ class DummyDb:
   def __init__(self):
     self.calls = []
     self._get_by_count = 0
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:identities:get_by_provider_identifier:1":
       self._get_by_count += 1

--- a/tests/test_auth_google_soft_undelete.py
+++ b/tests/test_auth_google_soft_undelete.py
@@ -1,6 +1,7 @@
 import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
+from server.registry.types import DBRequest
 
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from fastapi import FastAPI
@@ -43,7 +44,11 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:identities:get_by_provider_identifier:1":
       return DBRes([

--- a/tests/test_auth_microsoft_email_exists.py
+++ b/tests/test_auth_microsoft_email_exists.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 import json
 from fastapi import HTTPException, FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.oauth_module import OauthModule
 
@@ -26,7 +27,11 @@ class DummyDb:
   def __init__(self):
     self.calls = []
     self.linked = False
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:identities:get_by_provider_identifier:1":
       if self.linked:

--- a/tests/test_auth_microsoft_home_account_lookup.py
+++ b/tests/test_auth_microsoft_home_account_lookup.py
@@ -2,6 +2,7 @@ import sys, types, importlib.util, asyncio, base64, uuid
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.oauth_module import OauthModule
 
@@ -26,7 +27,11 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)

--- a/tests/test_auth_microsoft_link_by_email.py
+++ b/tests/test_auth_microsoft_link_by_email.py
@@ -2,6 +2,7 @@ import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.oauth_module import OauthModule
 
@@ -31,7 +32,11 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:identities:get_by_provider_identifier:1":
       return DBRes([], 0)

--- a/tests/test_auth_microsoft_oauth_login_creation.py
+++ b/tests/test_auth_microsoft_oauth_login_creation.py
@@ -2,6 +2,7 @@ import sys, types, pytest, importlib.util, importlib.machinery, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.oauth_module import OauthModule
 
@@ -24,7 +25,11 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:identities:get_by_provider_identifier:1":
       if len([c for c in self.calls if c[0] == op]) == 1:

--- a/tests/test_auth_microsoft_profile_image_clear.py
+++ b/tests/test_auth_microsoft_profile_image_clear.py
@@ -2,6 +2,7 @@ import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.oauth_module import OauthModule
 from server.registry.accounts.profile import set_profile_image_request
@@ -29,6 +30,10 @@ class DummyDb:
   def __init__(self):
     self.calls = []
   async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     if hasattr(op, "op") and hasattr(op, "params"):
       key = op.op
       params = op.params

--- a/tests/test_auth_microsoft_profile_image_update.py
+++ b/tests/test_auth_microsoft_profile_image_update.py
@@ -2,6 +2,7 @@ import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.oauth_module import OauthModule
 from server.registry.accounts.profile import set_profile_image_request
@@ -29,6 +30,10 @@ class DummyDb:
   def __init__(self):
     self.calls = []
   async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     if hasattr(op, "op") and hasattr(op, "params"):
       key = op.op
       params = op.params

--- a/tests/test_auth_microsoft_profile_refresh.py
+++ b/tests/test_auth_microsoft_profile_refresh.py
@@ -2,6 +2,7 @@ import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.oauth_module import OauthModule
 from server.registry.accounts.profile import update_if_unedited_request
@@ -35,6 +36,10 @@ class DummyDb:
     self.calls = []
     self.allow_update = allow_update
   async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     if hasattr(op, "op") and hasattr(op, "params"):
       key = op.op
       params = op.params

--- a/tests/test_auth_microsoft_relink_unlinked.py
+++ b/tests/test_auth_microsoft_relink_unlinked.py
@@ -2,6 +2,7 @@ import sys, types, importlib.util, asyncio
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.oauth_module import OauthModule
 
@@ -25,7 +26,11 @@ class DummyDb:
   def __init__(self):
     self.calls = []
     self._get_by_count = 0
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:identities:get_by_provider_identifier:1":
       self._get_by_count += 1

--- a/tests/test_bsky_module.py
+++ b/tests/test_bsky_module.py
@@ -1,5 +1,6 @@
 import asyncio
 from types import SimpleNamespace
+from server.registry.types import DBRequest
 
 import pytest
 from fastapi import FastAPI
@@ -19,7 +20,11 @@ class DummyDb(BaseModule):
   async def shutdown(self):
     pass
 
-  async def run(self, op: str, args: dict):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     class Res:
       def __init__(self, rows):
         self.rows = rows

--- a/tests/test_db_module_api_ids.py
+++ b/tests/test_db_module_api_ids.py
@@ -3,15 +3,16 @@ from fastapi import FastAPI
 
 from server.modules.db_module import DbModule
 from server.modules.providers import DBResult
+from server.registry.types import DBRequest
 
 
 def test_get_google_client_id():
   app = FastAPI()
   db = DbModule(app)
 
-  async def fake_run(op, args):
-    assert op == "db:system:config:get_config:1"
-    assert args == {"key": "GoogleClientId"}
+  async def fake_run(request: DBRequest):
+    assert request.op == "db:system:config:get_config:1"
+    assert request.params == {"key": "GoogleClientId"}
     return DBResult(rows=[{"value": "gid"}], rowcount=1)
 
   db.run = fake_run
@@ -35,9 +36,9 @@ def test_get_discord_client_id():
   app = FastAPI()
   db = DbModule(app)
 
-  async def fake_run(op, args):
-    assert op == "db:system:config:get_config:1"
-    assert args == {"key": "DiscordClientId"}
+  async def fake_run(request: DBRequest):
+    assert request.op == "db:system:config:get_config:1"
+    assert request.params == {"key": "DiscordClientId"}
     return DBResult(rows=[{"value": "dcid"}], rowcount=1)
 
   db.run = fake_run
@@ -48,9 +49,9 @@ def test_get_ms_api_id():
   app = FastAPI()
   db = DbModule(app)
 
-  async def fake_run(op, args):
-    assert op == "db:system:config:get_config:1"
-    assert args == {"key": "MsApiId"}
+  async def fake_run(request: DBRequest):
+    assert request.op == "db:system:config:get_config:1"
+    assert request.params == {"key": "MsApiId"}
     return DBResult(rows=[{"value": "mid"}], rowcount=1)
 
   db.run = fake_run
@@ -61,9 +62,9 @@ def test_get_auth_providers():
   app = FastAPI()
   db = DbModule(app)
 
-  async def fake_run(op, args):
-    assert op == "db:system:config:get_config:1"
-    assert args == {"key": "AuthProviders"}
+  async def fake_run(request: DBRequest):
+    assert request.op == "db:system:config:get_config:1"
+    assert request.params == {"key": "AuthProviders"}
     return DBResult(rows=[{"value": "microsoft,google,discord"}], rowcount=1)
 
   db.run = fake_run
@@ -74,9 +75,9 @@ def test_get_jwks_cache_time():
   app = FastAPI()
   db = DbModule(app)
 
-  async def fake_run(op, args):
-    assert op == "db:system:config:get_config:1"
-    assert args == {"key": "JwksCacheTime"}
+  async def fake_run(request: DBRequest):
+    assert request.op == "db:system:config:get_config:1"
+    assert request.params == {"key": "JwksCacheTime"}
     return DBResult(rows=[{"value": "45"}], rowcount=1)
 
   db.run = fake_run

--- a/tests/test_db_module_init.py
+++ b/tests/test_db_module_init.py
@@ -35,7 +35,11 @@ def test_db_module_run_propagates_query_error():
     async def shutdown(self):
       pass
 
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if isinstance(op, DBRequest):
+        args = op.params
+        op = op.op
+      args = args or {}
       raise DBQueryError(detail)
 
   db._provider = FailingProvider()
@@ -44,7 +48,7 @@ def test_db_module_run_propagates_query_error():
   db.set_registry(registry)
 
   with pytest.raises(DBQueryError) as exc:
-    asyncio.run(db.run("db:test:error", {}))
+    asyncio.run(db.run(DBRequest(op="db:test:error", params={})))
   assert exc.value.detail == detail
 
 
@@ -63,7 +67,11 @@ def test_db_module_forwards_operations_verbatim():
     async def shutdown(self):
       pass
 
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if isinstance(op, DBRequest):
+        args = op.params
+        op = op.op
+      args = args or {}
       captured["op"] = op
       captured["args"] = args
       return DBResult(rows=[{"ok": True}], rowcount=1)
@@ -73,7 +81,7 @@ def test_db_module_forwards_operations_verbatim():
   registry.bind_provider(db._provider)
   db.set_registry(registry)
 
-  result = asyncio.run(db.run("db:test:urn-op:1", {"foo": "bar"}))
+  result = asyncio.run(db.run(DBRequest(op="db:test:urn-op:1", params={"foo": "bar"})))
   assert captured["op"] == "db:test:urn-op:1"
   assert captured["args"] == {"foo": "bar"}
   assert isinstance(result, DBResult)
@@ -92,7 +100,11 @@ def test_db_module_run_constructs_registry_request():
     async def shutdown(self):
       pass
 
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if isinstance(op, DBRequest):
+        args = op.params
+        op = op.op
+      args = args or {}
       raise AssertionError("provider should not be invoked in this test")
 
   class RecordingRegistry(RegistryDispatcher):
@@ -109,7 +121,7 @@ def test_db_module_run_constructs_registry_request():
   registry = RecordingRegistry()
   db.set_registry(registry)
 
-  result = asyncio.run(db.run("db:test:op", {"key": "value"}))
+  result = asyncio.run(db.run(DBRequest(op="db:test:op", params={"key": "value"})))
 
   assert result.rows == [{"ok": True}]
   assert result.rowcount == 1
@@ -148,7 +160,11 @@ def test_registry_dispatcher_executes_provider_callable(monkeypatch):
     async def shutdown(self):
       pass
 
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if isinstance(op, DBRequest):
+        args = op.params
+        op = op.op
+      args = args or {}
       raise AssertionError("provider.run should not be used when route is registered")
 
   dispatcher = RegistryDispatcher(router=router)

--- a/tests/test_discord_events_router.py
+++ b/tests/test_discord_events_router.py
@@ -1,5 +1,6 @@
 import asyncio, logging
 from types import SimpleNamespace
+from server.registry.types import DBRequest
 
 import pytest
 from fastapi import FastAPI
@@ -35,7 +36,11 @@ class DummyDb:
     self.values = values
     self.calls: list[tuple[str, dict]] = []
 
-  async def run(self, op: str, args: dict):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     value = self.values.get(args.get("key"))
     rows = [{"value": value}] if value is not None else []

--- a/tests/test_discord_module.py
+++ b/tests/test_discord_module.py
@@ -1,5 +1,6 @@
 import asyncio, logging
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules import BaseModule
 from server.modules.discord_bot_module import DiscordBotModule
@@ -31,7 +32,11 @@ class DummyDb(BaseModule):
   async def shutdown(self):
     pass
 
-  async def run(self, op: str, args: dict):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     class Res:
       def __init__(self, rows):
         self.rows = rows

--- a/tests/test_google_services_helpers.py
+++ b/tests/test_google_services_helpers.py
@@ -3,6 +3,7 @@ import base64
 import logging
 import uuid
 from datetime import datetime, timezone, timedelta
+from server.registry.types import DBRequest
 
 from types import SimpleNamespace
 from fastapi import FastAPI
@@ -35,7 +36,11 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:sessions:create_session:1":
       return SimpleNamespace(rows=[{"session_guid": "sess", "device_guid": "dev"}])

--- a/tests/test_microsoft_services_helpers.py
+++ b/tests/test_microsoft_services_helpers.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone, timedelta
+from server.registry.types import DBRequest
 
 from types import SimpleNamespace
 from fastapi import FastAPI
@@ -22,7 +23,11 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == "db:security:sessions:create_session:1":
       return SimpleNamespace(rows=[{"session_guid": "sess", "device_guid": "dev"}])

--- a/tests/test_role_admin_module.py
+++ b/tests/test_role_admin_module.py
@@ -1,5 +1,6 @@
 import types, asyncio
 from fastapi import HTTPException
+from server.registry.types import DBRequest
 
 from server.modules.role_admin_module import RoleAdminModule
 
@@ -9,7 +10,11 @@ class DummyDb:
     self.roles = roles or []
   async def on_ready(self):
     pass
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     if op == "db:system:roles:list:1":
       return types.SimpleNamespace(rows=self.roles)
     return types.SimpleNamespace(rows=[])

--- a/tests/test_service_roles_services.py
+++ b/tests/test_service_roles_services.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import sys
 
 import pytest
+from server.registry.types import DBRequest
 
 # stub rpc package and load required modules
 root_path = pathlib.Path(__file__).resolve().parent.parent
@@ -76,12 +77,15 @@ class DummyDb:
     self.members = members or []
     self.non_members = non_members or []
 
-  async def run(self, op, args):
-    self.calls.append((op, args))
+  async def run(self, request: DBRequest):
+    self.calls.append(request)
+    op = request.op
     if op == "db:system:roles:get_role_members:1":
       return DBRes(self.members, len(self.members))
     if op == "db:system:roles:get_role_non_members:1":
       return DBRes(self.non_members, len(self.non_members))
+    if op == "db:system:roles:list:1":
+      return DBRes([], 0)
     return DBRes()
 
 
@@ -105,15 +109,17 @@ class RoleCache:
     self.upsert_args = (name, mask, display)
     if self.db:
       await self.db.run(
-        "db:system:roles:upsert_role:1",
-        {"name": name, "mask": mask, "display": display},
+        DBRequest(
+          op="db:system:roles:upsert_role:1",
+          params={"name": name, "mask": mask, "display": display},
+        )
       )
     await self.refresh_role_cache()
 
   async def delete_role(self, name):
     self.delete_args = name
     if self.db:
-      await self.db.run("db:system:roles:delete_role:1", {"name": name})
+      await self.db.run(DBRequest(op="db:system:roles:delete_role:1", params={"name": name}))
     await self.refresh_role_cache()
 
   def get_role_names(self, exclude_registered=False):
@@ -162,7 +168,7 @@ class DummyRoleAdmin:
     self.auth = auth
 
   async def list_roles(self):
-    res = await self.db.run("db:system:roles:list:1", {})
+    res = await self.db.run(DBRequest(op="db:system:roles:list:1", params={}))
     return [
       {
         "name": r.get("name", ""),
@@ -265,10 +271,11 @@ def test_upsert_role_calls_db_and_loads_roles():
   resp = asyncio.run(service_roles_upsert_role_v1(req))
   assert isinstance(resp, RPCResponse)
   assert auth.role_cache.upsert_args == ("ROLE_NEW", 4, "New")
-  assert (
-    "db:system:roles:upsert_role:1",
-    {"name": "ROLE_NEW", "mask": 4, "display": "New"},
-  ) in db.calls
+  assert any(
+    c.op == "db:system:roles:upsert_role:1"
+    and c.params == {"name": "ROLE_NEW", "mask": 4, "display": "New"}
+    for c in db.calls
+  )
   assert auth.role_cache.loaded
 
 
@@ -289,10 +296,10 @@ def test_delete_role_calls_db_and_loads_roles():
   resp = asyncio.run(svc_mod.service_roles_delete_role_v1(req))
   assert isinstance(resp, RPCResponse)
   assert auth.role_cache.delete_args == "ROLE_OLD"
-  assert (
-    "db:system:roles:delete_role:1",
-    {"name": "ROLE_OLD"},
-  ) in db.calls
+  assert any(
+    c.op == "db:system:roles:delete_role:1" and c.params == {"name": "ROLE_OLD"}
+    for c in db.calls
+  )
   assert auth.role_cache.loaded
 
 

--- a/tests/test_service_routes_services.py
+++ b/tests/test_service_routes_services.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.requests import Request
+from server.registry.types import DBRequest
 
 # Stub rpc packages
 pkg = types.ModuleType('rpc')
@@ -111,7 +112,11 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op: str, args: dict):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == 'db:system:routes:get_routes:1':
       rows = [{

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -133,7 +133,15 @@ def test_list_public_files(monkeypatch):
   monkeypatch.setattr(mssql_provider, "run_operation", fake_run_operation)
 
   mod = StorageModule(app)
-  mod.db = provider
+  class ProviderAdapter:
+    def __init__(self, provider):
+      self.provider = provider
+
+    async def run(self, request, args=None):
+      op, params = _extract_request(request, args)
+      return await self.provider.run(op, params)
+
+  mod.db = ProviderAdapter(provider)
   rows = asyncio.run(mod.list_public_files())
   assert rows == [
     {"user_guid": "u1", "display_name": "U1", "path": "", "name": "a.txt", "url": "u/a.txt", "content_type": "text/plain"},

--- a/tests/test_system_config_module.py
+++ b/tests/test_system_config_module.py
@@ -6,6 +6,7 @@ import types
 from types import SimpleNamespace
 import pytest
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 root = pathlib.Path(__file__).resolve().parent.parent
 
@@ -45,7 +46,11 @@ sys.modules['server.modules'] = modules_pkg
 
 db_module_pkg = types.ModuleType('server.modules.db_module')
 class DbModule:
-  async def run(self, op: str, args: dict):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     raise NotImplementedError
 
 db_module_pkg.DbModule = DbModule
@@ -65,7 +70,11 @@ class DummyDb(DbModule):
     self.calls = []
   async def on_ready(self):
     pass
-  async def run(self, op: str, args: dict):
+  async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     self.calls.append((op, args))
     if op == 'db:system:config:get_configs:1':
       rows = [{'element_key': 'LoggingLevel', 'element_value': '4'}]

--- a/tests/test_system_roles_services.py
+++ b/tests/test_system_roles_services.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.requests import Request
+from server.registry.types import DBRequest
 
 # Stub rpc package
 pkg = types.ModuleType('rpc')
@@ -43,13 +44,13 @@ class RoleCache:
   async def upsert_role(self, name, mask, display):
     self.upsert_args = (name, mask, display)
     if self.db:
-      await self.db.run('db:system:roles:upsert_role:1', {'name': name, 'mask': mask, 'display': display})
+      await self.db.run(DBRequest(op='db:system:roles:upsert_role:1', params={'name': name, 'mask': mask, 'display': display}))
     await self.refresh_role_cache()
 
   async def delete_role(self, name):
     self.delete_args = name
     if self.db:
-      await self.db.run('db:system:roles:delete_role:1', {'name': name})
+      await self.db.run(DBRequest(op='db:system:roles:delete_role:1', params={'name': name}))
     await self.refresh_role_cache()
 
 class AuthModule:
@@ -111,8 +112,9 @@ svc.unbox_request = fake_unbox
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op: str, args: dict):
-    self.calls.append((op, args))
+  async def run(self, request: DBRequest):
+    self.calls.append(request)
+    op = request.op
     if op == 'db:system:roles:list:1':
       rows = [{'name': 'ROLE_FOO', 'mask': 1, 'display': 'Foo'}]
       return SimpleNamespace(rows=rows, rowcount=1)
@@ -130,7 +132,7 @@ class DummyRoleAdmin:
     self.auth = auth
 
   async def list_roles(self):
-    res = await self.db.run('db:system:roles:list:1', {})
+    res = await self.db.run(DBRequest(op='db:system:roles:list:1', params={}))
     return [
       {
         'name': r.get('name', ''),
@@ -172,13 +174,20 @@ def test_get_roles_service():
   assert data['payload'] == {
     'roles': [{'name': 'ROLE_FOO', 'mask': '1', 'display': 'Foo'}]
   }
-  assert ('db:system:roles:list:1', {}) in db.calls
+  assert any(c.op == 'db:system:roles:list:1' and c.params == {} for c in db.calls)
 
 def test_upsert_and_delete_role_service():
   resp = client.post('/rpc', json={'op': 'urn:system:roles:upsert_role:1', 'payload': {'name': 'ROLE_FOO', 'mask': '1', 'display': 'Foo'}})
   assert resp.status_code == 200
   resp = client.post('/rpc', json={'op': 'urn:system:roles:delete_role:1', 'payload': {'name': 'ROLE_FOO'}})
   assert resp.status_code == 200
-  assert ('db:system:roles:upsert_role:1', {'name': 'ROLE_FOO', 'mask': 1, 'display': 'Foo'}) in db.calls
-  assert ('db:system:roles:delete_role:1', {'name': 'ROLE_FOO'}) in db.calls
+  assert any(
+    c.op == 'db:system:roles:upsert_role:1'
+    and c.params == {'name': 'ROLE_FOO', 'mask': 1, 'display': 'Foo'}
+    for c in db.calls
+  )
+  assert any(
+    c.op == 'db:system:roles:delete_role:1' and c.params == {'name': 'ROLE_FOO'}
+    for c in db.calls
+  )
   assert auth.role_cache.refreshed

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -4,6 +4,7 @@ import pathlib
 import sys
 import types
 from types import SimpleNamespace
+from server.registry.types import DBRequest
 
 import pytest
 from fastapi import HTTPException
@@ -77,6 +78,10 @@ class DummyDb:
     self.calls = []
     self.roles = roles
   async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     if hasattr(op, "op") and hasattr(op, "params"):
       key = op.op
       params = op.params

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone, timedelta
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.providers.auth.microsoft_provider import MicrosoftAuthProvider
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 
 from server.modules.oauth_module import OauthModule
 
@@ -99,6 +100,10 @@ class DummyDb:
   def __init__(self):
     self.calls = []
   async def run(self, op, args=None):
+    if isinstance(op, DBRequest):
+      args = op.params
+      op = op.op
+    args = args or {}
     key, params = _normalize_db_call(op, args)
     self.calls.append((key, params))
     return DBRes()
@@ -223,6 +228,10 @@ def test_link_provider_google_normalizes_identifier():
     def __init__(self):
       self.calls = []
     async def run(self, op, args=None):
+      if isinstance(op, DBRequest):
+        args = op.params
+        op = op.op
+      args = args or {}
       key, params = _normalize_db_call(op, args)
       self.calls.append((key, params))
       if key == "db:system:config:get_config:1":
@@ -279,7 +288,11 @@ def test_link_provider_discord_normalizes_identifier():
   class DummyDb:
     def __init__(self):
       self.calls = []
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if isinstance(op, DBRequest):
+        args = op.params
+        op = op.op
+      args = args or {}
       self.calls.append((op, args))
       if op == "db:system:config:get_config:1":
         key = args["key"]
@@ -336,6 +349,10 @@ def test_link_provider_microsoft_normalizes_identifier():
     def __init__(self):
       self.calls = []
     async def run(self, op, args=None):
+      if isinstance(op, DBRequest):
+        args = op.params
+        op = op.op
+      args = args or {}
       key, params = _normalize_db_call(op, args)
       self.calls.append((key, params))
       return DBRes()
@@ -357,6 +374,10 @@ def test_unlink_non_default_provider_retains_tokens():
 
   class LocalDb(DummyDb):
     async def run(self, op, args=None):
+      if isinstance(op, DBRequest):
+        args = op.params
+        op = op.op
+      args = args or {}
       key, params = _normalize_db_call(op, args)
       self.calls.append((key, params))
       if key == PROFILE_GET_REQUEST.op:
@@ -382,6 +403,10 @@ def test_unlink_default_provider_without_new_default_raises():
 
   class LocalDb(DummyDb):
     async def run(self, op, args=None):
+      if isinstance(op, DBRequest):
+        args = op.params
+        op = op.op
+      args = args or {}
       key, params = _normalize_db_call(op, args)
       self.calls.append((key, params))
       if key == PROFILE_GET_REQUEST.op:
@@ -406,6 +431,10 @@ def test_unlink_default_provider_sets_new_default_and_revokes_tokens():
 
   class LocalDb(DummyDb):
     async def run(self, op, args=None):
+      if isinstance(op, DBRequest):
+        args = op.params
+        op = op.op
+      args = args or {}
       key, params = _normalize_db_call(op, args)
       self.calls.append((key, params))
       if key == PROFILE_GET_REQUEST.op:
@@ -431,6 +460,10 @@ def test_unlink_last_provider_soft_deletes_and_revokes():
 
   class LocalDb(DummyDb):
     async def run(self, op, args=None):
+      if isinstance(op, DBRequest):
+        args = op.params
+        op = op.op
+      args = args or {}
       key, params = _normalize_db_call(op, args)
       self.calls.append((key, params))
       if key == PROFILE_GET_REQUEST.op:


### PR DESCRIPTION
## Summary
- update DB module helper methods and all module call sites to pass DBRequest objects to `run`
- adjust RPC services to build inline DBRequest instances when invoking the database
- refresh unit tests to understand the new DBRequest-based API and keep provider-based fixtures working

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df36a56a1083258cac807172c9d4b6