### PR TITLE
Introduce RPC auth service facades and boundary tests

### DIFF
--- a/rpc/account/handler.py
+++ b/rpc/account/handler.py
@@ -5,15 +5,16 @@ Handles account operations requiring ROLE_ACCOUNT_ADMIN.
 
 from fastapi import HTTPException, Request
 
+from rpc.dependencies import get_auth_service
 from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
-from server.modules.auth_module import AuthModule
+from server.modules import AuthService
 from . import HANDLERS
 
 
 async def handle_account_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
-  auth: AuthModule = request.app.state.auth
+  auth: AuthService = get_auth_service(request)
   required_mask = resolve_required_mask(auth, "ROLE_ACCOUNT_ADMIN")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail="Forbidden")

--- a/rpc/dependencies.py
+++ b/rpc/dependencies.py
@@ -1,0 +1,20 @@
+"""Helper dependencies for RPC handlers."""
+
+from fastapi import HTTPException, Request
+
+from server.modules import AuthService, ModuleServices
+
+
+def get_module_services(request: Request) -> ModuleServices:
+  services = getattr(request.app.state, "services", None)
+  if not services:
+    raise HTTPException(status_code=500, detail="Service registry unavailable")
+  return services
+
+
+def get_auth_service(request: Request) -> AuthService:
+  services = get_module_services(request)
+  auth = getattr(services, "auth", None)
+  if not auth:
+    raise HTTPException(status_code=500, detail="Authentication service unavailable")
+  return auth

--- a/rpc/discord/handler.py
+++ b/rpc/discord/handler.py
@@ -2,9 +2,10 @@
 
 from fastapi import HTTPException, Request
 
+from rpc.dependencies import get_auth_service
 from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
-from server.modules.auth_module import AuthModule
+from server.modules import AuthService
 
 from . import FORBIDDEN_DETAILS, HANDLERS, REQUIRED_ROLES
 
@@ -15,7 +16,7 @@ async def handle_discord_request(parts: list[str], request: Request) -> RPCRespo
   if not handler:
     raise HTTPException(status_code=404, detail='Unknown RPC subdomain')
   _, auth_ctx, _ = await unbox_request(request)
-  auth: AuthModule = request.app.state.auth
+  auth: AuthService = get_auth_service(request)
   role_name = REQUIRED_ROLES.get(subdomain)
   required_mask = resolve_required_mask(auth, role_name) if role_name else 0
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):

--- a/rpc/helpers.py
+++ b/rpc/helpers.py
@@ -8,7 +8,7 @@ from server.models import AuthContext
 from server.models import RPCRequest
 
 if TYPE_CHECKING:
-  from server.modules.auth_module import AuthModule
+  from server.modules import AuthService
 
 
 def mask_to_bit(mask: int) -> int:
@@ -52,7 +52,7 @@ def _get_mtls_subject(request: Request) -> str | None:
   return None
 
 
-def resolve_required_mask(auth: AuthModule, role_name: str) -> int:
+def resolve_required_mask(auth: 'AuthService', role_name: str) -> int:
   if not role_name:
     raise HTTPException(status_code=500, detail='Role name must be provided')
   try:

--- a/rpc/moderation/handler.py
+++ b/rpc/moderation/handler.py
@@ -6,16 +6,17 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
+from rpc.dependencies import get_auth_service
 from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
-from server.modules.auth_module import AuthModule
+from server.modules import AuthService
 
 from . import HANDLERS
 
 
 async def handle_moderation_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
-  auth: AuthModule = request.app.state.auth
+  auth: AuthService = get_auth_service(request)
   required_mask = resolve_required_mask(auth, "ROLE_MODERATOR")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')

--- a/rpc/service/handler.py
+++ b/rpc/service/handler.py
@@ -6,16 +6,17 @@ Handles service operations requiring ROLE_SERVICE_ADMIN.
 
 from fastapi import HTTPException, Request
 
+from rpc.dependencies import get_auth_service
 from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
-from server.modules.auth_module import AuthModule
+from server.modules import AuthService
 
 from . import HANDLERS
 
 
 async def handle_service_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
-  auth: AuthModule = request.app.state.auth
+  auth: AuthService = get_auth_service(request)
   required_mask = resolve_required_mask(auth, "ROLE_SERVICE_ADMIN")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail="Forbidden")

--- a/rpc/storage/handler.py
+++ b/rpc/storage/handler.py
@@ -6,16 +6,17 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
+from rpc.dependencies import get_auth_service
 from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
-from server.modules.auth_module import AuthModule
+from server.modules import AuthService
 
 from . import HANDLERS
 
 
 async def handle_storage_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
-  auth: AuthModule = request.app.state.auth
+  auth: AuthService = get_auth_service(request)
   required_mask = resolve_required_mask(auth, "ROLE_STORAGE")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')

