### PR TITLE
Refine MSSQL provider pooling and telemetry

### DIFF
--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -12,20 +12,33 @@ from importlib import import_module
 from server.registry.types import DBRequest, DBResponse
 
 
-def _get_provider_queries():
+def _load_provider_queries(bindings=None):
   module = import_module("server.registry.providers.mssql")
-  return getattr(module, "PROVIDER_QUERIES")
+  if bindings is None:
+    return getattr(module, "PROVIDER_QUERIES")
+  build = getattr(module, "build_provider_queries")
+  return build(bindings)
 
 
 class MssqlProvider(DbProviderBase):
+  def __init__(self, **config: Any):
+    self._provider_bindings = config.pop("provider_bindings", None)
+    self._provider_queries = config.pop("provider_query_map", None)
+    super().__init__(**config)
+
   async def startup(self) -> None:
     await init_pool(**self.config)
+    if self._provider_queries is None:
+      self._provider_queries = _load_provider_queries(self._provider_bindings)
 
   async def shutdown(self) -> None:
     await close_pool()
+    # retain cached bindings for potential warm restarts
 
   def _resolve_provider_callable(self, op: str):
-    provider_queries = _get_provider_queries()
+    provider_queries = self._provider_queries
+    if provider_queries is None:
+      provider_queries = self._provider_queries = _load_provider_queries(self._provider_bindings)
     parts = op.split(":")
     if len(parts) != 5 or parts[0] != "db":
       raise KeyError(f"Unsupported operation key: {op}")

