### PR TITLE
Harden RPC authentication and role validation

### DIFF
--- a/rpc/account/handler.py
+++ b/rpc/account/handler.py
@@ -5,7 +5,7 @@ Handles account operations requiring ROLE_ACCOUNT_ADMIN.
 
 from fastapi import HTTPException, Request
 
-from rpc.helpers import unbox_request
+from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 from . import HANDLERS
@@ -14,7 +14,7 @@ from . import HANDLERS
 async def handle_account_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  required_mask = auth.roles.get("ROLE_ACCOUNT_ADMIN", 0)
+  required_mask = resolve_required_mask(auth, "ROLE_ACCOUNT_ADMIN")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail="Forbidden")
 

--- a/rpc/discord/handler.py
+++ b/rpc/discord/handler.py
@@ -2,7 +2,7 @@
 
 from fastapi import HTTPException, Request
 
-from rpc.helpers import unbox_request
+from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 
@@ -17,7 +17,7 @@ async def handle_discord_request(parts: list[str], request: Request) -> RPCRespo
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
   role_name = REQUIRED_ROLES.get(subdomain)
-  required_mask = auth.roles.get(role_name, 0) if role_name else 0
+  required_mask = resolve_required_mask(auth, role_name) if role_name else 0
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     detail = FORBIDDEN_DETAILS.get(subdomain, 'Forbidden')
     raise HTTPException(status_code=403, detail=detail)

--- a/rpc/helpers.py
+++ b/rpc/helpers.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 import logging
-
 from typing import TYPE_CHECKING
+
 from fastapi import HTTPException, Request
 
-from server.models import RPCRequest
 from server.models import AuthContext
+from server.models import RPCRequest
 
 if TYPE_CHECKING:
   from server.modules.auth_module import AuthModule
-  from server.modules.db_module import DbModule
 
 
 def mask_to_bit(mask: int) -> int:
@@ -29,58 +28,149 @@ def _get_token_from_request(request: Request) -> str | None:
     return None
   return header.split(' ', 1)[1].strip()
 
+_logger = logging.getLogger(__name__)
+_audit_logger = logging.getLogger('security.audit')
+
+
 def _get_discord_id_from_request(request: Request) -> str | None:
   ctx = getattr(request.state, 'discord_ctx', None)
   if ctx and getattr(ctx, 'author', None):
     return str(getattr(ctx.author, 'id', ''))
