### PR TITLE
Add request correlation and structured RPC error handling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,13 @@ flowchart TD
 * **Providers** – External systems such as databases and identity services.
 * **Security** – Cross cutting layer enforcing authentication, authorization, and privacy rules. Data marked internal never leaves the server.
 
+## Logging and Request Correlation
+
+* Each RPC request receives a server-generated `request_id` during request unpacking.
+* The `request_id` propagates through RPC handlers, modules, providers, and database helpers via contextual metadata.
+* All log statements at those boundaries must include the `request_id` to provide end-to-end traceability.
+* Providers are responsible for translating internal exceptions into structured RPC errors so diagnostic context is logged while the client receives a user-safe message.
+
 ## Security Model
 
 ### Role Bit Assignments

--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -4,26 +4,60 @@ from fastapi import HTTPException, Request
 
 from rpc import HANDLERS
 from rpc.helpers import unbox_request
+from server.errors import (
+  RPCServiceError,
+  as_http_exception,
+  bad_request,
+  from_http_exception,
+  not_found,
+)
+from server.helpers.context import get_request_id, request_id_context
 from server.models import RPCResponse
+
+
+_logger = logging.getLogger(__name__)
 
 
 async def handle_rpc_request(request: Request) -> RPCResponse:
   rpc_request, _, parts = await unbox_request(request)
-  return await _dispatch_rpc_request(request, rpc_request, parts)
+  with request_id_context(rpc_request.request_id):
+    _logger.info(
+      "[RPC %s] Received request for %s", rpc_request.request_id, rpc_request.op,
+    )
+    return await _dispatch_rpc_request(request, rpc_request, parts)
 
 
 async def _dispatch_rpc_request(request, rpc_request, parts: list[str]) -> RPCResponse:
-  if parts[:1] != ['urn']:
-    raise HTTPException(status_code=400, detail='Invalid URN prefix')
+  request_id = get_request_id()
   try:
+    if parts[:1] != ['urn']:
+      raise bad_request('Invalid URN prefix', diagnostic=f'Parts={parts}')
     domain = parts[1]
     remainder = parts[2:]
     handler = HANDLERS.get(domain)
     if not handler:
-      raise HTTPException(status_code=404, detail='Unknown RPC domain')
+      raise not_found('Unknown RPC domain', diagnostic=f'Domain={domain}')
+    _logger.debug("[RPC %s] Dispatching domain handler %s", request_id, domain)
     response = await handler(remainder, request)
-    logging.info(f"RPC completed: {rpc_request.op}")
+    _logger.info("[RPC %s] RPC completed: %s", request_id, rpc_request.op)
     return response
+  except RPCServiceError as exc:
+    _logger.error(
+      "[RPC %s] RPC failed: %s (%s)",
+      request_id,
+      rpc_request.op,
+      exc.detail.diagnostic,
+    )
+    raise as_http_exception(exc) from exc
+  except HTTPException as exc:
+    wrapped = from_http_exception(exc)
+    _logger.error(
+      "[RPC %s] RPC failed: %s (%s)",
+      request_id,
+      rpc_request.op,
+      wrapped.detail.diagnostic,
+    )
+    raise as_http_exception(wrapped) from exc
   except Exception:
-    logging.exception(f"RPC failed: {rpc_request.op}")
+    _logger.exception("[RPC %s] RPC failed: %s", request_id, rpc_request.op)
     raise

--- a/rpc/helpers.py
+++ b/rpc/helpers.py
@@ -2,10 +2,19 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from fastapi import HTTPException, Request
+from fastapi import HTTPException as FastAPIHTTPException
+from fastapi import Request
 
 from server.models import AuthContext
 from server.models import RPCRequest
+from server.errors import (
+  RPCServiceError,
+  bad_request,
+  forbidden,
+  internal_error,
+  service_unavailable,
+  unauthorized,
+)
 
 if TYPE_CHECKING:
   from server.modules import AuthService
@@ -18,7 +27,7 @@ def mask_to_bit(mask: int) -> int:
 
 def bit_to_mask(bit: int) -> int:
   if bit < 0 or bit >= 63:
-    raise HTTPException(status_code=400, detail='Invalid bit index')
+    raise bad_request('Invalid bit index', diagnostic=f'Bit index {bit} out of range')
   return 1 << bit
 
 def _get_token_from_request(request: Request) -> str | None:
@@ -54,13 +63,13 @@ def _get_mtls_subject(request: Request) -> str | None:
 
 def resolve_required_mask(auth: 'AuthService', role_name: str) -> int:
   if not role_name:
-    raise HTTPException(status_code=500, detail='Role name must be provided')
+    raise internal_error('Role name must be provided', code='rpc.role.missing')
   try:
     return auth.require_role_mask(role_name)
   except KeyError as exc:
     message = f'Required role is undefined: {role_name}'
     _logger.error('[RPC] %s', message)
-    raise HTTPException(status_code=500, detail=message) from exc
+    raise internal_error('Required role is undefined', code='rpc.role.undefined', diagnostic=message) from exc
 
 
 async def _validate_rpc_identity(
@@ -77,25 +86,35 @@ async def _validate_rpc_identity(
   if not auth:
     if domain in ('public', 'auth'):
       return auth_ctx
-    raise HTTPException(status_code=500, detail='Authentication module is unavailable')
+    raise service_unavailable(
+      'Authentication module is unavailable',
+      code='rpc.auth.unavailable',
+      diagnostic='Authentication module is missing from app state',
+    )
 
   identity_source = None
   discord_id: str | None = None
 
   if domain in ('discord', 'webhook') and not (token or mtls_subject):
-    raise HTTPException(status_code=401, detail='Signed token or MTLS assertion required')
+    raise unauthorized(
+      'Signed token or MTLS assertion required',
+      code='rpc.auth.signature_required',
+      diagnostic='Discord/webhook request missing token or MTLS assertion',
+    )
 
   if token:
     try:
       data: dict = await auth.decode_session_token(token)
-    except HTTPException:
+    except RPCServiceError:
       raise
+    except FastAPIHTTPException as exc:
+      raise internal_error('Authentication failure', diagnostic=str(exc)) from exc
     except Exception as exc:
       _logger.exception('[RPC] Failed to decode session token')
-      raise HTTPException(status_code=401, detail='Invalid authorization token') from exc
+      raise unauthorized('Invalid authorization token', diagnostic=str(exc)) from exc
     user_guid = data.get('sub')
     if not user_guid:
-      raise HTTPException(status_code=401, detail='Invalid authorization token payload')
+      raise unauthorized('Invalid authorization token payload', diagnostic='Missing sub claim')
     roles, mask = await auth.get_user_roles(user_guid)
     auth_ctx.user_guid = user_guid
     auth_ctx.provider = data.get('provider')
@@ -122,18 +141,18 @@ async def _validate_rpc_identity(
   if domain == 'discord':
     discord_id = _get_discord_id_from_request(request)
     if not discord_id:
-      raise HTTPException(status_code=401, detail='Discord identity assertion missing')
+      raise unauthorized('Discord identity assertion missing', diagnostic='No Discord ID in request')
     guid, roles, mask = await auth.get_discord_user_security(discord_id)
     if not guid:
-      raise HTTPException(status_code=403, detail='Forbidden')
+      raise forbidden('Forbidden', diagnostic=f'No Discord user for {discord_id}')
     try:
       registered_mask = auth.require_role_mask('ROLE_REGISTERED')
     except KeyError as exc:
       message = 'Required role is undefined: ROLE_REGISTERED'
       _logger.error('[RPC] %s', message)
-      raise HTTPException(status_code=500, detail=message) from exc
+      raise internal_error('Required role is undefined', code='rpc.role.undefined', diagnostic=message) from exc
     if not (mask & registered_mask):
-      raise HTTPException(status_code=403, detail='Forbidden')
+      raise forbidden('Forbidden', diagnostic=f'Discord user {guid} missing ROLE_REGISTERED')
     auth_ctx.user_guid = guid
     auth_ctx.roles = roles
     auth_ctx.role_mask = mask
@@ -143,7 +162,10 @@ async def _validate_rpc_identity(
     identity_source = 'discord'
     _logger.debug('[RPC] Resolved Discord roles for %s: %s (mask=%#018x)', guid, roles, mask)
   elif domain not in ('public', 'auth') and not identity_source:
-    raise HTTPException(status_code=401, detail='Missing or invalid authorization header')
+    raise unauthorized(
+      'Missing or invalid authorization header',
+      diagnostic='Protected domain without token or MTLS assertion',
+    )
 
   if identity_source:
     audit_payload = {

--- a/rpc/public/vars/services.py
+++ b/rpc/public/vars/services.py
@@ -1,5 +1,6 @@
-from fastapi import HTTPException, Request
+from fastapi import Request
 from rpc.helpers import resolve_required_mask, unbox_request
+from server.errors import forbidden, internal_error
 from server.models import RPCResponse
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -54,11 +55,11 @@ async def public_vars_get_ffmpeg_version_v1(request: Request):
   if vars_mod.auth:
     required_mask = resolve_required_mask(vars_mod.auth, "ROLE_SERVICE_ADMIN")
   if not (auth_ctx.role_mask & required_mask):
-    raise HTTPException(status_code=403, detail="Forbidden")
+    raise forbidden("Forbidden", diagnostic="ROLE_SERVICE_ADMIN required")
   try:
     version_line = await vars_mod.get_ffmpeg_version()
   except Exception as e:
-    raise HTTPException(status_code=500, detail=str(e))
+    raise internal_error("Failed to read ffmpeg version", diagnostic=str(e))
   payload = PublicVarsFfmpegVersion1(ffmpeg_version=version_line)
   return RPCResponse(
     op=rpc_request.op,
@@ -73,11 +74,11 @@ async def public_vars_get_odbc_version_v1(request: Request):
   if vars_mod.auth:
     required_mask = resolve_required_mask(vars_mod.auth, "ROLE_SERVICE_ADMIN")
   if not (auth_ctx.role_mask & required_mask):
-    raise HTTPException(status_code=403, detail="Forbidden")
+    raise forbidden("Forbidden", diagnostic="ROLE_SERVICE_ADMIN required")
   try:
     version_line = await vars_mod.get_odbc_version()
   except Exception as e:
-    raise HTTPException(status_code=500, detail=str(e))
+    raise internal_error("Failed to read ODBC version", diagnostic=str(e))
   payload = PublicVarsOdbcVersion1(odbc_version=version_line)
   return RPCResponse(
     op=rpc_request.op,

--- a/server/errors.py
+++ b/server/errors.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import HTTPException
+
+JSONValue = Any
+
+__all__ = [
+  "ErrorDetail",
+  "RPCServiceError",
+  "as_http_exception",
+  "from_http_exception",
+  "bad_request",
+  "conflict",
+  "forbidden",
+  "internal_error",
+  "not_found",
+  "service_unavailable",
+  "unauthorized",
+]
+
+
+@dataclass(slots=True, frozen=True)
+class ErrorDetail:
+  code: str
+  status_code: int
+  message: str
+  public_details: JSONValue | None = None
+  diagnostic: str | None = None
+
+
+class RPCServiceError(Exception):
+  def __init__(self, *, code: str, status_code: int, message: str, public_details: JSONValue | None = None, diagnostic: str | None = None):
+    super().__init__(message)
+    self.detail = ErrorDetail(
+      code=code,
+      status_code=status_code,
+      message=message,
+      public_details=public_details,
+      diagnostic=diagnostic,
+    )
+
+  def to_http_exception(self) -> HTTPException:
+    return as_http_exception(self)
+
+
+def _http_detail(detail: ErrorDetail) -> dict[str, JSONValue]:
+  payload: dict[str, JSONValue] = {
+    "code": detail.code,
+    "message": detail.message,
+  }
+  if detail.public_details is not None:
+    payload["details"] = detail.public_details
+  return payload
+
+
+def as_http_exception(error: RPCServiceError) -> HTTPException:
+  payload = _http_detail(error.detail)
+  exc = HTTPException(status_code=error.detail.status_code, detail=payload)
+  setattr(exc, "rpc_error", error.detail)
+  return exc
+
+
+def from_http_exception(exc: HTTPException, *, default_code: str | None = None) -> RPCServiceError:
+  existing = getattr(exc, "rpc_error", None)
+  if isinstance(existing, ErrorDetail):
+    return RPCServiceError(
+      code=existing.code,
+      status_code=existing.status_code,
+      message=existing.message,
+      public_details=existing.public_details,
+      diagnostic=existing.diagnostic,
+    )
+  detail = getattr(exc, "detail", None)
+  code = default_code or f"rpc.http.{getattr(exc, 'status_code', 500)}"
+  public_details: JSONValue | None = None
+  diagnostic: str | None = None
+  if isinstance(detail, dict):
+    message = str(detail.get("message") or detail.get("detail") or "") or "RPC error"
+    code = str(detail.get("code") or code)
+    public_details = detail.get("details")
+    diagnostic = detail.get("diagnostic") or message
+  elif isinstance(detail, str):
+    message = detail
+    diagnostic = detail
+  else:
+    message = str(detail) if detail is not None else exc.__class__.__name__
+    diagnostic = message
+  return RPCServiceError(
+    code=code,
+    status_code=getattr(exc, "status_code", 500),
+    message=message,
+    public_details=public_details,
+    diagnostic=diagnostic,
+  )
+
+
+def _factory(status_code: int, code: str, message: str, *, public_details: JSONValue | None = None, diagnostic: str | None = None) -> RPCServiceError:
+  return RPCServiceError(
+    code=code,
+    status_code=status_code,
+    message=message,
+    public_details=public_details,
+    diagnostic=diagnostic or message,
+  )
+
+
+def bad_request(message: str, *, code: str = "rpc.bad_request", public_details: JSONValue | None = None, diagnostic: str | None = None) -> RPCServiceError:
+  return _factory(400, code, message, public_details=public_details, diagnostic=diagnostic)
+
+
+def unauthorized(message: str, *, code: str = "rpc.unauthorized", public_details: JSONValue | None = None, diagnostic: str | None = None) -> RPCServiceError:
+  return _factory(401, code, message, public_details=public_details, diagnostic=diagnostic)
+
+
+def forbidden(message: str, *, code: str = "rpc.forbidden", public_details: JSONValue | None = None, diagnostic: str | None = None) -> RPCServiceError:
+  return _factory(403, code, message, public_details=public_details, diagnostic=diagnostic)
+
+
+def not_found(message: str, *, code: str = "rpc.not_found", public_details: JSONValue | None = None, diagnostic: str | None = None) -> RPCServiceError:
+  return _factory(404, code, message, public_details=public_details, diagnostic=diagnostic)
+
+
+def conflict(message: str, *, code: str = "rpc.conflict", public_details: JSONValue | None = None, diagnostic: str | None = None) -> RPCServiceError:
+  return _factory(409, code, message, public_details=public_details, diagnostic=diagnostic)
+
+
+def internal_error(message: str = "Internal server error", *, code: str = "rpc.internal", public_details: JSONValue | None = None, diagnostic: str | None = None) -> RPCServiceError:
+  return _factory(500, code, message, public_details=public_details, diagnostic=diagnostic)
+
+
+def service_unavailable(message: str, *, code: str = "rpc.unavailable", public_details: JSONValue | None = None, diagnostic: str | None = None) -> RPCServiceError:
+  return _factory(503, code, message, public_details=public_details, diagnostic=diagnostic)

--- a/server/helpers/context.py
+++ b/server/helpers/context.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from typing import Iterator, Optional
+
+__all__ = [
+  "bind_request_id",
+  "get_request_id",
+  "request_id_context",
+  "reset_request_id",
+]
+
+_request_id_ctx: ContextVar[Optional[str]] = ContextVar("request_id", default=None)
+
+
+def get_request_id() -> Optional[str]:
+  return _request_id_ctx.get()
+
+
+def bind_request_id(request_id: Optional[str]) -> Token[Optional[str]]:
+  return _request_id_ctx.set(request_id)
+
+
+def reset_request_id(token: Token[Optional[str]]) -> None:
+  _request_id_ctx.reset(token)
+
+
+@contextmanager
+def request_id_context(request_id: Optional[str]) -> Iterator[None]:
+  token = bind_request_id(request_id)
+  try:
+    yield
+  finally:
+    reset_request_id(token)

--- a/server/models.py
+++ b/server/models.py
@@ -4,7 +4,7 @@ import re
 from collections.abc import Mapping, Sequence
 from datetime import date, datetime, timezone
 from decimal import Decimal
-from uuid import UUID
+from uuid import UUID, uuid4
 from typing import Any, Optional, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -76,6 +76,10 @@ class RPCRequest(BaseModel):
   op: str = Field(pattern=URN_PATTERN.pattern)
   payload: JSONValue | None = None
   version: int
+  request_id: str = Field(
+    default_factory=lambda: str(uuid4()),
+    description="Unique identifier generated for each RPC request",
+  )
 
   timestamp: Optional[datetime] = Field(
     default_factory=lambda: datetime.now(timezone.utc),

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -9,11 +9,15 @@ import logging
 from . import BaseModule
 from .env_module import EnvModule
 from .providers import DBResult, DbProviderBase, get_dbresult_cls
+from server.helpers.context import get_request_id
+from server.helpers.logging import update_logging_level
 from server.registry import RegistryDispatcher
 from server.registry.types import DBRequest, DBResponse
-from server.helpers.logging import update_logging_level
 from server.registry.security.accounts import account_exists_request
 from server.registry.system.config import get_config_request
+_logger = logging.getLogger(__name__)
+
+
 class DbModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
@@ -61,7 +65,18 @@ class DbModule(BaseModule):
       request = op
     else:
       request = DBRequest(op=op, params=args or {})
+    request_id = get_request_id()
+    metadata = dict(request.metadata or {})
+    if request_id and metadata.get('request_id') != request_id:
+      metadata['request_id'] = request_id
+      request = request.model_copy(update={'metadata': metadata})
+    elif request.metadata is None and request_id:
+      request = request.model_copy(update={'metadata': {'request_id': request_id}})
+    if request_id:
+      _logger.debug('[DB %s] Executing %s', request_id, request.op)
     response = await self._registry.execute(request)
+    if request_id:
+      _logger.debug('[DB %s] Completed %s', request_id, request.op)
     DBResultCls = get_dbresult_cls()
     if not isinstance(response, DBResponse):
       if isinstance(response, DBResultCls):

--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -2,6 +2,7 @@
 from typing import Any, Dict
 from collections.abc import Mapping
 import inspect
+import logging
 
 from ... import DbProviderBase, DBResult
 from .logic import init_pool, close_pool
@@ -10,6 +11,11 @@ from .db_helpers import run_operation
 from importlib import import_module
 
 from server.registry.types import DBRequest, DBResponse
+from server.helpers.context import get_request_id
+from server.errors import RPCServiceError, internal_error
+
+
+_logger = logging.getLogger(__name__)
 
 
 def _get_provider_queries():
@@ -52,13 +58,29 @@ class MssqlProvider(DbProviderBase):
 
   async def run(self, op: str, args: Dict[str, Any]) -> DBResult:
     handler = self._resolve_provider_callable(op)
-    request = DBRequest(op=op, params=args)
-    response = handler(request)
-    if inspect.isawaitable(response):
-      response = await response
+    request_id = get_request_id()
+    metadata = {'request_id': request_id} if request_id else None
+    request = DBRequest(op=op, params=args, metadata=metadata)
+    if request_id:
+      _logger.debug('[MSSQL %s] Dispatching provider handler for %s', request_id, op)
+    try:
+      response = handler(request)
+      if inspect.isawaitable(response):
+        response = await response
+    except RPCServiceError:
+      raise
+    except Exception as exc:
+      _logger.error('[MSSQL %s] Handler failure for %s: %s', request_id, op, exc)
+      raise internal_error(
+        'Database provider execution failed',
+        code='rpc.db.provider_failure',
+        diagnostic=str(exc),
+      ) from exc
     if not isinstance(response, DBResponse):
       raise TypeError(
         f"Handler '{op}' returned unsupported result type: {type(response)!r}."
         " Expected DBResponse."
       )
+    if request_id:
+      _logger.debug('[MSSQL %s] Provider handler completed for %s', request_id, op)
     return response.to_result(result_cls=DBResult)

--- a/server/modules/providers/database/mssql_provider/db_helpers.py
+++ b/server/modules/providers/database/mssql_provider/db_helpers.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Iterable, AsyncIterator, Callable
 from . import logic
 from ... import DBResult, DbRunMode
+from server.helpers.context import get_request_id
 
 
 def _current_run_mode():
@@ -30,6 +31,7 @@ class QueryErrorDetail:
   query: str
   params: tuple[Any, ...]
   message: str
+  request_id: str | None = None
 
 
 class DBQueryError(RuntimeError):
@@ -40,8 +42,10 @@ class DBQueryError(RuntimeError):
 
 
 def _raise_query_error(query: str, params: tuple[Any, ...], error: Exception, *, log: Callable[[str], Any]):
-  log(f"Query failed:\n{query}\nArgs: {params}\nError: {error}")
-  detail = QueryErrorDetail(query=query, params=params, message=str(error))
+  request_id = get_request_id()
+  prefix = f"[MSSQL {request_id}] " if request_id else "[MSSQL] "
+  log(f"{prefix}Query failed:\n{query}\nArgs: {params}\nError: {error}")
+  detail = QueryErrorDetail(query=query, params=params, message=str(error), request_id=request_id)
   raise DBQueryError(detail, original=error) from error
 
 def _rowdict(cols: Iterable[str], row: Iterable[Any]):

--- a/server/registry/providers/mssql.py
+++ b/server/registry/providers/mssql.py
@@ -7,8 +7,11 @@ import inspect
 from collections.abc import Iterable
 from typing import Any
 
+import logging
+
 from server.registry import ProviderBinding, RegistryRouter
 from server.registry.types import DBRequest, DBResponse
+from server.helpers.context import get_request_id
 
 from . import ProviderCallable, ProviderDescriptor, ProviderQueryMap, RawProvider
 
@@ -24,10 +27,21 @@ def _get_provider():
   return importlib.import_module("server.modules.providers.database.mssql_provider")
 
 
+_logger = logging.getLogger(__name__)
+
+
 async def _run_operation(kind: str, sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any] | None = None) -> DBResponse:
   provider = _get_provider()
+  request_id = get_request_id()
+  payload_meta = dict(meta or {})
+  if request_id and payload_meta.get('request_id') != request_id:
+    payload_meta['request_id'] = request_id
+  if request_id:
+    _logger.debug('[MSSQL %s] Executing query %s', request_id, sql.split()[0])
   result = await provider.run_operation(kind, sql, tuple(params))
-  return DBResponse.from_result(result, meta=meta)
+  if request_id:
+    _logger.debug('[MSSQL %s] Query completed %s', request_id, sql.split()[0])
+  return DBResponse.from_result(result, meta=payload_meta or None)
 
 
 async def run_json_one(sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any] | None = None) -> DBResponse:

--- a/tests/test_public_links_service.py
+++ b/tests/test_public_links_service.py
@@ -16,6 +16,7 @@ class RPCRequest(BaseModel):
   op: str
   payload: dict | None = None
   version: int
+  request_id: str = "test-request-id"
 
 class RPCResponse(BaseModel):
   op: str
@@ -34,8 +35,45 @@ models_pkg.RPCResponse = RPCResponse
 models_pkg.AuthContext = AuthContext
 models_pkg.ensure_json_serializable = ensure_json_serializable
 server_pkg.models = models_pkg
+errors_pkg = types.ModuleType('server.errors')
+
+class RPCServiceError(Exception):
+  def __init__(self, message, *, code='rpc.test', status_code=500, public_details=None, diagnostic=None):
+    super().__init__(message)
+    self.detail = types.SimpleNamespace(
+      code=code,
+      status_code=status_code,
+      message=message,
+      public_details=public_details,
+      diagnostic=diagnostic or message,
+    )
+
+
+def _factory(status_code: int, default_code: str):
+  def _build(message: str, *, code: str = default_code, public_details=None, diagnostic=None):
+    return RPCServiceError(
+      message,
+      code=code,
+      status_code=status_code,
+      public_details=public_details,
+      diagnostic=diagnostic,
+    )
+  return _build
+
+
+errors_pkg.RPCServiceError = RPCServiceError
+errors_pkg.bad_request = _factory(400, 'rpc.bad_request')
+errors_pkg.unauthorized = _factory(401, 'rpc.unauthorized')
+errors_pkg.forbidden = _factory(403, 'rpc.forbidden')
+errors_pkg.not_found = _factory(404, 'rpc.not_found')
+errors_pkg.conflict = _factory(409, 'rpc.conflict')
+errors_pkg.internal_error = _factory(500, 'rpc.internal')
+errors_pkg.service_unavailable = _factory(503, 'rpc.unavailable')
+errors_pkg.as_http_exception = lambda exc: exc
+server_pkg.errors = errors_pkg
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)
+sys.modules.setdefault('server.errors', errors_pkg)
 
 from rpc.public.links.services import public_links_get_home_links_v1, public_links_get_navbar_routes_v1
 

--- a/tests/test_public_users_service.py
+++ b/tests/test_public_users_service.py
@@ -16,6 +16,7 @@ class RPCRequest(BaseModel):
   op: str
   payload: dict | None = None
   version: int
+  request_id: str = "test-request-id"
 
 class RPCResponse(BaseModel):
   op: str
@@ -30,8 +31,45 @@ models_pkg.RPCRequest = RPCRequest
 models_pkg.RPCResponse = RPCResponse
 models_pkg.ensure_json_serializable = ensure_json_serializable
 server_pkg.models = models_pkg
+errors_pkg = types.ModuleType('server.errors')
+
+class RPCServiceError(Exception):
+  def __init__(self, message, *, code='rpc.test', status_code=500, public_details=None, diagnostic=None):
+    super().__init__(message)
+    self.detail = types.SimpleNamespace(
+      code=code,
+      status_code=status_code,
+      message=message,
+      public_details=public_details,
+      diagnostic=diagnostic or message,
+    )
+
+
+def _factory(status_code: int, default_code: str):
+  def _build(message: str, *, code: str = default_code, public_details=None, diagnostic=None):
+    return RPCServiceError(
+      message,
+      code=code,
+      status_code=status_code,
+      public_details=public_details,
+      diagnostic=diagnostic,
+    )
+  return _build
+
+
+errors_pkg.RPCServiceError = RPCServiceError
+errors_pkg.bad_request = _factory(400, 'rpc.bad_request')
+errors_pkg.unauthorized = _factory(401, 'rpc.unauthorized')
+errors_pkg.forbidden = _factory(403, 'rpc.forbidden')
+errors_pkg.not_found = _factory(404, 'rpc.not_found')
+errors_pkg.conflict = _factory(409, 'rpc.conflict')
+errors_pkg.internal_error = _factory(500, 'rpc.internal')
+errors_pkg.service_unavailable = _factory(503, 'rpc.unavailable')
+errors_pkg.as_http_exception = lambda exc: exc
+server_pkg.errors = errors_pkg
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)
+sys.modules.setdefault('server.errors', errors_pkg)
 
 from rpc.public.users.services import (
   public_users_get_profile_v1,

--- a/tests/test_public_vars_service.py
+++ b/tests/test_public_vars_service.py
@@ -16,6 +16,7 @@ class RPCRequest(BaseModel):
   op: str
   payload: dict | None = None
   version: int
+  request_id: str = "test-request-id"
 
 class RPCResponse(BaseModel):
   op: str
@@ -31,8 +32,45 @@ models_pkg.RPCResponse = RPCResponse
 models_pkg.AuthContext = AuthContext
 models_pkg.ensure_json_serializable = lambda value, *, field_name: value
 server_pkg.models = models_pkg
+errors_pkg = types.ModuleType('server.errors')
+
+class RPCServiceError(Exception):
+  def __init__(self, message, *, code='rpc.test', status_code=500, public_details=None, diagnostic=None):
+    super().__init__(message)
+    self.detail = types.SimpleNamespace(
+      code=code,
+      status_code=status_code,
+      message=message,
+      public_details=public_details,
+      diagnostic=diagnostic or message,
+    )
+
+
+def _factory(status_code: int, default_code: str):
+  def _build(message: str, *, code: str = default_code, public_details=None, diagnostic=None):
+    return RPCServiceError(
+      message,
+      code=code,
+      status_code=status_code,
+      public_details=public_details,
+      diagnostic=diagnostic,
+    )
+  return _build
+
+
+errors_pkg.RPCServiceError = RPCServiceError
+errors_pkg.bad_request = _factory(400, 'rpc.bad_request')
+errors_pkg.unauthorized = _factory(401, 'rpc.unauthorized')
+errors_pkg.forbidden = _factory(403, 'rpc.forbidden')
+errors_pkg.not_found = _factory(404, 'rpc.not_found')
+errors_pkg.conflict = _factory(409, 'rpc.conflict')
+errors_pkg.internal_error = _factory(500, 'rpc.internal')
+errors_pkg.service_unavailable = _factory(503, 'rpc.unavailable')
+errors_pkg.as_http_exception = lambda exc: exc
+server_pkg.errors = errors_pkg
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)
+sys.modules.setdefault('server.errors', errors_pkg)
 
 from rpc.public.vars.services import (
   public_vars_get_hostname_v1,

--- a/tests/test_rpc_helpers.py
+++ b/tests/test_rpc_helpers.py
@@ -20,6 +20,7 @@ models_mod = types.ModuleType('server.models')
 class RPCRequest:
   def __init__(self, **data):
     self.__dict__.update(data)
+    self.request_id = getattr(self, 'request_id', 'test-request-id')
 
 class RPCResponse:
   def __init__(self, **data):
@@ -43,6 +44,7 @@ sys.modules.pop('server', None)
 sys.modules['server'] = server_pkg
 
 from rpc.helpers import unbox_request
+from server.errors import RPCServiceError, as_http_exception
 
 class DummyAuth:
   role_registered = 1
@@ -62,7 +64,10 @@ app.state.auth = DummyAuth()
 
 @app.post('/rpc')
 async def parse_rpc(request: Request):
-  rpc_request, auth_ctx, parts = await unbox_request(request)
+  try:
+    rpc_request, auth_ctx, parts = await unbox_request(request)
+  except RPCServiceError as exc:
+    raise as_http_exception(exc)
   return {'user_role': auth_ctx.role_mask, 'parts': parts}
 
 client = TestClient(app)

--- a/tests/test_storage_files_services.py
+++ b/tests/test_storage_files_services.py
@@ -42,6 +42,7 @@ class RPCRequest(BaseModel):
   op: str
   payload: dict | None = None
   version: int
+  request_id: str = "test-request-id"
 
 
 class RPCResponse(BaseModel):
@@ -60,8 +61,45 @@ models_pkg.RPCResponse = RPCResponse
 models_pkg.AuthContext = AuthContext
 models_pkg.ensure_json_serializable = lambda value, *, field_name: value
 server_pkg.models = models_pkg
+errors_pkg = types.ModuleType("server.errors")
+
+class RPCServiceError(Exception):
+  def __init__(self, message, *, code="rpc.test", status_code=500, public_details=None, diagnostic=None):
+    super().__init__(message)
+    self.detail = types.SimpleNamespace(
+      code=code,
+      status_code=status_code,
+      message=message,
+      public_details=public_details,
+      diagnostic=diagnostic or message,
+    )
+
+
+def _factory(status_code: int, default_code: str):
+  def _build(message: str, *, code: str = default_code, public_details=None, diagnostic=None):
+    return RPCServiceError(
+      message,
+      code=code,
+      status_code=status_code,
+      public_details=public_details,
+      diagnostic=diagnostic,
+    )
+  return _build
+
+
+errors_pkg.RPCServiceError = RPCServiceError
+errors_pkg.bad_request = _factory(400, "rpc.bad_request")
+errors_pkg.unauthorized = _factory(401, "rpc.unauthorized")
+errors_pkg.forbidden = _factory(403, "rpc.forbidden")
+errors_pkg.not_found = _factory(404, "rpc.not_found")
+errors_pkg.conflict = _factory(409, "rpc.conflict")
+errors_pkg.internal_error = _factory(500, "rpc.internal")
+errors_pkg.service_unavailable = _factory(503, "rpc.unavailable")
+errors_pkg.as_http_exception = lambda exc: exc
+server_pkg.errors = errors_pkg
 sys.modules.setdefault("server", server_pkg)
 sys.modules.setdefault("server.models", models_pkg)
+sys.modules.setdefault("server.errors", errors_pkg)
 
 # load services module
 spec = importlib.util.spec_from_file_location(


### PR DESCRIPTION
## Summary
- generate a request identifier for each RPCRequest and propagate it through module, provider, and database layers with contextual logging
- introduce structured RPCServiceError helpers and central HTTP mapping to separate user messages from diagnostics
- update MSSQL provider utilities and documentation to log with the correlated request id and surface failures via the shared error contract

## Testing
- pytest tests/test_rpc_helpers.py
- pytest tests/test_public_vars_service.py
- pytest tests/test_public_links_service.py tests/test_public_users_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e2c47285bc8325bbb6c6181747479e