--- a/server/modules/providers/database/mssql_provider/db_helpers.py
+++ b/server/modules/providers/database/mssql_provider/db_helpers.py
@@ -47,7 +47,22 @@ def _raise_query_error(query: str, params: tuple[Any, ...], error: Exception, *,
 def _rowdict(cols: Iterable[str], row: Iterable[Any]):
   return dict(zip(cols, row))
 
-async def fetch_rows(kind: DbRunMode | str, sql: str, params: Iterable[Any] = (), *, stream: bool = False) -> DBResult | AsyncIterator[dict]:
+
+async def _execute(cur, query: str, params: tuple[Any, ...], timeout: float | None):
+  if timeout is not None:
+    await cur.execute(query, params, timeout=timeout)
+  else:
+    await cur.execute(query, params)
+
+
+async def fetch_rows(
+  kind: DbRunMode | str,
+  sql: str,
+  params: Iterable[Any] = (),
+  *,
+  stream: bool = False,
+  timeout: float | None = None,
+) -> DBResult | AsyncIterator[dict]:
   assert logic._pool, "MSSQL pool not initialized"
   run_mode_cls = _current_run_mode()
   mode = _coerce_run_mode(kind)
@@ -66,39 +81,43 @@ async def fetch_rows(kind: DbRunMode | str, sql: str, params: Iterable[Any] = ()
   if stream:
     async def _stream() -> AsyncIterator[dict]:
       try:
-        async with logic._pool.acquire() as conn:
-          async with conn.cursor() as cur:
-            await cur.execute(query, params)
-            if not await _ensure_result_set(cur):
-              return
-            cols = [c[0] for c in cur.description]
-            while True:
-              row = await cur.fetchone()
-              if not row:
-                break
-              yield _rowdict(cols, row)
+        async with logic.transaction() as cur:
+          await _execute(cur, query, params, timeout)
+          if not await _ensure_result_set(cur):
+            return
+          cols = [c[0] for c in cur.description]
+          while True:
+            row = await cur.fetchone()
+            if not row:
+              break
+            yield _rowdict(cols, row)
       except Exception as e:
         _raise_query_error(query, params, e, log=logging.debug)
     return _stream()
   try:
-    async with logic._pool.acquire() as conn:
-      async with conn.cursor() as cur:
-        await cur.execute(query, params)
-        if not await _ensure_result_set(cur):
+    async with logic.transaction() as cur:
+      await _execute(cur, query, params, timeout)
+      if not await _ensure_result_set(cur):
+        return DBResult()
+      cols = [c[0] for c in cur.description]
+      if one:
+        row = await cur.fetchone()
+        if not row:
           return DBResult()
-        cols = [c[0] for c in cur.description]
-        if one:
-          row = await cur.fetchone()
-          if not row:
-            return DBResult()
-          return DBResult(rows=[_rowdict(cols, row)], rowcount=1)
-        rows_raw = await cur.fetchall()
-        rows = [_rowdict(cols, r) for r in rows_raw]
-        return DBResult(rows=rows, rowcount=len(rows))
+        return DBResult(rows=[_rowdict(cols, row)], rowcount=1)
+      rows_raw = await cur.fetchall()
+      rows = [_rowdict(cols, r) for r in rows_raw]
+      return DBResult(rows=rows, rowcount=len(rows))
   except Exception as e:
     _raise_query_error(query, params, e, log=logging.debug)
 
-async def fetch_json(kind: DbRunMode | str, sql: str, params: Iterable[Any] = ()) -> DBResult:
+async def fetch_json(
+  kind: DbRunMode | str,
+  sql: str,
+  params: Iterable[Any] = (),
+  *,
+  timeout: float | None = None,
+) -> DBResult:
   assert logic._pool, "MSSQL pool not initialized"
   run_mode_cls = _current_run_mode()
   mode = _coerce_run_mode(kind)
@@ -108,50 +127,59 @@ async def fetch_json(kind: DbRunMode | str, sql: str, params: Iterable[Any] = ()
   params = tuple(params)
   many = mode is run_mode_cls.JSON_MANY
   try:
-    async with logic._pool.acquire() as conn:
-      async with conn.cursor() as cur:
-        await cur.execute(query, params)
-        parts: list[str] = []
-        while True:
-          row = await cur.fetchone()
-          if not row or not row[0]:
-            break
-          parts.append(row[0])
-        if not parts:
-          return DBResult()
-        data = json.loads("".join(parts))
-        if data is None:
-          return DBResult()
-        if many:
-          if isinstance(data, list):
-            return DBResult(rows=data, rowcount=len(data))
-          return DBResult(rows=[data], rowcount=1)
+    async with logic.transaction() as cur:
+      await _execute(cur, query, params, timeout)
+      parts: list[str] = []
+      while True:
+        row = await cur.fetchone()
+        if not row or not row[0]:
+          break
+        parts.append(row[0])
+      if not parts:
+        return DBResult()
+      data = json.loads("".join(parts))
+      if data is None:
+        return DBResult()
+      if many:
         if isinstance(data, list):
           return DBResult(rows=data, rowcount=len(data))
         return DBResult(rows=[data], rowcount=1)
+      if isinstance(data, list):
+        return DBResult(rows=data, rowcount=len(data))
+      return DBResult(rows=[data], rowcount=1)
   except Exception as e:
     _raise_query_error(query, params, e, log=logging.error)
 
-async def exec_query(sql: str, params: Iterable[Any] = ()) -> DBResult:
+async def exec_query(
+  sql: str,
+  params: Iterable[Any] = (),
+  *,
+  timeout: float | None = None,
+) -> DBResult:
   assert logic._pool, "MSSQL pool not initialized"
   query = sql
   params = tuple(params)
   try:
-    async with logic._pool.acquire() as conn:
-      async with conn.cursor() as cur:
-        await cur.execute(query, params)
-        return DBResult(rowcount=cur.rowcount or 0)
+    async with logic.transaction() as cur:
+      await _execute(cur, query, params, timeout)
+      return DBResult(rowcount=cur.rowcount or 0)
   except Exception as e:
     _raise_query_error(query, params, e, log=logging.error)
 
 
-async def run_operation(kind: DbRunMode | str, sql: str, params: Iterable[Any] = ()) -> DBResult:
+async def run_operation(
+  kind: DbRunMode | str,
+  sql: str,
+  params: Iterable[Any] = (),
+  *,
+  timeout: float | None = None,
+) -> DBResult:
   run_mode_cls = _current_run_mode()
   mode = _coerce_run_mode(kind)
   if mode in (run_mode_cls.ROW_ONE, run_mode_cls.ROW_MANY):
-    return await fetch_rows(mode, sql, params)
+    return await fetch_rows(mode, sql, params, timeout=timeout)
   if mode in (run_mode_cls.JSON_ONE, run_mode_cls.JSON_MANY):
-    return await fetch_json(mode, sql, params)
+    return await fetch_json(mode, sql, params, timeout=timeout)
   if mode is run_mode_cls.EXEC:
-    return await exec_query(sql, params)
+    return await exec_query(sql, params, timeout=timeout)
   raise ValueError(f"Unknown operation kind: {mode}")

--- a/server/modules/providers/database/mssql_provider/logic.py
+++ b/server/modules/providers/database/mssql_provider/logic.py
@@ -1,25 +1,44 @@
 # providers/database/mssql_provider/logic.py
-import aioodbc, logging
+import asyncio
+import logging
+import aioodbc
 from contextlib import asynccontextmanager
-from typing import Callable, Optional
 
 _pool: aioodbc.pool.Pool | None = None
+_pool_config: dict[str, object] | None = None
+_init_lock = asyncio.Lock()
 
-async def init_pool(*, dsn: str | None = None, **cfg):
-    global _pool
-    if not dsn:
-        # allow explicit pieces if you pass them later
-        raise RuntimeError("MSSQL DSN is required")
-    _pool = await aioodbc.create_pool(dsn=dsn, autocommit=True)
+
+async def init_pool(*, dsn: str | None = None, minsize: int | None = None, maxsize: int | None = None, **cfg):
+  global _pool, _pool_config
+  if not dsn:
+    raise RuntimeError("MSSQL DSN is required")
+  pool_kwargs: dict[str, object] = {"dsn": dsn, "autocommit": True}
+  if minsize is not None:
+    pool_kwargs["minsize"] = int(minsize)
+  if maxsize is not None:
+    pool_kwargs["maxsize"] = int(maxsize)
+  pool_kwargs.update(cfg)
+  async with _init_lock:
+    if _pool is not None:
+      if _pool_config != pool_kwargs:
+        raise RuntimeError("MSSQL pool already initialized with different configuration")
+      return _pool
+    _pool = await aioodbc.create_pool(**pool_kwargs)
+    _pool_config = dict(pool_kwargs)
     logging.info("MSSQL ODBC Connection Pool Created")
+    return _pool
+
 
 async def close_pool():
-  global _pool
-  if _pool:
-    _pool.close()
-    await _pool.wait_closed()
-    _pool = None
-    logging.info("MSSQL ODBC Connection Pool Closed")
+  global _pool, _pool_config
+  async with _init_lock:
+    if _pool:
+      _pool.close()
+      await _pool.wait_closed()
+      _pool = None
+      _pool_config = None
+      logging.info("MSSQL ODBC Connection Pool Closed")
 
 @asynccontextmanager
 async def transaction():

--- a/server/registry/providers/mssql.py
+++ b/server/registry/providers/mssql.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import inspect
 from collections.abc import Iterable
+from time import perf_counter
 from typing import Any
 
 from server.registry import ProviderBinding, RegistryRouter
@@ -24,22 +25,63 @@ def _get_provider():
   return importlib.import_module("server.modules.providers.database.mssql_provider")
 
 
-async def _run_operation(kind: str, sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any] | None = None) -> DBResponse:
+async def _run_operation(
+  kind: str,
+  sql: str,
+  params: Iterable[Any] = (),
+  *,
+  timeout: float | None = None,
+  meta: dict[str, Any] | None = None,
+) -> DBResponse:
   provider = _get_provider()
-  result = await provider.run_operation(kind, sql, tuple(params))
-  return DBResponse.from_result(result, meta=meta)
+  bound_params = tuple(params)
+  start = perf_counter()
+  result = await provider.run_operation(kind, sql, bound_params, timeout=timeout)
+  elapsed_ms = (perf_counter() - start) * 1000
+  execution_meta: dict[str, Any] = {
+    "execution": {
+      "run_mode": kind,
+      "rowcount": result.rowcount,
+      "transaction": True,
+      "elapsed_ms": round(elapsed_ms, 3),
+    },
+  }
+  if timeout is not None:
+    execution_meta["execution"]["timeout"] = timeout
+  execution_meta["execution"]["params_count"] = len(bound_params)
+  if meta:
+    execution_meta.update(meta)
+  return DBResponse.from_result(result, meta=execution_meta)
 
 
-async def run_json_one(sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any] | None = None) -> DBResponse:
-  return await _run_operation("json_one", sql, params, meta=meta)
+async def run_json_one(
+  sql: str,
+  params: Iterable[Any] = (),
+  *,
+  timeout: float | None = None,
+  meta: dict[str, Any] | None = None,
+) -> DBResponse:
+  return await _run_operation("json_one", sql, params, timeout=timeout, meta=meta)
 
 
-async def run_json_many(sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any] | None = None) -> DBResponse:
-  return await _run_operation("json_many", sql, params, meta=meta)
+async def run_json_many(
+  sql: str,
+  params: Iterable[Any] = (),
+  *,
+  timeout: float | None = None,
+  meta: dict[str, Any] | None = None,
+) -> DBResponse:
+  return await _run_operation("json_many", sql, params, timeout=timeout, meta=meta)
 
 
-async def run_exec(sql: str, params: Iterable[Any] = (), *, meta: dict[str, Any] | None = None) -> DBResponse:
-  return await _run_operation("exec", sql, params, meta=meta)
+async def run_exec(
+  sql: str,
+  params: Iterable[Any] = (),
+  *,
+  timeout: float | None = None,
+  meta: dict[str, Any] | None = None,
+) -> DBResponse:
+  return await _run_operation("exec", sql, params, timeout=timeout, meta=meta)
 
 
 async def _coerce_response(spec: Any) -> DBResponse:

--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -13,7 +13,7 @@ def test_assistant_conversations_list_by_time(monkeypatch):
 
   captured: dict[str, object] = {}
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     captured["kind"] = kind
     captured["sql"] = sql
     captured["params"] = params
@@ -51,7 +51,7 @@ def test_assistant_conversations_insert(monkeypatch):
 
   captured: dict[str, object] = {}
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     captured["kind"] = kind
     captured["sql"] = sql
     captured["params"] = params
@@ -81,7 +81,7 @@ def test_assistant_conversations_find_recent(monkeypatch):
 
   captured: dict[str, object] = {}
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     captured["kind"] = kind
     captured["sql"] = sql
     captured["params"] = params
@@ -104,7 +104,7 @@ def test_assistant_conversations_update_output(monkeypatch):
 
   captured: dict[str, object] = {}
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     captured["kind"] = kind
     captured["sql"] = sql
     captured["params"] = params
@@ -125,7 +125,7 @@ def test_assistant_conversations_list_recent(monkeypatch):
 
   captured: dict[str, object] = {}
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     captured["kind"] = kind
     captured["sql"] = sql
     captured["params"] = params

--- a/tests/test_db_module_init.py
+++ b/tests/test_db_module_init.py
@@ -81,8 +81,8 @@ def test_db_module_forwards_operations_verbatim():
   registry.bind_provider(db._provider)
   db.set_registry(registry)
 
