### PR TITLE
Refactor users profile services to use new module

### DIFF
--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -2,19 +2,10 @@ from fastapi import HTTPException, Request
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.db_module import DbModule
-from server.registry.users.content.profile import (
-  get_profile_request,
-  set_display_request,
-  set_optin_request,
-  set_profile_image_request,
-)
-from server.registry.users.security.accounts import get_security_profile_request
+from server.modules.user_profile_module import UserProfileModule
 from .models import (
-  UsersProfileProfile1,
   UsersProfileSetDisplay1,
   UsersProfileSetOptin1,
-  UsersProfileRoles1,
   UsersProfileSetProfileImage1,
 )
 
@@ -33,18 +24,8 @@ async def users_profile_get_profile_v1(request: Request):
   if user_guid is None:
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
-  db: DbModule = request.app.state.db
-  request_db = get_profile_request(guid=user_guid)
-  res = await db.run(request_db)
-  if not res.rows:
-    raise HTTPException(status_code=404, detail="Profile not found")
-  row = res.rows[0]
-  row["guid"] = str(row.get("guid", ""))
-  auth_providers = row.get("auth_providers")
-  if isinstance(auth_providers, str):
-    import json
-    row["auth_providers"] = json.loads(auth_providers) if auth_providers else []
-  profile = UsersProfileProfile1(**row)
+  profile_mod: UserProfileModule = request.app.state.user_profile
+  profile = await profile_mod.get_profile(user_guid)
   return RPCResponse(
     op=rpc_request.op,
     payload=profile.model_dump(),
@@ -58,9 +39,8 @@ async def users_profile_set_display_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   payload = UsersProfileSetDisplay1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  request_db = set_display_request(guid=user_guid, display_name=payload.display_name)
-  await db.run(request_db)
+  profile_mod: UserProfileModule = request.app.state.user_profile
+  await profile_mod.set_display(user_guid, payload.display_name)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -74,9 +54,8 @@ async def users_profile_set_optin_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   payload = UsersProfileSetOptin1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  request_db = set_optin_request(guid=user_guid, display_email=payload.display_email)
-  await db.run(request_db)
+  profile_mod: UserProfileModule = request.app.state.user_profile
+  await profile_mod.set_optin(user_guid, payload.display_email)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -89,12 +68,8 @@ async def users_profile_get_roles_v1(request: Request):
   if user_guid is None:
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
-  db: DbModule = request.app.state.db
-  request_db = get_security_profile_request(guid=user_guid)
-  res = await db.run(request_db)
-  row = res.rows[0] if res.rows else {}
-  roles = int(row.get("user_roles") or row.get("element_roles") or 0)
-  payload = UsersProfileRoles1(roles=roles)
+  profile_mod: UserProfileModule = request.app.state.user_profile
+  payload = await profile_mod.get_roles(user_guid)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -108,13 +83,12 @@ async def users_profile_set_profile_image_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   payload = UsersProfileSetProfileImage1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  request_db = set_profile_image_request(
-    guid=user_guid,
-    image_b64=payload.image_b64,
-    provider=payload.provider,
+  profile_mod: UserProfileModule = request.app.state.user_profile
+  await profile_mod.set_profile_image(
+    user_guid,
+    payload.image_b64,
+    payload.provider,
   )
-  await db.run(request_db)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),

--- a/server/modules/user_profile_module.py
+++ b/server/modules/user_profile_module.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+
+from fastapi import FastAPI, HTTPException
+
+from server.modules import BaseModule
+from server.modules.db_module import DbModule
+from server.registry.users.content.profile import (
+  get_profile_request,
+  set_display_request,
+  set_optin_request,
+  set_profile_image_request,
+)
+from server.registry.users.security.accounts import get_security_profile_request
+from rpc.users.profile.models import (
+  UsersProfileProfile1,
+  UsersProfileRoles1,
+)
+
+
+class UserProfileModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    self.db = None
+
+  async def get_profile(self, guid: str) -> UsersProfileProfile1:
+    assert self.db, "database module not initialised"
+    request = get_profile_request(guid=guid)
+    res = await self.db.run(request)
+    if not res.rows:
+      raise HTTPException(status_code=404, detail="Profile not found")
+    row = dict(res.rows[0])
+    row["guid"] = str(row.get("guid") or row.get("user_guid") or "")
+    auth_providers = row.get("auth_providers")
+    if isinstance(auth_providers, str):
+      row["auth_providers"] = json.loads(auth_providers) if auth_providers else []
+    elif auth_providers is None:
+      row["auth_providers"] = []
+    return UsersProfileProfile1(**row)
+
+  async def set_display(self, guid: str, display_name: str) -> None:
+    assert self.db, "database module not initialised"
+    request = set_display_request(guid=guid, display_name=display_name)
+    await self.db.run(request)
+
+  async def set_optin(self, guid: str, display_email: bool) -> None:
+    assert self.db, "database module not initialised"
+    request = set_optin_request(guid=guid, display_email=display_email)
+    await self.db.run(request)
+
+  async def get_roles(self, guid: str) -> UsersProfileRoles1:
+    assert self.db, "database module not initialised"
+    request = get_security_profile_request(guid=guid)
+    res = await self.db.run(request)
+    row = res.rows[0] if res.rows else {}
+    roles = int(row.get("user_roles") or row.get("element_roles") or 0)
+    return UsersProfileRoles1(roles=roles)
+
+  async def set_profile_image(self, guid: str, image_b64: str, provider: str) -> None:
+    assert self.db, "database module not initialised"
+    request = set_profile_image_request(guid=guid, image_b64=image_b64, provider=provider)
+    await self.db.run(request)

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -4,11 +4,12 @@ import pathlib
 import sys
 import types
 from types import SimpleNamespace
-from server.registry.types import DBRequest
-
 import pytest
 from fastapi import HTTPException
-from server.registry.users.content.profile import set_profile_image_request
+from rpc.users.profile.models import (
+  UsersProfileProfile1,
+  UsersProfileRoles1,
+)
 
 # stub rpc package
 pkg = types.ModuleType("rpc")
@@ -25,10 +26,10 @@ sys.modules["server.models"] = models
 # stub server packages for loading real helpers
 server_pkg = types.ModuleType("server")
 modules_pkg = types.ModuleType("server.modules")
-db_module_pkg = types.ModuleType("server.modules.db_module")
-class DbModule: ...
-db_module_pkg.DbModule = DbModule
-modules_pkg.db_module = db_module_pkg
+user_profile_pkg = types.ModuleType("server.modules.user_profile_module")
+class UserProfileModule: ...
+user_profile_pkg.UserProfileModule = UserProfileModule
+modules_pkg.user_profile_module = user_profile_pkg
 server_pkg.modules = modules_pkg
 models_pkg = types.ModuleType("server.models")
 class AuthContext:
@@ -40,7 +41,7 @@ server_pkg.models = models_pkg
 
 sys.modules.setdefault("server", server_pkg)
 sys.modules.setdefault("server.modules", modules_pkg)
-sys.modules.setdefault("server.modules.db_module", db_module_pkg)
+sys.modules.setdefault("server.modules.user_profile_module", user_profile_pkg)
 sys.modules.setdefault("server.models", models_pkg)
 
 # load real helpers then override for service import
@@ -65,47 +66,40 @@ sys.modules["rpc.helpers"] = real_helpers
 users_profile_get_roles_v1 = svc_mod.users_profile_get_roles_v1
 users_profile_set_profile_image_v1 = svc_mod.users_profile_set_profile_image_v1
 
-class DBRes:
-  def __init__(self, rows=None, rowcount=0):
-    self.rows = rows or []
-    self.rowcount = rowcount
 
-PROFILE_IMAGE_REQUEST = set_profile_image_request(guid="", provider="", image_b64=None)
-
-
-class DummyDb:
+class DummyProfileModule:
   def __init__(self, roles=0):
     self.calls = []
     self.roles = roles
-  async def run(self, op, args=None):
-    if isinstance(op, DBRequest):
-      args = op.params
-      op = op.op
-    args = args or {}
-    if hasattr(op, "op") and hasattr(op, "params"):
-      key = op.op
-      params = op.params
-    else:
-      key = op
-      params = args
-    self.calls.append((key, params))
-    if key == "db:users:security_accounts:get_security_profile:1":
-      return DBRes([
-        {
-          "guid": params.get("guid"),
-          "user_guid": params.get("guid"),
-          "user_roles": self.roles,
-          "provider_name": "microsoft",
-          "provider_display": "Microsoft",
-        }
-      ], 1)
-    if key == PROFILE_IMAGE_REQUEST.op:
-      return DBRes([], 1)
-    return DBRes()
+  async def get_roles(self, guid):
+    self.calls.append(("get_roles", guid))
+    return UsersProfileRoles1(roles=self.roles)
+
+  async def set_profile_image(self, guid, image_b64, provider):
+    self.calls.append(("set_profile_image", guid, image_b64, provider))
+
+  async def get_profile(self, guid):
+    self.calls.append(("get_profile", guid))
+    return UsersProfileProfile1(
+      guid=guid,
+      display_name="User",
+      email="user@example.com",
+      display_email=True,
+      credits=0,
+      profile_image=None,
+      default_provider="microsoft",
+      auth_providers=[],
+    )
+
+  async def set_display(self, guid, display_name):
+    self.calls.append(("set_display", guid, display_name))
+
+  async def set_optin(self, guid, display_email):
+    self.calls.append(("set_optin", guid, display_email))
 
 class DummyState:
-  def __init__(self, db):
-    self.db = db
+  def __init__(self, user_profile):
+    self.user_profile = user_profile
 
 class DummyApp:
   def __init__(self, state):
@@ -121,23 +115,22 @@ def test_get_roles_service_returns_mask():
     rpc = RPCRequest(op="urn:users:profile:get_roles:1", payload=None, version=1)
     return rpc, SimpleNamespace(user_guid="u1"), None
   svc_mod.unbox_request = fake_get
-  db = DummyDb(roles=5)
-  req = DummyRequest(DummyState(db))
+  module = DummyProfileModule(roles=5)
+  req = DummyRequest(DummyState(module))
   resp = asyncio.run(users_profile_get_roles_v1(req))
   assert isinstance(resp, RPCResponse)
   assert resp.payload["roles"] == 5
-  assert ("db:users:security_accounts:get_security_profile:1", {"guid": "u1"}) in db.calls
+  assert ("get_roles", "u1") in module.calls
 
 def test_set_profile_image_calls_db():
   async def fake_img(request):
     rpc = RPCRequest(op="urn:users:profile:set_profile_image:1", payload={"image_b64": "abc", "provider": "microsoft"}, version=1)
     return rpc, SimpleNamespace(user_guid="u1"), None
   svc_mod.unbox_request = fake_img
-  db = DummyDb()
-  req = DummyRequest(DummyState(db))
+  module = DummyProfileModule()
+  req = DummyRequest(DummyState(module))
   resp = asyncio.run(users_profile_set_profile_image_v1(req))
-  expected_request = set_profile_image_request(guid="u1", image_b64="abc", provider="microsoft")
-  assert (expected_request.op, expected_request.params) in db.calls
+  assert ("set_profile_image", "u1", "abc", "microsoft") in module.calls
   assert resp.payload["image_b64"] == "abc"
 
 
@@ -146,8 +139,8 @@ def test_missing_user_guid_raises():
     rpc = RPCRequest(op="urn:users:profile:get_roles:1", payload=None, version=1)
     return rpc, SimpleNamespace(user_guid=None), None
   svc_mod.unbox_request = fake_get
-  db = DummyDb()
-  req = DummyRequest(DummyState(db))
+  module = DummyProfileModule()
+  req = DummyRequest(DummyState(module))
   with pytest.raises(HTTPException) as exc:
     asyncio.run(users_profile_get_roles_v1(req))
   assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary
- add a dedicated UserProfileModule that wraps profile registry requests and exposes helper methods
- refactor users profile RPC services to delegate to the module interface
- update service tests to stub the new module rather than direct DbModule calls

## Testing
- pytest tests/test_users_profile_services.py

------
https://chatgpt.com/codex/tasks/task_e_68e45e135d94832595f635872cb3fc74