### PR TITLE
Refactor support user RPC dispatchers

### DIFF
--- a/rpc/support/users/__init__.py
+++ b/rpc/support/users/__init__.py
@@ -1,17 +1,12 @@
-from .services import (
-  support_users_get_displayname_v1,
-  support_users_get_credits_v1,
-  support_users_reset_display_v1,
-  support_users_set_credits_v1,
-)
+from rpc.account.user import services as account_user_services
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   # This module is used by moderators to manage user accounts.
   # This namespace is restricted to those with the SUPPORT role.
-  ("get_displayname", "1"): support_users_get_displayname_v1,
-  ("get_credits", "1"): support_users_get_credits_v1,
-  ("set_credits", "1"): support_users_set_credits_v1,
-  ("reset_display", "1"): support_users_reset_display_v1,
+  ("get_displayname", "1"): account_user_services.account_user_get_displayname_v1,
+  ("get_credits", "1"): account_user_services.account_user_get_credits_v1,
+  ("set_credits", "1"): account_user_services.account_user_set_credits_v1,
+  ("reset_display", "1"): account_user_services.account_user_reset_display_v1,
 }
 

--- a/rpc/support/users/services.py
+++ b/rpc/support/users/services.py
@@ -1,15 +1,13 @@
-from fastapi import Request
-from server.models import RPCResponse
-from rpc.account.user import services as account_user_services
+from rpc.account.user.services import (
+  account_user_get_displayname_v1 as support_users_get_displayname_v1,
+  account_user_get_credits_v1 as support_users_get_credits_v1,
+  account_user_reset_display_v1 as support_users_reset_display_v1,
+  account_user_set_credits_v1 as support_users_set_credits_v1,
+)
 
-async def support_users_get_displayname_v1(request: Request) -> RPCResponse:
-  return await account_user_services.account_user_get_displayname_v1(request)
-
-async def support_users_get_credits_v1(request: Request) -> RPCResponse:
-  return await account_user_services.account_user_get_credits_v1(request)
-
-async def support_users_set_credits_v1(request: Request) -> RPCResponse:
-  return await account_user_services.account_user_set_credits_v1(request)
-
-async def support_users_reset_display_v1(request: Request) -> RPCResponse:
-  return await account_user_services.account_user_reset_display_v1(request)
+__all__ = (
+  "support_users_get_displayname_v1",
+  "support_users_get_credits_v1",
+  "support_users_reset_display_v1",
+  "support_users_set_credits_v1",
+)

--- a/tests/test_support_services.py
+++ b/tests/test_support_services.py
@@ -25,9 +25,9 @@ spec_helpers.loader.exec_module(helpers)
 sys.modules["rpc.helpers"] = helpers
 
 account_mod = importlib.import_module("rpc.account.user.services")
-support_mod = importlib.import_module("rpc.support.users.services")
+support_pkg = importlib.import_module("rpc.support.users")
 importlib.reload(account_mod)
-importlib.reload(support_mod)
+importlib.reload(support_pkg)
 
 
 class DummyUserAdmin:
@@ -68,83 +68,59 @@ def _make_rpc(op, payload=None):
   return RPCRequest(op=op, payload=payload, version=1)
 
 
-def test_support_routes_reuse_account_routes():
-  calls = []
-
-  async def fake_displayname(request):
-    calls.append("get_displayname")
-    return RPCResponse(op="urn:support:users:get_displayname:1", payload={}, version=1)
-
-  orig_displayname = account_mod.account_user_get_displayname_v1
-  account_mod.account_user_get_displayname_v1 = fake_displayname
-  asyncio.run(support_mod.support_users_get_displayname_v1(None))
-  account_mod.account_user_get_displayname_v1 = orig_displayname
-  assert "get_displayname" in calls
-
-  async def fake_credits(request):
-    calls.append("get_credits")
-    return RPCResponse(op="urn:support:users:get_credits:1", payload={}, version=1)
-
-  orig_credits = account_mod.account_user_get_credits_v1
-  account_mod.account_user_get_credits_v1 = fake_credits
-  asyncio.run(support_mod.support_users_get_credits_v1(None))
-  account_mod.account_user_get_credits_v1 = orig_credits
-  assert "get_credits" in calls
-
-  async def fake_set_credits(request):
-    calls.append("set_credits")
-    return RPCResponse(op="urn:support:users:set_credits:1", payload={}, version=1)
-
-  orig_set_credits = account_mod.account_user_set_credits_v1
-  account_mod.account_user_set_credits_v1 = fake_set_credits
-  asyncio.run(support_mod.support_users_set_credits_v1(None))
-  account_mod.account_user_set_credits_v1 = orig_set_credits
-  assert "set_credits" in calls
-
-  async def fake_reset_display(request):
-    calls.append("reset_display")
-    return RPCResponse(op="urn:support:users:reset_display:1", payload={}, version=1)
-
-  orig_reset_display = account_mod.account_user_reset_display_v1
-  account_mod.account_user_reset_display_v1 = fake_reset_display
-  asyncio.run(support_mod.support_users_reset_display_v1(None))
-  account_mod.account_user_reset_display_v1 = orig_reset_display
-  assert "reset_display" in calls
+def test_support_dispatchers_reference_account_services():
+  assert support_pkg.DISPATCHERS[("get_displayname", "1")] is account_mod.account_user_get_displayname_v1
+  assert support_pkg.DISPATCHERS[("get_credits", "1")] is account_mod.account_user_get_credits_v1
+  assert support_pkg.DISPATCHERS[("set_credits", "1")] is account_mod.account_user_set_credits_v1
+  assert support_pkg.DISPATCHERS[("reset_display", "1")] is account_mod.account_user_reset_display_v1
 
 
 