-  result = asyncio.run(db.run(DBRequest(op="db:test:urn-op:1", params={"foo": "bar"})))
-  assert captured["op"] == "db:test:urn-op:1"
+  result = asyncio.run(db.run(DBRequest(op="db:test:urn:op:1", params={"foo": "bar"})))
+  assert captured["op"] == "db:test:urn:op:1"
   assert captured["args"] == {"foo": "bar"}
   assert isinstance(result, DBResult)
   assert result.rows == [{"ok": True}]

--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -24,7 +24,7 @@ def test_run_json_one(monkeypatch):
     assert params == {}
     return registry_mssql.run_json_one("select 1")
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     captured["kind"] = kind
     captured["sql"] = sql
     captured["params"] = params
@@ -53,7 +53,7 @@ def test_run_row_one(monkeypatch):
     assert params == {}
     return registry_mssql._run_operation("row_one", "select 1")
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     captured["kind"] = kind
     captured["sql"] = sql
     captured["params"] = params
@@ -79,7 +79,7 @@ def test_run_row_many(monkeypatch):
 
   captured: dict[str, object] = {}
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     captured["kind"] = kind
     captured["sql"] = sql
     captured["params"] = params
@@ -107,7 +107,7 @@ def test_run_json_many(monkeypatch):
     assert params == {}
     return registry_mssql.run_json_many("select")
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     captured["kind"] = kind
     captured["sql"] = sql
     captured["params"] = params