-  return request.headers.get('x-discord-id') or request.headers.get('x-discord-user-id')
+  header_id = request.headers.get('x-discord-id') or request.headers.get('x-discord-user-id')
+  if header_id:
+    return str(header_id)
+  return None
+
+
+def _get_mtls_subject(request: Request) -> str | None:
+  subject = getattr(request.state, 'mtls_subject_guid', None)
+  if subject:
+    return str(subject)
+  header_subject = request.headers.get('x-mtls-subject-guid')
+  if header_subject:
+    return str(header_subject)
+  return None
+
+
+def resolve_required_mask(auth: AuthModule, role_name: str) -> int:
+  if not role_name:
+    raise HTTPException(status_code=500, detail='Role name must be provided')
+  try:
+    return auth.require_role_mask(role_name)
+  except KeyError as exc:
+    message = f'Required role is undefined: {role_name}'
+    _logger.error('[RPC] %s', message)
+    raise HTTPException(status_code=500, detail=message) from exc
+
+
+async def _validate_rpc_identity(
+  request: Request,
+  rpc_request: RPCRequest,
+  parts: list[str],
+) -> AuthContext:
+  auth_ctx = AuthContext()
+  token = _get_token_from_request(request)
+  mtls_subject = _get_mtls_subject(request)
+  domain = parts[1] if len(parts) > 1 else ''
+
+  auth: AuthModule | None = getattr(request.app.state, 'auth', None)
+  if not auth:
+    if domain in ('public', 'auth'):
+      return auth_ctx
+    raise HTTPException(status_code=500, detail='Authentication module is unavailable')
+
+  identity_source = None
+  discord_id: str | None = None
+
+  if domain in ('discord', 'webhook') and not (token or mtls_subject):
+    raise HTTPException(status_code=401, detail='Signed token or MTLS assertion required')
+
+  if token:
+    try:
+      data: dict = await auth.decode_session_token(token)
+    except HTTPException:
+      raise
+    except Exception as exc:
+      _logger.exception('[RPC] Failed to decode session token')
+      raise HTTPException(status_code=401, detail='Invalid authorization token') from exc
+    user_guid = data.get('sub')
+    if not user_guid:
+      raise HTTPException(status_code=401, detail='Invalid authorization token payload')
+    roles, mask = await auth.get_user_roles(user_guid)
+    auth_ctx.user_guid = user_guid
+    auth_ctx.provider = data.get('provider')
+    auth_ctx.claims = data
+    auth_ctx.roles = roles
+    auth_ctx.role_mask = mask
+    rpc_request.user_guid = user_guid
+    rpc_request.roles = roles
+    rpc_request.role_mask = mask
+    identity_source = 'token'
+    _logger.debug('[RPC] Resolved roles for %s: %s (mask=%#018x)', user_guid, roles, mask)
+
+  if not token and mtls_subject:
+    roles, mask = await auth.get_user_roles(mtls_subject)
+    auth_ctx.user_guid = mtls_subject
+    auth_ctx.roles = roles
+    auth_ctx.role_mask = mask
+    rpc_request.user_guid = mtls_subject
+    rpc_request.roles = roles
+    rpc_request.role_mask = mask
+    identity_source = 'mtls'
+    _logger.debug('[RPC] Resolved MTLS roles for %s: %s (mask=%#018x)', mtls_subject, roles, mask)
+
+  if domain == 'discord':
+    discord_id = _get_discord_id_from_request(request)
+    if not discord_id:
+      raise HTTPException(status_code=401, detail='Discord identity assertion missing')
+    guid, roles, mask = await auth.get_discord_user_security(discord_id)
+    if not guid:
+      raise HTTPException(status_code=403, detail='Forbidden')
+    try:
+      registered_mask = auth.require_role_mask('ROLE_REGISTERED')
+    except KeyError as exc:
+      message = 'Required role is undefined: ROLE_REGISTERED'
+      _logger.error('[RPC] %s', message)
+      raise HTTPException(status_code=500, detail=message) from exc
+    if not (mask & registered_mask):
+      raise HTTPException(status_code=403, detail='Forbidden')
+    auth_ctx.user_guid = guid
+    auth_ctx.roles = roles
+    auth_ctx.role_mask = mask
+    rpc_request.user_guid = guid
+    rpc_request.roles = roles
+    rpc_request.role_mask = mask
+    identity_source = 'discord'
+    _logger.debug('[RPC] Resolved Discord roles for %s: %s (mask=%#018x)', guid, roles, mask)
+  elif domain not in ('public', 'auth') and not identity_source:
+    raise HTTPException(status_code=401, detail='Missing or invalid authorization header')
+
+  if identity_source:
+    audit_payload = {
+      'event': 'rpc.request.validated',
+      'op': rpc_request.op,
+      'domain': domain,
+      'user_guid': auth_ctx.user_guid,
+      'role_mask': auth_ctx.role_mask,
+      'roles': auth_ctx.roles,
+      'identity_source': identity_source,
+    }
+    if discord_id:
+      audit_payload['discord_id'] = discord_id
+    if token:
+      audit_payload['token_present'] = True
+    if mtls_subject:
+      audit_payload['mtls_subject'] = mtls_subject
+    _audit_logger.info('rpc.request.validated', extra=audit_payload)
+
+  return auth_ctx
+
 
 async def _process_rpcrequest(request: Request) -> tuple[RPCRequest, AuthContext]:
   body = await request.json()
   rpc_request = RPCRequest(**body)
-
-  token = _get_token_from_request(request)
   parts = rpc_request.op.split(':')
