### PR TITLE
Normalize registry subdomain URNs

### DIFF
--- a/server/registry/README.md
+++ b/server/registry/README.md
@@ -80,8 +80,8 @@ server/registry/
 
 * **System domain** centralises assistant orchestration, runtime configuration,
   and global public metadata. Assistant conversations/models/personas and
-  navigation helpers now live under the `db:system:*` namespace with dotted
-  subdomains such as `assistant.conversations` or `public.links`.
+  navigation helpers now live under the `db:system:*` namespace with canonical
+  subdomain identifiers such as `assistant_conversations` or `public_links`.
 * **Users domain** handles end-user data. Content storage/profile helpers are
   exposed via `db:users:content.*` while security/authentication flows remain
   under `db:users:security.*`. Public profile lookups now live at
@@ -91,21 +91,21 @@ server/registry/
 
 Representative URNs:
 
-| Registry key | Target module | Notes |
+| Registry key | Provider map key | Notes |
 | --- | --- | --- |
-| `db:system:assistant.conversations:insert:1` | `system.assistant.conversations` | Persists assistant conversation transcripts. |
-| `db:system:assistant.models:list:1` | `system.assistant.models` | Lists configured LLM backends. |
-| `db:system:assistant.personas:get_by_name:1` | `system.assistant.personas` | Retrieves configured persona metadata. |
-| `db:users:content.cache:list:1` | `users.content.cache` | Fetches cached storage items for a user. |
-| `db:users:content.public:get_public_files:1` | `users.content.public` | Returns public gallery entries. |
-| `db:users:content.files:set_gallery:1` | `users.content.files` | Toggles gallery status for a file. |
-| `db:system:public.links:get_navbar_routes:1` | `system.public.links` | Provides navigation metadata for the UI shell. |
-| `db:users:public:get_published_files:1` | `users.public` | Exposes public profile assets. |
-| `db:users:content.profile:get_profile:1` | `users.content.profile` | Retrieves a user's profile and linked providers. |
-| `db:system:public.vars:get_version:1` | `system.public.vars` | Reports service version/host metadata. |
-| `db:users:security.sessions:create_session:1` | `users.security.sessions` | Issues a new session + device token. |
-| `db:users:security.accounts:get_security_profile:1` | `users.security.accounts` | Primary security/profile view. |
-| `db:finance:credits:set:1` | `finance.credits` | Writes billing credit balances. |
+| `db:system:assistant_conversations:insert:1` | `system.assistant_conversations.insert` | Persists assistant conversation transcripts. |
+| `db:system:assistant_models:list:1` | `system.assistant_models.list` | Lists configured LLM backends. |
+| `db:system:assistant_personas:get_by_name:1` | `system.assistant_personas.get_by_name` | Retrieves configured persona metadata. |
+| `db:users:content_cache:list:1` | `users.content_cache.list` | Fetches cached storage items for a user. |
+| `db:users:content_public:get_public_files:1` | `users.content_public.get_public_files` | Returns public gallery entries. |
+| `db:users:content_files:set_gallery:1` | `users.content_files.set_gallery` | Toggles gallery status for a file. |
+| `db:system:public_links:get_navbar_routes:1` | `system.public_links.get_navbar_routes` | Provides navigation metadata for the UI shell. |
+| `db:users:public:get_published_files:1` | `users.public.get_published_files` | Exposes public profile assets. |
+| `db:users:content_profile:get_profile:1` | `users.content_profile.get_profile` | Retrieves a user's profile and linked providers. |
+| `db:system:public_vars:get_version:1` | `system.public_vars.get_version` | Reports service version/host metadata. |
+| `db:users:security_sessions:create_session:1` | `users.security_sessions.create_session` | Issues a new session + device token. |
+| `db:users:security_accounts:get_security_profile:1` | `users.security_accounts.get_security_profile` | Primary security/profile view. |
+| `db:finance:credits:set:1` | `finance.credits.set` | Writes billing credit balances. |
 
 Legacy `db:assistant:*`, `db:content:*`, `db:public:*`, and `db:security:*`
 namespaces have been folded into the consolidated layout above. Modules now call
@@ -129,8 +129,8 @@ def register(registry: RegistryRouter) -> None:
 ```
 
 Each subdomain exposes a `register` helper that wires its functions to the
-provider map. Aggregators such as `users/content/__init__.py` translate dotted
-subdomain names into the correct `SubdomainRouter`:
+provider map. Aggregators such as `users/content/__init__.py` build nested
+routers to compose multi-segment identifiers:
 
 ```python
 # server/registry/users/content/__init__.py
@@ -138,17 +138,18 @@ from . import cache, files, profile, public
 
 
 def register(domain: DomainRouter) -> None:
-  cache.register(domain.subdomain("content.cache"))
-  files.register(domain.subdomain("content.files"))
-  public.register(domain.subdomain("content.public"))
-  profile.register(domain.subdomain("content.profile"))
+  content_router = domain.subdomain("content")
+  cache.register(content_router.subdomain("cache"))
+  files.register(content_router.subdomain("files"))
+  public.register(content_router.subdomain("public"))
+  profile.register(content_router.subdomain("profile"))
 ```
 
 Leaf modules (`users/content/cache/__init__.py`,
 `users/content/cache/mssql.py`, …) define their `db:` functions using
 `SubdomainRouter.add_function`. By default the router derives the provider map
-(`"{domain}.{subdomain}.{name}"`) and MSSQL binding
-(`"server.registry.{domain}.{subdomain}.mssql", "{name}_v{version}"`). When a
+(`"{domain}.{identifier}.{name}"`) and MSSQL binding
+(`"server.registry.{domain}.{module_path}.mssql", "{name}_v{version}"`). When a
 provider uses a descriptive name you can supply an `implementation=` hint (for
 example `implementation="insert_conversation"`).
 
@@ -178,7 +179,7 @@ async def get_gallery_v1(request: DBRequest) -> DBResponse:
 ```
 
 Each registration call binds the canonical `db:` key
-(`db:users:content.cache:get_gallery:1`) to metadata about how to execute it. During
+(`db:users:content_cache:get_gallery:1`) to metadata about how to execute it. During
 provider load the registry asserts that every registered key resolves to a
 callable implementation. Startup fails fast if any bindings are missing so
 module contracts cannot drift from provider coverage.