@@ -136,7 +136,7 @@ def test_run_exec(monkeypatch):
     assert params == {}
     return registry_mssql.run_exec("update", (1,))
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     captured["kind"] = kind
     captured["sql"] = sql
     captured["params"] = params
@@ -162,7 +162,7 @@ def test_storage_files_set_gallery(monkeypatch):
 
   captured: dict[str, object] = {}
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     captured["kind"] = kind
     captured["sql"] = sql
     captured["params"] = params
@@ -188,7 +188,7 @@ def test_storage_cache_set_public(monkeypatch):
 
   captured: dict[str, object] = {}
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     captured["kind"] = kind
     captured["sql"] = sql
     captured["params"] = params
@@ -216,7 +216,7 @@ def test_storage_public_lists_share_query(monkeypatch):
   provider = MssqlProvider()
   seen: list[tuple[object, str, tuple]] = []
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     seen.append((kind, sql, params))
     assert kind in (DbRunMode.JSON_MANY, DbRunMode.JSON_MANY.value)
     assert params == ()

--- a/tests/test_discord_handler.py
+++ b/tests/test_discord_handler.py
@@ -59,6 +59,7 @@ class DummyAuth:
 def _get_client(allowed: bool):
   app = FastAPI()
   app.state.auth = DummyAuth(allowed)
+  app.state.services = types.SimpleNamespace(auth=app.state.auth)
   discord_handler.HANDLERS = {'command': dummy_handler}
 
   @app.post('/rpc')