-  domain = parts[1] if len(parts) > 1 else ''
-
-  auth_ctx = AuthContext()
-
-  if token:
-    _auth: AuthModule = request.app.state.auth
-    data: dict = await _auth.decode_session_token(token)
-    auth_ctx.user_guid = data.get('sub')
-    auth_ctx.provider = data.get('provider')
-    auth_ctx.claims = data
-    roles, mask = await _auth.get_user_roles(auth_ctx.user_guid)
-    auth_ctx.roles = roles
-    auth_ctx.role_mask = mask
-    rpc_request.user_guid = auth_ctx.user_guid
-    rpc_request.roles = roles
-    rpc_request.role_mask = mask
-    logging.debug("[RPC] Resolved roles for %s: %s (mask=%#018x)", auth_ctx.user_guid, roles, mask)
-  else:
-    if domain == 'discord':
-      discord_id = _get_discord_id_from_request(request)
-      if not discord_id and rpc_request.payload:
-        discord_id = rpc_request.payload.get('discord_id')
-      if not discord_id:
-        raise HTTPException(status_code=401, detail='Missing or invalid authorization header')
-      _auth: AuthModule = request.app.state.auth
-      guid, roles, mask = await _auth.get_discord_user_security(discord_id)
-      if not guid:
-        raise HTTPException(status_code=401, detail='Missing or invalid authorization header')
-      auth_ctx.user_guid = guid
-      auth_ctx.roles = roles
-      auth_ctx.role_mask = mask
-      rpc_request.user_guid = guid
-      rpc_request.roles = roles
-      rpc_request.role_mask = mask
-      if not (mask & _auth.role_registered):
-        raise HTTPException(status_code=403, detail='Forbidden')
-      logging.debug("[RPC] Resolved roles for %s: %s (mask=%#018x)", guid, roles, mask)
-    elif domain not in ('public', 'auth'):
-      raise HTTPException(status_code=401, detail='Missing or invalid authorization header')
-
+  auth_ctx = await _validate_rpc_identity(request, rpc_request, parts)
   return rpc_request, auth_ctx
 
 async def unbox_request(request):

--- a/rpc/moderation/handler.py
+++ b/rpc/moderation/handler.py
@@ -6,7 +6,7 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
-from rpc.helpers import unbox_request
+from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 
@@ -16,7 +16,7 @@ from . import HANDLERS
 async def handle_moderation_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  required_mask = auth.roles.get("ROLE_MODERATOR", 0)
+  required_mask = resolve_required_mask(auth, "ROLE_MODERATOR")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')
 

--- a/rpc/public/vars/services.py
+++ b/rpc/public/vars/services.py
@@ -1,5 +1,5 @@
 from fastapi import HTTPException, Request
-from rpc.helpers import unbox_request
+from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -52,7 +52,7 @@ async def public_vars_get_ffmpeg_version_v1(request: Request):
   vars_mod: PublicVarsModule = request.app.state.public_vars
   required_mask = 0
   if vars_mod.auth:
-    required_mask = vars_mod.auth.roles.get("ROLE_SERVICE_ADMIN", 0)
+    required_mask = resolve_required_mask(vars_mod.auth, "ROLE_SERVICE_ADMIN")
   if not (auth_ctx.role_mask & required_mask):
     raise HTTPException(status_code=403, detail="Forbidden")
   try:
@@ -71,7 +71,7 @@ async def public_vars_get_odbc_version_v1(request: Request):
   vars_mod: PublicVarsModule = request.app.state.public_vars
   required_mask = 0
   if vars_mod.auth:
-    required_mask = vars_mod.auth.roles.get("ROLE_SERVICE_ADMIN", 0)
+    required_mask = resolve_required_mask(vars_mod.auth, "ROLE_SERVICE_ADMIN")
   if not (auth_ctx.role_mask & required_mask):
     raise HTTPException(status_code=403, detail="Forbidden")
   try:

--- a/rpc/service/handler.py
+++ b/rpc/service/handler.py
@@ -6,7 +6,7 @@ Handles service operations requiring ROLE_SERVICE_ADMIN.
 
 from fastapi import HTTPException, Request
 