-def test_support_users_calls_user_admin():
+def test_account_user_services_call_user_admin():
   ua = DummyUserAdmin()
   state = DummyState(ua)
   req = DummyRequest(state)
 
-  async def fake_get_displayname(request):
-    return _make_rpc("urn:support:users:get_displayname:1", {"userGuid": "u1"}), None, None
-  helpers.unbox_request = fake_get_displayname
-  account_mod.unbox_request = fake_get_displayname
-  resp = asyncio.run(support_mod.support_users_get_displayname_v1(req))
-  assert ("get_displayname", "u1") in ua.calls
-  assert isinstance(resp, RPCResponse)
+  orig_helpers_unbox = helpers.unbox_request
+  orig_account_unbox = account_mod.unbox_request
 
-  async def fake_get_credits(request):
-    return _make_rpc("urn:support:users:get_credits:1", {"userGuid": "u1"}), None, None
-  helpers.unbox_request = fake_get_credits
-  account_mod.unbox_request = fake_get_credits
-  resp2 = asyncio.run(support_mod.support_users_get_credits_v1(req))
-  assert ("get_credits", "u1") in ua.calls
-  assert isinstance(resp2, RPCResponse)
+  try:
+    async def fake_get_displayname(request):
+      return _make_rpc("urn:support:users:get_displayname:1", {"userGuid": "u1"}), None, None
 
-  async def fake_set_credits(request):
-    return _make_rpc("urn:support:users:set_credits:1", {"userGuid": "u1", "credits": 5}), None, None
-  helpers.unbox_request = fake_set_credits
-  account_mod.unbox_request = fake_set_credits
-  asyncio.run(support_mod.support_users_set_credits_v1(req))
-  assert ("set_credits", "u1", 5) in ua.calls
+    helpers.unbox_request = fake_get_displayname
+    account_mod.unbox_request = fake_get_displayname
+    resp = asyncio.run(account_mod.account_user_get_displayname_v1(req))
+    assert ("get_displayname", "u1") in ua.calls
+    assert isinstance(resp, RPCResponse)
 
-  async def fake_reset_display(request):
-    return _make_rpc("urn:support:users:reset_display:1", {"userGuid": "u1"}), None, None
-  helpers.unbox_request = fake_reset_display
-  account_mod.unbox_request = fake_reset_display
-  asyncio.run(support_mod.support_users_reset_display_v1(req))
-  assert ("reset_display", "u1") in ua.calls
+    async def fake_get_credits(request):
+      return _make_rpc("urn:support:users:get_credits:1", {"userGuid": "u1"}), None, None
+
+    helpers.unbox_request = fake_get_credits
+    account_mod.unbox_request = fake_get_credits
+    resp2 = asyncio.run(account_mod.account_user_get_credits_v1(req))
+    assert ("get_credits", "u1") in ua.calls
+    assert isinstance(resp2, RPCResponse)
+
+    async def fake_set_credits(request):
+      return _make_rpc(
+        "urn:support:users:set_credits:1", {"userGuid": "u1", "credits": 5}
+      ), None, None
+
+    helpers.unbox_request = fake_set_credits
+    account_mod.unbox_request = fake_set_credits
+    asyncio.run(account_mod.account_user_set_credits_v1(req))
+    assert ("set_credits", "u1", 5) in ua.calls
+
+    async def fake_reset_display(request):
+      return _make_rpc("urn:support:users:reset_display:1", {"userGuid": "u1"}), None, None
+
+    helpers.unbox_request = fake_reset_display
+    account_mod.unbox_request = fake_reset_display
+    asyncio.run(account_mod.account_user_reset_display_v1(req))
+    assert ("reset_display", "u1") in ua.calls
+  finally:
+    helpers.unbox_request = orig_helpers_unbox
+    account_mod.unbox_request = orig_account_unbox
 


### PR DESCRIPTION
## Summary
- map support user dispatcher entries directly to account user service functions
- replace redundant support user service wrappers with direct re-exports
- update support service tests to exercise the account user services and verify dispatcher wiring

## Testing
- pytest tests/test_support_services.py

------
https://chatgpt.com/codex/tasks/task_e_68e45ce378648325800fd9ebc1e5313a