--- a/tests/test_mssql_logic.py
+++ b/tests/test_mssql_logic.py
@@ -1,0 +1,91 @@
+import asyncio
+
+import pytest
+
+from server.modules.providers.database.mssql_provider import logic
+
+
+class DummyPool:
+  def __init__(self):
+    self.closed = False
+    self.waited = False
+
+  def close(self):
+    self.closed = True
+
+  async def wait_closed(self):
+    self.waited = True
+
+
+def _reset_pool_state(monkeypatch):
+  monkeypatch.setattr(logic, "_pool", None)
+  monkeypatch.setattr(logic, "_pool_config", None)
+  monkeypatch.setattr(logic, "_init_lock", asyncio.Lock())
+
+
+def test_init_pool_idempotent(monkeypatch):
+  dummy_pool = DummyPool()
+  created = 0
+
+  async def fake_create_pool(**kwargs):
+    nonlocal created
+    created += 1
+    await asyncio.sleep(0)
+    return dummy_pool
+
+  _reset_pool_state(monkeypatch)
+  monkeypatch.setattr(logic.aioodbc, "create_pool", fake_create_pool)
+
+  asyncio.run(logic.init_pool(dsn="dsn://test", minsize=1, maxsize=5))
+  asyncio.run(logic.init_pool(dsn="dsn://test", minsize=1, maxsize=5))
+
+  assert created == 1
+  assert logic._pool is dummy_pool
+
+  asyncio.run(logic.close_pool())
+  assert dummy_pool.closed is True
+  assert dummy_pool.waited is True
+
+
+def test_init_pool_conflicting_configuration(monkeypatch):
+  dummy_pool = DummyPool()
+
+  async def fake_create_pool(**kwargs):
+    return dummy_pool
+
+  _reset_pool_state(monkeypatch)
+  monkeypatch.setattr(logic.aioodbc, "create_pool", fake_create_pool)
+
+  asyncio.run(logic.init_pool(dsn="dsn://test", minsize=1))
+
+  with pytest.raises(RuntimeError):
+    asyncio.run(logic.init_pool(dsn="dsn://test", minsize=2))
+
+  asyncio.run(logic.close_pool())
+
+
+def test_init_pool_concurrent_calls(monkeypatch):
+  dummy_pool = DummyPool()
+  created = 0
+
+  async def fake_create_pool(**kwargs):
+    nonlocal created
+    created += 1
+    await asyncio.sleep(0.01)
+    return dummy_pool
+
+  _reset_pool_state(monkeypatch)
+  monkeypatch.setattr(logic.aioodbc, "create_pool", fake_create_pool)
+
+  async def _runner():
+    await asyncio.gather(*[
+      logic.init_pool(dsn="dsn://test", minsize=1, maxsize=4)
+      for _ in range(5)
+    ])
+
+  asyncio.run(_runner())
+
+  assert created == 1
+  assert logic._pool is dummy_pool
+
+  asyncio.run(logic.close_pool())

--- a/tests/test_mssql_personas_registry.py
+++ b/tests/test_mssql_personas_registry.py
@@ -7,7 +7,7 @@ from server.registry.types import DBResponse
 def test_persona_lookup_query_targets_element_name(monkeypatch):
   captured: dict[str, object] = {}
 
-  async def fake_run_json_one(sql, params=(), *, meta=None):
+  async def fake_run_json_one(sql, params=(), *, timeout=None, meta=None):
     captured["sql"] = sql
     captured["params"] = params
     return DBResponse()

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -5,9 +5,10 @@ from uuid import uuid4
 import pytest
 
 from server.modules.providers.database.mssql_provider import db_helpers
-from server.modules.providers import DbRunMode
+from server.modules.providers import DBResult, DbRunMode
 from server.registry.security.accounts import mssql as security_accounts
 from server.registry.providers.mssql import PROVIDER_QUERIES
+from server.registry.providers import mssql as registry_mssql
 from server.registry.support.users import mssql as support_users
 from server.registry.users.profile import mssql as users_profile
 from server.registry.security.identities import mssql as security_identities
@@ -24,7 +25,7 @@ def _provider_map_for(urn: str) -> str:
 def test_mssql_get_by_provider_identifier_uses_user_view(monkeypatch):
   captured: dict[str, Any] = {}
 
-  async def fake_run_json_one(sql, params=(), *, meta=None):
+  async def fake_run_json_one(sql, params=(), *, timeout=None, meta=None):
     captured["sql"] = sql
     captured["params"] = params
     return DBResponse()
@@ -43,7 +44,7 @@ def test_mssql_get_by_provider_identifier_uses_user_view(monkeypatch):
 def test_mssql_get_profile_uses_profile_view(monkeypatch):
   captured: dict[str, Any] = {}
 
-  async def fake_run_json_one(sql, params=(), *, meta=None):
+  async def fake_run_json_one(sql, params=(), *, timeout=None, meta=None):
     captured["sql"] = sql
     captured["params"] = params
     return DBResponse()
@@ -84,7 +85,7 @@ def test_mssql_accounts_security_profile_routes_through_security_view(
 ):
   captured: dict[str, Any] = {}
 