-from rpc.helpers import unbox_request
+from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 
@@ -16,7 +16,7 @@ from . import HANDLERS
 async def handle_service_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  required_mask = auth.roles.get("ROLE_SERVICE_ADMIN", 0)
+  required_mask = resolve_required_mask(auth, "ROLE_SERVICE_ADMIN")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail="Forbidden")
 

--- a/rpc/service/routes/services.py
+++ b/rpc/service/routes/services.py
@@ -1,6 +1,8 @@
 from fastapi import Request
 import logging
 
+from fastapi import HTTPException
+
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.db_module import DbModule
@@ -63,7 +65,10 @@ async def service_routes_upsert_route_v1(request: Request):
   payload = ServiceRoutesRouteItem1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
   auth: AuthModule = request.app.state.auth
-  mask = auth.names_to_mask(payload.required_roles)
+  try:
+    mask = auth.names_to_mask(payload.required_roles)
+  except KeyError as exc:
+    raise HTTPException(status_code=400, detail=str(exc)) from exc
   db_request = upsert_route_request(
     path=payload.path,
     name=payload.name,

--- a/rpc/storage/handler.py
+++ b/rpc/storage/handler.py
@@ -6,7 +6,7 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
-from rpc.helpers import unbox_request
+from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 
@@ -16,7 +16,7 @@ from . import HANDLERS
 async def handle_storage_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  required_mask = auth.roles.get("ROLE_STORAGE", 0)
+  required_mask = resolve_required_mask(auth, "ROLE_STORAGE")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')
 

--- a/rpc/support/handler.py
+++ b/rpc/support/handler.py
@@ -6,7 +6,7 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
-from rpc.helpers import unbox_request
+from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 
@@ -16,7 +16,7 @@ from . import HANDLERS
 async def handle_support_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  required_mask = auth.roles.get("ROLE_SUPPORT", 0)
+  required_mask = resolve_required_mask(auth, "ROLE_SUPPORT")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')
 

--- a/rpc/system/handler.py
+++ b/rpc/system/handler.py
@@ -6,7 +6,7 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
-from rpc.helpers import unbox_request
+from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 
@@ -16,7 +16,7 @@ from . import HANDLERS
 async def handle_system_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  required_mask = auth.roles.get("ROLE_SYSTEM_ADMIN", 0)
+  required_mask = resolve_required_mask(auth, "ROLE_SYSTEM_ADMIN")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail="Forbidden")
 

--- a/rpc/users/handler.py
+++ b/rpc/users/handler.py
@@ -6,7 +6,7 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
-from rpc.helpers import unbox_request
+from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 
@@ -16,7 +16,7 @@ from . import HANDLERS
 async def handle_users_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
   auth: AuthModule = request.app.state.auth
-  required_mask = auth.roles.get("ROLE_REGISTERED", 0)
+  required_mask = resolve_required_mask(auth, "ROLE_REGISTERED")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')
 

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -50,7 +50,9 @@ class RoleCache:
     self.roles.clear()
     for r in rows:
       self.roles[r["name"]] = int(r["mask"])
-    self.role_registered = self.roles.get("ROLE_REGISTERED", 0)
+    if "ROLE_REGISTERED" not in self.roles:
+      raise RuntimeError('Role ROLE_REGISTERED is not defined')
+    self.role_registered = self.roles["ROLE_REGISTERED"]
     self.role_names = [n for n in self.roles.keys() if n != "ROLE_REGISTERED"]
     self._user_roles.clear()
     self._user_security.clear()
@@ -77,9 +79,18 @@ class RoleCache:
 
   def names_to_mask(self, names: list[str]) -> int:
     mask = 0
+    missing = [name for name in names if name not in self.roles]
+    if missing:
+      missing_str = ', '.join(missing)
+      raise KeyError(f'Undefined roles: {missing_str}')
     for name in names:
-      mask |= self.roles.get(name, 0)
+      mask |= self.roles[name]
     return mask
