### PR TITLE
Refactor social input orchestration

### DIFF
--- a/server/modules/providers/social/discord_input_provider.py
+++ b/server/modules/providers/social/discord_input_provider.py
@@ -1,9 +1,9 @@
-"""Discord input provider that registers commands and dispatches workflows."""
+"""Discord input provider that registers Discord bot commands."""
 
 from __future__ import annotations
 
-import json, logging, time
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, TYPE_CHECKING
 
 from discord.ext import commands
 
@@ -11,12 +11,46 @@ from . import SocialInputProvider
 
 if TYPE_CHECKING:  # pragma: no cover
   from ...discord_bot_module import DiscordBotModule
-  from ...discord_output_module import DiscordOutputModule
   from ...social_input_module import SocialInputModule
   from discord.ext.commands import Bot
 
 
+@dataclass(slots=True)
+class DiscordCommandContext:
+  guild_id: int | None
+  channel_id: int | None
+  user_id: int | None
+  raw_context: Any
+
+
+@dataclass(slots=True)
+class RpcCommandRequest:
+  context: DiscordCommandContext
+  operation: str
+
+
+@dataclass(slots=True)
+class SummarizeCommandRequest:
+  context: DiscordCommandContext
+  hours_argument: str
+
+
+@dataclass(slots=True)
+class PersonaCommandRequest:
+  context: DiscordCommandContext
+  request_text: str | None
+
+
+@dataclass(slots=True)
+class DiscordCommandHandlers:
+  rpc: Callable[[RpcCommandRequest], Awaitable[None]]
+  summarize: Callable[[SummarizeCommandRequest], Awaitable[None]]
+  persona: Callable[[PersonaCommandRequest], Awaitable[None]]
+
+
 class DiscordInputProvider(SocialInputProvider):
+  """Provider exposing Discord command wiring and DTO creation."""
+
   name = "discord"
 
   def __init__(self, module: "SocialInputModule", discord: "DiscordBotModule"):
@@ -24,8 +58,14 @@ class DiscordInputProvider(SocialInputProvider):
     self.discord = discord
     self.bot: "Bot" | None = None
     self._registered: dict[str, commands.Command] = {}
+    self._handlers: DiscordCommandHandlers | None = None
+
+  def configure(self, handlers: DiscordCommandHandlers) -> None:
+    self._handlers = handlers
 
   async def startup(self):
+    if not self._handlers:
+      raise RuntimeError("DiscordInputProvider handlers not configured")
     await self.discord.on_ready()
     if not self.discord.bot:
       raise RuntimeError("Discord bot is not initialized")
@@ -44,17 +84,18 @@ class DiscordInputProvider(SocialInputProvider):
     assert self.bot
     for name in list(self._registered.keys()):
       self.bot.remove_command(name)
+
     @commands.command(name="rpc")
     async def rpc_command(ctx, *, op: str):
-      await self._handle_rpc_command(ctx, op=op)
+      await self._dispatch_rpc(ctx, op)
 
     @commands.command(name="summarize")
     async def summarize_command(ctx, hours: str):
-      await self._handle_summarize_command(ctx, hours)
+      await self._dispatch_summarize(ctx, hours)
 
     @commands.command(name="persona")
     async def persona_command(ctx, *, request: str | None = None):
-      await self._handle_persona_command(ctx, request)
+      await self._dispatch_persona(ctx, request)
 
     self.bot.add_command(rpc_command)
     self.bot.add_command(summarize_command)
@@ -65,230 +106,38 @@ class DiscordInputProvider(SocialInputProvider):
       "persona": persona_command,
     }
 
