### PR TITLE
Enforce registry and RPC schema validation

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -1,7 +1,50 @@
-from datetime import datetime, timezone
-from typing import Any, Optional
+from __future__ import annotations
 
-from pydantic import BaseModel, Field
+import re
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from uuid import UUID
+from typing import Any, Optional, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+JSONPrimitive: TypeAlias = None | bool | int | float | str
+JSONValue: TypeAlias = Any
+
+URN_PATTERN = re.compile(r"^urn:(?:[a-z0-9_]+:){3,}[0-9]+$")
+
+__all__ = [
+  "AuthContext",
+  "JSONValue",
+  "RPCError",
+  "RPCRequest",
+  "RPCResponse",
+  "ensure_json_serializable",
+]
+
+
+def ensure_json_serializable(value: Any, *, field_name: str) -> JSONValue:
+  """Ensure the provided value can be serialised as JSON."""
+
+  if value is None or isinstance(value, (str, int, float, bool)):
+    return value
+  if isinstance(value, (datetime, date)):
+    return value.isoformat()
+  if isinstance(value, UUID):
+    return str(value)
+  if isinstance(value, Decimal):
+    return float(value)
+  if isinstance(value, Mapping):
+    return {
+      str(key): ensure_json_serializable(sub_value, field_name=field_name)
+      for key, sub_value in value.items()
+    }
+  if isinstance(value, set):
+    return [ensure_json_serializable(item, field_name=field_name) for item in value]
+  if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+    return [ensure_json_serializable(item, field_name=field_name) for item in value]
+  raise TypeError(f"{field_name} must be JSON-serializable")
 
 
 class AuthContext(BaseModel):