+
+  def require_role_mask(self, name: str) -> int:
+    if name not in self.roles:
+      raise KeyError(f'Role {name} is not defined')
+    return self.roles[name]
 
   def get_role_names(self, exclude_registered: bool = False) -> list[str]:
     if exclude_registered:
@@ -370,6 +381,9 @@ class AuthModule(BaseModule):
 
   def names_to_mask(self, names: list[str]) -> int:
     return self.role_cache.names_to_mask(names)
+
+  def require_role_mask(self, role_name: str) -> int:
+    return self.role_cache.require_role_mask(role_name)
 
   def get_role_names(self, exclude_registered: bool = False) -> list[str]:
     return self.role_cache.get_role_names(exclude_registered)

--- a/server/modules/public_vars_module.py
+++ b/server/modules/public_vars_module.py
@@ -117,7 +117,10 @@ class PublicVarsModule(BaseModule):
     res = {"version": version, "hostname": hostname, "repo": repo}
     required_mask = 0
     if self.auth:
-      required_mask = self.auth.roles.get("ROLE_SERVICE_ADMIN", 0)
+      try:
+        required_mask = self.auth.require_role_mask("ROLE_SERVICE_ADMIN")
+      except KeyError as exc:
+        raise RuntimeError(str(exc)) from exc
     if role_mask & required_mask:
       ffmpeg_version = await self.get_ffmpeg_version()
       odbc_version = await self.get_odbc_version()

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -77,7 +77,10 @@ class RoleAdminModule(BaseModule):
 
   async def add_role_member(self, role: str, user_guid: str, actor_mask: int | None = None) -> tuple[list[dict], list[dict]]:
     if actor_mask is not None:
-      role_mask = self.auth.roles.get(role, 0)
+      try:
+        role_mask = self.auth.require_role_mask(role)
+      except KeyError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
       self._ensure_can_manage(actor_mask, role_mask)
     assert self.db, "database module not initialised"
     request = add_role_member_request(role, user_guid)
@@ -87,7 +90,10 @@ class RoleAdminModule(BaseModule):
 
   async def remove_role_member(self, role: str, user_guid: str, actor_mask: int | None = None) -> tuple[list[dict], list[dict]]:
     if actor_mask is not None:
-      role_mask = self.auth.roles.get(role, 0)
+      try:
+        role_mask = self.auth.require_role_mask(role)
+      except KeyError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
       self._ensure_can_manage(actor_mask, role_mask)
     assert self.db, "database module not initialised"
     request = remove_role_member_request(role, user_guid)
@@ -102,6 +108,9 @@ class RoleAdminModule(BaseModule):
 
   async def delete_role(self, name: str, actor_mask: int | None = None) -> None:
     if actor_mask is not None:
-      role_mask = self.auth.roles.get(name, 0)
+      try:
+        role_mask = self.auth.require_role_mask(name)
+      except KeyError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
       self._ensure_can_manage(actor_mask, role_mask)
     await self.auth.delete_role(name)

--- a/tests/test_discord_handler.py
+++ b/tests/test_discord_handler.py
@@ -49,6 +49,9 @@ class DummyAuth:
     self.allowed = allowed
     self.roles = {"ROLE_DISCORD_BOT": 0x40}
 
+  def require_role_mask(self, name: str) -> int:
+    return self.roles[name]
+
   async def user_has_role(self, guid: str, mask: int) -> bool:
     return self.allowed
 

--- a/tests/test_discord_unbox_request.py
+++ b/tests/test_discord_unbox_request.py
@@ -28,6 +28,20 @@ class AuthModule:
   def __init__(self):
     self.roles = {"ROLE_REGISTERED": 0x1}
     self.role_registered = 0x1
+
+  async def decode_session_token(self, token: str) -> dict:
+    if token != "valid":
+      raise ValueError("invalid token")
+    return {"sub": "service-guid", "provider": "discord"}
+
+  async def get_user_roles(self, guid: str):
+    return (["ROLE_REGISTERED"], 0x1)
+
+  def require_role_mask(self, name: str) -> int:
+    if name not in self.roles:
+      raise KeyError(f"Role {name} is not defined")
+    return self.roles[name]
+
   async def get_discord_user_security(self, discord_id: str):
     guid = str(uuid.uuid5(uuid.NAMESPACE_URL, f"discord:{discord_id}"))
     return (guid, ["ROLE_REGISTERED"], 0x1)