-  async def _handle_rpc_command(self, ctx, *, op: str):
-    start = time.perf_counter()
-    guild_id = getattr(ctx.guild, "id", 0)
-    user_id = getattr(ctx.author, "id", 0)
-    if guild_id and user_id:
-      self.discord.bump_rate_limits(guild_id, user_id)
-    metadata = {
-      "guild_id": guild_id,
-      "channel_id": getattr(ctx.channel, "id", 0),
-      "user_id": user_id,
-    }
-
-    try:
-      resp = await self.discord.call_rpc(op, None, metadata=metadata)
-      payload = resp.payload
-      if hasattr(payload, "model_dump"):
-        data = json.dumps(payload.model_dump())
-      else:
-        data = str(payload)
-      await self._queue_channel_notice(ctx, data, reason="rpc_command")
-      elapsed = time.perf_counter() - start
-      logging.info(
-        "[DiscordInputProvider] rpc",
-        extra={
-          "guild_id": guild_id,
-          "channel_id": ctx.channel.id,
-          "user_id": user_id,
-          "op": op,
-          "elapsed": elapsed,
-        },
-      )
-    except Exception as exc:
-      elapsed = time.perf_counter() - start
-      logging.exception(
-        "[DiscordInputProvider] rpc failed",
-        extra={
-          "guild_id": guild_id,
-          "channel_id": getattr(ctx.channel, "id", 0),
-          "user_id": user_id,
-          "op": op,
-          "elapsed": elapsed,
-        },
-      )
-      await self._queue_channel_notice(ctx, f"Error: {exc}", reason="rpc_command_error")
-
-  async def _handle_summarize_command(self, ctx, hours: str):
-    start = time.perf_counter()
-    guild_id = getattr(ctx.guild, "id", 0)
-    user_id = getattr(ctx.author, "id", 0)
-    if guild_id and user_id:
-      self.discord.bump_rate_limits(guild_id, user_id)
-
-    try:
-      hrs = int(hours)
-    except ValueError:
-      await self._queue_channel_notice(ctx, "Usage: !summarize <hours>", reason="invalid_hours")
-      return
-    if hrs < 1 or hrs > 336:
-      await self._queue_channel_notice(ctx, "Hours must be between 1 and 336", reason="hours_out_of_range")
-      return
-
-    payload = {
-      "guild_id": guild_id,
-      "channel_id": getattr(ctx.channel, "id", 0),
-      "hours": hrs,
-      "user_id": user_id,
-    }
-    metadata = {
-      "guild_id": guild_id,
-      "channel_id": payload["channel_id"],
-      "user_id": user_id,
-    }
-
-    try:
-      resp = await self.discord.call_rpc(
-        "urn:discord:chat:summarize_channel:1",
-        payload,
-        metadata=metadata,
-      )
-      payload = resp.payload
-      if hasattr(payload, "model_dump"):
-        data = payload.model_dump()
-      elif isinstance(payload, dict):
-        data = dict(payload)
-      else:
-        data = {"success": bool(payload)}
-      if not data.get("success"):
-        message = data.get("ack_message") or "Failed to send summary. Please try again later."
-        await self._queue_channel_notice(ctx, message, reason=data.get("reason") or "delivery_failed")
-      elapsed = time.perf_counter() - start
-      logging.info(
-        "[DiscordInputProvider] summarize",
-        extra={
-          "guild_id": guild_id,
-          "channel_id": getattr(ctx.channel, "id", 0),
-          "user_id": user_id,
-          "hours": hrs,
-          "token_count_estimate": data.get("token_count_estimate"),
-          "messages_collected": data.get("messages_collected"),
-          "cap_hit": data.get("cap_hit"),
-          "queue_id": data.get("queue_id"),
-          "dm_enqueued": data.get("dm_enqueued"),
-          "channel_ack_enqueued": data.get("channel_ack_enqueued"),
-          "reason": data.get("reason"),
-          "elapsed": elapsed,
-        },
-      )
-      logging.debug("[DiscordInputProvider] summarize response", extra=data)
-      return
-    except Exception:
-      elapsed = time.perf_counter() - start
-      logging.exception(
-        "[DiscordInputProvider] summarize failed",
-        extra={
-          "guild_id": guild_id,
-          "channel_id": getattr(ctx.channel, "id", 0),
-          "user_id": user_id,
-          "hours": hrs,
-          "elapsed": elapsed,
-        },
-      )
-      await self._queue_channel_notice(ctx, "Failed to fetch messages. Please try again later.", reason="rpc_failure")
-
-  async def _handle_persona_command(self, ctx, request: str | None):
-    start = time.perf_counter()
-    guild_id = getattr(ctx.guild, "id", 0)
-    user_id = getattr(ctx.author, "id", 0)
-    channel_id = getattr(ctx.channel, "id", 0)
-    if guild_id and user_id:
-      self.discord.bump_rate_limits(guild_id, user_id)
-    if not request or not request.strip():
-      await self._queue_channel_notice(ctx, "Usage: !persona <persona> <message>", reason="invalid_persona_usage")
-      return
-    module = getattr(self.discord.app.state, "discord_chat", None)
-    if not module:
-      await self._queue_channel_notice(ctx, "Persona chat is currently unavailable.", reason="persona_module_unavailable")
-      return
-    try:
-      await module.on_ready()
-      result = await module.handle_persona_command(
-        guild_id=guild_id,
-        channel_id=channel_id,
-        user_id=user_id,
-        command_text=request,
-      )
-    except ValueError:
-      await self._queue_channel_notice(ctx, "Usage: !persona <persona> <message>", reason="invalid_persona_usage")
-      return
-    except Exception:
-      elapsed = time.perf_counter() - start
-      logging.exception(
-        "[DiscordInputProvider] persona failed",
-        extra={
-          "guild_id": guild_id,
-          "channel_id": channel_id,
-          "user_id": user_id,
-          "request": request,
-          "elapsed": elapsed,
-        },
-      )
-      await self._queue_channel_notice(ctx, "Persona chat is currently unavailable.", reason="persona_rpc_failure")
-      return
-    ack_message = result.get("ack_message")
-    reason = result.get("reason") or ("persona_response" if result.get("success") else "persona_failed")
-    elapsed = time.perf_counter() - start
-    logging.info(
-      "[DiscordInputProvider] persona",
-      extra={
-        "guild_id": guild_id,
-        "channel_id": channel_id,
-        "user_id": user_id,
-        "persona": result.get("persona"),
-        "success": result.get("success"),
-        "reason": reason,
-        "elapsed": elapsed,
-      },
+  async def _dispatch_rpc(self, ctx, op: str) -> None:
+    assert self._handlers
+    request = RpcCommandRequest(
+      context=self._build_context(ctx),
+      operation=op,
     )
-    if not ack_message:
-      return
-    try:
-      await self.discord.send_channel_message(channel_id, ack_message)
-    except Exception:
-      logging.exception(
-        "[DiscordInputProvider] failed to send persona acknowledgement",
-        extra={
-          "channel_id": channel_id,
-          "guild_id": guild_id,
-          "user_id": user_id,
-          "reason": reason,
-        },
-      )
+    await self._handlers.rpc(request)
 
-  async def _queue_channel_notice(self, ctx, message: str, *, reason: str | None = None) -> None:
-    channel_id = getattr(ctx.channel, "id", 0)
-    guild_id = getattr(ctx.guild, "id", 0)
-    user_id = getattr(ctx.author, "id", 0)
-    module = getattr(self.discord.app.state, "discord_chat", None)
-    if module:
-      try:
-        await module.deliver_summary(
-          guild_id=guild_id,
-          channel_id=channel_id,
-          user_id=user_id,
-          summary_text=None,
-          ack_message=message,
-          success=False,
-          reason=reason,
-        )
-        return
-      except Exception:
-        logging.exception(
-          "[DiscordInputProvider] failed to queue channel notice",
-          extra={
-            "channel_id": channel_id,
-            "guild_id": guild_id,
-            "user_id": user_id,
-            "reason": reason,
-          },
-        )
-    try:
-      await self.discord.send_channel_message(channel_id, message)
-    except Exception:
-      logging.exception(
-        "[DiscordInputProvider] failed to send channel message",
-        extra={"channel_id": channel_id},
-      )
+  async def _dispatch_summarize(self, ctx, hours: str) -> None:
+    assert self._handlers
+    request = SummarizeCommandRequest(
+      context=self._build_context(ctx),
+      hours_argument=hours,
+    )
+    await self._handlers.summarize(request)
+
+  async def _dispatch_persona(self, ctx, request_text: str | None) -> None:
+    assert self._handlers
+    request = PersonaCommandRequest(
+      context=self._build_context(ctx),
+      request_text=request_text,
+    )
+    await self._handlers.persona(request)
+
+  def _build_context(self, ctx) -> DiscordCommandContext:
+    guild_id = getattr(getattr(ctx, "guild", None), "id", None)
+    channel_id = getattr(getattr(ctx, "channel", None), "id", None)
+    user_id = getattr(getattr(ctx, "author", None), "id", None)
+    return DiscordCommandContext(
+      guild_id=guild_id,
+      channel_id=channel_id,
+      user_id=user_id,
+      raw_context=ctx,
+    )
 

--- a/server/modules/social_input_module.py
+++ b/server/modules/social_input_module.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
-import logging
+import asyncio, contextlib, json, logging, time
 from typing import Any, Dict, TYPE_CHECKING
 
 from fastapi import FastAPI
 
 from . import BaseModule
+from .providers.social.discord_input_provider import (
+  DiscordCommandHandlers,
+  DiscordInputProvider,
+  PersonaCommandRequest,
+  RpcCommandRequest,
+  SummarizeCommandRequest,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
   from .discord_bot_module import DiscordBotModule
+  from .discord_chat_module import DiscordChatModule
   from .providers.social import SocialInputProvider
 
 
@@ -19,17 +27,32 @@ class SocialInputModule(BaseModule):
     super().__init__(app)
     self.providers: Dict[str, "SocialInputProvider"] = {}
     self.discord: "DiscordBotModule" | None = None
+    self.discord_chat: "DiscordChatModule" | None = None
+    self._provider_start_timeout = 15.0
+    self._rpc_timeout = 30.0
+    self._notice_timeout = 15.0
     self.app.state.social_input = self
 
   async def startup(self):
     self.discord = getattr(self.app.state, "discord_bot", None)
-    if self.discord:
-      await self.discord.on_ready()
-      self.discord.register_social_input_module(self)
-      from .providers.social.discord_input_provider import DiscordInputProvider
-
-      provider = DiscordInputProvider(self, self.discord)
-      await self.register_provider(provider)
+    self.discord_chat = getattr(self.app.state, "discord_chat", None)
+    if self.discord_chat:
+      await self.discord_chat.on_ready()
+    if not self.discord:
+      logging.info("[SocialInputModule] no Discord bot available; skipping provider registration")
+      self.mark_ready()
+      return
+    await self.discord.on_ready()
+    self.discord.register_social_input_module(self)
+    provider = self._create_discord_provider(self.discord)
+    provider.configure(self._build_handlers())
+    task = asyncio.create_task(provider.startup())
+    try:
+      await asyncio.wait_for(task, timeout=self._provider_start_timeout)
+    except Exception:
+      await self._cancel_task(task)
+      raise
+    await self.register_provider(provider)
     logging.info("[SocialInputModule] loaded providers: %s", list(self.providers.keys()))
     self.mark_ready()
 
@@ -45,12 +68,12 @@ class SocialInputModule(BaseModule):
     if getattr(self.app.state, "social_input", None) is self:
       self.app.state.social_input = None
     self.discord = None
+    self.discord_chat = None
 
   async def register_provider(self, provider: "SocialInputProvider"):
     name = provider.name
     if name in self.providers:
       raise ValueError(f"Provider '{name}' already registered")
-    await provider.startup()
     self.providers[name] = provider
     setattr(self.app.state, f"{name}_input_provider", provider)
 
@@ -62,3 +85,342 @@ class SocialInputModule(BaseModule):
 
   def get_provider(self, name: str) -> "SocialInputProvider | None":
     return self.providers.get(name)
+
+  def _create_discord_provider(self, discord: "DiscordBotModule") -> DiscordInputProvider:
+    return DiscordInputProvider(self, discord)
+
+  def _build_handlers(self) -> DiscordCommandHandlers:
+    return DiscordCommandHandlers(
+      rpc=self.handle_rpc_command,
+      summarize=self.handle_summarize_command,
+      persona=self.handle_persona_command,
+    )
+
+  async def handle_rpc_command(self, request: RpcCommandRequest) -> None:
+    context = request.context
+    discord = self._require_discord()
+    guild_id = context.guild_id or 0
+    user_id = context.user_id or 0
+    channel_id = context.channel_id or 0
+    if guild_id and user_id:
+      discord.bump_rate_limits(guild_id, user_id)
+    metadata = {
+      "guild_id": guild_id,
+      "channel_id": channel_id,
+      "user_id": user_id,
+    }
+    start = time.perf_counter()
+    rpc_task = asyncio.create_task(discord.call_rpc(request.operation, None, metadata=metadata))
+    try:
+      response = await asyncio.wait_for(rpc_task, timeout=self._rpc_timeout)
+    except asyncio.TimeoutError:
+      await self._cancel_task(rpc_task)
+      await self._queue_channel_notice(context, "Request timed out.", reason="rpc_timeout")
+      logging.exception(
+        "[SocialInputModule] rpc timed out",
+        extra={"op": request.operation, "guild_id": guild_id, "channel_id": channel_id, "user_id": user_id},
+      )
+      return
+    except Exception as exc:
+      await self._cancel_task(rpc_task)
+      await self._queue_channel_notice(context, f"Error: {exc}", reason="rpc_command_error")
+      elapsed = time.perf_counter() - start
+      logging.exception(
+        "[SocialInputModule] rpc failed",
+        extra={
+          "guild_id": guild_id,
+          "channel_id": channel_id,
+          "user_id": user_id,
+          "op": request.operation,
+          "elapsed": elapsed,
+        },
+      )
+      return
+    payload = response.payload
+    message = self._format_payload(payload)
+    await self._queue_channel_notice(context, message, reason="rpc_command")
+    elapsed = time.perf_counter() - start
+    logging.info(
+      "[SocialInputModule] rpc",
+      extra={
+        "guild_id": guild_id,
+        "channel_id": channel_id,
+        "user_id": user_id,
+        "op": request.operation,
+        "elapsed": elapsed,
+      },
+    )
+
+  async def handle_summarize_command(self, request: SummarizeCommandRequest) -> None:
+    context = request.context
+    discord = self._require_discord()
+    guild_id = context.guild_id or 0
+    user_id = context.user_id or 0
+    channel_id = context.channel_id or 0
+    if guild_id and user_id:
+      discord.bump_rate_limits(guild_id, user_id)
+    try:
+      hours = int(request.hours_argument)
+    except (TypeError, ValueError):
+      await self._queue_channel_notice(context, "Usage: !summarize <hours>", reason="invalid_hours")
+      return
+    if hours < 1 or hours > 336:
+      await self._queue_channel_notice(context, "Hours must be between 1 and 336", reason="hours_out_of_range")
+      return
+    payload = {
+      "guild_id": guild_id,
+      "channel_id": channel_id,
+      "hours": hours,
+      "user_id": user_id,
+    }
+    metadata = {
+      "guild_id": guild_id,
+      "channel_id": channel_id,
+      "user_id": user_id,
+    }
+    start = time.perf_counter()
+    rpc_task = asyncio.create_task(
+      discord.call_rpc("urn:discord:chat:summarize_channel:1", payload, metadata=metadata)
+    )
+    try:
+      response = await asyncio.wait_for(rpc_task, timeout=self._rpc_timeout)
+    except asyncio.TimeoutError:
+      await self._cancel_task(rpc_task)
+      await self._queue_channel_notice(
+        context,
+        "Failed to fetch messages. Please try again later.",
+        reason="rpc_timeout",
+      )
+      logging.exception(
+        "[SocialInputModule] summarize timed out",
+        extra={"guild_id": guild_id, "channel_id": channel_id, "user_id": user_id, "hours": hours},
+      )
+      return
+    except Exception:
+      await self._cancel_task(rpc_task)
+      await self._queue_channel_notice(
+        context,
+        "Failed to fetch messages. Please try again later.",
+        reason="rpc_failure",
+      )
+      elapsed = time.perf_counter() - start
+      logging.exception(
+        "[SocialInputModule] summarize failed",
+        extra={
+          "guild_id": guild_id,
+          "channel_id": channel_id,
+          "user_id": user_id,
+          "hours": hours,
+          "elapsed": elapsed,
+        },
+      )
+      return
+    result = self._coerce_payload_dict(response.payload)
+    if not result.get("success"):
+      message = result.get("ack_message") or "Failed to send summary. Please try again later."
+      await self._queue_channel_notice(
+        context,
+        message,
+        reason=result.get("reason") or "delivery_failed",
+        details=result,
+      )
+    elapsed = time.perf_counter() - start
+    logging.info(
+      "[SocialInputModule] summarize",
+      extra={
+        "guild_id": guild_id,
+        "channel_id": channel_id,
+        "user_id": user_id,
+        "hours": hours,
+        "token_count_estimate": result.get("token_count_estimate"),
+        "messages_collected": result.get("messages_collected"),
+        "cap_hit": result.get("cap_hit"),
+        "queue_id": result.get("queue_id"),
+        "dm_enqueued": result.get("dm_enqueued"),
+        "channel_ack_enqueued": result.get("channel_ack_enqueued"),
+        "reason": result.get("reason"),
+        "elapsed": elapsed,
+      },
+    )
+
+  async def handle_persona_command(self, request: PersonaCommandRequest) -> None:
+    context = request.context
+    discord = self._require_discord()
+    guild_id = context.guild_id or 0
+    user_id = context.user_id or 0
+    channel_id = context.channel_id or 0
+    if guild_id and user_id:
+      discord.bump_rate_limits(guild_id, user_id)
+    command_text = (request.request_text or "").strip()
+    if not command_text:
+      await self._queue_channel_notice(context, "Usage: !persona <persona> <message>", reason="invalid_persona_usage")
+      return
+    chat_module = self.discord_chat
+    if not chat_module:
+      await self._queue_channel_notice(
+        context,
+        "Persona chat is currently unavailable.",
+        reason="persona_module_unavailable",
+      )
+      return
+    try:
+      task = asyncio.create_task(
+        chat_module.handle_persona_command(
+          guild_id=guild_id,
+          channel_id=channel_id,
+          user_id=user_id,
+          command_text=command_text,
+        )
+      )
+      result = await asyncio.wait_for(task, timeout=self._rpc_timeout)
+    except ValueError:
+      await self._cancel_task(task)
+      await self._queue_channel_notice(context, "Usage: !persona <persona> <message>", reason="invalid_persona_usage")
+      return
+    except asyncio.TimeoutError:
+      await self._cancel_task(task)
+      await self._queue_channel_notice(
+        context,
+        "Persona chat is currently unavailable.",
+        reason="persona_timeout",
+      )
+      logging.exception(
+        "[SocialInputModule] persona timed out",
+        extra={"guild_id": guild_id, "channel_id": channel_id, "user_id": user_id},
+      )
+      return
+    except Exception:
+      await self._cancel_task(task)
+      await self._queue_channel_notice(
+        context,
+        "Persona chat is currently unavailable.",
+        reason="persona_rpc_failure",
+      )
+      logging.exception(
+        "[SocialInputModule] persona failed",
+        extra={
+          "guild_id": guild_id,
+          "channel_id": channel_id,
+          "user_id": user_id,
+          "request": command_text,
+        },
+      )
+      return
+    ack_message = result.get("ack_message")
+    reason = result.get("reason") or ("persona_response" if result.get("success") else "persona_failed")
+    logging.info(
+      "[SocialInputModule] persona",
+      extra={
+        "guild_id": guild_id,
+        "channel_id": channel_id,
+        "user_id": user_id,
+        "persona": result.get("persona"),
+        "success": result.get("success"),
+        "reason": reason,
+      },
+    )
+    if ack_message:
+      await self._send_channel_message(context, ack_message, reason=reason)
+
+  def _require_discord(self) -> "DiscordBotModule":
+    if not self.discord:
+      raise RuntimeError("Discord bot module is not available")
+    return self.discord
+
+  async def _queue_channel_notice(
+    self,
+    context,
+    message: str,
+    *,
+    reason: str | None = None,
+    success: bool = False,
+    details: Dict[str, Any] | None = None,
+  ) -> None:
+    if not message:
+      return
+    details = details or {}
+    guild_id = context.guild_id or 0
+    channel_id = context.channel_id
+    user_id = context.user_id
+    if self.discord_chat:
+      try:
+        task = asyncio.create_task(
+          self.discord_chat.deliver_summary(
+            guild_id=guild_id,
+            channel_id=channel_id,
+            user_id=user_id,
+            summary_text=details.get("summary_text"),
+            ack_message=message,
+            success=success,
+            reason=reason,
+            messages_collected=details.get("messages_collected"),
+            token_count_estimate=details.get("token_count_estimate"),
+            cap_hit=details.get("cap_hit"),
+          )
+        )
+        await asyncio.wait_for(task, timeout=self._notice_timeout)
+        return
+      except Exception:
+        await self._cancel_task(task)
+        logging.exception(
+          "[SocialInputModule] failed to queue channel notice",
+          extra={
+            "channel_id": channel_id,
+            "guild_id": guild_id,
+            "user_id": user_id,
+            "reason": reason,
+          },
+        )
+    await self._send_channel_message(context, message, reason=reason)
+
+  async def _send_channel_message(self, context, message: str, *, reason: str | None = None) -> None:
+    if not message:
+      return
+    discord = self.discord
+    channel_id = context.channel_id
+    if not discord or not channel_id:
+      return
+    task = asyncio.create_task(discord.send_channel_message(channel_id, message))
+    try:
+      await asyncio.wait_for(task, timeout=self._notice_timeout)
+    except Exception:
+      await self._cancel_task(task)
+      logging.exception(
+        "[SocialInputModule] failed to send channel message",
+        extra={"channel_id": channel_id, "reason": reason},
+      )
+
+  async def _cancel_task(self, task: asyncio.Task[Any]) -> None:
+    if task.done():
+      return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+      await task
+
+  def _format_payload(self, payload: Any) -> str:
+    if payload is None:
+      return "Success"
+    if hasattr(payload, "model_dump"):
+      try:
+        return json.dumps(payload.model_dump())
+      except Exception:
+        return str(payload)
+    if isinstance(payload, dict):
+      try:
+        return json.dumps(payload)
+      except Exception:
+        return str(payload)
+    return str(payload)
+
+  def _coerce_payload_dict(self, payload: Any) -> Dict[str, Any]:
+    if payload is None:
+      return {}
+    if hasattr(payload, "model_dump"):
+      try:
+        return dict(payload.model_dump())
+      except Exception:
+        return {"payload": str(payload)}
+    if isinstance(payload, dict):
+      return dict(payload)
+    return {"success": bool(payload)}
+

--- a/tests/test_discord_bot_commands.py
+++ b/tests/test_discord_bot_commands.py
@@ -6,7 +6,6 @@ from fastapi import FastAPI
 from server.models import RPCResponse
 from server.modules.discord_bot_module import DiscordBotModule
 from server.modules.discord_chat_module import DiscordChatModule
-from server.modules.providers.social.discord_input_provider import DiscordInputProvider
 from server.modules.social_input_module import SocialInputModule
 
 
@@ -37,19 +36,18 @@ def _setup_bot():
   bot_module.output_module = output
   app.state.discord_output = output
 
-  social = SocialInputModule(app)
-  social.discord = bot_module
-  bot_module.register_social_input_module(social)
-
-  provider = DiscordInputProvider(social, bot_module)
-  asyncio.run(social.register_provider(provider))
-
   chat_module = DiscordChatModule(app)
   chat_module.discord = bot_module
   app.state.discord_chat = chat_module
   chat_module.mark_ready()
 
-  return bot_module, provider, output
+  social = SocialInputModule(app)
+  asyncio.run(social.startup())
+
+  provider = social.get_provider("discord")
+  assert provider is not None
+
+  return bot_module, social, output
 
 
 def _make_ctx():
@@ -60,7 +58,7 @@ def _make_ctx():
 
 
 def test_summarize_command(monkeypatch):
-  bot_module, provider, output = _setup_bot()
+  bot_module, _, output = _setup_bot()
 
   responses = {
     "urn:discord:chat:summarize_channel:1": {
@@ -101,7 +99,7 @@ def test_summarize_command(monkeypatch):
 
 
 def test_summarize_command_usage_error(monkeypatch):
-  bot_module, provider, output = _setup_bot()
+  bot_module, _, output = _setup_bot()
   ctx = _make_ctx()
   cmd = bot_module.bot.get_command("summarize")
   asyncio.run(cmd.callback(ctx, hours="bad"))
@@ -109,7 +107,7 @@ def test_summarize_command_usage_error(monkeypatch):
 
 
 def test_summarize_command_empty_history(monkeypatch):
-  bot_module, provider, output = _setup_bot()
+  bot_module, _, output = _setup_bot()
 
   responses = {
     "urn:discord:chat:summarize_channel:1": {
@@ -145,7 +143,7 @@ def test_summarize_command_empty_history(monkeypatch):
 
 
 def test_summarize_command_cap_hit(monkeypatch):
-  bot_module, provider, output = _setup_bot()
+  bot_module, _, output = _setup_bot()
 
   responses = {
     "urn:discord:chat:summarize_channel:1": {
@@ -181,7 +179,7 @@ def test_summarize_command_cap_hit(monkeypatch):
 
 
 def test_summarize_command_transient_error(monkeypatch):
-  bot_module, provider, output = _setup_bot()
+  bot_module, _, output = _setup_bot()
 
   rpc_calls: list[tuple[str, dict | None, dict | None]] = []
 
@@ -203,7 +201,8 @@ def test_summarize_command_transient_error(monkeypatch):
 
 
 def test_persona_command_workflow(monkeypatch):
-  bot_module, provider, output = _setup_bot()
+  bot_module, _, output = _setup_bot()
+  module = bot_module.app.state.discord_chat
 
   responses = {
     "urn:discord:chat:persona_command:1": {"success": True, "model": "gpt-4o-mini", "max_tokens": 512},
@@ -267,7 +266,7 @@ def test_persona_command_workflow(monkeypatch):
 
 
 def test_persona_command_usage_error():
-  bot_module, provider, output = _setup_bot()
+  bot_module, _, output = _setup_bot()
   ctx = _make_ctx()
   cmd = bot_module.bot.get_command("persona")
   asyncio.run(cmd.callback(ctx, request=None))
@@ -275,7 +274,7 @@ def test_persona_command_usage_error():
 
 
 def test_persona_command_failure(monkeypatch):
-  bot_module, provider, output = _setup_bot()
+  bot_module, _, output = _setup_bot()
   module = bot_module.app.state.discord_chat
 
   async def dummy_handle(**kwargs):

--- a/tests/test_discord_bot_macros.py
+++ b/tests/test_discord_bot_macros.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 
 from server.models import RPCResponse
 from server.modules.discord_bot_module import DiscordBotModule
-from server.modules.providers.social.discord_input_provider import DiscordInputProvider
+from server.modules.discord_chat_module import DiscordChatModule
 from server.modules.social_input_module import SocialInputModule
 
 
@@ -62,12 +62,15 @@ def _setup_bot():
   module.output_module = output
   app.state.discord_output = output
 
-  social = SocialInputModule(app)
-  social.discord = module
-  module.register_social_input_module(social)
+  chat_module = DiscordChatModule(app)
+  chat_module.discord = module
+  app.state.discord_chat = chat_module
+  chat_module.mark_ready()
 
-  provider = DiscordInputProvider(social, module)
-  asyncio.run(social.register_provider(provider))
+  social = SocialInputModule(app)
+  asyncio.run(social.startup())
+  assert social.get_provider("discord") is not None
+
   return module, output
 
 
@@ -111,3 +114,4 @@ def test_summarize_macro_dm(monkeypatch):
   assert output.user_messages == []
   assert output.channel_messages == []
   assert channel.sent == []
+

--- a/tests/test_discord_input_provider.py
+++ b/tests/test_discord_input_provider.py
@@ -1,132 +1,101 @@
 import asyncio
 from types import SimpleNamespace
 
-from fastapi import FastAPI
+import discord
+from discord.ext import commands
 
-from server.modules.providers.social.discord_input_provider import DiscordInputProvider
+from server.modules.providers.social.discord_input_provider import (
+  DiscordCommandHandlers,
+  DiscordInputProvider,
+  PersonaCommandRequest,
+  RpcCommandRequest,
+  SummarizeCommandRequest,
+)
 
 
-def test_summarize_command_relies_on_ack():
-  app = FastAPI()
+class DummyDiscord:
+  def __init__(self):
+    intents = discord.Intents.default()
+    intents.message_content = True
+    self.bot = commands.Bot(command_prefix="!", intents=intents)
+    self.app = SimpleNamespace()
+    self.registered = None
 
-  class DummyChatModule:
-    def __init__(self):
-      self.deliveries = []
+  async def on_ready(self):  # pragma: no cover - matches production signature
+    return
 
-    async def deliver_summary(
-      self,
-      *,
-      guild_id,
-      channel_id,
-      user_id,
-      summary_text,
-      ack_message,
-      success,
-      reason=None,
-      messages_collected=None,
-      token_count_estimate=None,
-      cap_hit=None,
-    ):
-      self.deliveries.append(
-        {
-          'guild_id': guild_id,
-          'channel_id': channel_id,
-          'user_id': user_id,
-          'summary_text': summary_text,
-          'ack_message': ack_message,
-          'success': success,
-          'reason': reason,
-        }
+  def register_input_provider(self, provider):
+    self.registered = provider
+
+
+def test_provider_dispatches_command_dtos():
+  discord = DummyDiscord()
+  provider = DiscordInputProvider(SimpleNamespace(), discord)
+  events: dict[str, object] = {}
+
+  async def rpc_handler(request: RpcCommandRequest):
+    events["rpc"] = request
+
+  async def summarize_handler(request: SummarizeCommandRequest):
+    events["summarize"] = request
+
+  async def persona_handler(request: PersonaCommandRequest):
+    events["persona"] = request
+
+  async def run_test():
+    provider.configure(
+      DiscordCommandHandlers(
+        rpc=rpc_handler,
+        summarize=summarize_handler,
+        persona=persona_handler,
       )
-      return {
-        'success': False,
-        'queue_id': 'noop',
-        'summary_success': success,
-        'dm_enqueued': False,
-        'channel_ack_enqueued': bool(ack_message),
-        'reason': reason,
-        'ack_message': ack_message,
-        'messages_collected': messages_collected,
-        'token_count_estimate': token_count_estimate,
-        'cap_hit': cap_hit,
-      }
+    )
 
-  class DummyQueue:
-    def __init__(self):
-      self.calls = []
+    await provider.startup()
 
-    async def add(self, *args, **kwargs):
-      self.calls.append((args, kwargs))
+    ctx = SimpleNamespace(
+      guild=SimpleNamespace(id=42),
+      channel=SimpleNamespace(id=11),
+      author=SimpleNamespace(id=7),
+    )
 
-  class DummyOpenAI:
-    def __init__(self):
-      self.summary_queue = DummyQueue()
+    rpc_cmd = discord.bot.get_command("rpc")
+    summarize_cmd = discord.bot.get_command("summarize")
+    persona_cmd = discord.bot.get_command("persona")
 
-  class DummyDiscord:
-    def __init__(self, app):
-      self.app = app
-      self.sent_user_messages = []
-      self.sent_channel_messages = []
-      self.rate_limits = []
-      self.rpc_calls = []
+    await rpc_cmd.callback(ctx, op="urn:test:1")
+    await summarize_cmd.callback(ctx, hours="24")
+    await persona_cmd.callback(ctx, request="helper hi")
 
-    def bump_rate_limits(self, guild_id, user_id):
-      self.rate_limits.append((guild_id, user_id))
+    assert isinstance(events["rpc"], RpcCommandRequest)
+    assert events["rpc"].operation == "urn:test:1"
+    assert events["rpc"].context.guild_id == 42
 
-    async def send_channel_message(self, channel_id, message):
-      self.sent_channel_messages.append((channel_id, message))
+    assert isinstance(events["summarize"], SummarizeCommandRequest)
+    assert events["summarize"].hours_argument == "24"
+    assert events["summarize"].context.channel_id == 11
 
-    async def send_user_message(self, user_id, message):
-      self.sent_user_messages.append((user_id, message))
+    assert isinstance(events["persona"], PersonaCommandRequest)
+    assert events["persona"].request_text == "helper hi"
+    assert events["persona"].context.user_id == 7
 
-    async def call_rpc(self, op, payload=None, *, metadata=None):
-      self.rpc_calls.append((op, payload, metadata))
-      return DummyResponse(ack_payload)
+    await provider.shutdown()
+    await discord.bot.close()
 
-  social_module = SimpleNamespace()
-  discord = DummyDiscord(app)
-  provider = DiscordInputProvider(social_module, discord)
+  asyncio.run(run_test())
 
-  chat_module = DummyChatModule()
-  app.state.discord_chat = chat_module
-  app.state.openai = DummyOpenAI()
 
-  ack_payload = {
-    'success': True,
-    'queue_id': 'queue-123',
-    'messages_collected': 5,
-    'token_count_estimate': 12,
-    'cap_hit': False,
-    'dm_enqueued': True,
-    'channel_ack_enqueued': True,
-    'reason': None,
-    'ack_message': 'Summary queued for delivery to <@3>.',
-  }
+def test_provider_requires_configuration():
+  discord = DummyDiscord()
+  provider = DiscordInputProvider(SimpleNamespace(), discord)
 
-  class DummyResponse:
-    def __init__(self, payload):
-      self.payload = payload
+  async def run_test():
+    try:
+      await provider.startup()
+    except RuntimeError:
+      await discord.bot.close()
+      return
+    assert False, "Provider should require handlers"
 
-  ctx = SimpleNamespace(
-    guild=SimpleNamespace(id=1),
-    channel=SimpleNamespace(id=2),
-    author=SimpleNamespace(id=3),
-  )
+  asyncio.run(run_test())
 
-  asyncio.run(provider._handle_summarize_command(ctx, '2'))
-
-  assert discord.sent_user_messages == []
-  assert discord.sent_channel_messages == []
-  assert chat_module.deliveries == []
-  assert app.state.openai.summary_queue.calls == []
-  assert ack_payload['queue_id']
-  assert discord.rate_limits == [(1, 3)]
-  assert discord.rpc_calls
-  op, payload, metadata = discord.rpc_calls[0]
-  assert op == 'urn:discord:chat:summarize_channel:1'
-  assert payload['guild_id'] == 1
-  assert payload['channel_id'] == 2
-  assert payload['user_id'] == 3
-  assert metadata['guild_id'] == 1
-  assert metadata['channel_id'] == 2
-  assert metadata['user_id'] == 3


### PR DESCRIPTION
## Summary
- move command handling, rate limiting, and summarization logic into SocialInputModule
- slim the Discord input provider to DTO-focused command wiring
- update Discord-related tests to reflect the new module/provider contract

## Testing
- `pytest tests/test_discord_input_provider.py tests/test_discord_bot_commands.py tests/test_discord_bot_macros.py`


------
https://chatgpt.com/codex/tasks/task_e_68e1b9ec3df48325b93d2b745fe2aa4b