### PR TITLE
Enforce registry coverage for database operations

### DIFF
--- a/server/registry/__init__.py
+++ b/server/registry/__init__.py
@@ -130,7 +130,11 @@ class RegistryRouter:
     self._provider_queries = queries
     self._provider_executors.clear()
     for route in self._routes.values():
-      self._attach_provider_callable(route)
+      try:
+        self._attach_provider_callable(route)
+      except (KeyError, TypeError):
+        pass
+    self.verify_provider_coverage()
 
   @property
   def provider_bindings(self) -> Mapping[str, ProviderBinding]:
@@ -153,25 +157,64 @@ class RegistryRouter:
     if executor:
       return executor
     self._attach_provider_callable(route)
-    return self._provider_executors.get(route.key)
+    executor = self._provider_executors.get(route.key)
+    if executor:
+      return executor
+    raise KeyError(
+      f"No provider callable registered for '{route.provider_map}' version {route.version}"
+    )
 
   def _attach_provider_callable(self, route: FunctionRoute) -> None:
     if not self._provider_queries:
       return
     entry = self._provider_queries.get(route.provider_map)
     if entry is None:
-      return
+      raise KeyError(f"No provider callable registered for '{route.provider_map}'")
     if isinstance(entry, Mapping):
       provider_callable = entry.get(route.version)
     else:
       provider_callable = entry
     if provider_callable is None:
-      return
+      raise KeyError(
+        f"No provider callable registered for '{route.provider_map}' version {route.version}"
+      )
     if not callable(provider_callable):
       raise TypeError(
         f"Provider mapping for '{route.provider_map}' version {route.version} is not callable"
       )
     self._provider_executors[route.key] = provider_callable
+
+  def verify_provider_coverage(self) -> None:
+    if not self._provider_queries:
+      if self._routes:
+        provider = self._provider_name or "<unset>"
+        details = "\n  ".join(
+          f"{route.key} (provider module returned no callables)"
+          for route in sorted(self._routes.values(), key=lambda item: item.key)
+        )
+        raise RuntimeError(
+          "Provider '"
+          + provider
+          + "' is missing callables for the following registry operations:\n  "
+          + details
+        )
+      return
+    missing: list[str] = []
+    for route in sorted(self._routes.values(), key=lambda item: item.key):
+      try:
+        if route.key not in self._provider_executors:
+          self._attach_provider_callable(route)
+      except (KeyError, TypeError) as exc:
+        missing.append(f"{route.key} ({exc})")
+    if missing:
+      provider = self._provider_name or "<unset>"
+      details = "\n  ".join(missing)
+      raise RuntimeError(
+        "Provider '"
+        + provider
+        + "' is missing callables for the following registry operations:\n  "
+        + details
+      )
 
 
 class DomainRouter:
@@ -249,6 +292,7 @@ class RegistryDispatcher:
     if provider_key:
       self.router.set_provider(provider_key)
       self.router.load_provider(provider_key)
+      self.router.verify_provider_coverage()
     DBResultCls = get_dbresult_cls()
 
     def _ensure_response(result: DBResponse | DBResult | object) -> DBResponse:
@@ -263,15 +307,10 @@ class RegistryDispatcher:
     async def _execute(request: DBRequest) -> DBResponse:
       route = self.router.resolve(request.op)
       if not route:
-        result = await provider.run(request.op, request.params)
-        return _ensure_response(result)
+        raise KeyError(f"Unknown registry operation: {request.op}")
       if route.key != request.op:
         request = request.model_copy(update={"op": route.key})
       executor = self.router.get_executor(route)
-      if not executor:
-        raise KeyError(
-          f"No provider callable registered for '{route.provider_map}' version {route.version}"
-        )
       result = await executor(request)
       return _ensure_response(result)
 

--- a/tests/test_db_module_init.py
+++ b/tests/test_db_module_init.py
@@ -13,6 +13,31 @@ from server.registry import RegistryDispatcher, RegistryRouter
 from server.registry.types import DBRequest, DBResponse
 
 