@@ -196,7 +197,7 @@ server/registry/providers/
 ```
 
 Each provider module exports a `PROVIDER_QUERIES` dictionary keyed by the same
-`users.content.cache.list` identifiers referenced during registration. The
+`users.content_cache.list` identifiers referenced during registration. The
 values are callables that receive `(request: DBRequest)` and return a
 `DBResponse` (or awaitable `DBResponse` for async helpers). SQL strings and
 stored procedure calls are defined here, keeping provider-specific details out

--- a/server/registry/__init__.py
+++ b/server/registry/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import importlib
 import pkgutil
+import re
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 
 from server.modules.providers import DBResult, DbProviderBase, get_dbresult_cls
@@ -25,6 +26,27 @@ __all__ = [
 
 
 Executor = Callable[[DBRequest], Awaitable[DBResponse]]
+
+_SEGMENT_PATTERN = re.compile(r"^[a-z0-9_]+$")
+
+
+def _normalize_segments(*segments: str) -> tuple[str, ...]:
+  parts: list[str] = []
+  for segment in segments:
+    if not segment:
+      raise ValueError("Subdomain segments cannot be empty")
+    for value in segment.split('.'):
+      value = value.strip()
+      if not value:
+        continue
+      if not _SEGMENT_PATTERN.fullmatch(value):
+        raise ValueError(
+          f"Invalid subdomain segment '{value}'. Only lowercase letters, numbers, and underscores are allowed."
+        )
+      parts.append(value)
+  if not parts:
+    raise ValueError("Subdomain path must include at least one segment")
+  return tuple(parts)
 @dataclass(slots=True)
 class FunctionRoute:
   domain: str
@@ -223,25 +245,36 @@ class DomainRouter:
   def __init__(self, registry: RegistryRouter, name: str):
     self._registry = registry
     self._name = name
-    self._subdomains: dict[str, SubdomainRouter] = {}
+    self._subdomains: dict[tuple[str, ...], SubdomainRouter] = {}
 
   @property
   def name(self) -> str:
     return self._name
 
-  def subdomain(self, name: str) -> "SubdomainRouter":
-    if name not in self._subdomains:
-      self._subdomains[name] = SubdomainRouter(self._registry, self, name)
-    return self._subdomains[name]
+  def _get_subdomain(self, path: tuple[str, ...]) -> "SubdomainRouter":
+    if path not in self._subdomains:
+      self._subdomains[path] = SubdomainRouter(self._registry, self, path)
+    return self._subdomains[path]
+
+  def subdomain(self, *segments: str) -> "SubdomainRouter":
+    path = _normalize_segments(*segments)
+    return self._get_subdomain(path)
 
 
 class SubdomainRouter:
   """Registers concrete registry functions for a subdomain."""
 
-  def __init__(self, registry: RegistryRouter, domain: DomainRouter, name: str):
+  def __init__(
+    self,
+    registry: RegistryRouter,
+    domain: DomainRouter,
+    path: tuple[str, ...],
+  ):
     self._registry = registry
     self._domain = domain
-    self._name = name
+    self._path = path
+    self._identifier = "_".join(path)
+    self._module_path = ".".join(path)
 
   @property
   def domain(self) -> DomainRouter:
@@ -249,7 +282,19 @@ class SubdomainRouter:
 
   @property
   def name(self) -> str:
-    return self._name
+    return self._identifier
+
+  @property
+  def identifier(self) -> str:
+    return self._identifier
+
+  @property
+  def module_path(self) -> str:
+    return self._module_path
+
+  def subdomain(self, *segments: str) -> "SubdomainRouter":
+    path = self._path + _normalize_segments(*segments)
+    return self._domain._get_subdomain(path)
 
   def add_function(
     self,
@@ -261,10 +306,10 @@ class SubdomainRouter:
     provider: ProviderDescriptor | None = None,
     implementation: str | None = None,
   ) -> None:
-    provider_map = provider_map or f"{self.domain.name}.{self.name}.{name}"
+    provider_map = provider_map or f"{self.domain.name}.{self.identifier}.{name}"
     route = FunctionRoute(
       domain=self._domain.name,
-      subdomain=self._name,
+      subdomain=self._identifier,
       name=name,
       version=version,
       provider_map=provider_map,
@@ -272,7 +317,7 @@ class SubdomainRouter:
     self._registry.add_route(route)
     if provider is None:
       provider = (
-        f"server.registry.{self.domain.name}.{self.name}.mssql",
+        f"server.registry.{self.domain.name}.{self.module_path}.mssql",
         f"{(implementation or name)}_v{version}",
       )
     self._registry.register_provider_binding(route, provider)

--- a/server/registry/system/assistant/__init__.py
+++ b/server/registry/system/assistant/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
 
 
 def register(domain: "DomainRouter") -> None:
-  conversations.register(domain.subdomain("assistant.conversations"))
-  models.register(domain.subdomain("assistant.models"))
-  personas.register(domain.subdomain("assistant.personas"))
+  assistant_router = domain.subdomain("assistant")
+  conversations.register(assistant_router.subdomain("conversations"))
+  models.register(assistant_router.subdomain("models"))
+  personas.register(assistant_router.subdomain("personas"))

--- a/server/registry/system/assistant/conversations/__init__.py
+++ b/server/registry/system/assistant/conversations/__init__.py
@@ -18,7 +18,7 @@ __all__ = [
   "update_output_request",
 ]
 
-_OP_PREFIX = "db:system:assistant.conversations"
+_OP_PREFIX = "db:system:assistant_conversations"
 
 
 def _op(name: str) -> str:

--- a/server/registry/system/assistant/models/__init__.py
+++ b/server/registry/system/assistant/models/__init__.py
@@ -15,7 +15,7 @@ __all__ = [
   "register",
 ]
 
-_OP_PREFIX = "db:system:assistant.models"
+_OP_PREFIX = "db:system:assistant_models"
 
 
 def _op(name: str) -> str:

--- a/server/registry/system/assistant/personas/__init__.py
+++ b/server/registry/system/assistant/personas/__init__.py
@@ -17,7 +17,7 @@ __all__ = [
   "upsert_persona_request",
 ]
 
-_OP_PREFIX = "db:system:assistant.personas"
+_OP_PREFIX = "db:system:assistant_personas"
 
 
 def _op(name: str) -> str:

--- a/server/registry/system/public/__init__.py
+++ b/server/registry/system/public/__init__.py
@@ -17,5 +17,6 @@ __all__ = [
 
 
 def register(domain: "DomainRouter") -> None:
-  links.register(domain.subdomain("public.links"))
-  vars.register(domain.subdomain("public.vars"))
+  public_router = domain.subdomain("public")
+  links.register(public_router.subdomain("links"))
+  vars.register(public_router.subdomain("vars"))

--- a/server/registry/system/public/links/__init__.py
+++ b/server/registry/system/public/links/__init__.py
@@ -21,11 +21,11 @@ def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
 
 
 def get_home_links_request() -> DBRequest:
-  return _request("db:system:public.links:get_home_links:1")
+  return _request("db:system:public_links:get_home_links:1")
 
 
 def get_navbar_routes_request(*, role_mask: int) -> DBRequest:
-  return _request("db:system:public.links:get_navbar_routes:1", {"role_mask": role_mask})
+  return _request("db:system:public_links:get_navbar_routes:1", {"role_mask": role_mask})
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/system/public/vars/__init__.py
+++ b/server/registry/system/public/vars/__init__.py
@@ -22,15 +22,15 @@ def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
 
 
 def get_version_request() -> DBRequest:
-  return _request("db:system:public.vars:get_version:1")
+  return _request("db:system:public_vars:get_version:1")
 
 
 def get_hostname_request() -> DBRequest:
-  return _request("db:system:public.vars:get_hostname:1")
+  return _request("db:system:public_vars:get_hostname:1")
 
 
 def get_repo_request() -> DBRequest:
-  return _request("db:system:public.vars:get_repo:1")
+  return _request("db:system:public_vars:get_repo:1")
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/types.py
+++ b/server/registry/types.py
@@ -22,7 +22,7 @@ __all__ = [
   "DBResult",
 ]
 
-DB_PATTERN = re.compile(r"^db:[a-z0-9_]+:(?:[a-z0-9_.]+:){2,}[0-9]+$")
+DB_PATTERN = re.compile(r"^db:[a-z0-9_]+:[a-z0-9_]+:[a-z0-9_]+:[0-9]+$")
 
 
 class DBRequest(BaseModel):
@@ -56,7 +56,7 @@ class DBRequest(BaseModel):
   @model_validator(mode="after")
   def _validate_op(self):
     parts = self.op.split(":")
-    if len(parts) < 5:
+    if len(parts) != 5:
       raise ValueError("op must include domain, subdomain, name, and version segments")
     version_segment = parts[-1]
     try:

--- a/server/registry/users/content/__init__.py
+++ b/server/registry/users/content/__init__.py
@@ -19,7 +19,8 @@ __all__ = [
 
 
 def register(domain: "DomainRouter") -> None:
-  cache.register(domain.subdomain("content.cache"))
-  files.register(domain.subdomain("content.files"))
-  public.register(domain.subdomain("content.public"))
-  profile.register(domain.subdomain("content.profile"))
+  content_router = domain.subdomain("content")
+  cache.register(content_router.subdomain("cache"))
+  files.register(content_router.subdomain("files"))
+  public.register(content_router.subdomain("public"))
+  profile.register(content_router.subdomain("profile"))

--- a/server/registry/users/content/cache/__init__.py
+++ b/server/registry/users/content/cache/__init__.py
@@ -35,13 +35,13 @@ def _normalize_cache_item_payload(item: Dict[str, Any]) -> Dict[str, Any]:
 
 def list_cache_request(user_guid: str):
   from server.registry.types import DBRequest
-  return DBRequest(op="db:users:content.cache:list:1", params={"user_guid": user_guid})
+  return DBRequest(op="db:users:content_cache:list:1", params={"user_guid": user_guid})
 
 
 def replace_user_cache_request(user_guid: str, items: Iterable[Dict[str, Any]]):
   from server.registry.types import DBRequest
   normalized = [_normalize_cache_item_payload(item) for item in items]
-  return DBRequest(op="db:users:content.cache:replace_user:1", params={
+  return DBRequest(op="db:users:content_cache:replace_user:1", params={
     "user_guid": user_guid,
     "items": normalized,
   })
@@ -50,12 +50,12 @@ def replace_user_cache_request(user_guid: str, items: Iterable[Dict[str, Any]]):
 def upsert_cache_item_request(item: Dict[str, Any]):
   from server.registry.types import DBRequest
   normalized = _normalize_cache_item_payload(item)
-  return DBRequest(op="db:users:content.cache:upsert:1", params=normalized)
+  return DBRequest(op="db:users:content_cache:upsert:1", params=normalized)
 
 
 def delete_cache_item_request(user_guid: str, path: str, filename: str):
   from server.registry.types import DBRequest
-  return DBRequest(op="db:users:content.cache:delete:1", params={
+  return DBRequest(op="db:users:content_cache:delete:1", params={
     "user_guid": user_guid,
     "path": path,
     "filename": filename,
@@ -64,7 +64,7 @@ def delete_cache_item_request(user_guid: str, path: str, filename: str):
 
 def delete_cache_folder_request(user_guid: str, path: str):
   from server.registry.types import DBRequest
-  return DBRequest(op="db:users:content.cache:delete_folder:1", params={
+  return DBRequest(op="db:users:content_cache:delete_folder:1", params={
     "user_guid": user_guid,
     "path": path,
   })
@@ -89,7 +89,7 @@ def set_public_request(
     params["path"] = path
   if filename is not None:
     params["filename"] = filename
-  return DBRequest(op="db:users:content.cache:set_public:1", params=params)
+  return DBRequest(op="db:users:content_cache:set_public:1", params=params)
 
 
 def set_reported_request(
@@ -100,7 +100,7 @@ def set_reported_request(
   reported: bool = True,
 ):
   from server.registry.types import DBRequest
-  return DBRequest(op="db:users:content.cache:set_reported:1", params={
+  return DBRequest(op="db:users:content_cache:set_reported:1", params={
     "user_guid": user_guid,
     "path": path,
     "filename": filename,
@@ -110,7 +110,7 @@ def set_reported_request(
 
 def count_rows_request():
   from server.registry.types import DBRequest
-  return DBRequest(op="db:users:content.cache:count_rows:1", params={})
+  return DBRequest(op="db:users:content_cache:count_rows:1", params={})
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/users/content/files/__init__.py
+++ b/server/registry/users/content/files/__init__.py
@@ -17,7 +17,7 @@ __all__ = [
 
 def set_gallery_request(user_guid: str, name: str, gallery: bool) -> DBRequest:
   return DBRequest(
-    op="db:users:content.files:set_gallery:1",
+    op="db:users:content_files:set_gallery:1",
     params={
       "user_guid": user_guid,
       "name": name,

--- a/server/registry/users/content/profile/__init__.py
+++ b/server/registry/users/content/profile/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
 
 
 def _request(name: str, params: dict[str, Any]) -> DBRequest:
-  return DBRequest(op=f"db:users:content.profile:{name}:1", params=params)
+  return DBRequest(op=f"db:users:content_profile:{name}:1", params=params)
 
 
 def get_profile_request(*, guid: str) -> DBRequest:

--- a/server/registry/users/content/public/__init__.py
+++ b/server/registry/users/content/public/__init__.py
@@ -22,15 +22,15 @@ def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
 
 
 def list_public_request() -> DBRequest:
-  return _request("db:users:content.public:list_public:1")
+  return _request("db:users:content_public:list_public:1")
 
 
 def list_reported_request() -> DBRequest:
-  return _request("db:users:content.public:list_reported:1")
+  return _request("db:users:content_public:list_reported:1")
 
 
 def get_public_files_request() -> DBRequest:
-  return _request("db:users:content.public:get_public_files:1")
+  return _request("db:users:content_public:get_public_files:1")
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/users/security/__init__.py
+++ b/server/registry/users/security/__init__.py
@@ -19,7 +19,8 @@ __all__ = [
 
 
 def register(domain: "DomainRouter") -> None:
-  accounts.register(domain.subdomain("security.accounts"))
-  identities.register(domain.subdomain("security.identities"))
-  oauth.register(domain.subdomain("security.oauth"))
-  sessions.register(domain.subdomain("security.sessions"))
+  security_router = domain.subdomain("security")
+  accounts.register(security_router.subdomain("accounts"))
+  identities.register(security_router.subdomain("identities"))
+  oauth.register(security_router.subdomain("oauth"))
+  sessions.register(security_router.subdomain("sessions"))

--- a/server/registry/users/security/accounts/__init__.py
+++ b/server/registry/users/security/accounts/__init__.py
@@ -35,12 +35,12 @@ def get_security_profile_request(
     params["provider_identifier"] = provider_identifier
   if discord_id is not None:
     params["discord_id"] = discord_id
-  return DBRequest(op="db:users:security.accounts:get_security_profile:1", params=params)
+  return DBRequest(op="db:users:security_accounts:get_security_profile:1", params=params)
 
 
 def account_exists_request(user_guid: str) -> DBRequest:
   return DBRequest(
-    op="db:users:security.accounts:account_exists:1",
+    op="db:users:security_accounts:account_exists:1",
     params={"user_guid": user_guid},
   )
 

--- a/server/registry/users/security/identities/__init__.py
+++ b/server/registry/users/security/identities/__init__.py
@@ -36,7 +36,7 @@ def create_from_provider_request(
   provider_profile_image: str | None = None,
 ) -> DBRequest:
   return _request(
-    "db:users:security.identities:create_from_provider:1",
+    "db:users:security_identities:create_from_provider:1",
     {
       "provider": provider,
       "provider_identifier": provider_identifier,
@@ -53,7 +53,7 @@ def get_by_provider_identifier_request(
   provider_identifier: str,
 ) -> DBRequest:
   return _request(
-    "db:users:security.identities:get_by_provider_identifier:1",
+    "db:users:security_identities:get_by_provider_identifier:1",
     {
       "provider": provider,
       "provider_identifier": provider_identifier,
@@ -67,7 +67,7 @@ def get_any_by_provider_identifier_request(
   provider_identifier: str,
 ) -> DBRequest:
   return _request(
-    "db:users:security.identities:get_any_by_provider_identifier:1",
+    "db:users:security_identities:get_any_by_provider_identifier:1",
     {
       "provider": provider,
       "provider_identifier": provider_identifier,
@@ -77,7 +77,7 @@ def get_any_by_provider_identifier_request(
 
 def get_user_by_email_request(*, email: str) -> DBRequest:
   return _request(
-    "db:users:security.identities:get_user_by_email:1",
+    "db:users:security_identities:get_user_by_email:1",
     {"email": email},
   )
 
@@ -89,7 +89,7 @@ def link_provider_request(
   provider_identifier: str,
 ) -> DBRequest:
   return _request(
-    "db:users:security.identities:link_provider:1",
+    "db:users:security_identities:link_provider:1",
     {
       "guid": guid,
       "provider": provider,
@@ -100,7 +100,7 @@ def link_provider_request(
 
 def set_provider_request(*, guid: str, provider: str) -> DBRequest:
   return _request(
-    "db:users:security.identities:set_provider:1",
+    "db:users:security_identities:set_provider:1",
     {
       "guid": guid,
       "provider": provider,
@@ -110,7 +110,7 @@ def set_provider_request(*, guid: str, provider: str) -> DBRequest:
 
 def soft_delete_account_request(*, guid: str) -> DBRequest:
   return _request(
-    "db:users:security.identities:soft_delete_account:1",
+    "db:users:security_identities:soft_delete_account:1",
     {"guid": guid},
   )
 
@@ -127,12 +127,12 @@ def unlink_provider_request(
   }
   if new_provider_recid is not None:
     params["new_provider_recid"] = new_provider_recid
-  return _request("db:users:security.identities:unlink_provider:1", params)
+  return _request("db:users:security_identities:unlink_provider:1", params)
 
 
 def unlink_last_provider_request(*, guid: str, provider: str) -> DBRequest:
   return _request(
-    "db:users:security.identities:unlink_last_provider:1",
+    "db:users:security_identities:unlink_last_provider:1",
     {
       "guid": guid,
       "provider": provider,

--- a/server/registry/users/security/oauth/__init__.py
+++ b/server/registry/users/security/oauth/__init__.py
@@ -53,7 +53,7 @@ def relink_discord_request(
   reauth_token: str | None = None,
 ) -> DBRequest:
   return _relink_request(
-    "db:users:security.oauth:relink_discord:1",
+    "db:users:security_oauth:relink_discord:1",
     _common_params(
       provider_identifier=provider_identifier,
       email=email,
@@ -75,7 +75,7 @@ def relink_google_request(
   reauth_token: str | None = None,
 ) -> DBRequest:
   return _relink_request(
-    "db:users:security.oauth:relink_google:1",
+    "db:users:security_oauth:relink_google:1",
     _common_params(
       provider_identifier=provider_identifier,
       email=email,
@@ -97,7 +97,7 @@ def relink_microsoft_request(
   reauth_token: str | None = None,
 ) -> DBRequest:
   return _relink_request(
-    "db:users:security.oauth:relink_microsoft:1",
+    "db:users:security_oauth:relink_microsoft:1",
     _common_params(
       provider_identifier=provider_identifier,
       email=email,

--- a/server/registry/users/security/sessions/__init__.py
+++ b/server/registry/users/security/sessions/__init__.py
@@ -22,7 +22,7 @@ __all__ = [
 
 
 def _request(name: str, params: dict[str, Any]) -> DBRequest:
-  return DBRequest(op=f"db:users:security.sessions:{name}:1", params=params)
+  return DBRequest(op=f"db:users:security_sessions:{name}:1", params=params)
 
 
 def create_session_request(

--- a/tests/test_auth_discord_link_by_email.py
+++ b/tests/test_auth_discord_link_by_email.py
@@ -41,19 +41,19 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.identities:get_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_by_provider_identifier:1":
       return DBRes([], 0)
-    if op == "db:users:security.identities:get_any_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_any_by_provider_identifier:1":
       return DBRes([], 0)
-    if op == "db:users:security.oauth:relink_discord:1":
+    if op == "db:users:security_oauth:relink_discord:1":
       return DBRes([
         {"guid": "existing-guid", "display_name": "User", "credits": 0}
       ], 1)
-    if op == "db:users:security.sessions:set_rotkey:1":
+    if op == "db:users:security_sessions:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     if op == "db:system:config:get_config:1":
       return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
@@ -158,5 +158,5 @@ def test_links_by_email(monkeypatch):
   data = json.loads(resp.body)
   assert data["payload"]["display_name"] == "User"
   calls = req.app.state.db.calls
-  assert any(op == "db:users:security.oauth:relink_discord:1" for op, _ in calls)
-  assert not any(op == "db:users:security.identities:create_from_provider:1" for op, _ in calls)
+  assert any(op == "db:users:security_oauth:relink_discord:1" for op, _ in calls)
+  assert not any(op == "db:users:security_identities:create_from_provider:1" for op, _ in calls)

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -43,24 +43,24 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.identities:get_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_by_provider_identifier:1":
       if self.linked:
         return DBRes([
           {"guid": "existing-guid", "display_name": "User", "credits": 0, "profile_image": None}
         ], 1)
       return DBRes([], 0)
-    if op == "db:users:security.oauth:relink_google:1":
+    if op == "db:users:security_oauth:relink_google:1":
       if args.get("confirm"):
         self.linked = True
         return DBRes([
           {"guid": "existing-guid", "display_name": "User", "credits": 0, "profile_image": None}
         ], 1)
       raise HTTPException(status_code=409, detail={"default_provider": "microsoft"})
-    if op == "db:users:security.sessions:set_rotkey:1":
+    if op == "db:users:security_sessions:set_rotkey:1":
       return DBRes(rowcount=1)
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return DBRes(rowcount=1)
     if op == "db:system:config:get_config:1":
       key = args.get("key")
@@ -162,8 +162,8 @@ def test_email_exists_prompt(monkeypatch):
     asyncio.run(auth_google_oauth_login_v1(req))
   assert exc.value.status_code == 409
   assert exc.value.detail == {"default_provider": "microsoft"}
-  assert any(op == "db:users:security.oauth:relink_google:1" for op, _ in req.app.state.db.calls)
-  assert not any(op == "db:users:security.identities:create_from_provider:1" for op, _ in req.app.state.db.calls)
+  assert any(op == "db:users:security_oauth:relink_google:1" for op, _ in req.app.state.db.calls)
+  assert not any(op == "db:users:security_identities:create_from_provider:1" for op, _ in req.app.state.db.calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())
 
 
@@ -231,5 +231,5 @@ def test_email_exists_confirm_links(monkeypatch):
   res = asyncio.run(auth_google_oauth_login_v1(req))
   data = json.loads(res.body)
   assert data["payload"]["display_name"] == "User"
-  assert any(op == "db:users:security.oauth:relink_google:1" for op, _ in req.app.state.db.calls)
+  assert any(op == "db:users:security_oauth:relink_google:1" for op, _ in req.app.state.db.calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -45,17 +45,17 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.identities:get_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
     if op == "db:system:config:get_config:1":
       key = args.get("key")
       if key == "Hostname":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
-    if op == "db:users:security.sessions:set_rotkey:1":
+    if op == "db:users:security_sessions:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 
@@ -152,5 +152,5 @@ def test_lookup_existing_user(monkeypatch):
   req.app.state.oauth.exchange_code_for_tokens = fake_exchange
   resp = asyncio.run(auth_google_oauth_login_v1(req))
   assert "rotation_token=" in resp.headers.get("set-cookie", "")
-  assert not any(op == "db:users:security.identities:create_from_provider:1" for op, _ in req.app.state.db.calls)
+  assert not any(op == "db:users:security_identities:create_from_provider:1" for op, _ in req.app.state.db.calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_link_by_email.py
+++ b/tests/test_auth_google_link_by_email.py
@@ -48,19 +48,19 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.identities:get_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_by_provider_identifier:1":
       return DBRes([], 0)
-    if op == "db:users:security.identities:get_any_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_any_by_provider_identifier:1":
       return DBRes([], 0)
-    if op == "db:users:security.oauth:relink_google:1":
+    if op == "db:users:security_oauth:relink_google:1":
       return DBRes([
         {"guid": "existing-guid", "display_name": "User", "credits": 0}
       ], 1)
-    if op == "db:users:security.sessions:set_rotkey:1":
+    if op == "db:users:security_sessions:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     if op == "db:system:config:get_config:1":
       return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
@@ -161,6 +161,6 @@ def test_links_by_email(monkeypatch):
   data = json.loads(resp.body)
   assert data["payload"]["display_name"] == "User"
   calls = req.app.state.db.calls
-  assert any(op == "db:users:security.oauth:relink_google:1" for op, _ in calls)
-  assert not any(op == "db:users:security.identities:create_from_provider:1" for op, _ in calls)
+  assert any(op == "db:users:security_oauth:relink_google:1" for op, _ in calls)
+  assert not any(op == "db:users:security_identities:create_from_provider:1" for op, _ in calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -45,7 +45,7 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.identities:get_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_by_provider_identifier:1":
       if len([c for c in self.calls if c[0] == op]) == 1:
         return DBRes([], 0)
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
@@ -53,11 +53,11 @@ class DummyDb:
       key = args.get("key")
       if key == "Hostname":
         return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
-    if op == "db:users:security.identities:create_from_provider:1":
+    if op == "db:users:security_identities:create_from_provider:1":
       return DBRes([], 1)
-    if op == "db:users:security.sessions:set_rotkey:1":
+    if op == "db:users:security_sessions:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:users:security.accounts:get_security_profile:1":
+    if op == "db:users:security_accounts:get_security_profile:1":
       return DBRes([
         {
           "guid": args.get("guid"),
@@ -66,9 +66,9 @@ class DummyDb:
           "provider_name": args.get("provider") if "provider" in args else "google",
         }
       ], 1)
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 
@@ -165,15 +165,15 @@ def test_fetch_user_after_create(monkeypatch):
   req.app.state.oauth.exchange_code_for_tokens = fake_exchange
   resp = asyncio.run(auth_google_oauth_login_v1(req))
   assert "rotation_token=" in resp.headers.get("set-cookie", "")
-  calls = [op for op, _ in req.app.state.db.calls if op == "db:users:security.identities:get_by_provider_identifier:1"]
+  calls = [op for op, _ in req.app.state.db.calls if op == "db:users:security_identities:get_by_provider_identifier:1"]
   assert len(calls) == 2
   assert any(
-    op == "db:users:security.sessions:create_session:1" and args.get("provider") == "google"
+    op == "db:users:security_sessions:create_session:1" and args.get("provider") == "google"
     for op, args in req.app.state.db.calls
   )
   expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "google-id"))
   assert any(
-    op == "db:users:security.identities:create_from_provider:1" and args["provider_identifier"] == expected
+    op == "db:users:security_identities:create_from_provider:1" and args["provider_identifier"] == expected
     for op, args in req.app.state.db.calls
   )
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_profile_image_update.py
+++ b/tests/test_auth_google_profile_image_update.py
@@ -55,13 +55,13 @@ class DummyDb:
       key = op
       params = args
     self.calls.append((key, params))
-    if key == "db:users:security.identities:get_by_provider_identifier:1":
+    if key == "db:users:security_identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
-    if key == "db:users:security.sessions:set_rotkey:1" or key == PROFILE_IMAGE_OP:
+    if key == "db:users:security_sessions:set_rotkey:1" or key == PROFILE_IMAGE_OP:
       return DBRes([], 1)
-    if key == "db:users:security.sessions:create_session:1":
+    if key == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if key == "db:users:security.sessions:update_device_token:1":
+    if key == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     if key == "db:system:config:get_config:1":
       config_key = params.get("key") if isinstance(params, dict) else None

--- a/tests/test_auth_google_profile_refresh.py
+++ b/tests/test_auth_google_profile_refresh.py
@@ -45,17 +45,17 @@ class DummyDb:
       key = op
       params = args
     self.calls.append((key, params))
-    if key == "db:users:security.identities:get_by_provider_identifier:1":
+    if key == "db:users:security_identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "provider_name": "google" }], 1)
     if key == UPDATE_IF_UNEDITED_OP:
       if self.allow_update and isinstance(params, dict):
         return DBRes([{ "display_name": params.get("display_name"), "email": params.get("email") }], 1)
       return DBRes([], 0)
-    if key == "db:users:security.sessions:set_rotkey:1":
+    if key == "db:users:security_sessions:set_rotkey:1":
       return DBRes([], 1)
-    if key == "db:users:security.sessions:create_session:1":
+    if key == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if key == "db:users:security.sessions:update_device_token:1":
+    if key == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     if key == "db:system:config:get_config:1":
       if isinstance(params, dict) and params.get("key") == "Hostname":

--- a/tests/test_auth_google_relink_unlinked.py
+++ b/tests/test_auth_google_relink_unlinked.py
@@ -42,20 +42,20 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.identities:get_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_by_provider_identifier:1":
       self._get_by_count += 1
       if self._get_by_count == 1:
         return DBRes([], 0)
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
-    if op == "db:users:security.identities:get_any_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_any_by_provider_identifier:1":
       return DBRes([{"guid": "user-guid"}], 1)
-    if op == "db:users:security.oauth:relink_google:1":
+    if op == "db:users:security_oauth:relink_google:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
-    if op == "db:users:security.sessions:set_rotkey:1":
+    if op == "db:users:security_sessions:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     if op == "db:system:config:get_config:1":
       return DBRes([{ "value": "http://localhost:8000/userpage" }], 1)
@@ -148,6 +148,6 @@ def test_relinks_unlinked_account(monkeypatch):
   req.app.state.oauth.exchange_code_for_tokens = fake_exchange
   asyncio.run(auth_google_oauth_login_v1(req))
   calls = req.app.state.db.calls
-  assert any(op == "db:users:security.oauth:relink_google:1" for op, _ in calls)
-  assert not any(op == "db:users:security.identities:create_from_provider:1" for op, _ in calls)
+  assert any(op == "db:users:security_oauth:relink_google:1" for op, _ in calls)
+  assert not any(op == "db:users:security_identities:create_from_provider:1" for op, _ in calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())

--- a/tests/test_auth_google_soft_undelete.py
+++ b/tests/test_auth_google_soft_undelete.py
@@ -50,7 +50,7 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.identities:get_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_by_provider_identifier:1":
       return DBRes([
         {
           "guid": "user-guid",
@@ -59,13 +59,13 @@ class DummyDb:
           "element_soft_deleted_at": "2024-01-01T00:00:00Z",
         }
       ], 1)
-    if op == "db:users:security.oauth:relink_google:1":
+    if op == "db:users:security_oauth:relink_google:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
-    if op == "db:users:security.sessions:set_rotkey:1":
+    if op == "db:users:security_sessions:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     if op == "db:system:config:get_config:1":
       key = args.get("key")
@@ -183,7 +183,7 @@ def test_undeletes_soft_deleted_account(monkeypatch):
   req.app.state.oauth.exchange_code_for_tokens = fake_exchange
   asyncio.run(auth_google_oauth_login_v1(req))
   calls = req.app.state.db.calls
-  assert any(op == "db:users:security.oauth:relink_google:1" for op, _ in calls)
-  assert not any(op == "db:users:security.identities:create_from_provider:1" for op, _ in calls)
+  assert any(op == "db:users:security_oauth:relink_google:1" for op, _ in calls)
+  assert not any(op == "db:users:security_identities:create_from_provider:1" for op, _ in calls)
   asyncio.run(req.app.state.auth.providers["google"].shutdown())
 

--- a/tests/test_auth_microsoft_email_exists.py
+++ b/tests/test_auth_microsoft_email_exists.py
@@ -33,24 +33,24 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.identities:get_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_by_provider_identifier:1":
       if self.linked:
         return DBRes([
           {"guid": "existing-guid", "display_name": "User", "credits": 0, "profile_image": None}
         ], 1)
       return DBRes([], 0)
-    if op == "db:users:security.oauth:relink_microsoft:1":
+    if op == "db:users:security_oauth:relink_microsoft:1":
       if args.get("confirm"):
         self.linked = True
         return DBRes([
           {"guid": "existing-guid", "display_name": "User", "credits": 0, "profile_image": None}
         ], 1)
       raise HTTPException(status_code=409, detail={"default_provider": "google"})
-    if op == "db:users:security.sessions:set_rotkey:1":
+    if op == "db:users:security_sessions:set_rotkey:1":
       return DBRes(rowcount=1)
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return DBRes(rowcount=1)
     return DBRes()
 
@@ -124,8 +124,8 @@ def test_email_exists_prompt(monkeypatch):
     asyncio.run(auth_microsoft_oauth_login_v1(req))
   assert exc.value.status_code == 409
   assert exc.value.detail == {"default_provider": "google"}
-  assert any(op == "db:users:security.oauth:relink_microsoft:1" for op, _ in req.app.state.db.calls)
-  assert not any(op == "db:users:security.identities:create_from_provider:1" for op, _ in req.app.state.db.calls)
+  assert any(op == "db:users:security_oauth:relink_microsoft:1" for op, _ in req.app.state.db.calls)
+  assert not any(op == "db:users:security_identities:create_from_provider:1" for op, _ in req.app.state.db.calls)
 
 def test_email_exists_confirm_links(monkeypatch):
   spec = importlib.util.spec_from_file_location("server.models", "server/models.py")
@@ -178,4 +178,4 @@ def test_email_exists_confirm_links(monkeypatch):
   res = asyncio.run(auth_microsoft_oauth_login_v1(req))
   data = json.loads(res.body)
   assert data["payload"]["display_name"] == "User"
-  assert any(op == "db:users:security.oauth:relink_microsoft:1" for op, _ in req.app.state.db.calls)
+  assert any(op == "db:users:security_oauth:relink_microsoft:1" for op, _ in req.app.state.db.calls)

--- a/tests/test_auth_microsoft_home_account_lookup.py
+++ b/tests/test_auth_microsoft_home_account_lookup.py
@@ -33,13 +33,13 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.identities:get_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
-    if op == "db:users:security.sessions:set_rotkey:1":
+    if op == "db:users:security_sessions:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 
@@ -112,4 +112,4 @@ def test_lookup_with_home_account_id(monkeypatch):
   req = DummyRequest()
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
   assert "rotation_token=" in resp.headers.get("set-cookie", "")
-  assert not any(op == "db:users:security.identities:create_from_provider:1" for op, _ in req.app.state.db.calls)
+  assert not any(op == "db:users:security_identities:create_from_provider:1" for op, _ in req.app.state.db.calls)

--- a/tests/test_auth_microsoft_link_by_email.py
+++ b/tests/test_auth_microsoft_link_by_email.py
@@ -38,19 +38,19 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.identities:get_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_by_provider_identifier:1":
       return DBRes([], 0)
-    if op == "db:users:security.identities:get_any_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_any_by_provider_identifier:1":
       return DBRes([], 0)
-    if op == "db:users:security.oauth:relink_microsoft:1":
+    if op == "db:users:security_oauth:relink_microsoft:1":
       return DBRes([
         {"guid": "existing-guid", "display_name": "User", "credits": 0}
       ], 1)
-    if op == "db:users:security.sessions:set_rotkey:1":
+    if op == "db:users:security_sessions:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 
@@ -124,5 +124,5 @@ def test_links_by_email(monkeypatch):
   req = DummyRequest()
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
   calls = req.app.state.db.calls
-  assert any(op == "db:users:security.oauth:relink_microsoft:1" for op, _ in calls)
-  assert not any(op == "db:users:security.identities:create_from_provider:1" for op, _ in calls)
+  assert any(op == "db:users:security_oauth:relink_microsoft:1" for op, _ in calls)
+  assert not any(op == "db:users:security_identities:create_from_provider:1" for op, _ in calls)

--- a/tests/test_auth_microsoft_oauth_login_creation.py
+++ b/tests/test_auth_microsoft_oauth_login_creation.py
@@ -31,15 +31,15 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.identities:get_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_by_provider_identifier:1":
       if len([c for c in self.calls if c[0] == op]) == 1:
         return DBRes([], 0)
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
-    if op == "db:users:security.identities:create_from_provider:1":
+    if op == "db:users:security_identities:create_from_provider:1":
       return DBRes([], 1)
-    if op == "db:users:security.sessions:set_rotkey:1":
+    if op == "db:users:security_sessions:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:users:security.accounts:get_security_profile:1":
+    if op == "db:users:security_accounts:get_security_profile:1":
       return DBRes([
         {
           "guid": args.get("guid"),
@@ -48,9 +48,9 @@ class DummyDb:
           "provider_name": args.get("provider") if "provider" in args else "microsoft",
         }
       ], 1)
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 
@@ -123,10 +123,10 @@ def test_fetch_user_after_create(monkeypatch):
   req = DummyRequest()
   resp = asyncio.run(auth_microsoft_oauth_login_v1(req))
   assert "rotation_token=" in resp.headers.get("set-cookie", "")
-  calls = [op for op, _ in req.app.state.db.calls if op == "db:users:security.identities:get_by_provider_identifier:1"]
+  calls = [op for op, _ in req.app.state.db.calls if op == "db:users:security_identities:get_by_provider_identifier:1"]
   assert len(calls) == 2
   assert any(
-    op == "db:users:security.sessions:create_session:1" and args.get("provider") == "microsoft"
+    op == "db:users:security_sessions:create_session:1" and args.get("provider") == "microsoft"
     for op, args in req.app.state.db.calls
   )
 

--- a/tests/test_auth_microsoft_profile_image_clear.py
+++ b/tests/test_auth_microsoft_profile_image_clear.py
@@ -41,13 +41,13 @@ class DummyDb:
       key = op
       params = args
     self.calls.append((key, params))
-    if key == "db:users:security.identities:get_by_provider_identifier:1":
+    if key == "db:users:security_identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
-    if key == "db:users:security.sessions:set_rotkey:1" or key == PROFILE_IMAGE_OP:
+    if key == "db:users:security_sessions:set_rotkey:1" or key == PROFILE_IMAGE_OP:
       return DBRes([], 1)
-    if key == "db:users:security.sessions:create_session:1":
+    if key == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if key == "db:users:security.sessions:update_device_token:1":
+    if key == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 

--- a/tests/test_auth_microsoft_profile_image_update.py
+++ b/tests/test_auth_microsoft_profile_image_update.py
@@ -41,13 +41,13 @@ class DummyDb:
       key = op
       params = args
     self.calls.append((key, params))
-    if key == "db:users:security.identities:get_by_provider_identifier:1":
+    if key == "db:users:security_identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)
-    if key == "db:users:security.sessions:set_rotkey:1" or key == PROFILE_IMAGE_OP:
+    if key == "db:users:security_sessions:set_rotkey:1" or key == PROFILE_IMAGE_OP:
       return DBRes([], 1)
-    if key == "db:users:security.sessions:create_session:1":
+    if key == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if key == "db:users:security.sessions:update_device_token:1":
+    if key == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 

--- a/tests/test_auth_microsoft_profile_refresh.py
+++ b/tests/test_auth_microsoft_profile_refresh.py
@@ -47,17 +47,17 @@ class DummyDb:
       key = op
       params = args
     self.calls.append((key, params))
-    if key == "db:users:security.identities:get_by_provider_identifier:1":
+    if key == "db:users:security_identities:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "provider_name": "microsoft" }], 1)
     if key == UPDATE_IF_UNEDITED_OP:
       if self.allow_update and isinstance(params, dict):
         return DBRes([{ "display_name": params.get("display_name"), "email": params.get("email") }], 1)
       return DBRes([], 0)
-    if key == "db:users:security.sessions:set_rotkey:1":
+    if key == "db:users:security_sessions:set_rotkey:1":
       return DBRes([], 1)
-    if key == "db:users:security.sessions:create_session:1":
+    if key == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if key == "db:users:security.sessions:update_device_token:1":
+    if key == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 

--- a/tests/test_auth_microsoft_relink_unlinked.py
+++ b/tests/test_auth_microsoft_relink_unlinked.py
@@ -32,20 +32,20 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.identities:get_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_by_provider_identifier:1":
       self._get_by_count += 1
       if self._get_by_count == 1:
         return DBRes([], 0)
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
-    if op == "db:users:security.identities:get_any_by_provider_identifier:1":
+    if op == "db:users:security_identities:get_any_by_provider_identifier:1":
       return DBRes([{"guid": "user-guid"}], 1)
-    if op == "db:users:security.oauth:relink_microsoft:1":
+    if op == "db:users:security_oauth:relink_microsoft:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)
-    if op == "db:users:security.sessions:set_rotkey:1":
+    if op == "db:users:security_sessions:set_rotkey:1":
       return DBRes([], 1)
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return DBRes([{ "session_guid": "sess", "device_guid": "dev" }], 1)
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return DBRes([], 1)
     return DBRes()
 
@@ -115,5 +115,5 @@ def test_relinks_unlinked_account(monkeypatch):
   req = DummyRequest()
   asyncio.run(auth_microsoft_oauth_login_v1(req))
   calls = req.app.state.db.calls
-  assert any(op == "db:users:security.oauth:relink_microsoft:1" for op, _ in calls)
-  assert not any(op == "db:users:security.identities:create_from_provider:1" for op, _ in calls)
+  assert any(op == "db:users:security_oauth:relink_microsoft:1" for op, _ in calls)
+  assert not any(op == "db:users:security_identities:create_from_provider:1" for op, _ in calls)

--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -28,7 +28,7 @@ def test_assistant_conversations_list_by_time(monkeypatch):
   monkeypatch.setattr(mssql_provider, 'run_operation', fake_run_operation)
 
   res = asyncio.run(provider.run(
-    'db:system:assistant.conversations:list_by_time:1',
+    'db:system:assistant_conversations:list_by_time:1',
     {'personas_recid': personas_recid, 'start': start, 'end': end},
   ))
   assert isinstance(res, DBResult)
@@ -62,7 +62,7 @@ def test_assistant_conversations_insert(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, 'run_operation', fake_run_operation)
 
-  res = asyncio.run(provider.run('db:system:assistant.conversations:insert:1', args))
+  res = asyncio.run(provider.run('db:system:assistant_conversations:insert:1', args))
   assert res.rows == [{'recid': 9}]
   assert captured["kind"] in (DbRunMode.JSON_ONE, DbRunMode.JSON_ONE.value)
 
@@ -93,7 +93,7 @@ def test_assistant_conversations_find_recent(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, 'run_operation', fake_run_operation)
 
-  res = asyncio.run(provider.run('db:system:assistant.conversations:find_recent:1', args))
+  res = asyncio.run(provider.run('db:system:assistant_conversations:find_recent:1', args))
   assert res.rows == [{'recid': 5}]
   assert captured["kind"] in (DbRunMode.JSON_ONE, DbRunMode.JSON_ONE.value)
 
@@ -115,7 +115,7 @@ def test_assistant_conversations_update_output(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, 'run_operation', fake_run_operation)
 
-  res = asyncio.run(provider.run('db:system:assistant.conversations:update_output:1', args))
+  res = asyncio.run(provider.run('db:system:assistant_conversations:update_output:1', args))
   assert res.rowcount == 1
   assert captured["kind"] in (DbRunMode.EXEC, DbRunMode.EXEC.value)
 
@@ -139,7 +139,7 @@ def test_assistant_conversations_list_recent(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, 'run_operation', fake_run_operation)
 
-  res = asyncio.run(provider.run('db:system:assistant.conversations:list_recent:1', {}))
+  res = asyncio.run(provider.run('db:system:assistant_conversations:list_recent:1', {}))
   assert isinstance(res, DBResult)
   assert res.rows == [{"recid": 2}]
   assert captured["kind"] in (DbRunMode.JSON_MANY, DbRunMode.JSON_MANY.value)

--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -224,8 +224,8 @@ def test_storage_public_lists_share_query(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, "run_operation", fake_run_operation)
 
-  asyncio.run(provider.run("db:users:content.public:list_public:1", {}))
-  asyncio.run(provider.run("db:users:content.public:get_public_files:1", {}))
+  asyncio.run(provider.run("db:users:content_public:list_public:1", {}))
+  asyncio.run(provider.run("db:users:content_public:get_public_files:1", {}))
 
   assert len(seen) == 2
   assert seen[0][1] == seen[1][1]
@@ -236,7 +236,7 @@ def test_unlink_provider_dict_result(monkeypatch):
   guid = "00000000-0000-0000-0000-000000000002"
 
   async def fake_callable(request):
-    assert request.op == "db:users:security.identities:unlink_provider:1"
+    assert request.op == "db:users:security_identities:unlink_provider:1"
     assert request.params == {
       "guid": guid,
       "provider": "google",
@@ -246,11 +246,11 @@ def test_unlink_provider_dict_result(monkeypatch):
 
   _set_provider_callable(
     monkeypatch,
-    "users.security.identities.unlink_provider",
+    "users.security_identities.unlink_provider",
     fake_callable,
   )
 
-  res = asyncio.run(provider.run("db:users:security.identities:unlink_provider:1", {
+  res = asyncio.run(provider.run("db:users:security_identities:unlink_provider:1", {
     "guid": guid,
     "provider": "google",
     "new_provider_recid": 123,
@@ -266,7 +266,7 @@ def test_create_session_dict_result(monkeypatch):
   guid = "00000000-0000-0000-0000-000000000003"
 
   async def fake_callable(request):
-    assert request.op == "db:users:security.sessions:create_session:1"
+    assert request.op == "db:users:security_sessions:create_session:1"
     assert request.params == {
       "access_token": "token",
       "expires": "2024-01-01T00:00:00Z",
@@ -280,11 +280,11 @@ def test_create_session_dict_result(monkeypatch):
 
   _set_provider_callable(
     monkeypatch,
-    "users.security.sessions.create_session",
+    "users.security_sessions.create_session",
     fake_callable,
   )
 
-  res = asyncio.run(provider.run("db:users:security.sessions:create_session:1", {
+  res = asyncio.run(provider.run("db:users:security_sessions:create_session:1", {
     "access_token": "token",
     "expires": "2024-01-01T00:00:00Z",
     "fingerprint": "fingerprint",

--- a/tests/test_google_services_helpers.py
+++ b/tests/test_google_services_helpers.py
@@ -42,9 +42,9 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return SimpleNamespace(rows=[{"session_guid": "sess", "device_guid": "dev"}])
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return SimpleNamespace(rows=[], rowcount=1)
     return SimpleNamespace(rows=[])
 
@@ -81,7 +81,7 @@ def test_create_session_handles_missing_roles():
   assert token == "sess"
   assert rot == "rot"
   ops = [op for op, _ in db.calls]
-  assert "db:users:security.sessions:create_session:1" in ops
-  args = [a for op, a in db.calls if op == "db:users:security.sessions:create_session:1"][0]
+  assert "db:users:security_sessions:create_session:1" in ops
+  args = [a for op, a in db.calls if op == "db:users:security_sessions:create_session:1"][0]
   assert args["provider"] == "google"
 

--- a/tests/test_microsoft_services_helpers.py
+++ b/tests/test_microsoft_services_helpers.py
@@ -29,9 +29,9 @@ class DummyDb:
       op = op.op
     args = args or {}
     self.calls.append((op, args))
-    if op == "db:users:security.sessions:create_session:1":
+    if op == "db:users:security_sessions:create_session:1":
       return SimpleNamespace(rows=[{"session_guid": "sess", "device_guid": "dev"}])
-    if op == "db:users:security.sessions:update_device_token:1":
+    if op == "db:users:security_sessions:update_device_token:1":
       return SimpleNamespace(rows=[], rowcount=1)
     return SimpleNamespace(rows=[])
 
@@ -68,7 +68,7 @@ def test_create_session_handles_missing_roles():
   assert token == "sess"
   assert rot == "rot"
   ops = [op for op, _ in db.calls]
-  assert "db:users:security.sessions:create_session:1" in ops
-  args = [a for op, a in db.calls if op == "db:users:security.sessions:create_session:1"][0]
+  assert "db:users:security_sessions:create_session:1" in ops
+  args = [a for op, a in db.calls if op == "db:users:security_sessions:create_session:1"][0]
   assert args["provider"] == "microsoft"
 

--- a/tests/test_openai_module.py
+++ b/tests/test_openai_module.py
@@ -104,7 +104,7 @@ def test_fetch_chat_logs_conversation():
       self.calls.append(request)
       op = request.op
       params = request.params
-      if op == "db:system:assistant.personas:get_by_name:1":
+      if op == "db:system:assistant_personas:get_by_name:1":
         return DBResult(
           rows=[
             {
@@ -116,7 +116,7 @@ def test_fetch_chat_logs_conversation():
           ],
           rowcount=1,
         )
-      if op == "db:system:assistant.conversations:find_recent:1":
+      if op == "db:system:assistant_conversations:find_recent:1":
         assert params["personas_recid"] == 1
         assert params["models_recid"] == 2
         assert params["guild_id"] == "1"
@@ -124,7 +124,7 @@ def test_fetch_chat_logs_conversation():
         assert params["user_id"] == "3"
         assert params["input_data"] == "hello"
         return DBResult(rows=[], rowcount=0)
-      if op == "db:system:assistant.conversations:insert:1":
+      if op == "db:system:assistant_conversations:insert:1":
         assert params["personas_recid"] == 1
         assert params["models_recid"] == 2
         assert params["guild_id"] == "1"
@@ -133,7 +133,7 @@ def test_fetch_chat_logs_conversation():
         assert params["input_data"] == "hello"
         assert params["tokens"] == 7
         return DBResult(rows=[{"recid": 99}], rowcount=1)
-      if op == "db:system:assistant.conversations:update_output:1":
+      if op == "db:system:assistant_conversations:update_output:1":
         assert params == {"recid": 99, "output_data": "hi", "tokens": 42}
         return DBResult(rowcount=1)
       return DBResult()
@@ -159,10 +159,10 @@ def test_fetch_chat_logs_conversation():
   assert "tools" not in dummy_create.kwargs
   calls = [request.op for request in module.db.calls]
   assert calls == [
-    "db:system:assistant.personas:get_by_name:1",
-    "db:system:assistant.conversations:find_recent:1",
-    "db:system:assistant.conversations:insert:1",
-    "db:system:assistant.conversations:update_output:1",
+    "db:system:assistant_personas:get_by_name:1",
+    "db:system:assistant_conversations:find_recent:1",
+    "db:system:assistant_conversations:insert:1",
+    "db:system:assistant_conversations:update_output:1",
   ]
 
 
@@ -173,7 +173,7 @@ def test_log_conversation_end_warns_when_no_rows_updated(caplog):
   class DummyDB:
     async def run(self, request):
       assert isinstance(request, DBRequest)
-      assert request.op == "db:system:assistant.conversations:update_output:1"
+      assert request.op == "db:system:assistant_conversations:update_output:1"
       assert request.params == {"recid": 99, "output_data": "done", "tokens": 3}
       return DBResult(rowcount=0)
 
@@ -210,7 +210,7 @@ def test_fetch_chat_reuses_existing_conversation():
       assert isinstance(request, DBRequest)
       self.calls.append(request)
       op = request.op
-      if op == "db:system:assistant.personas:get_by_name:1":
+      if op == "db:system:assistant_personas:get_by_name:1":
         return DBResult(
           rows=[
             {
@@ -222,14 +222,14 @@ def test_fetch_chat_reuses_existing_conversation():
           ],
           rowcount=1,
         )
-      if op == "db:system:assistant.conversations:find_recent:1":
+      if op == "db:system:assistant_conversations:find_recent:1":
         if self.insert_count:
           return DBResult(rows=[{"recid": 555}], rowcount=1)
         return DBResult(rows=[], rowcount=0)
-      if op == "db:system:assistant.conversations:insert:1":
+      if op == "db:system:assistant_conversations:insert:1":
         self.insert_count += 1
         return DBResult(rows=[{"recid": 555}], rowcount=1)
-      if op == "db:system:assistant.conversations:update_output:1":
+      if op == "db:system:assistant_conversations:update_output:1":
         return DBResult(rowcount=1)
       return DBResult()
 
@@ -254,13 +254,13 @@ def test_fetch_chat_reuses_existing_conversation():
   assert module.db.insert_count == 1
   call_ops = [request.op for request in module.db.calls]
   assert call_ops == [
-    "db:system:assistant.personas:get_by_name:1",
-    "db:system:assistant.conversations:find_recent:1",
-    "db:system:assistant.conversations:insert:1",
-    "db:system:assistant.conversations:update_output:1",
-    "db:system:assistant.personas:get_by_name:1",
-    "db:system:assistant.conversations:find_recent:1",
-    "db:system:assistant.conversations:update_output:1",
+    "db:system:assistant_personas:get_by_name:1",
+    "db:system:assistant_conversations:find_recent:1",
+    "db:system:assistant_conversations:insert:1",
+    "db:system:assistant_conversations:update_output:1",
+    "db:system:assistant_personas:get_by_name:1",
+    "db:system:assistant_conversations:find_recent:1",
+    "db:system:assistant_conversations:update_output:1",
   ]
 
 
@@ -289,7 +289,7 @@ def test_persona_response_calls_openai():
       self.calls.append(request)
       op = request.op
       params = request.params
-      if op == "db:system:assistant.personas:get_by_name:1":
+      if op == "db:system:assistant_personas:get_by_name:1":
         return DBResult(
           rows=[{
             "recid": 1,
@@ -301,10 +301,10 @@ def test_persona_response_calls_openai():
           }],
           rowcount=1,
         )
-      if op == "db:system:assistant.conversations:find_recent:1":
+      if op == "db:system:assistant_conversations:find_recent:1":
         assert params["input_data"] == "Tell me"
         return DBResult(rows=[], rowcount=0)
-      if op == "db:system:assistant.conversations:insert:1":
+      if op == "db:system:assistant_conversations:insert:1":
         assert params["personas_recid"] == 1
         assert params["models_recid"] == 2
         assert params["guild_id"] == "1"
@@ -313,7 +313,7 @@ def test_persona_response_calls_openai():
         assert params["input_data"] == "Tell me"
         assert params["tokens"] is None
         return DBResult(rows=[{"recid": 77}], rowcount=1)
-      if op == "db:system:assistant.conversations:update_output:1":
+      if op == "db:system:assistant_conversations:update_output:1":
         assert params == {"recid": 77, "output_data": "Response", "tokens": 11}
         return DBResult(rowcount=1)
       return DBResult()
@@ -343,10 +343,10 @@ def test_persona_response_calls_openai():
     {"role": "user", "content": "Tell me"},
   ]
   assert [request.op for request in module.db.calls] == [
-    "db:system:assistant.personas:get_by_name:1",
-    "db:system:assistant.conversations:find_recent:1",
-    "db:system:assistant.conversations:insert:1",
-    "db:system:assistant.conversations:update_output:1",
+    "db:system:assistant_personas:get_by_name:1",
+    "db:system:assistant_conversations:find_recent:1",
+    "db:system:assistant_conversations:insert:1",
+    "db:system:assistant_conversations:update_output:1",
   ]
 
 
@@ -357,7 +357,7 @@ def test_persona_response_missing_persona():
   class DummyDB:
     async def run(self, request):
       assert isinstance(request, DBRequest)
-      if request.op == "db:system:assistant.personas:get_by_name:1":
+      if request.op == "db:system:assistant_personas:get_by_name:1":
         return DBResult(rows=[], rowcount=0)
       return DBResult()
 
@@ -375,7 +375,7 @@ def test_persona_response_stub_without_client():
   class DummyDB:
     async def run(self, request):
       assert isinstance(request, DBRequest)
-      if request.op == "db:system:assistant.personas:get_by_name:1":
+      if request.op == "db:system:assistant_personas:get_by_name:1":
         return DBResult(
           rows=[{
             "recid": 1,

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -41,19 +41,19 @@ class RegistryDispatchMixin:
       value = self._config_result(params.get("key"))
       rows = [] if value is None else [{"value": value}]
       return DBResult(rows=rows, rowcount=len(rows))
-    if op == "db:users:content.cache:list:1" and hasattr(self, "list_storage_cache"):
+    if op == "db:users:content_cache:list:1" and hasattr(self, "list_storage_cache"):
       res = await self.list_storage_cache(params.get("user_guid"))
       return _ensure_result(res)
-    if op == "db:users:content.cache:replace_user:1" and hasattr(self, "replace_storage_cache"):
+    if op == "db:users:content_cache:replace_user:1" and hasattr(self, "replace_storage_cache"):
       res = await self.replace_storage_cache(params.get("user_guid"), params.get("items", []))
       return _ensure_result(res)
-    if op == "db:users:content.cache:upsert:1" and hasattr(self, "upsert_storage_cache"):
+    if op == "db:users:content_cache:upsert:1" and hasattr(self, "upsert_storage_cache"):
       res = await self.upsert_storage_cache(params)
       return _ensure_result(res)
-    if op == "db:users:content.cache:delete:1" and hasattr(self, "delete_storage_cache"):
+    if op == "db:users:content_cache:delete:1" and hasattr(self, "delete_storage_cache"):
       await self.delete_storage_cache(params.get("user_guid"), params.get("path", ""), params.get("filename", ""))
       return DBResult()
-    if op == "db:users:content.cache:delete_folder:1" and hasattr(self, "delete_storage_cache_folder"):
+    if op == "db:users:content_cache:delete_folder:1" and hasattr(self, "delete_storage_cache_folder"):
       await self.delete_storage_cache_folder(params.get("user_guid"), params.get("path", ""))
       return DBResult()
     return DBResult()
@@ -895,7 +895,7 @@ def test_get_storage_stats_counts_all_folders(monkeypatch):
   class DummyDb:
     async def run(self, request, args=None):
       op, params = _extract_request(request, args)
-      if op == "db:users:content.cache:count_rows:1":
+      if op == "db:users:content_cache:count_rows:1":
         return DBResult(rows=[{"count": 10}], rowcount=1)
       if op == "db:system:config:get_config:1" and params.get("key") == "AzureBlobContainerName":
         return DBResult(rows=[{"value": "container"}], rowcount=1)
@@ -1093,7 +1093,7 @@ def test_get_storage_stats_counts_user_folders(monkeypatch):
   class DummyDb:
     async def run(self, request, args=None):
       op, params = _extract_request(request, args)
-      if op == "db:users:content.cache:count_rows:1":
+      if op == "db:users:content_cache:count_rows:1":
         return DBResult(rows=[{"count": 0}], rowcount=1)
       if op == "db:system:config:get_config:1" and params.get("key") == "AzureBlobContainerName":
         return DBResult(rows=[{"value": "container"}], rowcount=1)

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -89,7 +89,7 @@ class DummyDb:
       key = op
       params = args
     self.calls.append((key, params))
-    if key == "db:users:security.accounts:get_security_profile:1":
+    if key == "db:users:security_accounts:get_security_profile:1":
       return DBRes([
         {
           "guid": params.get("guid"),
@@ -126,7 +126,7 @@ def test_get_roles_service_returns_mask():
   resp = asyncio.run(users_profile_get_roles_v1(req))
   assert isinstance(resp, RPCResponse)
   assert resp.payload["roles"] == 5
-  assert ("db:users:security.accounts:get_security_profile:1", {"guid": "u1"}) in db.calls
+  assert ("db:users:security_accounts:get_security_profile:1", {"guid": "u1"}) in db.calls
 
 def test_set_profile_image_calls_db():
   async def fake_img(request):

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -147,7 +147,7 @@ def test_set_provider_calls_db():
       return "pid", {"email": "e", "username": "n"}, {}
   req = DummyRequest(DummyState(db, auth=DummyAuth()))
   resp = asyncio.run(users_providers_set_provider_v1(req))
-  assert ("db:users:security.identities:set_provider:1", {"guid": "u1", "provider": "microsoft"}) in db.calls
+  assert ("db:users:security_identities:set_provider:1", {"guid": "u1", "provider": "microsoft"}) in db.calls
   expected_update = update_if_unedited_request(
     guid="u1",
     email="e",
@@ -257,7 +257,7 @@ def test_link_provider_google_normalizes_identifier():
   req.app.state.oauth.exchange_code_for_tokens = fake_exchange
   asyncio.run(users_providers_link_provider_v1(req))
   expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "google-id"))
-  assert ("db:users:security.identities:link_provider:1", {"guid": "u1", "provider": "google", "provider_identifier": expected}) in db.calls
+  assert ("db:users:security_identities:link_provider:1", {"guid": "u1", "provider": "google", "provider_identifier": expected}) in db.calls
   asyncio.run(auth.providers["google"].shutdown())
 
 
@@ -315,7 +315,7 @@ def test_link_provider_discord_normalizes_identifier():
   asyncio.run(users_providers_link_provider_v1(req))
   expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "discord-id"))
   assert (
-    "db:users:security.identities:link_provider:1",
+    "db:users:security_identities:link_provider:1",
     {"guid": "u1", "provider": "discord", "provider_identifier": expected},
   ) in db.calls
 
@@ -362,7 +362,7 @@ def test_link_provider_microsoft_normalizes_identifier():
   req = DummyRequest(DummyState(db, auth))
   asyncio.run(users_providers_link_provider_v1(req))
   expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "ms-id"))
-  assert ("db:users:security.identities:link_provider:1", {"guid": "u1", "provider": "microsoft", "provider_identifier": expected}) in db.calls
+  assert ("db:users:security_identities:link_provider:1", {"guid": "u1", "provider": "microsoft", "provider_identifier": expected}) in db.calls
   asyncio.run(auth.providers["microsoft"].shutdown())
 
 
@@ -382,16 +382,16 @@ def test_unlink_non_default_provider_retains_tokens():
       self.calls.append((key, params))
       if key == PROFILE_GET_REQUEST.op:
         return DBRes(rows=[{"default_provider": "microsoft"}])
-      if key == "db:users:security.identities:unlink_provider:1":
+      if key == "db:users:security_identities:unlink_provider:1":
         return DBRes(rows=[{"providers_remaining": 1}], rowcount=1)
       return DBRes()
 
   db = LocalDb()
   req = DummyRequest(DummyState(db))
   asyncio.run(users_providers_unlink_provider_v1(req))
-  assert ("db:users:security.sessions:revoke_provider_tokens:1", {"guid": "u1", "provider": "google"}) not in db.calls
-  assert not any(op == "db:users:security.sessions:revoke_all_device_tokens:1" for op, _ in db.calls)
-  assert not any(op == "db:users:security.identities:soft_delete_account:1" for op, _ in db.calls)
+  assert ("db:users:security_sessions:revoke_provider_tokens:1", {"guid": "u1", "provider": "google"}) not in db.calls
+  assert not any(op == "db:users:security_sessions:revoke_all_device_tokens:1" for op, _ in db.calls)
+  assert not any(op == "db:users:security_identities:soft_delete_account:1" for op, _ in db.calls)
 
 
 
@@ -411,7 +411,7 @@ def test_unlink_default_provider_without_new_default_raises():
       self.calls.append((key, params))
       if key == PROFILE_GET_REQUEST.op:
         return DBRes(rows=[{"default_provider": "google"}])
-      if key == "db:users:security.identities:unlink_provider:1":
+      if key == "db:users:security_identities:unlink_provider:1":
         return DBRes(rows=[{"providers_remaining": 1}], rowcount=1)
       return DBRes()
 
@@ -419,8 +419,8 @@ def test_unlink_default_provider_without_new_default_raises():
   req = DummyRequest(DummyState(db))
   with pytest.raises(HTTPException):
     asyncio.run(users_providers_unlink_provider_v1(req))
-  assert not any(op == "db:users:security.identities:set_provider:1" for op, _ in db.calls)
-  assert not any(op == "db:users:security.sessions:revoke_provider_tokens:1" for op, _ in db.calls)
+  assert not any(op == "db:users:security_identities:set_provider:1" for op, _ in db.calls)
+  assert not any(op == "db:users:security_sessions:revoke_provider_tokens:1" for op, _ in db.calls)
 
 
 def test_unlink_default_provider_sets_new_default_and_revokes_tokens():
@@ -439,17 +439,17 @@ def test_unlink_default_provider_sets_new_default_and_revokes_tokens():
       self.calls.append((key, params))
       if key == PROFILE_GET_REQUEST.op:
         return DBRes(rows=[{"default_provider": "google"}])
-      if key == "db:users:security.identities:unlink_provider:1":
+      if key == "db:users:security_identities:unlink_provider:1":
         return DBRes(rows=[{"providers_remaining": 1}], rowcount=1)
       return DBRes()
 
   db = LocalDb()
   req = DummyRequest(DummyState(db))
   asyncio.run(users_providers_unlink_provider_v1(req))
-  assert ("db:users:security.identities:set_provider:1", {"guid": "u1", "provider": "microsoft"}) in db.calls
-  assert ("db:users:security.sessions:revoke_provider_tokens:1", {"guid": "u1", "provider": "google"}) in db.calls
-  assert not any(op == "db:users:security.sessions:revoke_all_device_tokens:1" for op, _ in db.calls)
-  assert not any(op == "db:users:security.identities:soft_delete_account:1" for op, _ in db.calls)
+  assert ("db:users:security_identities:set_provider:1", {"guid": "u1", "provider": "microsoft"}) in db.calls
+  assert ("db:users:security_sessions:revoke_provider_tokens:1", {"guid": "u1", "provider": "google"}) in db.calls
+  assert not any(op == "db:users:security_sessions:revoke_all_device_tokens:1" for op, _ in db.calls)
+  assert not any(op == "db:users:security_identities:soft_delete_account:1" for op, _ in db.calls)
 
 
 def test_unlink_last_provider_soft_deletes_and_revokes():
@@ -468,15 +468,15 @@ def test_unlink_last_provider_soft_deletes_and_revokes():
       self.calls.append((key, params))
       if key == PROFILE_GET_REQUEST.op:
         return DBRes(rows=[{"default_provider": "google"}])
-      if key == "db:users:security.identities:unlink_provider:1":
+      if key == "db:users:security_identities:unlink_provider:1":
         return DBRes(rows=[{"providers_remaining": 0}], rowcount=1)
-      if key == "db:users:security.identities:unlink_last_provider:1":
+      if key == "db:users:security_identities:unlink_last_provider:1":
         return DBRes([], 1)
       return DBRes()
 
   db = LocalDb()
   req = DummyRequest(DummyState(db))
   asyncio.run(users_providers_unlink_provider_v1(req))
-  assert ("db:users:security.identities:unlink_last_provider:1", {"guid": "u1", "provider": "google"}) in db.calls
-  assert not any(op == "db:users:security.sessions:revoke_provider_tokens:1" for op, _ in db.calls)
+  assert ("db:users:security_identities:unlink_last_provider:1", {"guid": "u1", "provider": "google"}) in db.calls
+  assert not any(op == "db:users:security_sessions:revoke_provider_tokens:1" for op, _ in db.calls)
 


### PR DESCRIPTION
## Summary
- add canonical subdomain composition utilities so nested routers emit underscore identifiers and tighten DB request validation
- refactor registry packages, documentation, and tests to use the normalized subdomain identifiers end-to-end

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e449dd89088325b170caadf037bb83