--- a/rpc/support/handler.py
+++ b/rpc/support/handler.py
@@ -6,16 +6,17 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
+from rpc.dependencies import get_auth_service
 from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
-from server.modules.auth_module import AuthModule
+from server.modules import AuthService
 
 from . import HANDLERS
 
 
 async def handle_support_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
-  auth: AuthModule = request.app.state.auth
+  auth: AuthService = get_auth_service(request)
   required_mask = resolve_required_mask(auth, "ROLE_SUPPORT")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')

--- a/rpc/system/handler.py
+++ b/rpc/system/handler.py
@@ -6,16 +6,17 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
+from rpc.dependencies import get_auth_service
 from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
-from server.modules.auth_module import AuthModule
+from server.modules import AuthService
 
 from . import HANDLERS
 
 
 async def handle_system_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
-  auth: AuthModule = request.app.state.auth
+  auth: AuthService = get_auth_service(request)
   required_mask = resolve_required_mask(auth, "ROLE_SYSTEM_ADMIN")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail="Forbidden")

--- a/rpc/users/handler.py
+++ b/rpc/users/handler.py
@@ -6,16 +6,17 @@ Auth and public domains are exempt from role checks.
 
 from fastapi import HTTPException, Request
 
+from rpc.dependencies import get_auth_service
 from rpc.helpers import resolve_required_mask, unbox_request
 from server.models import RPCResponse
-from server.modules.auth_module import AuthModule
+from server.modules import AuthService
 
 from . import HANDLERS
 
 
 async def handle_users_request(parts: list[str], request: Request) -> RPCResponse:
   _, auth_ctx, _ = await unbox_request(request)
-  auth: AuthModule = request.app.state.auth
+  auth: AuthService = get_auth_service(request)
   required_mask = resolve_required_mask(auth, "ROLE_REGISTERED")
   if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
     raise HTTPException(status_code=403, detail='Forbidden')

--- a/server/modules/__init__.py
+++ b/server/modules/__init__.py
@@ -1,11 +1,37 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from types import SimpleNamespace
+from typing import Dict, Optional, Protocol, runtime_checkable
+
 from fastapi import FastAPI
-from typing import Dict
+
 from server.helpers.strings import camel_case
 import asyncio, os, importlib
 from server.registry import RegistryDispatcher
 
 MODULES_FOLDER = os.path.dirname(__file__)
+
+
+class ModuleServices(SimpleNamespace):
+  """Container for RPC-facing service facades."""
+
+  def require(self, name: str):
+    service = getattr(self, name, None)
+    if not service:
+      raise RuntimeError(f"Service facade '{name}' is not registered")
+    return service
+
+
+@runtime_checkable
+class AuthService(Protocol):
+  """RPC-safe authentication service facade."""
+
+  def require_role_mask(self, name: str) -> int:
+    ...
+
+  async def user_has_role(self, guid: str, required_mask: int) -> bool:
+    ...
 
 class BaseModule(ABC):
   def __init__(self, app: FastAPI):
@@ -26,13 +52,19 @@ class BaseModule(ABC):
   async def on_ready(self):
     await self._ready_event.wait()
 
+  def create_service(self) -> Optional[object]:
+    """Return an optional RPC-facing facade for this module."""
+    return None
+
 class ModuleManager:
   def __init__(self, app: FastAPI):
     self.app = app
     self.instances: Dict[str, BaseModule] = {}
+    self.services = ModuleServices()
     self.registry = RegistryDispatcher()
     self.registry.initialise()
     setattr(app.state, "registry", self.registry)
+    setattr(app.state, "services", self.services)
 
     for fname in os.listdir(MODULES_FOLDER):
       if not fname.endswith("_module.py") or fname == "__init__.py":
@@ -54,6 +86,10 @@ class ModuleManager:
 
       setattr(app.state, module_name, instance)
       self.instances[module_name] = instance
