### PR TITLE
Remove registry mssql alias exports

### DIFF
--- a/server/registry/finance/credits/__init__.py
+++ b/server/registry/finance/credits/__init__.py
@@ -4,20 +4,15 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
-from . import mssql as credits_mssql
-
 from server.registry.types import DBRequest
 
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
 __all__ = [
-  "mssql",
   "register",
   "set_credits_request",
 ]
-
-mssql = credits_mssql
 
 
 def _request(name: str, params: dict[str, Any]) -> DBRequest:

--- a/server/registry/users/content/profile/__init__.py
+++ b/server/registry/users/content/profile/__init__.py
@@ -4,15 +4,12 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
-from . import mssql as profile_mssql
-
 from server.registry.types import DBRequest
 
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
 __all__ = [
-  "mssql",
   "get_profile_request",
   "set_display_request",
   "set_optin_request",
@@ -21,8 +18,6 @@ __all__ = [
   "update_if_unedited_request",
   "register",
 ]
-
-mssql = profile_mssql
 
 
 def _request(name: str, params: dict[str, Any]) -> DBRequest:

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -10,9 +10,9 @@ from server.modules.providers import DbRunMode
 from server.registry.users.security.accounts import mssql as security_accounts
 from server.registry.providers.mssql import PROVIDER_QUERIES
 from server.registry.users.security.identities import mssql as security_identities
-from server.registry.finance.credits import mssql as finance_credits_backend
+import server.registry.finance.credits.mssql as finance_credits_backend
 from server.registry.finance.credits import set_credits_request
-from server.registry.users.content.profile import mssql as users_profile_backend
+import server.registry.users.content.profile.mssql as users_profile_backend
 from server.registry.types import DBResponse
 
 


### PR DESCRIPTION
## Summary
- stop re-exporting the mssql provider modules from the finance credits and user profile registries
- update provider query tests to import the concrete mssql submodules directly

## Testing
- pytest tests/test_provider_queries.py

------
https://chatgpt.com/codex/tasks/task_e_68e42a09fb148325baf71ecc4edff53d