@@ -19,10 +62,20 @@ user GUID, we then look up their security details in the DB
 and populate the below data structure which shepherds the
 request internally until a response is generated.
 """
+class RPCError(BaseModel):
+  """Structured error returned from RPC handlers."""
+
+  code: str
+  message: str
+  details: JSONValue | None = None
+
+  model_config = ConfigDict(frozen=True, extra="forbid")
+
+
 class RPCRequest(BaseModel):
-  op: str
-  payload: Optional[dict[str, Any]] = None
-  version: int = 1
+  op: str = Field(pattern=URN_PATTERN.pattern)
+  payload: JSONValue | None = None
+  version: int
 
   timestamp: Optional[datetime] = Field(
     default_factory=lambda: datetime.now(timezone.utc),
@@ -42,17 +95,71 @@ class RPCRequest(BaseModel):
     description="Bitmask representing user roles",
   )
 
+  model_config = ConfigDict(extra="forbid")
+
+  @field_validator("payload")
+  @classmethod
+  def _validate_payload(cls, value: Any | None):
+    if value is None:
+      return None
+    return ensure_json_serializable(value, field_name="payload")
+
+  @model_validator(mode="after")
+  def _validate_version(self):
+    parts = self.op.split(":")
+    if len(parts) < 5:
+      raise ValueError("op must include domain, subdomain, name, and version segments")
+    version_segment = parts[-1]
+    try:
+      op_version = int(version_segment)
+    except ValueError as exc:  # pragma: no cover - guarded by regex but defensive
+      raise ValueError("op must terminate with an integer version segment") from exc
+    if self.version != op_version:
+      raise ValueError("version must match the operation version suffix")
+    return self
+
 
 """
 This is the internal RPC response class and contains the main
 payload to be packaged into the server response object.
 """
 class RPCResponse(BaseModel):
-  op: str
-  payload: Any
-  version: int = 1
+  op: str = Field(pattern=URN_PATTERN.pattern)
+  payload: Any | None = None
+  error: RPCError | None = None
+  version: int
 
   timestamp: Optional[datetime] = Field(
     default_factory=lambda: datetime.now(timezone.utc),
     description="Server UTC timestamp of response generation",
   )
+
+  model_config = ConfigDict(extra="forbid")
+
+  @field_validator("payload")
+  @classmethod
+  def _validate_payload(cls, value: Any | None):
+    if value is None:
+      return None
+    return ensure_json_serializable(value, field_name="payload")
+
+  @field_validator("error")
+  @classmethod
+  def _freeze_error(cls, value: RPCError | None):
+    return value
+
+  @model_validator(mode="after")
+  def _validate_version(self):
+    parts = self.op.split(":")
+    if len(parts) < 5:
+      raise ValueError("op must include domain, subdomain, name, and version segments")
+    version_segment = parts[-1]
+    try:
+      op_version = int(version_segment)
+    except ValueError as exc:  # pragma: no cover
+      raise ValueError("op must terminate with an integer version segment") from exc
+    if self.version != op_version:
+      raise ValueError("version must match the operation version suffix")
+    if self.error and self.payload is not None:
+      raise ValueError("payload must be null when an error is supplied")
+    return self

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -70,7 +70,7 @@ class DbModule(BaseModule):
         payload = response.model_dump() if hasattr(response, "model_dump") else response
         validated = DBResultCls.model_validate(payload)
         response = DBResponse.from_result(validated)
-    return response.to_result()
+    return response.to_result(result_cls=DBResultCls)
 
   async def startup(self):
     env: EnvModule = self.app.state.env

--- a/server/modules/discord_bot_module.py
+++ b/server/modules/discord_bot_module.py
@@ -215,7 +215,11 @@ class DiscordBotModule(BaseModule):
     channel_id = metadata.get("channel_id")
     if channel_id:
       headers["X-Discord-Channel-Id"] = str(channel_id)
-    body = {"op": op}
+    try:
+      version = int(op.split(":")[-1])
+    except (ValueError, IndexError) as exc:
+      raise ValueError(f"Invalid RPC operation key: {op}") from exc
+    body = {"op": op, "version": version}
     if payload is not None:
       body["payload"] = payload
     async with aiohttp.ClientSession() as session:

--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -61,4 +61,4 @@ class MssqlProvider(DbProviderBase):
         f"Handler '{op}' returned unsupported result type: {type(response)!r}."
         " Expected DBResponse."
       )
-    return response.to_result()
+    return response.to_result(result_cls=DBResult)

--- a/server/registry/types.py
+++ b/server/registry/types.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import re
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from server.modules.providers import DBResult, get_dbresult_cls
+try:  # pragma: no cover - fallback for test stubs
+  from server.models import ensure_json_serializable
+except ImportError:  # pragma: no cover - simplified validation for isolated tests
+  def ensure_json_serializable(value: Any, *, field_name: str) -> Any:
+    return value
+from server.modules.providers import DBResult
 
 __all__ = [
   "DBRequest",
@@ -14,16 +22,48 @@ __all__ = [
   "DBResult",
 ]
 
+DB_PATTERN = re.compile(r"^db:(?:[a-z0-9_]+:){3,}[0-9]+$")
+
+
 class DBRequest(BaseModel):
   """Payload describing a database registry operation."""
 
-  op: str
+  op: str = Field(pattern=DB_PATTERN.pattern)
   params: dict[str, Any] = Field(default_factory=dict)
-  metadata: dict[str, Any] | None = None
+  metadata: Mapping[str, Any] | None = None
 
-  class Config:
-    frozen = True
-    arbitrary_types_allowed = True
+  model_config = ConfigDict(frozen=True)
+
+  @field_validator("params")
+  @classmethod
+  def _validate_params(cls, value: dict[str, Any]):
+    return {
+      str(key): ensure_json_serializable(param_value, field_name=f"params['{key}']")
+      for key, param_value in value.items()
+    }
+
+  @field_validator("metadata")
+  @classmethod
+  def _freeze_metadata(cls, value: Mapping[str, Any] | None):
+    if value is None:
+      return None
+    frozen = {
+      str(key): ensure_json_serializable(meta_value, field_name=f"metadata['{key}']")
+      for key, meta_value in value.items()
+    }
+    return MappingProxyType(frozen)
+
+  @model_validator(mode="after")
+  def _validate_op(self):
+    parts = self.op.split(":")
+    if len(parts) < 5:
+      raise ValueError("op must include domain, subdomain, name, and version segments")
+    version_segment = parts[-1]
+    try:
+      int(version_segment)
+    except ValueError as exc:  # pragma: no cover
+      raise ValueError("op must terminate with an integer version segment") from exc
+    return self
 
 
 class DBResponse(BaseModel):
@@ -37,7 +77,5 @@ class DBResponse(BaseModel):
   def from_result(cls, result: DBResult, *, meta: dict[str, Any] | None = None) -> "DBResponse":
     return cls(rows=list(result.rows), rowcount=result.rowcount, meta=meta)
 
-  def to_result(self) -> DBResult:
-    DBResultCls = _DBRESULT_CLASS or get_dbresult_cls()
-    return DBResultCls(rows=list(self.rows), rowcount=self.rowcount)
-_DBRESULT_CLASS = DBResult
+  def to_result(self, *, result_cls: type[DBResult]) -> DBResult:
+    return result_cls(rows=list(self.rows), rowcount=self.rowcount)

--- a/tests/test_db_module_init.py
+++ b/tests/test_db_module_init.py
@@ -48,7 +48,7 @@ def test_db_module_run_propagates_query_error():
   db.set_registry(registry)
 
   with pytest.raises(DBQueryError) as exc:
-    asyncio.run(db.run(DBRequest(op="db:test:error", params={})))
+    asyncio.run(db.run(DBRequest(op="db:test:error:trigger:1", params={})))
   assert exc.value.detail == detail
 
 
@@ -121,13 +121,13 @@ def test_db_module_run_constructs_registry_request():
   registry = RecordingRegistry()
   db.set_registry(registry)
 
-  result = asyncio.run(db.run(DBRequest(op="db:test:op", params={"key": "value"})))
+  result = asyncio.run(db.run(DBRequest(op="db:test:ops:trigger:1", params={"key": "value"})))
 
   assert result.rows == [{"ok": True}]
   assert result.rowcount == 1
   assert len(registry.requests) == 1
   request = registry.requests[0]
-  assert request.op == "db:test:op"
+  assert request.op == "db:test:ops:trigger:1"
   assert request.params == {"key": "value"}
 
 

--- a/tests/test_discord_bot_commands.py
+++ b/tests/test_discord_bot_commands.py
@@ -80,7 +80,7 @@ def test_summarize_command(monkeypatch):
 
   async def dummy_call_rpc(self, op, payload=None, *, metadata=None):
     rpc_calls.append((op, payload, metadata))
-    return RPCResponse(op=op, payload=responses[op])
+    return RPCResponse(op=op, payload=responses[op], version=1)
 
   monkeypatch.setattr(DiscordBotModule, "call_rpc", dummy_call_rpc)
 
@@ -129,7 +129,7 @@ def test_summarize_command_empty_history(monkeypatch):
 
   async def dummy_call_rpc(self, op, payload=None, *, metadata=None):
     rpc_calls.append((op, payload, metadata))
-    return RPCResponse(op=op, payload=responses[op])
+    return RPCResponse(op=op, payload=responses[op], version=1)
 
   monkeypatch.setattr(DiscordBotModule, "call_rpc", dummy_call_rpc)
 
@@ -165,7 +165,7 @@ def test_summarize_command_cap_hit(monkeypatch):
 
   async def dummy_call_rpc(self, op, payload=None, *, metadata=None):
     rpc_calls.append((op, payload, metadata))
-    return RPCResponse(op=op, payload=responses[op])
+    return RPCResponse(op=op, payload=responses[op], version=1)
 
   monkeypatch.setattr(DiscordBotModule, "call_rpc", dummy_call_rpc)
 
@@ -241,7 +241,7 @@ def test_persona_command_workflow(monkeypatch):
 
   async def dummy_call_rpc(self, op, payload=None, *, metadata=None):
     rpc_calls.append((op, payload, metadata))
-    return RPCResponse(op=op, payload=responses.get(op, {"success": True}))
+    return RPCResponse(op=op, payload=responses.get(op, {"success": True}), version=1)
 
   monkeypatch.setattr(DiscordBotModule, "call_rpc", dummy_call_rpc)
 

--- a/tests/test_discord_bot_macros.py
+++ b/tests/test_discord_bot_macros.py
@@ -93,7 +93,7 @@ def test_summarize_macro_dm(monkeypatch):
 
   async def dummy_call_rpc(self, op, payload=None, *, metadata=None):
     rpc_calls.append((op, payload, metadata))
-    return RPCResponse(op=op, payload=responses[op])
+    return RPCResponse(op=op, payload=responses[op], version=1)
 
   monkeypatch.setattr(DiscordBotModule, "call_rpc", dummy_call_rpc)
 

--- a/tests/test_discord_bsky_services.py
+++ b/tests/test_discord_bsky_services.py
@@ -55,7 +55,7 @@ def test_bsky_post_message_handler():
 
   async def fake_unbox(request):
     return (
-      RPCRequest(op='urn:discord:bsky:post:1', payload={'message': 'hello world'}),
+      RPCRequest(op='urn:discord:bsky:post:1', payload={'message': 'hello world'}, version=1),
       AuthContext(),
       [],
     )
@@ -68,7 +68,7 @@ def test_bsky_post_message_handler():
     return await bsky_services.discord_bsky_post_message_v1(request)
 
   client = TestClient(app)
-  resp = client.post('/rpc', json={'op': 'urn:discord:bsky:post:1'})
+  resp = client.post('/rpc', json={'op': 'urn:discord:bsky:post:1', 'version': 1})
   assert resp.status_code == 200
   assert module.ready is True
   assert module.calls == ['hello world']
@@ -91,7 +91,7 @@ def test_bsky_post_message_handler_error():
 
   async def fake_unbox(request):
     return (
-      RPCRequest(op='urn:discord:bsky:post:1', payload={'message': 'hello world'}),
+      RPCRequest(op='urn:discord:bsky:post:1', payload={'message': 'hello world'}, version=1),
       AuthContext(),
       [],
     )
@@ -104,7 +104,7 @@ def test_bsky_post_message_handler_error():
     return await bsky_services.discord_bsky_post_message_v1(request)
 
   client = TestClient(app)
-  resp = client.post('/rpc', json={'op': 'urn:discord:bsky:post:1'})
+  resp = client.post('/rpc', json={'op': 'urn:discord:bsky:post:1', 'version': 1})
   assert resp.status_code == 400
   assert module.calls == ['hello world']
   data = resp.json()

--- a/tests/test_discord_chat_services.py
+++ b/tests/test_discord_chat_services.py
@@ -121,7 +121,7 @@ def test_summarize_channel_handler():
 
   async def fake_unbox(request):
     return (
-      RPCRequest(op='urn:discord:chat:summarize_channel:1', payload={'guild_id': 1, 'channel_id': 2, 'hours': 1, 'user_id': 3}),
+      RPCRequest(op='urn:discord:chat:summarize_channel:1', payload={'guild_id': 1, 'channel_id': 2, 'hours': 1, 'user_id': 3}, version=1),
       AuthContext(),
       [],
     )
@@ -134,7 +134,7 @@ def test_summarize_channel_handler():
     return await chat_services.discord_chat_summarize_channel_v1(request)
 
   client = TestClient(app)
-  resp = client.post('/rpc', json={'op': 'urn:discord:chat:summarize_channel:1'})
+  resp = client.post('/rpc', json={'op': 'urn:discord:chat:summarize_channel:1', 'version': 1})
   assert resp.status_code == 200
   assert module.summary_called
   assert len(module.delivery_calls) == 1
@@ -175,6 +175,7 @@ def test_persona_response_handler():
           'channel_id': 2,
           'user_id': 3,
         },
+        version=1,
       ),
       AuthContext(),
       [],
@@ -188,7 +189,7 @@ def test_persona_response_handler():
     return await chat_services.discord_chat_persona_response_v1(request)
 
   client = TestClient(app)
-  resp = client.post('/rpc', json={'op': 'urn:discord:chat:persona_response:1'})
+  resp = client.post('/rpc', json={'op': 'urn:discord:chat:persona_response:1', 'version': 1})
   assert resp.status_code == 200
   assert module.calls == [('stark', 'Tell me about rain', 1, 2, 3)]
   data = resp.json()
@@ -226,6 +227,7 @@ def test_persona_response_handler_uses_openai_results():
           'channel_id': 2,
           'user_id': 3,
         },
+        version=1,
       ),
       AuthContext(),
       [],
@@ -239,7 +241,7 @@ def test_persona_response_handler_uses_openai_results():
     return await chat_services.discord_chat_persona_response_v1(request)
 
   client = TestClient(app)
-  resp = client.post('/rpc', json={'op': 'urn:discord:chat:persona_response:1'})
+  resp = client.post('/rpc', json={'op': 'urn:discord:chat:persona_response:1', 'version': 1})
   assert resp.status_code == 200
   assert module.calls == [('stark', 'Tell me about rain', 1, 2, 3)]
   data = resp.json()

--- a/tests/test_discord_command_get_roles_service.py
+++ b/tests/test_discord_command_get_roles_service.py
@@ -40,7 +40,7 @@ client = TestClient(app)
 def test_discord_command_get_roles_service():
   async def _stub_unbox_request(request):
     return (
-      RPCRequest(op='urn:discord:command:get_roles:1'),
+      RPCRequest(op='urn:discord:command:get_roles:1', version=1),
       AuthContext(user_guid='u1', roles=['ROLE_STORAGE'], role_mask=0x2),
       [],
     )
@@ -48,7 +48,7 @@ def test_discord_command_get_roles_service():
   original = discord_services.unbox_request
   discord_services.unbox_request = _stub_unbox_request
   try:
-    resp = client.post('/rpc', json={'op': 'urn:discord:command:get_roles:1'})
+    resp = client.post('/rpc', json={'op': 'urn:discord:command:get_roles:1', 'version': 1})
   finally:
     discord_services.unbox_request = original
   assert resp.status_code == 200

--- a/tests/test_discord_command_service.py
+++ b/tests/test_discord_command_service.py
@@ -28,7 +28,7 @@ from rpc.discord.command import services as discord_services
 
 
 async def _stub_unbox_request(request):
-  return RPCRequest(op='urn:discord:command:get_roles:1'), AuthContext(roles=['ROLE_A']), []
+  return RPCRequest(op='urn:discord:command:get_roles:1', version=1), AuthContext(roles=['ROLE_A']), []
 
 discord_services.unbox_request = _stub_unbox_request
 
@@ -44,7 +44,7 @@ client = TestClient(app)
 
 
 def test_discord_command_get_roles_service():
-  resp = client.post('/rpc', json={'op': 'urn:discord:command:get_roles:1'})
+  resp = client.post('/rpc', json={'op': 'urn:discord:command:get_roles:1', 'version': 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data['op'] == 'urn:discord:command:get_roles:1'

--- a/tests/test_discord_handler.py
+++ b/tests/test_discord_handler.py
@@ -1,3 +1,4 @@
+import importlib
 import importlib.util
 import pathlib
 import sys
@@ -8,6 +9,7 @@ from fastapi.testclient import TestClient
 # Stub rpc package to avoid side effects from rpc.__init__
 pkg = types.ModuleType('rpc')
 pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc')]
+pkg.HANDLERS = {}
 sys.modules.setdefault('rpc', pkg)
 
 # Load server models
@@ -26,8 +28,7 @@ AuthContext = models.AuthContext
 RPCResponse = models.RPCResponse
 
 # Stub server modules
-modules_pkg = types.ModuleType('server.modules')
-sys.modules.setdefault('server.modules', modules_pkg)
+modules_pkg = importlib.import_module('server.modules')
 auth_module_pkg = types.ModuleType('server.modules.auth_module')
 class AuthModule: ...
 auth_module_pkg.AuthModule = AuthModule
@@ -37,7 +38,7 @@ sys.modules['server.modules.auth_module'] = auth_module_pkg
 from rpc.discord import handler as discord_handler
 
 async def _stub_unbox_request(request):
-  return RPCRequest(op='urn:discord:command:get_roles:1'), AuthContext(user_guid='u1'), []
+  return RPCRequest(op='urn:discord:command:get_roles:1', version=1), AuthContext(user_guid='u1'), []
 
 discord_handler.unbox_request = _stub_unbox_request
 
@@ -68,7 +69,7 @@ def _get_client(allowed: bool):
 
 def test_discord_handler_rejects_missing_role():
   client = _get_client(False)
-  resp = client.post('/rpc', json={'op': 'urn:discord:command:get_roles:1'})
+  resp = client.post('/rpc', json={'op': 'urn:discord:command:get_roles:1', 'version': 1})
   assert resp.status_code == 403
   data = resp.json()
   assert (
@@ -78,7 +79,7 @@ def test_discord_handler_rejects_missing_role():
 
 def test_discord_handler_allows_role():
   client = _get_client(True)
-  resp = client.post('/rpc', json={'op': 'urn:discord:command:get_roles:1'})
+  resp = client.post('/rpc', json={'op': 'urn:discord:command:get_roles:1', 'version': 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data['payload'] == {'roles': ['ROLE_A']}

--- a/tests/test_discord_personas_services.py
+++ b/tests/test_discord_personas_services.py
@@ -64,10 +64,12 @@ server_pkg.modules = modules_pkg
 
 class RPCResponse:
   def __init__(self, **data):
+    data.setdefault('error', None)
     self.__dict__.update(data)
 
 
 models_pkg.RPCResponse = RPCResponse
+models_pkg.ensure_json_serializable = lambda value, *, field_name: value
 server_pkg.models = models_pkg
 
 sys.modules.setdefault('server', server_pkg)
@@ -126,7 +128,7 @@ client = TestClient(app)
 
 
 def test_get_personas_service():
-  resp = client.post('/rpc', json={'op': 'urn:discord:personas:get_personas:1'})
+  resp = client.post('/rpc', json={'op': 'urn:discord:personas:get_personas:1', 'version': 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data['payload'] == {
@@ -144,7 +146,7 @@ def test_get_personas_service():
 
 
 def test_get_models_service():
-  resp = client.post('/rpc', json={'op': 'urn:discord:personas:get_models:1'})
+  resp = client.post('/rpc', json={'op': 'urn:discord:personas:get_models:1', 'version': 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data['payload'] == {
@@ -167,12 +169,12 @@ def test_upsert_and_delete_persona_service():
   }
   resp = client.post(
     '/rpc',
-    json={'op': 'urn:discord:personas:upsert_persona:1', 'payload': upsert_payload},
+    json={'op': 'urn:discord:personas:upsert_persona:1', 'payload': upsert_payload, 'version': 1},
   )
   assert resp.status_code == 200
   resp = client.post(
     '/rpc',
-    json={'op': 'urn:discord:personas:delete_persona:1', 'payload': {'recid': 1}},
+    json={'op': 'urn:discord:personas:delete_persona:1', 'payload': {'recid': 1}, 'version': 1},
   )
   assert resp.status_code == 200
   assert db.upserts == [upsert_payload]

--- a/tests/test_discord_rpc_client.py
+++ b/tests/test_discord_rpc_client.py
@@ -25,7 +25,7 @@ def test_call_rpc_builds_headers(monkeypatch):
       return False
 
     async def text(self):
-      return json.dumps({"op": "urn:test:op:1", "payload": {"ok": True}})
+      return json.dumps({"op": "urn:test:ops:trigger:1", "payload": {"ok": True}, "version": 1})
 
   class DummySession:
     def __init__(self, *args, **kwargs):
@@ -53,7 +53,7 @@ def test_call_rpc_builds_headers(monkeypatch):
 
   response = asyncio.run(
     module.call_rpc(
-      "urn:test:op:1",
+      "urn:test:ops:trigger:1",
       {"foo": "bar"},
       metadata={"user_id": 7, "guild_id": 9, "channel_id": 11},
     )
@@ -63,8 +63,9 @@ def test_call_rpc_builds_headers(monkeypatch):
   assert response.payload["ok"] is True
   assert captured["url"] == "https://example.test/api/rpc"
   assert captured["json"] == {
-    "op": "urn:test:op:1",
+    "op": "urn:test:ops:trigger:1",
     "payload": {"foo": "bar"},
+    "version": 1,
   }
   headers = captured["headers"]
   assert headers["Authorization"] == "Bearer super-secret"

--- a/tests/test_discord_unbox_request.py
+++ b/tests/test_discord_unbox_request.py
@@ -72,7 +72,7 @@ def test_unbox_request_requires_token_for_discord():
   client = TestClient(app)
   resp = client.post(
     '/rpc',
-    json={'op': 'urn:discord:command:get_roles:1'},
+    json={'op': 'urn:discord:command:get_roles:1', 'version': 1},
   )
   assert resp.status_code == 401
 
@@ -93,7 +93,7 @@ def test_unbox_request_with_discord_header_and_token():
   client = TestClient(app)
   resp = client.post(
     '/rpc',
-    json={'op': 'urn:discord:command:get_roles:1'},
+    json={'op': 'urn:discord:command:get_roles:1', 'version': 1},
     headers=_headers_with_token(**{'x-discord-id': '42'})
   )
   assert resp.status_code == 200
@@ -125,7 +125,7 @@ def test_unbox_request_with_context_discord_id():
   client = TestClient(app)
   resp = client.post(
     '/rpc',
-    json={'op': 'urn:discord:command:get_roles:1'},
+    json={'op': 'urn:discord:command:get_roles:1', 'version': 1},
     headers=_headers_with_token()
   )
   assert resp.status_code == 200
@@ -151,7 +151,7 @@ def test_unbox_request_rejects_payload_discord_id():
   client = TestClient(app)
   resp = client.post(
     '/rpc',
-    json={'op': 'urn:discord:command:get_roles:1', 'payload': {'discord_id': '123'}},
+    json={'op': 'urn:discord:command:get_roles:1', 'payload': {'discord_id': '123'}, 'version': 1},
     headers=_headers_with_token()
   )
   assert resp.status_code == 401

--- a/tests/test_public_links_service.py
+++ b/tests/test_public_links_service.py
@@ -15,19 +15,24 @@ from pydantic import BaseModel
 class RPCRequest(BaseModel):
   op: str
   payload: dict | None = None
-  version: int = 1
+  version: int
 
 class RPCResponse(BaseModel):
   op: str
   payload: dict
-  version: int = 1
+  version: int
+  error: dict | None = None
 
 class AuthContext(BaseModel):
   role_mask: int = 0
 
+def ensure_json_serializable(value, *, field_name):
+  return value
+
 models_pkg.RPCRequest = RPCRequest
 models_pkg.RPCResponse = RPCResponse
 models_pkg.AuthContext = AuthContext
+models_pkg.ensure_json_serializable = ensure_json_serializable
 server_pkg.models = models_pkg
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)
@@ -64,7 +69,7 @@ client = TestClient(app)
 
 
 def test_get_home_links_service():
-  resp = client.post("/rpc", json={"op": "urn:public:links:get_home_links:1"})
+  resp = client.post("/rpc", json={"op": "urn:public:links:get_home_links:1", "version": 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data["op"] == "urn:public:links:get_home_links:1"
@@ -74,7 +79,7 @@ def test_get_home_links_service():
 
 
 def test_get_navbar_routes_service():
-  resp = client.post("/rpc", json={"op": "urn:public:links:get_navbar_routes:1"})
+  resp = client.post("/rpc", json={"op": "urn:public:links:get_navbar_routes:1", "version": 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data["op"] == "urn:public:links:get_navbar_routes:1"

--- a/tests/test_public_users_service.py
+++ b/tests/test_public_users_service.py
@@ -15,15 +15,20 @@ from pydantic import BaseModel
 class RPCRequest(BaseModel):
   op: str
   payload: dict | None = None
-  version: int = 1
+  version: int
 
 class RPCResponse(BaseModel):
   op: str
   payload: dict
-  version: int = 1
+  version: int
+  error: dict | None = None
+
+def ensure_json_serializable(value, *, field_name):
+  return value
 
 models_pkg.RPCRequest = RPCRequest
 models_pkg.RPCResponse = RPCResponse
+models_pkg.ensure_json_serializable = ensure_json_serializable
 server_pkg.models = models_pkg
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)
@@ -57,7 +62,7 @@ async def rpc_endpoint(request: Request):
 client = TestClient(app)
 
 def test_get_profile_service():
-  resp = client.post('/rpc', json={'op': 'urn:public:users:get_profile:1', 'payload': {'guid': '123'}})
+  resp = client.post('/rpc', json={'op': 'urn:public:users:get_profile:1', 'payload': {'guid': '123'}, 'version': 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data['payload'] == {
@@ -67,7 +72,7 @@ def test_get_profile_service():
   }
 
 def test_get_published_files_service():
-  resp = client.post('/rpc', json={'op': 'urn:public:users:get_published_files:1', 'payload': {'guid': '123'}})
+  resp = client.post('/rpc', json={'op': 'urn:public:users:get_published_files:1', 'payload': {'guid': '123'}, 'version': 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data['payload'] == {

--- a/tests/test_public_vars_service.py
+++ b/tests/test_public_vars_service.py
@@ -15,12 +15,13 @@ from pydantic import BaseModel
 class RPCRequest(BaseModel):
   op: str
   payload: dict | None = None
-  version: int = 1
+  version: int
 
 class RPCResponse(BaseModel):
   op: str
   payload: dict
-  version: int = 1
+  version: int
+  error: dict | None = None
 
 class AuthContext(BaseModel):
   role_mask: int = 0
@@ -28,6 +29,7 @@ class AuthContext(BaseModel):
 models_pkg.RPCRequest = RPCRequest
 models_pkg.RPCResponse = RPCResponse
 models_pkg.AuthContext = AuthContext
+models_pkg.ensure_json_serializable = lambda value, *, field_name: value
 server_pkg.models = models_pkg
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)
@@ -71,7 +73,7 @@ client = TestClient(app)
 
 
 def test_get_hostname_service():
-  resp = client.post("/rpc", json={"op": "urn:public:vars:get_hostname:1"})
+  resp = client.post("/rpc", json={"op": "urn:public:vars:get_hostname:1", "version": 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data["op"] == "urn:public:vars:get_hostname:1"
@@ -91,7 +93,7 @@ client_version = TestClient(app_version)
 
 
 def test_get_version_service():
-  resp = client_version.post("/rpc", json={"op": "urn:public:vars:get_version:1"})
+  resp = client_version.post("/rpc", json={"op": "urn:public:vars:get_version:1", "version": 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data["op"] == "urn:public:vars:get_version:1"
@@ -104,7 +106,7 @@ app_versions.state.public_vars = DummyVarsVersionsModule()
 
 @app_versions.post("/rpc")
 async def rpc_endpoint_versions(request: Request):
-  request.state.rpc_request = RPCRequest(op="urn:public:vars:get_versions:1")
+  request.state.rpc_request = RPCRequest(op="urn:public:vars:get_versions:1", version=1)
   request.state.auth_ctx = AuthContext(role_mask=0)
   return await public_vars_get_versions_v1(request)
 
@@ -126,7 +128,7 @@ app_versions_admin.state.public_vars = DummyVarsVersionsModule()
 
 @app_versions_admin.post("/rpc")
 async def rpc_endpoint_versions_admin(request: Request):
-  request.state.rpc_request = RPCRequest(op="urn:public:vars:get_versions:1")
+  request.state.rpc_request = RPCRequest(op="urn:public:vars:get_versions:1", version=1)
   request.state.auth_ctx = AuthContext(role_mask=1)
   return await public_vars_get_versions_v1(request)
 

--- a/tests/test_rpc_handler_facades.py
+++ b/tests/test_rpc_handler_facades.py
@@ -74,7 +74,7 @@ def test_rpc_handlers_deny_unauthorised_access(monkeypatch, module_name, handler
     monkeypatch.setattr(module, 'FORBIDDEN_DETAILS', {})
 
   async def fake_unbox_request(request):
-    return SimpleNamespace(op='urn:test', version='1'), SimpleNamespace(user_guid='user', role_mask=0), []
+    return SimpleNamespace(op='urn:test:noop:op:1', version=1), SimpleNamespace(user_guid='user', role_mask=0), []
 
   monkeypatch.setattr(module, 'unbox_request', fake_unbox_request)
 

--- a/tests/test_rpc_helpers.py
+++ b/tests/test_rpc_helpers.py
@@ -7,6 +7,7 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 # Avoid importing rpc.__init__ which has side effects that trigger circular imports
 pkg = types.ModuleType('rpc')
 pkg.__path__ = [str(ROOT / 'rpc')]
+pkg.HANDLERS = {}
 sys.modules.setdefault('rpc', pkg)
 
 spec_helpers = importlib.util.spec_from_file_location('rpc.helpers', ROOT / 'rpc/helpers.py')
@@ -24,8 +25,13 @@ class RPCResponse:
   def __init__(self, **data):
     self.__dict__.update(data)
 
+class AuthContext:
+  def __init__(self, **data):
+    self.__dict__.update(data)
+
 models_mod.RPCRequest = RPCRequest
 models_mod.RPCResponse = RPCResponse
+models_mod.AuthContext = AuthContext
 sys.modules['server.models'] = models_mod
 
 if str(ROOT) not in sys.path:
@@ -62,12 +68,12 @@ async def parse_rpc(request: Request):
 client = TestClient(app)
 
 def test_public_request_without_token():
-  resp = client.post('/rpc', json={'op': 'urn:public:links:get_home_links:1'})
+  resp = client.post('/rpc', json={'op': 'urn:public:links:get_home_links:1', 'version': 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data['user_role'] == 0
   assert data['parts'][1] == 'public'
 
 def test_private_request_requires_token():
-  resp = client.post('/rpc', json={'op': 'urn:users:profile:get_profile:1'})
+  resp = client.post('/rpc', json={'op': 'urn:users:profile:get_profile:1', 'version': 1})
   assert resp.status_code == 401

--- a/tests/test_service_roles_services.py
+++ b/tests/test_service_roles_services.py
@@ -256,7 +256,7 @@ def test_get_roles_allows_system_admin():
   async def stub(parts, request):
     nonlocal called
     called = True
-    return RPCResponse(op="ok", payload=None, version=1)
+    return RPCResponse(op="urn:service:roles:get_roles:1", payload=None, version=1)
 
   service_pkg.HANDLERS["roles"] = stub
   req = DummyRequest(DummyState(DummyDb(), DummyAuth()))

--- a/tests/test_service_routes_services.py
+++ b/tests/test_service_routes_services.py
@@ -71,10 +71,12 @@ modules_pkg.auth_module = auth_module_pkg
 
 class RPCResponse:
   def __init__(self, **data):
+    data.setdefault('error', None)
     self.__dict__.update(data)
 
 
 models_pkg.RPCResponse = RPCResponse
+models_pkg.ensure_json_serializable = lambda value, *, field_name: value
 server_pkg.modules = modules_pkg
 server_pkg.models = models_pkg
 
@@ -160,7 +162,7 @@ client = TestClient(app)
 
 
 def test_get_routes_service():
-  resp = client.post('/rpc', json={'op': 'urn:service:routes:get_routes:1'})
+  resp = client.post('/rpc', json={'op': 'urn:service:routes:get_routes:1', 'version': 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data['payload'] == {
@@ -183,9 +185,9 @@ def test_upsert_and_delete_route_service():
     'sequence': 1,
     'required_roles': ['ROLE_SERVICE_ADMIN'],
   }
-  resp = client.post('/rpc', json={'op': 'urn:service:routes:upsert_route:1', 'payload': upsert_payload})
+  resp = client.post('/rpc', json={'op': 'urn:service:routes:upsert_route:1', 'payload': upsert_payload, 'version': 1})
   assert resp.status_code == 200
-  resp = client.post('/rpc', json={'op': 'urn:service:routes:delete_route:1', 'payload': {'path': '/a'}})
+  resp = client.post('/rpc', json={'op': 'urn:service:routes:delete_route:1', 'payload': {'path': '/a'}, 'version': 1})
   assert resp.status_code == 200
   assert ('db:system:routes:upsert_route:1', {
     'path': '/a',

--- a/tests/test_storage_files_handler.py
+++ b/tests/test_storage_files_handler.py
@@ -39,7 +39,7 @@ def test_handle_files_request_dispatches():
   async def stub_service(request):
     nonlocal called
     called = True
-    return RPCResponse(op="ok", payload=None, version=1)
+    return RPCResponse(op="urn:storage:files:get_files:1", payload=None, version=1)
 
   files_pkg.DISPATCHERS[("get_files", "1")] = stub_service
   req = DummyRequest()

--- a/tests/test_storage_files_services.py
+++ b/tests/test_storage_files_services.py
@@ -41,13 +41,14 @@ models_pkg = types.ModuleType("server.models")
 class RPCRequest(BaseModel):
   op: str
   payload: dict | None = None
-  version: int = 1
+  version: int
 
 
 class RPCResponse(BaseModel):
   op: str
   payload: dict
-  version: int = 1
+  version: int
+  error: dict | None = None
 
 
 class AuthContext(BaseModel):
@@ -57,6 +58,7 @@ class AuthContext(BaseModel):
 models_pkg.RPCRequest = RPCRequest
 models_pkg.RPCResponse = RPCResponse
 models_pkg.AuthContext = AuthContext
+models_pkg.ensure_json_serializable = lambda value, *, field_name: value
 server_pkg.models = models_pkg
 sys.modules.setdefault("server", server_pkg)
 sys.modules.setdefault("server.models", models_pkg)

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -861,8 +861,10 @@ def test_upload_files_sets_created_on(monkeypatch):
 
   assert fake_container.uploads[0][0] == "u1/docs/a.txt"
   created_on = mod.db.upserts[0]["created_on"]
-  assert isinstance(created_on, datetime)
-  assert created_on.tzinfo == timezone.utc
+  assert isinstance(created_on, str)
+  parsed = datetime.fromisoformat(created_on)
+  assert parsed.tzinfo == timezone.utc
+  assert (datetime.now(timezone.utc) - parsed).total_seconds() < 5
 
 
 def test_create_folder_creates_marker_and_cache(monkeypatch):

--- a/tests/test_support_services.py
+++ b/tests/test_support_services.py
@@ -73,7 +73,7 @@ def test_support_routes_reuse_account_routes():
 
   async def fake_displayname(request):
     calls.append("get_displayname")
-    return RPCResponse(op="o", payload={}, version=1)
+    return RPCResponse(op="urn:support:users:get_displayname:1", payload={}, version=1)
 
   orig_displayname = account_mod.account_user_get_displayname_v1
   account_mod.account_user_get_displayname_v1 = fake_displayname
@@ -83,7 +83,7 @@ def test_support_routes_reuse_account_routes():
 
   async def fake_credits(request):
     calls.append("get_credits")
-    return RPCResponse(op="o", payload={}, version=1)
+    return RPCResponse(op="urn:support:users:get_credits:1", payload={}, version=1)
 
   orig_credits = account_mod.account_user_get_credits_v1
   account_mod.account_user_get_credits_v1 = fake_credits
@@ -93,7 +93,7 @@ def test_support_routes_reuse_account_routes():
 
   async def fake_set_credits(request):
     calls.append("set_credits")
-    return RPCResponse(op="o", payload={}, version=1)
+    return RPCResponse(op="urn:support:users:set_credits:1", payload={}, version=1)
 
   orig_set_credits = account_mod.account_user_set_credits_v1
   account_mod.account_user_set_credits_v1 = fake_set_credits
@@ -103,7 +103,7 @@ def test_support_routes_reuse_account_routes():
 
   async def fake_reset_display(request):
     calls.append("reset_display")
-    return RPCResponse(op="o", payload={}, version=1)
+    return RPCResponse(op="urn:support:users:reset_display:1", payload={}, version=1)
 
   orig_reset_display = account_mod.account_user_reset_display_v1
   account_mod.account_user_reset_display_v1 = fake_reset_display

--- a/tests/test_system_config_services.py
+++ b/tests/test_system_config_services.py
@@ -25,7 +25,8 @@ models_pkg = types.ModuleType('server.models')
 class RPCResponse(BaseModel):
   op: str
   payload: dict
-  version: int = 1
+  version: int
+  error: dict | None = None
 
 class AuthContext(BaseModel):
   user_guid: str = ''
@@ -33,6 +34,7 @@ class AuthContext(BaseModel):
 
 models_pkg.RPCResponse = RPCResponse
 models_pkg.AuthContext = AuthContext
+models_pkg.ensure_json_serializable = lambda value, *, field_name: value
 server_pkg.models = models_pkg
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)
@@ -97,7 +99,7 @@ async def rpc_endpoint(request: Request):
 client = TestClient(app)
 
 def test_get_configs_service():
-  resp = client.post('/rpc', json={'op': 'urn:system:config:get_configs:1'})
+  resp = client.post('/rpc', json={'op': 'urn:system:config:get_configs:1', 'version': 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data['payload'] == {
@@ -106,9 +108,9 @@ def test_get_configs_service():
   assert ('get_configs', 'u1', []) in mod.calls
 
 def test_upsert_and_delete_config_service():
-  resp = client.post('/rpc', json={'op': 'urn:system:config:upsert_config:1', 'payload': {'key': 'LoggingLevel', 'value': '2'}})
+  resp = client.post('/rpc', json={'op': 'urn:system:config:upsert_config:1', 'payload': {'key': 'LoggingLevel', 'value': '2'}, 'version': 1})
   assert resp.status_code == 200
-  resp = client.post('/rpc', json={'op': 'urn:system:config:delete_config:1', 'payload': {'key': 'LoggingLevel'}})
+  resp = client.post('/rpc', json={'op': 'urn:system:config:delete_config:1', 'payload': {'key': 'LoggingLevel'}, 'version': 1})
   assert resp.status_code == 200
   assert ('upsert_config', 'LoggingLevel', '2') in mod.calls
   assert ('delete_config', 'LoggingLevel') in mod.calls

--- a/tests/test_system_roles_services.py
+++ b/tests/test_system_roles_services.py
@@ -76,6 +76,7 @@ class AuthContext:
     self.__dict__.update(data)
 
 models_pkg.AuthContext = AuthContext
+models_pkg.ensure_json_serializable = lambda value, *, field_name: value
 server_pkg.modules = modules_pkg
 server_pkg.models = models_pkg
 
@@ -168,7 +169,7 @@ async def rpc_endpoint(request: Request):
 client = TestClient(app)
 
 def test_get_roles_service():
-  resp = client.post('/rpc', json={'op': 'urn:system:roles:get_roles:1'})
+  resp = client.post('/rpc', json={'op': 'urn:system:roles:get_roles:1', 'version': 1})
   assert resp.status_code == 200
   data = resp.json()
   assert data['payload'] == {
@@ -177,9 +178,9 @@ def test_get_roles_service():
   assert any(c.op == 'db:system:roles:list:1' and c.params == {} for c in db.calls)
 
 def test_upsert_and_delete_role_service():
-  resp = client.post('/rpc', json={'op': 'urn:system:roles:upsert_role:1', 'payload': {'name': 'ROLE_FOO', 'mask': '1', 'display': 'Foo'}})
+  resp = client.post('/rpc', json={'op': 'urn:system:roles:upsert_role:1', 'payload': {'name': 'ROLE_FOO', 'mask': '1', 'display': 'Foo'}, 'version': 1})
   assert resp.status_code == 200
-  resp = client.post('/rpc', json={'op': 'urn:system:roles:delete_role:1', 'payload': {'name': 'ROLE_FOO'}})
+  resp = client.post('/rpc', json={'op': 'urn:system:roles:delete_role:1', 'payload': {'name': 'ROLE_FOO'}, 'version': 1})
   assert resp.status_code == 200
   assert any(
     c.op == 'db:system:roles:upsert_role:1'

--- a/tests/test_system_storage_services.py
+++ b/tests/test_system_storage_services.py
@@ -26,7 +26,8 @@ models_pkg = types.ModuleType('server.models')
 class RPCResponse(BaseModel):
   op: str
   payload: dict
-  version: int = 1
+  version: int
+  error: dict | None = None
 
 
 class AuthContext(BaseModel):
@@ -36,6 +37,7 @@ class AuthContext(BaseModel):
 
 models_pkg.RPCResponse = RPCResponse
 models_pkg.AuthContext = AuthContext
+models_pkg.ensure_json_serializable = lambda value, *, field_name: value
 server_pkg.models = models_pkg
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -133,7 +133,7 @@ class DummyRequest:
 def test_set_provider_calls_db():
   async def fake_get(request):
     rpc = RPCRequest(
-      op="db:security:identities:set_provider:1",
+      op="urn:users:providers:set_provider:1",
       payload={"provider": "microsoft", "id_token": "id", "access_token": "acc"},
       version=1,
     )


### PR DESCRIPTION
## Summary
- tighten RPC request/response schemas by enforcing urn/db regexes, version alignment, and JSON-safe payload serialization
- freeze registry metadata and convert database provider results through explicit request/response wrappers
- update RPC consumers and extensive test coverage to include versioned ops and new error envelopes

## Testing
- pytest tests/test_discord_handler.py *(fails: handler returns 500 due to registry initialization stub)*

------
https://chatgpt.com/codex/tasks/task_e_68e1204cb504832580ffd2140a8c1acd