-  async def fake_run_json_one(sql, params=(), *, meta=None):
+  async def fake_run_json_one(sql, params=(), *, timeout=None, meta=None):
     captured["sql"] = sql
     captured["params"] = params
     return DBResponse()
@@ -114,7 +115,7 @@ def test_removed_security_aliases_are_not_registered(urn):
 def test_mssql_support_users_set_credits_updates_table(monkeypatch):
   captured: dict[str, Any] = {}
 
-  async def fake_run_exec(sql, params, *, meta=None):
+  async def fake_run_exec(sql, params, *, timeout=None, meta=None):
     captured["sql"] = sql
     captured["params"] = params
     return DBResponse()
@@ -131,18 +132,36 @@ def test_fetch_rows_raises_structured_error(monkeypatch):
       return self
     async def __aexit__(self, exc_type, exc, tb):
       pass
-    async def execute(self, q, p):
+    async def execute(self, q, p, timeout=None):
       raise Exception("boom")
     async def fetchone(self):
       return None
 
   class Conn:
+    def __init__(self):
+      self.autocommit = True
     async def __aenter__(self):
       return self
     async def __aexit__(self, exc_type, exc, tb):
       pass
     def cursor(self):
       return Cur()
+    async def commit(self):
+      pass
+    async def rollback(self):
+      pass
+    async def commit(self):
+      pass
+    async def rollback(self):
+      pass
+    async def commit(self):
+      pass
+    async def rollback(self):
+      pass
+    async def commit(self):
+      pass
+    async def rollback(self):
+      pass
 
   class Pool:
     def acquire(self):
@@ -166,18 +185,24 @@ def test_fetch_json_raises_structured_error(monkeypatch):
       return self
     async def __aexit__(self, exc_type, exc, tb):
       pass
-    async def execute(self, q, p):
+    async def execute(self, q, p, timeout=None):
       raise Exception("boom")
     async def fetchone(self):
       return None
 
   class Conn:
+    def __init__(self):
+      self.autocommit = True
     async def __aenter__(self):
       return self
     async def __aexit__(self, exc_type, exc, tb):
       pass
     def cursor(self):
       return Cur()
+    async def commit(self):
+      pass
+    async def rollback(self):
+      pass
 
   class Pool:
     def acquire(self):
@@ -203,7 +228,7 @@ def test_fetch_json_handles_multiple_rows(monkeypatch):
       return self
     async def __aexit__(self, exc_type, exc, tb):
       pass
-    async def execute(self, q, p):
+    async def execute(self, q, p, timeout=None):
       pass
     async def fetchone(self):
       if self._idx >= len(self._rows):
@@ -213,12 +238,18 @@ def test_fetch_json_handles_multiple_rows(monkeypatch):
       return row
 
   class Conn:
+    def __init__(self):
+      self.autocommit = True
     async def __aenter__(self):
       return self
     async def __aexit__(self, exc_type, exc, tb):
       pass
     def cursor(self):
       return Cur()
+    async def commit(self):
+      pass
+    async def rollback(self):
+      pass
 
   class Pool:
     def acquire(self):
@@ -240,19 +271,25 @@ def test_run_operation_handles_exec(monkeypatch):
       return self
     async def __aexit__(self, exc_type, exc, tb):
       pass
-    async def execute(self, q, p):
+    async def execute(self, q, p, timeout=None):
       pass
     @property
     def rowcount(self):
       return 3
 
   class Conn:
+    def __init__(self):
+      self.autocommit = True
     async def __aenter__(self):
       return self
     async def __aexit__(self, exc_type, exc, tb):
       pass
     def cursor(self):
       return Cur()
+    async def commit(self):
+      pass
+    async def rollback(self):
+      pass
 
   class Pool:
     def acquire(self):
@@ -266,3 +303,29 @@ def test_run_operation_handles_exec(monkeypatch):
   monkeypatch.setattr(db_helpers.logic, "_pool", Pool())
   result = asyncio.run(db_helpers.run_operation(DbRunMode.EXEC, "UPDATE"))
   assert result.rowcount == 3
