### PR TITLE
Remove redundant aliases in system public registry

### DIFF
--- a/server/registry/system/public/__init__.py
+++ b/server/registry/system/public/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from . import links as _links, vars as _vars
+from . import links, vars
 
 if TYPE_CHECKING:
   from server.registry import DomainRouter
@@ -14,9 +14,6 @@ __all__ = [
   "register",
   "vars",
 ]
-
-links = _links
-vars = _vars
 
 
 def register(domain: "DomainRouter") -> None:


### PR DESCRIPTION
## Summary
- import the system public links and vars modules directly in the package init
- rely on the direct package exports without redundant alias assignments

## Testing
- pytest tests/test_public_links_service.py tests/test_public_vars_service.py *(fails: ModuleNotFoundError: No module named 'server.helpers'; 'server' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68e42b7761d8832590b7b563082aa3bb