+def _install_stub_provider(monkeypatch, name: str, queries: dict[str, Any]) -> str:
+  module_name = f"server.registry.providers.{name}"
+  module = ModuleType(module_name)
+  module.PROVIDER_QUERIES = queries
+  monkeypatch.setitem(sys.modules, module_name, module)
+  return name
+
+
+class _NoopProvider(DbProviderBase):
+  async def startup(self):
+    pass
+
+  async def shutdown(self):
+    pass
+
+  async def run(self, op, args=None):
+    raise AssertionError("provider.run should not be invoked in tests")
+
+
+class _StubRegistryRouter(RegistryRouter):
+  def register_domains(self) -> None:
+    if not getattr(self, "_initialised", False):
+      self._initialised = True
+
+
 def test_init_uses_concrete_provider():
   app = FastAPI()
   db = DbModule(app)
@@ -20,31 +45,31 @@ def test_init_uses_concrete_provider():
   assert isinstance(db._provider, MssqlProvider)
 
 
-def test_db_module_run_propagates_query_error():
+def test_db_module_run_propagates_query_error(monkeypatch):
   app = FastAPI()
   db = DbModule(app)
   detail = QueryErrorDetail(query="SELECT 1", params=(), message="boom")
 
-  class FailingProvider(DbProviderBase):
-    def __init__(self):
-      super().__init__()
+  router = _StubRegistryRouter()
+  router.domain("test").subdomain("error").add_function(
+    "trigger",
+    version=1,
+    provider_map="test.error.trigger",
+  )
 
-    async def startup(self):
-      pass
+  async def failing_callable(request: DBRequest) -> DBResponse:
+    raise DBQueryError(detail)
 
-    async def shutdown(self):
-      pass
+  provider_name = _install_stub_provider(
+    monkeypatch,
+    "stub_error",
+    {"test.error.trigger": {1: failing_callable}},
+  )
 
-    async def run(self, op, args=None):
-      if isinstance(op, DBRequest):
-        args = op.params
-        op = op.op
-      args = args or {}
-      raise DBQueryError(detail)
-
-  db._provider = FailingProvider()
-  registry = RegistryDispatcher()
-  registry.bind_provider(db._provider)
+  provider = _NoopProvider()
+  db._provider = provider
+  registry = RegistryDispatcher(router=router)
+  registry.bind_provider(provider, provider_name=provider_name)
   db.set_registry(registry)
 
   with pytest.raises(DBQueryError) as exc:
@@ -52,37 +77,39 @@ def test_db_module_run_propagates_query_error():
   assert exc.value.detail == detail
 
 
-def test_db_module_forwards_operations_verbatim():
+def test_db_module_forwards_operations_verbatim(monkeypatch):
   app = FastAPI()
   db = DbModule(app)
   captured: dict[str, Any] = {}
 
-  class RecordingProvider(DbProviderBase):
-    def __init__(self):
-      super().__init__()
+  router = _StubRegistryRouter()
+  router.domain("test").subdomain("ops").add_function(
+    "urn_op",
+    version=1,
+    provider_map="test.ops.urn_op",
+  )
 
-    async def startup(self):
-      pass
+  async def recording_callable(request: DBRequest) -> DBResponse:
+    captured["op"] = request.op
+    captured["args"] = request.params
+    return DBResponse(rows=[{"ok": True}], rowcount=1)
 
-    async def shutdown(self):
-      pass
+  provider_name = _install_stub_provider(
+    monkeypatch,
+    "stub_record",
+    {"test.ops.urn_op": {1: recording_callable}},
+  )
 
-    async def run(self, op, args=None):
-      if isinstance(op, DBRequest):
-        args = op.params
-        op = op.op
-      args = args or {}
-      captured["op"] = op
-      captured["args"] = args
-      return DBResult(rows=[{"ok": True}], rowcount=1)
-
-  db._provider = RecordingProvider()
-  registry = RegistryDispatcher()
-  registry.bind_provider(db._provider)
+  provider = _NoopProvider()
+  db._provider = provider
+  registry = RegistryDispatcher(router=router)
+  registry.bind_provider(provider, provider_name=provider_name)
   db.set_registry(registry)
 
-  result = asyncio.run(db.run(DBRequest(op="db:test:urn-op:1", params={"foo": "bar"})))
-  assert captured["op"] == "db:test:urn-op:1"
+  result = asyncio.run(
+    db.run(DBRequest(op="db:test:ops:urn_op:1", params={"foo": "bar"}))
+  )
+  assert captured["op"] == "db:test:ops:urn_op:1"
   assert captured["args"] == {"foo": "bar"}
   assert isinstance(result, DBResult)
   assert result.rows == [{"ok": True}]