+def test_run_json_one_includes_execution_meta(monkeypatch):
+  class DummyProvider:
+    async def run_operation(self, kind, sql, params, *, timeout=None):
+      assert kind == "json_one"
+      assert sql == "SELECT 1"
+      assert params == ()
+      assert timeout == 3.5
+      return DBResult(rows=[{"value": 1}], rowcount=1)
+
+  monkeypatch.setattr(registry_mssql, "_get_provider", lambda: DummyProvider())
+
+  response = asyncio.run(
+    registry_mssql.run_json_one("SELECT 1", timeout=3.5, meta={"custom": "meta"})
+  )
+
+  assert response.rowcount == 1
+  assert response.meta is not None
+  assert response.meta["custom"] == "meta"
+  execution = response.meta["execution"]
+  assert execution["run_mode"] == "json_one"
+  assert execution["timeout"] == 3.5
+  assert execution["transaction"] is True
+  assert execution["rowcount"] == 1
+  assert execution["params_count"] == 0
+  assert execution["elapsed_ms"] >= 0
+

--- a/tests/test_service_roles_services.py
+++ b/tests/test_service_roles_services.py
@@ -202,6 +202,7 @@ class DummyState:
     self.db = db
     self.auth = auth
     self.role_admin = DummyRoleAdmin(db, auth)
+    self.services = SimpleNamespace(auth=auth)
 
 
 class DummyApp:

--- a/tests/test_storage_cache_upsert.py
+++ b/tests/test_storage_cache_upsert.py
@@ -7,7 +7,7 @@ from server.registry.types import DBResponse
 def test_storage_cache_upsert_sets_created_on(monkeypatch):
   captured = []
 
-  async def fake_run_exec(sql, params):
+  async def fake_run_exec(sql, params, *, timeout=None, meta=None):
     captured.append(params)
     return DBResponse(rowcount=1)
 

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -121,7 +121,7 @@ def test_list_public_files(monkeypatch):
   app = FastAPI()
   provider = MssqlProvider()
 
-  async def fake_run_operation(kind, sql, params):
+  async def fake_run_operation(kind, sql, params, *, timeout=None):
     assert kind in (DbRunMode.JSON_MANY, DbRunMode.JSON_MANY.value)
     assert "FOR JSON PATH" in sql
     assert params == ()

--- a/tests/test_user_creation_profile_img.py
+++ b/tests/test_user_creation_profile_img.py
@@ -30,7 +30,7 @@ def test_create_from_provider_inserts_profile_image(monkeypatch):
     lookups.append((provider, cursor is not None))
     return 1
 
-  async def fake_run_json_one(sql, params=(), *, meta=None):
+  async def fake_run_json_one(sql, params=(), *, timeout=None, meta=None):
     q = sql.strip().lower()
     if q.startswith("select recid from auth_providers"):
       return DBResponse(rows=[{"recid": 1}], rowcount=1)
@@ -38,7 +38,7 @@ def test_create_from_provider_inserts_profile_image(monkeypatch):
       return DBResponse(rows=[], rowcount=0)
     return DBResponse(rows=[{"guid": "gid", "profile_image": args["provider_profile_image"]}], rowcount=1)
 
-  async def fake_run_exec(sql, params=(), *, meta=None):
+  async def fake_run_exec(sql, params=(), *, timeout=None, meta=None):
     executed.append(sql.lower())
     return DBResponse(rows=[], rowcount=1)
 


### PR DESCRIPTION
## Summary
- enforce idempotent MSSQL connection pool initialization with configurable limits and concurrency guards
- execute registry database helpers inside transactions, add timeout support, and emit execution metadata to DBResponse
- refresh MSSQL-related tests and add coverage for connection pool initialization semantics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1c2d67a4083258847e2a9ba34bd51