### PR TITLE
Add RPC contract validation tests and documentation

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -38,5 +38,8 @@ jobs:
     - name: Generate RPC bindings
       run: python scripts/generate_rpc_bindings.py
 
+    - name: Run RPC contract tests
+      run: pytest tests/test_rpc_contracts.py -q
+
     - name: Run tests
       run: python scripts/run_tests.py --test

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,12 +22,18 @@ flowchart TD
 * **Providers** – External systems such as databases and identity services.
 * **Security** – Cross cutting layer enforcing authentication, authorization, and privacy rules. Data marked internal never leaves the server.
 
+## RPC Ingress Contract
+
+* All external calls flow through a single FastAPI ingress mounted at `/rpc`. The router performs no branching logic; every request is handed directly to the RPC dispatcher for validation and dispatch.
+* The dispatcher validates the RPC URN structure before routing. Requests must include the `urn:` prefix, domain, subsystem, function, and version segments. Invalid or unknown domains are rejected with structured `rpc.bad_request` or `rpc.not_found` errors.
+* Registry routes are registered alongside provider bindings. The registry verifies that every `db:` contract has a callable implementation before the provider is marked ready, preventing runtime gaps between modules and SQL providers.
+
 ## Logging and Request Correlation
 
 * Each RPC request receives a server-generated `request_id` during request unpacking.
 * The `request_id` propagates through RPC handlers, modules, providers, and database helpers via contextual metadata.
-* All log statements at those boundaries must include the `request_id` to provide end-to-end traceability.
-* Providers are responsible for translating internal exceptions into structured RPC errors so diagnostic context is logged while the client receives a user-safe message.
+* All log statements at those boundaries must include the `request_id` to provide end-to-end traceability. Security-sensitive events additionally emit audit logs tagged with the RPC operation and identity source.
+* Providers are responsible for translating internal exceptions into structured RPC errors so diagnostic context is logged while the client receives a user-safe message. Registry start-up will fail fast if a provider omits handlers so missing telemetry cannot silently skip logging.
 
 ## Security Model
 

--- a/ARCH_REVIEW.md
+++ b/ARCH_REVIEW.md
@@ -1,0 +1,21 @@
+# Architecture Review Summary
+
+## RPC Ingress
+
+* All external RPC traffic terminates at the FastAPI router mounted on `/rpc`. No other ingress paths are permitted for RPC contracts.
+* The router delegates to `rpc.handler.handle_rpc_request`, which validates URN syntax and rejects unknown namespaces before module logic executes.
+
+## Authentication and Capability Enforcement
+
+* `resolve_required_mask` resolves role bitmasks through the `AuthService` and raises `rpc.role.undefined` if a capability name is missing.
+* RPC domain handlers (for example the Service domain) call `user_has_role` before invoking subdomain handlers. Calls short-circuit with `403 Forbidden` when the caller is not authorized, ensuring downstream modules cannot bypass capability checks.
+
+## Registry and Provider Bindings
+
+* Registry routes pair each `db:` contract with a provider map and optional descriptor metadata when they are registered.
+* Loading a provider module hydrates callable implementations for every contract. `RegistryRouter.verify_provider_coverage()` fails start-up if any mapping is missing, preventing partially wired providers from serving traffic.
+
+## Structured Logging
+
+* `request_id` values are propagated through async context variables so every log entry related to a request can be correlated.
+* Security audit logs record the RPC operation, caller identity source, and authorization status for Discord, MTLS, and bearer token flows.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ These items were previously implemented and are on the rebuild roadmap.
 - Deploy the Azure Web App Container Quickstart configuration.
 - Use Deployment Center to configure CI/CD from GitHub Actions post deploy, target build-ready repo.
 
+### Developer Onboarding Checklist
+
+- [ ] Confirm the FastAPI app exposes a single RPC ingress at `/rpc` and that new handlers are wired through the shared dispatcher rather than creating ad-hoc routes.
+- [ ] Validate new RPC contracts by running `pytest tests/test_rpc_contracts.py -q` locally before opening a pull request.
+- [ ] Ensure structured logging is preserved: every RPC handler should emit request/audit logs that include the `request_id` and identity metadata when applicable.
+- [ ] Run `python scripts/run_tests.py --test` to execute the combined Node and Python suites that CI will run.
+
 ### Pull Request Testing
 GitHub Actions run both the Node and Python test suites whenever a pull request targets the `main` branch. The workflow is defined in `.github/workflows/pr-tests.yml`.
 