@@ -36,7 +50,34 @@ modules_pkg.auth_module = auth_module_pkg
 sys.modules['server.modules.auth_module'] = auth_module_pkg
 
 
-def test_unbox_request_with_discord_id():
+def _headers_with_token(**extra):
+  headers = {"Authorization": "Bearer valid"}
+  headers.update({k: str(v) for k, v in extra.items()})
+  return headers
+
+
+def test_unbox_request_requires_token_for_discord():
+  if 'rpc.helpers' in sys.modules:
+    del sys.modules['rpc.helpers']
+  helpers = importlib.import_module('rpc.helpers')
+
+  app = FastAPI()
+  app.state.auth = AuthModule()
+
+  @app.post('/rpc')
+  async def endpoint(request: Request):
+    await helpers.unbox_request(request)
+    return {}
+
+  client = TestClient(app)
+  resp = client.post(
+    '/rpc',
+    json={'op': 'urn:discord:command:get_roles:1'},
+  )
+  assert resp.status_code == 401
+
+
+def test_unbox_request_with_discord_header_and_token():
   if 'rpc.helpers' in sys.modules:
     del sys.modules['rpc.helpers']
   helpers = importlib.import_module('rpc.helpers')
@@ -53,62 +94,11 @@ def test_unbox_request_with_discord_id():
   resp = client.post(
     '/rpc',
     json={'op': 'urn:discord:command:get_roles:1'},
-    headers={'x-discord-id': '42'}
+    headers=_headers_with_token(**{'x-discord-id': '42'})
   )
   assert resp.status_code == 200
   data = resp.json()
   expected_guid = str(uuid.uuid5(uuid.NAMESPACE_URL, 'discord:42'))
-  assert data['user_guid'] == expected_guid
-  assert data['roles'] == ['ROLE_REGISTERED']
-
-
-def test_unbox_request_with_discord_user_id():
-  if 'rpc.helpers' in sys.modules:
-    del sys.modules['rpc.helpers']
-  helpers = importlib.import_module('rpc.helpers')
-
-  app = FastAPI()
-  app.state.auth = AuthModule()
-
-  @app.post('/rpc')
-  async def endpoint(request: Request):
-    rpc_request, auth_ctx, _ = await helpers.unbox_request(request)
-    return {'user_guid': rpc_request.user_guid, 'roles': auth_ctx.roles}
-
-  client = TestClient(app)
-  resp = client.post(
-    '/rpc',
-    json={'op': 'urn:discord:command:get_roles:1'},
-    headers={'x-discord-user-id': '99'}
-  )
-  assert resp.status_code == 200
-  data = resp.json()
-  expected_guid = str(uuid.uuid5(uuid.NAMESPACE_URL, 'discord:99'))
-  assert data['user_guid'] == expected_guid
-  assert data['roles'] == ['ROLE_REGISTERED']
-
-
-def test_unbox_request_with_payload_discord_id():
-  if 'rpc.helpers' in sys.modules:
-    del sys.modules['rpc.helpers']
-  helpers = importlib.import_module('rpc.helpers')
-
-  app = FastAPI()
-  app.state.auth = AuthModule()
-
-  @app.post('/rpc')
-  async def endpoint(request: Request):
-    rpc_request, auth_ctx, _ = await helpers.unbox_request(request)
-    return {'user_guid': rpc_request.user_guid, 'roles': auth_ctx.roles}
-
-  client = TestClient(app)
-  resp = client.post(
-    '/rpc',
-    json={'op': 'urn:discord:command:get_roles:1', 'payload': {'discord_id': '123'}},
-  )
-  assert resp.status_code == 200
-  data = resp.json()
-  expected_guid = str(uuid.uuid5(uuid.NAMESPACE_URL, 'discord:123'))
   assert data['user_guid'] == expected_guid
   assert data['roles'] == ['ROLE_REGISTERED']
 