@@ -132,7 +159,7 @@ def test_db_module_run_constructs_registry_request():
 
 
 def test_registry_dispatcher_executes_provider_callable(monkeypatch):
-  router = RegistryRouter()
+  router = _StubRegistryRouter()
   router.domain("demo").subdomain("ops").add_function(
     "test",
     version=1,
@@ -147,11 +174,11 @@ def test_registry_dispatcher_executes_provider_callable(monkeypatch):
     value = request.params.get("value")
     return DBResponse(rows=[{"value": value}], rowcount=1)
 
-  module = ModuleType("server.registry.providers.stub")
-  module.PROVIDER_QUERIES = {
-    "demo.ops.test": {1: stub_callable},
-  }
-  monkeypatch.setitem(sys.modules, module.__name__, module)
+  provider_name = _install_stub_provider(
+    monkeypatch,
+    "stub",
+    {"demo.ops.test": {1: stub_callable}},
+  )
 
   class DummyProvider(DbProviderBase):
     async def startup(self):
@@ -168,7 +195,7 @@ def test_registry_dispatcher_executes_provider_callable(monkeypatch):
       raise AssertionError("provider.run should not be used when route is registered")
 
   dispatcher = RegistryDispatcher(router=router)
-  dispatcher.bind_provider(DummyProvider(), provider_name="stub")
+  dispatcher.bind_provider(DummyProvider(), provider_name=provider_name)
 
   response = asyncio.run(dispatcher.execute(DBRequest(op="db:demo:ops:test:1", params={"value": 7})))
 
@@ -188,3 +215,33 @@ def test_mssql_provider_requires_binding():
 
   with pytest.raises(ValueError, match="does not declare a provider binding"):
     router.load_provider("mssql")
+
+
+def test_dispatcher_raises_for_unknown_operation(monkeypatch):
+  dispatcher = RegistryDispatcher(router=_StubRegistryRouter())
+  provider = _NoopProvider()
+  provider_name = _install_stub_provider(monkeypatch, "stub_unknown", {})
+  dispatcher.bind_provider(provider, provider_name=provider_name)
+
+  with pytest.raises(KeyError, match="Unknown registry operation"):
+    asyncio.run(
+      dispatcher.execute(DBRequest(op="db:test:missing:op:1", params={}))
+    )
+
+
+def test_provider_startup_checks_missing_callable(monkeypatch):
+  router = _StubRegistryRouter()
+  router.domain("demo").subdomain("ops").add_function(
+    "missing",
+    version=1,
+    provider_map="demo.ops.missing",
+  )
+
+  provider = _NoopProvider()
+  provider_name = _install_stub_provider(monkeypatch, "stub_incomplete", {})
+  dispatcher = RegistryDispatcher(router=router)
+
+  with pytest.raises(RuntimeError) as exc:
+    dispatcher.bind_provider(provider, provider_name=provider_name)
+
+  assert "db:demo:ops:missing:1" in str(exc.value)

--- a/tests/test_discord_handler.py
+++ b/tests/test_discord_handler.py
@@ -59,6 +59,7 @@ class DummyAuth:
 def _get_client(allowed: bool):
   app = FastAPI()
   app.state.auth = DummyAuth(allowed)
+  app.state.services = types.SimpleNamespace(auth=app.state.auth)
   discord_handler.HANDLERS = {'command': dummy_handler}
 
   @app.post('/rpc')

--- a/tests/test_service_roles_services.py
+++ b/tests/test_service_roles_services.py
@@ -202,6 +202,7 @@ class DummyState:
     self.db = db
     self.auth = auth
     self.role_admin = DummyRoleAdmin(db, auth)
+    self.services = SimpleNamespace(auth=auth, role_admin=self.role_admin)
 
 
 class DummyApp:


### PR DESCRIPTION
## Summary
- harden the registry dispatcher to require explicit provider callables for every registered DB operation
- add startup verification that enumerates db: URNs and fails fast when provider bindings are missing
- update registry-related tests and helpers to use stub providers and assert the new behaviour while fixing RPC tests to supply service stubs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e12dbe677c832586705ff7ae440fd9