### PR TITLE
Align public gallery registry route with list implementation

### DIFF
--- a/server/registry/users/content/public/__init__.py
+++ b/server/registry/users/content/public/__init__.py
@@ -36,4 +36,4 @@ def get_public_files_request() -> DBRequest:
 def register(router: "SubdomainRouter") -> None:
   router.add_function("list_public", version=1)
   router.add_function("list_reported", version=1)
-  router.add_function("get_public_files", version=1)
+  router.add_function("get_public_files", version=1, implementation="list_public")

--- a/server/registry/users/content/public/mssql.py
+++ b/server/registry/users/content/public/mssql.py
@@ -8,7 +8,6 @@ from server.registry.providers.mssql import run_json_many
 from server.registry.types import DBResponse
 
 __all__ = [
-  "get_public_files_v1",
   "list_public_v1",
   "list_reported_v1",
 ]
@@ -30,10 +29,6 @@ async def list_public_v1(_: Dict[str, Any]) -> DBResponse:
     FOR JSON PATH;
   """
   return await run_json_many(sql)
-
-
-async def get_public_files_v1(params: Dict[str, Any]) -> DBResponse:
-  return await list_public_v1(params)
 
 
 async def list_reported_v1(_: Dict[str, Any]) -> DBResponse:


### PR DESCRIPTION
## Summary
- ensure the get_public_files registry route points at the list_public implementation
- remove the redundant MSSQL get_public_files wrapper now that the route is forwarded

## Testing
- pytest tests/test_storage_module.py::test_list_public_files tests/test_storage_files_services.py::test_get_public_files_lists_files

------
https://chatgpt.com/codex/tasks/task_e_68e42fad4e548325b2e81a5226fea94d