@@ -136,9 +126,32 @@ def test_unbox_request_with_context_discord_id():
   resp = client.post(
     '/rpc',
     json={'op': 'urn:discord:command:get_roles:1'},
+    headers=_headers_with_token()
   )
   assert resp.status_code == 200
   data = resp.json()
   expected_guid = str(uuid.uuid5(uuid.NAMESPACE_URL, 'discord:555'))
   assert data['user_guid'] == expected_guid
   assert data['roles'] == ['ROLE_REGISTERED']
+
+
+def test_unbox_request_rejects_payload_discord_id():
+  if 'rpc.helpers' in sys.modules:
+    del sys.modules['rpc.helpers']
+  helpers = importlib.import_module('rpc.helpers')
+
+  app = FastAPI()
+  app.state.auth = AuthModule()
+
+  @app.post('/rpc')
+  async def endpoint(request: Request):
+    rpc_request, auth_ctx, _ = await helpers.unbox_request(request)
+    return {'user_guid': rpc_request.user_guid, 'roles': auth_ctx.roles}
+
+  client = TestClient(app)
+  resp = client.post(
+    '/rpc',
+    json={'op': 'urn:discord:command:get_roles:1', 'payload': {'discord_id': '123'}},
+    headers=_headers_with_token()
+  )
+  assert resp.status_code == 401

--- a/tests/test_rpc_helpers.py
+++ b/tests/test_rpc_helpers.py
@@ -38,7 +38,21 @@ sys.modules['server'] = server_pkg
 
 from rpc.helpers import unbox_request
 
+class DummyAuth:
+  role_registered = 1
+
+  async def decode_session_token(self, token):
+    raise NotImplementedError
+
+  async def get_user_roles(self, guid):
+    return ([], 0)
+
+  def require_role_mask(self, name):
+    return 1
+
+
 app = FastAPI()
+app.state.auth = DummyAuth()
 
 @app.post('/rpc')
 async def parse_rpc(request: Request):

--- a/tests/test_service_roles_services.py
+++ b/tests/test_service_roles_services.py
@@ -127,9 +127,17 @@ class RoleCache:
 
   def names_to_mask(self, names):
     mask = 0
+    missing = [n for n in names if n not in self.roles]
+    if missing:
+      raise KeyError(f"Undefined roles: {', '.join(missing)}")
     for n in names:
-      mask |= self.roles.get(n, 0)
+      mask |= self.roles[n]
     return mask
+
+  def require_role_mask(self, name):
+    if name not in self.roles:
+      raise KeyError(f"Role {name} is not defined")
+    return self.roles[name]
 
   async def user_has_role(self, guid: str, mask: int) -> bool:
     return bool(self.user_roles.get(guid, 0) & mask)
@@ -157,6 +165,9 @@ class DummyAuth:
 
   def names_to_mask(self, names):
     return self.role_cache.names_to_mask(names)
+
+  def require_role_mask(self, name):
+    return self.role_cache.require_role_mask(name)
 
   async def user_has_role(self, guid: str, mask: int) -> bool:
     return await self.role_cache.user_has_role(guid, mask)

--- a/tests/test_service_routes_services.py
+++ b/tests/test_service_routes_services.py
@@ -43,8 +43,11 @@ class RoleCache:
 
   def names_to_mask(self, names):
     mask = 0
+    missing = [n for n in names if n not in self.roles]
+    if missing:
+      raise KeyError(f"Undefined roles: {', '.join(missing)}")
     for n in names:
-      mask |= self.roles.get(n, 0)
+      mask |= self.roles[n]
     return mask
 
 class AuthModule:


### PR DESCRIPTION
## Summary
- add a shared RPC identity validator that enforces token or mTLS assertions, logs audits, and unifies Discord ingress handling
- tighten role resolution to raise on undefined roles and reuse a helper across RPC handlers and supporting modules
- update tests to cover the stricter Discord authorization and shared helper changes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0923da118832594ffd4ba83325ea2