+
+      service = instance.create_service()
+      if service is not None:
+        setattr(self.services, module_name, service)
 
   async def startup_all(self):
     await asyncio.gather(*(mod.startup() for mod in self.instances.values()))

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Authentication module handling login and token workflows."""
 
 import base64, logging, uuid
@@ -6,7 +8,7 @@ from fastapi import FastAPI, HTTPException, status
 from jose import jwt, JWTError, ExpiredSignatureError
 from typing import Any, Dict
 
-from server.modules import BaseModule
+from server.modules import BaseModule, AuthService
 from server.modules.env_module import EnvModule
 from server.modules.db_module import DbModule
 from server.modules.providers import AuthProviderBase
@@ -160,6 +162,23 @@ class RoleCache:
     await self.get_user_security_profile(guid, refresh=True)
 
 
+class _AuthServiceFacade:
+  def __init__(self, module: AuthModule | None = None):
+    self._module = module
+
+  def bind(self, module: AuthModule):
+    self._module = module
+    return self
+
+  def require_role_mask(self, name: str) -> int:
+    assert self._module, "Auth module is not bound"
+    return self._module.require_role_mask(name)
+
+  async def user_has_role(self, guid: str, required_mask: int) -> bool:
+    assert self._module, "Auth module is not bound"
+    return await self._module.user_has_role(guid, required_mask)
+
+
 class AuthModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
@@ -169,6 +188,7 @@ class AuthModule(BaseModule):
     self.jwks_cache_minutes: int = 60
     self.role_cache = RoleCache()
     self.discord: DiscordBotModule | None = None
+    self._service_facade = _AuthServiceFacade(self)
 
   @property
   def roles(self) -> dict[str, int]:
@@ -189,6 +209,9 @@ class AuthModule(BaseModule):
   @property
   def _user_security(self) -> dict[str, dict[str, Any]]:
     return self.role_cache._user_security
+
+  def create_service(self) -> AuthService:
+    return self._service_facade.bind(self)
 
   async def startup(self):
     self.env: EnvModule = self.app.state.env

--- a/tests/test_rpc_handler_facades.py
+++ b/tests/test_rpc_handler_facades.py
@@ -1,0 +1,102 @@
+import asyncio
+import ast
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from starlette.requests import Request
+
+from server.modules import ModuleServices
+
+
+HANDLER_PATHS = list(Path('rpc').glob('*/handler.py'))
+
+
+def _iter_handler_paths():
+  for path in HANDLER_PATHS:
+    yield path
+  yield Path('rpc/handler.py')
+
+
+def test_rpc_handlers_do_not_import_module_internals():
+  for path in _iter_handler_paths():
+    if not path.exists():
+      continue
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+      if isinstance(node, ast.Import):
+        for alias in node.names:
+          if alias.name.startswith('server.modules.'):
+            pytest.fail(f"{path} imports module internals via '{alias.name}'")
+      if isinstance(node, ast.ImportFrom):
+        module = node.module or ''
+        if module.startswith('server.modules') and module != 'server.modules':
+          pytest.fail(f"{path} imports module internals via '{module}'")
+
+
+class _DenyAuthService:
+  def __init__(self):
+    self.required_names: list[str] = []
+
+  def require_role_mask(self, name: str) -> int:
+    self.required_names.append(name)
+    return 1
+
+  async def user_has_role(self, guid: str, required_mask: int) -> bool:
+    return False
+
+
+@pytest.mark.parametrize('module_name, handler_name', [
+  ('rpc.account.handler', 'handle_account_request'),
+  ('rpc.moderation.handler', 'handle_moderation_request'),
+  ('rpc.service.handler', 'handle_service_request'),
+  ('rpc.storage.handler', 'handle_storage_request'),
+  ('rpc.support.handler', 'handle_support_request'),
+  ('rpc.system.handler', 'handle_system_request'),
+  ('rpc.users.handler', 'handle_users_request'),
+  ('rpc.discord.handler', 'handle_discord_request'),
+])
+def test_rpc_handlers_deny_unauthorised_access(monkeypatch, module_name, handler_name):
+  module = importlib.import_module(module_name)
+  handler = getattr(module, handler_name)
+
+  call_tracker = {'invoked': False}
+
+  async def noop_handler(parts, request):
+    call_tracker['invoked'] = True
+
+  monkeypatch.setattr(module, 'HANDLERS', {'noop': noop_handler})
+  if hasattr(module, 'REQUIRED_ROLES'):
+    monkeypatch.setattr(module, 'REQUIRED_ROLES', {'noop': 'ROLE_TEST'})
+  if hasattr(module, 'FORBIDDEN_DETAILS'):
+    monkeypatch.setattr(module, 'FORBIDDEN_DETAILS', {})
+
+  async def fake_unbox_request(request):
+    return SimpleNamespace(op='urn:test', version='1'), SimpleNamespace(user_guid='user', role_mask=0), []
+
+  monkeypatch.setattr(module, 'unbox_request', fake_unbox_request)
+
+  app = FastAPI()
+  services = ModuleServices()
+  app.state.services = services
+  services.auth = _DenyAuthService()
+
+  scope = {
+    'type': 'http',
+    'http_version': '1.1',
+    'scheme': 'http',
+    'app': app,
+    'headers': [],
+    'path': '/',
+    'method': 'POST',
+    'query_string': b'',
+  }
+  request = Request(scope)
+
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(handler(['noop'], request))
+
+  assert exc.value.status_code == 403
+  assert call_tracker['invoked'] is False


### PR DESCRIPTION
## Summary
- register RPC-safe module facades on the FastAPI app state and expose an authentication service interface
- switch RPC domain handlers to resolve the shared auth facade via helper dependencies instead of importing module internals
- add tests that enforce handler boundary imports and validate 403 responses when authorization fails

## Testing
- pytest tests/test_rpc_handler_facades.py

------
https://chatgpt.com/codex/tasks/task_e_68e118d0f39083258ea2b0c332aefec1