--- a/RPC.md
+++ b/RPC.md
@@ -5,6 +5,8 @@ This document describes each RPC operation in the project and groups them by dom
 ## Naming Scheme
 
 Every RPC uses a URN in the form `urn:{domain}:{subsystem}:{function}:{version}`.
+The dispatcher validates this shape before reaching module code and rejects
+unknown domains to guarantee that only registered namespaces execute.
 
 ## Security Alignment
 

--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -1,3 +1,5 @@
+"""RPC ingress dispatcher with strict URN validation and request logging."""
+
 import logging
 
 from fastapi import HTTPException, Request

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,5 +1,6 @@
+"""Server package exports with lazy router imports to avoid circular deps."""
+
 from . import lifespan
-from .routers import rpc_router, web_router
 from .helpers.logging import configure_root_logging
 
 
@@ -9,3 +10,13 @@ __all__ = [
   "lifespan",
   "configure_root_logging",
 ]
+
+
+def __getattr__(name):
+  if name == "rpc_router":
+    from .routers import rpc_router as _rpc_router
+    return _rpc_router
+  if name == "web_router":
+    from .routers import web_router as _web_router
+    return _web_router
+  raise AttributeError(f"module 'server' has no attribute {name!r}")

--- a/server/registry/README.md
+++ b/server/registry/README.md
@@ -140,7 +140,10 @@ async def get_gallery_v1(request: DBRequest) -> DBResponse:
 ```
 
 Each registration call binds the canonical `db:` key
-(`db:content:cache:get_gallery:1`) to metadata about how to execute it.
+(`db:content:cache:get_gallery:1`) to metadata about how to execute it. During
+provider load the registry asserts that every registered key resolves to a
+callable implementation. Startup fails fast if any bindings are missing so
+module contracts cannot drift from provider coverage.
 
 ## 5. Provider maps and query stores
 Providers live under `server/registry/providers`. For every supported database

--- a/server/routers/rpc_router.py
+++ b/server/routers/rpc_router.py
@@ -1,3 +1,5 @@
+"""Single RPC ingress router that forwards to the contract dispatcher."""
+
 from fastapi import APIRouter, Request
 from rpc.handler import handle_rpc_request
 from server.models import RPCResponse

--- a/tests/test_rpc_contracts.py
+++ b/tests/test_rpc_contracts.py
@@ -1,0 +1,152 @@
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from starlette.requests import Request
+
+from rpc.service import handler as service_handler
+from rpc.service.handler import handle_service_request
+import rpc.handler as root_handler
+from rpc.handler import handle_rpc_request
+from server.registry import RegistryRouter
+from server.registry.types import DBRequest, DBResponse
+
+
+def _make_request() -> Request:
+  app = FastAPI()
+  scope = {
+    'type': 'http',
+    'http_version': '1.1',
+    'scheme': 'http',
+    'method': 'POST',
+    'path': '/rpc',
+    'query_string': b'',
+    'headers': [],
+    'app': app,
+  }
+  return Request(scope)
+
+
+def test_handle_rpc_request_rejects_non_urn_prefix(monkeypatch):
+  request = _make_request()
+
+  async def fake_unbox(req):
+    rpc_request = SimpleNamespace(op='invalid', request_id='req-123', version=1)
+    auth_ctx = SimpleNamespace(user_guid='user')
+    return rpc_request, auth_ctx, ['invalid', 'service', 'noop']
+
+  monkeypatch.setattr(root_handler, 'unbox_request', fake_unbox)
+
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(handle_rpc_request(request))
+
+  assert exc.value.status_code == 400
+  assert exc.value.detail['code'] == 'rpc.bad_request'
+  assert 'Invalid URN prefix' in exc.value.detail['message']
+
+
+def test_handle_rpc_request_unknown_domain(monkeypatch):
+  request = _make_request()
+
+  async def fake_unbox(req):
+    rpc_request = SimpleNamespace(op='urn:missing:noop:op:1', request_id='req-456', version=1)
+    auth_ctx = SimpleNamespace(user_guid='user')
+    return rpc_request, auth_ctx, ['urn', 'missing', 'noop', 'op', '1']
+
+  monkeypatch.setattr(root_handler, 'unbox_request', fake_unbox)
+
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(handle_rpc_request(request))
+
+  assert exc.value.status_code == 404
+  assert exc.value.detail['code'] == 'rpc.not_found'
+  assert 'Unknown RPC domain' in exc.value.detail['message']
+
+
+def test_service_handler_enforces_role_capabilities(monkeypatch):
+  called = {'invoked': False}
+
+  async def fake_handler(parts, request):
+    called['invoked'] = True
+    return DBResponse(rows=[], rowcount=0)
+
+  monkeypatch.setitem(service_handler.HANDLERS, 'roles', fake_handler)
+
+  async def fake_unbox(req):
+    rpc_request = SimpleNamespace(op='urn:service:roles:list:1', request_id='req-service', version=1)
+    auth_ctx = SimpleNamespace(user_guid='user-1')
+    return rpc_request, auth_ctx, ['urn', 'service', 'roles', 'list', '1']
+
+  monkeypatch.setattr(service_handler, 'unbox_request', fake_unbox)
+
+  class DummyAuth:
+    def __init__(self):
+      self.required = []
+      self.checked = []
+
+    def require_role_mask(self, name):
+      self.required.append(name)
+      return 0x4000000000000000
+
+    async def user_has_role(self, guid, mask):
+      self.checked.append((guid, mask))
+      return False
+
+  services = SimpleNamespace(auth=DummyAuth())
+  request = _make_request()
+  request.app.state.services = services
+
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(handle_service_request(['roles'], request))
+
+  assert exc.value.status_code == 403
+  assert services.auth.required == ['ROLE_SERVICE_ADMIN']
+  assert services.auth.checked == [('user-1', 0x4000000000000000)]
+  assert called['invoked'] is False
+
+
+def test_registry_router_detects_missing_provider_bindings(monkeypatch):
+  router = RegistryRouter()
+  subdomain = router.domain('demo').subdomain('widgets')
+  subdomain.add_function('list', version=1, provider_map='demo.widgets.list')
+
+  module_name = 'server.registry.providers.testcontracts'
+  provider_module = types.ModuleType(module_name)
+  provider_module.PROVIDER_QUERIES = {}
+  monkeypatch.setitem(sys.modules, module_name, provider_module)
+
+  with pytest.raises(RuntimeError) as exc:
+    router.load_provider('testcontracts')
+
+  message = str(exc.value)
+  assert "provider 'testcontracts'" in message.lower()
+  assert 'db:demo:widgets:list:1' in message
+
+
+def test_registry_router_executes_bound_provider(monkeypatch):
+  router = RegistryRouter()
+  subdomain = router.domain('demo').subdomain('widgets')
+  subdomain.add_function('list', version=1, provider_map='demo.widgets.list')
+
+  async def fake_executor(request):
+    return DBResponse(rows=[{'id': 1}], rowcount=1)
+
+  module_name = 'server.registry.providers.contractdemo'
+  provider_module = types.ModuleType(module_name)
+  provider_module.PROVIDER_QUERIES = {'demo.widgets.list': {1: fake_executor}}
+  monkeypatch.setitem(sys.modules, module_name, provider_module)
+
+  router.load_provider('contractdemo')
+  route = router.resolve('db:demo:widgets:list:1')
+  assert route is not None
+
+  executor = router.get_executor(route)
+  request = DBRequest(op=route.key, params={})
+  result = asyncio.run(executor(request))
+
+  assert isinstance(result, DBResponse)
+  assert result.rows == [{'id': 1}]
+  assert result.rowcount == 1


### PR DESCRIPTION
## Summary
- add RPC contract coverage tests for URN parsing, capability enforcement, and registry/provider bindings
- document the single ingress flow, contract validation, and structured logging across architecture and module docs
- expand developer onboarding guidance and CI to include the new RPC contract tests

## Testing
- pytest tests/test_rpc_contracts.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e32ca8e604832592e3aee18437da71