### PR TITLE
Add user providers module and refactor provider services

### DIFF
--- a/rpc/auth/providers/services.py
+++ b/rpc/auth/providers/services.py
@@ -3,8 +3,7 @@ from pydantic import ValidationError
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.db_module import DbModule
-from server.registry.users.security.identities import unlink_last_provider_request
+from server.modules.user_providers_module import UserProvidersModule
 
 from .models import AuthProvidersUnlinkLastProvider1
 
@@ -15,8 +14,6 @@ async def auth_providers_unlink_last_provider_v1(request: Request):
     payload = AuthProvidersUnlinkLastProvider1(**(rpc_request.payload or {}))
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
-  db: DbModule = request.app.state.db
-  await db.run(
-    unlink_last_provider_request(guid=payload.guid, provider=payload.provider)
-  )
+  providers: UserProvidersModule = request.app.state.user_providers
+  await providers.unlink_last_provider(guid=payload.guid, provider=payload.provider)
   return RPCResponse(op=rpc_request.op, payload={"ok": True}, version=rpc_request.version)

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -1,11 +1,9 @@
 from fastapi import HTTPException, Request
 from pydantic import ValidationError
-import uuid
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.auth_module import AuthModule
-from server.modules.db_module import DbModule
+from server.modules.user_providers_module import UserProvidersModule
 from .models import (
   UsersProvidersSetProvider1,
   UsersProvidersLinkProvider1,
@@ -13,29 +11,6 @@ from .models import (
   UsersProvidersGetByProviderIdentifier1,
   UsersProvidersCreateFromProvider1,
 )
-from server.modules.oauth_module import OauthModule
-from server.registry.users.content.profile import (
-  get_profile_request,
-  update_if_unedited_request,
-)
-from server.registry.users.security.identities import (
-  create_from_provider_request,
-  get_by_provider_identifier_request,
-  get_user_by_email_request,
-  link_provider_request,
-  set_provider_request,
-  unlink_last_provider_request,
-  unlink_provider_request,
-)
-from server.registry.users.security.sessions import revoke_provider_tokens_request
-from server.registry.system.config import get_config_request
-
-
-def normalize_provider_identifier(pid: str) -> str:
-  try:
-    return str(uuid.UUID(pid))
-  except ValueError:
-    return str(uuid.uuid5(uuid.NAMESPACE_URL, pid))
 
 async def users_providers_set_provider_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
@@ -43,104 +18,14 @@ async def users_providers_set_provider_v1(request: Request):
     payload = UsersProvidersSetProvider1(**(rpc_request.payload or {}))
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
-  db: DbModule = request.app.state.db
-  auth: AuthModule = request.app.state.auth
-  oauth: OauthModule = request.app.state.oauth
-  profile = None
-  if payload.code or (payload.id_token and payload.access_token):
-    if payload.provider == "google":
-      if payload.code:
-        google_provider = getattr(auth, "providers", {}).get("google")
-        if not google_provider or not google_provider.audience:
-          raise HTTPException(status_code=500, detail="Google OAuth client_id not configured")
-        client_id = google_provider.audience
-        env = request.app.state.env
-        client_secret = env.get("GOOGLE_AUTH_SECRET")
-        if not client_secret:
-          raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
-        res_redirect = await db.run(get_config_request("Hostname"))
-        if not res_redirect.rows:
-          raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
-        redirect_uri = res_redirect.rows[0]["value"]
-        id_token, access_token = await oauth.exchange_code_for_tokens(
-          payload.code,
-          client_id,
-          client_secret,
-          redirect_uri,
-          payload.provider,
-        )
-        if not id_token:
-          raise HTTPException(status_code=400, detail="Missing id_token")
-      else:
-        id_token, access_token = payload.id_token, payload.access_token
-    elif payload.provider == "discord":
-      discord_provider = getattr(auth, "providers", {}).get("discord")
-      if not discord_provider or not getattr(discord_provider, "audience", None):
-        raise HTTPException(status_code=500, detail="Discord OAuth client_id not configured")
-      if payload.code:
-        client_id = getattr(discord_provider, "audience")
-        env = request.app.state.env
-        client_secret = env.get("DISCORD_AUTH_SECRET")
-        if not client_secret:
-          raise HTTPException(status_code=500, detail="Discord OAuth client_secret not configured")
-        res_redirect = await db.run(get_config_request("Hostname"))
-        if not res_redirect.rows:
-          raise HTTPException(status_code=500, detail="Discord OAuth redirect URI not configured")
-        redirect_uri = res_redirect.rows[0]["value"]
-        id_token, access_token = await oauth.exchange_code_for_tokens(
-          payload.code,
-          client_id,
-          client_secret,
-          redirect_uri,
-          payload.provider,
-        )
-      else:
-        if not payload.access_token:
-          raise HTTPException(status_code=400, detail="access_token required")
-        id_token, access_token = payload.id_token, payload.access_token
-    elif payload.provider == "microsoft":
-      ms_provider = getattr(auth, "providers", {}).get("microsoft")
-      if not ms_provider or not ms_provider.audience:
-        raise HTTPException(status_code=500, detail="Microsoft OAuth client_id not configured")
-      if payload.code:
-        client_id = ms_provider.audience
-        env = request.app.state.env
-        client_secret = env.get("MICROSOFT_AUTH_SECRET")
-        if not client_secret:
-          raise HTTPException(status_code=500, detail="Microsoft OAuth client_secret not configured")
-        res_redirect = await db.run(get_config_request("Hostname"))
-        if not res_redirect.rows:
-          raise HTTPException(status_code=500, detail="Microsoft OAuth redirect URI not configured")
-        redirect_uri = res_redirect.rows[0]["value"]
-        id_token, access_token = await oauth.exchange_code_for_tokens(
-          payload.code,
-          client_id,
-          client_secret,
-          redirect_uri,
-          payload.provider,
-        )
-        if not id_token:
-          raise HTTPException(status_code=400, detail="Missing id_token")
-      else:
-        if not payload.id_token or not payload.access_token:
-          raise HTTPException(status_code=400, detail="id_token and access_token required")
-        id_token, access_token = payload.id_token, payload.access_token
-    else:
-      raise HTTPException(status_code=400, detail="Unsupported auth provider")
-    _, profile, _ = await auth.handle_auth_login(payload.provider, id_token, access_token)
-  set_request = set_provider_request(guid=auth_ctx.user_guid, provider=payload.provider)
-  await db.run(set_request)
-  if profile:
-    raw_email = (profile.get("email") or "").strip()
-    raw_name = (profile.get("username") or "").strip()
-    email = raw_email
-    display_name = raw_name or (raw_email.split("@")[0] if raw_email else "User")
-    update_request = update_if_unedited_request(
-      guid=auth_ctx.user_guid,
-      email=email,
-      display_name=display_name,
-    )
-    await db.run(update_request)
+  providers: UserProvidersModule = request.app.state.user_providers
+  await providers.set_provider(
+    guid=auth_ctx.user_guid,
+    provider=payload.provider,
+    code=payload.code,
+    id_token=payload.id_token,
+    access_token=payload.access_token,
+  )
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -153,104 +38,16 @@ async def users_providers_link_provider_v1(request: Request):
     payload = UsersProvidersLinkProvider1(**(rpc_request.payload or {}))
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
-  auth: AuthModule = request.app.state.auth
-  db: DbModule = request.app.state.db
-  oauth: OauthModule = request.app.state.oauth
-  if payload.provider == "google":
-    if not payload.code:
-      raise HTTPException(status_code=400, detail="code required")
-    google_provider = getattr(auth, "providers", {}).get("google")
-    if not google_provider or not google_provider.audience:
-      raise HTTPException(status_code=500, detail="Google OAuth client_id not configured")
-    client_id = google_provider.audience
-    env = request.app.state.env
-    client_secret = env.get("GOOGLE_AUTH_SECRET")
-    if not client_secret:
-      raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
-    res_redirect = await db.run(get_config_request("Hostname"))
-    if not res_redirect.rows:
-      raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
-    redirect_uri = res_redirect.rows[0]["value"]
-    id_token, access_token = await oauth.exchange_code_for_tokens(
-      payload.code,
-      client_id,
-      client_secret,
-      redirect_uri,
-      payload.provider,
-    )
-    if not id_token:
-      raise HTTPException(status_code=400, detail="Missing id_token")
-  elif payload.provider == "discord":
-    discord_provider = getattr(auth, "providers", {}).get("discord")
-    if not discord_provider or not getattr(discord_provider, "audience", None):
-      raise HTTPException(status_code=500, detail="Discord OAuth client_id not configured")
-    if payload.code:
-      client_id = getattr(discord_provider, "audience")
-      env = request.app.state.env
-      client_secret = env.get("DISCORD_AUTH_SECRET")
-      if not client_secret:
-        raise HTTPException(status_code=500, detail="Discord OAuth client_secret not configured")
-      res_redirect = await db.run(get_config_request("Hostname"))
-      if not res_redirect.rows:
-        raise HTTPException(status_code=500, detail="Discord OAuth redirect URI not configured")
-      redirect_uri = res_redirect.rows[0]["value"]
-      id_token, access_token = await oauth.exchange_code_for_tokens(
-        payload.code,
-        client_id,
-        client_secret,
-        redirect_uri,
-        payload.provider,
-      )
-    else:
-      if not payload.access_token:
-        raise HTTPException(status_code=400, detail="access_token required")
-      id_token = payload.id_token
-      access_token = payload.access_token
-  elif payload.provider == "microsoft":
-    ms_provider = getattr(auth, "providers", {}).get("microsoft")
-    if not ms_provider or not ms_provider.audience:
-      raise HTTPException(status_code=500, detail="Microsoft OAuth client_id not configured")
-    if payload.code:
-      client_id = ms_provider.audience
-      env = request.app.state.env
-      client_secret = env.get("MICROSOFT_AUTH_SECRET")
-      if not client_secret:
-        raise HTTPException(status_code=500, detail="Microsoft OAuth client_secret not configured")
-      res_redirect = await db.run(get_config_request("Hostname"))
-      if not res_redirect.rows:
-        raise HTTPException(status_code=500, detail="Microsoft OAuth redirect URI not configured")
-      redirect_uri = res_redirect.rows[0]["value"]
-      id_token, access_token = await oauth.exchange_code_for_tokens(
-        payload.code,
-        client_id,
-        client_secret,
-        redirect_uri,
-        payload.provider,
-      )
-      if not id_token:
-        raise HTTPException(status_code=400, detail="Missing id_token")
-    else:
-      if not payload.id_token or not payload.access_token:
-        raise HTTPException(status_code=400, detail="id_token and access_token required")
-      id_token = payload.id_token
-      access_token = payload.access_token
-  else:
-    raise HTTPException(status_code=400, detail="Unsupported auth provider")
-  provider_uid, _, _ = await auth.handle_auth_login(payload.provider, id_token, access_token)
-  provider_uid = normalize_provider_identifier(provider_uid)
-  request_db = get_by_provider_identifier_request(
-    provider=payload.provider,
-    provider_identifier=provider_uid,
-  )
-  res = await db.run(request_db)
-  if res.rows and res.rows[0].get("guid") != auth_ctx.user_guid:
-    raise HTTPException(status_code=409, detail="Provider already linked")
-  link_request = link_provider_request(
+  providers: UserProvidersModule = request.app.state.user_providers
+  if payload.provider == "google" and not payload.code:
+    raise HTTPException(status_code=400, detail="code required")
+  await providers.link_provider(
     guid=auth_ctx.user_guid,
     provider=payload.provider,
-    provider_identifier=provider_uid,
+    code=payload.code,
+    id_token=payload.id_token,
+    access_token=payload.access_token,
   )
-  await db.run(link_request)
   return RPCResponse(op=rpc_request.op, payload={"provider": payload.provider}, version=rpc_request.version)
 
 async def users_providers_unlink_provider_v1(request: Request):
@@ -259,35 +56,12 @@ async def users_providers_unlink_provider_v1(request: Request):
     payload = UsersProvidersUnlinkProvider1(**(rpc_request.payload or {}))
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
-  db: DbModule = request.app.state.db
-  profile_request = get_profile_request(guid=auth_ctx.user_guid)
-  res_prof = await db.run(profile_request)
-  default_provider = res_prof.rows[0].get("default_provider") if res_prof.rows else None
-  unlink_request = unlink_provider_request(
+  providers: UserProvidersModule = request.app.state.user_providers
+  await providers.unlink_provider(
     guid=auth_ctx.user_guid,
     provider=payload.provider,
+    new_default=payload.new_default,
   )
-  res = await db.run(unlink_request)
-  remaining = res.rows[0].get("providers_remaining") if res.rows else 0
-  if remaining == 0:
-    final_unlink_request = unlink_last_provider_request(
-      guid=auth_ctx.user_guid,
-      provider=payload.provider,
-    )
-    await db.run(final_unlink_request)
-  elif payload.provider == default_provider:
-    if not payload.new_default:
-      raise HTTPException(status_code=400, detail="new_default required")
-    set_request = set_provider_request(
-      guid=auth_ctx.user_guid,
-      provider=payload.new_default,
-    )
-    await db.run(set_request)
-    revoke_request = revoke_provider_tokens_request(
-      guid=auth_ctx.user_guid,
-      provider=payload.provider,
-    )
-    await db.run(revoke_request)
   return RPCResponse(op=rpc_request.op, payload={"provider": payload.provider}, version=rpc_request.version)
 
 async def users_providers_get_by_provider_identifier_v1(request: Request):
@@ -296,13 +70,11 @@ async def users_providers_get_by_provider_identifier_v1(request: Request):
     payload = UsersProvidersGetByProviderIdentifier1(**(rpc_request.payload or {}))
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
-  db: DbModule = request.app.state.db
-  lookup_request = get_by_provider_identifier_request(
+  providers: UserProvidersModule = request.app.state.user_providers
+  row = await providers.get_by_provider_identifier(
     provider=payload.provider,
     provider_identifier=payload.provider_identifier,
   )
-  res = await db.run(lookup_request)
-  row = res.rows[0] if res.rows else None
   return RPCResponse(op=rpc_request.op, payload=row, version=rpc_request.version)
 
 async def users_providers_create_from_provider_v1(request: Request):
@@ -311,19 +83,13 @@ async def users_providers_create_from_provider_v1(request: Request):
     payload = UsersProvidersCreateFromProvider1(**(rpc_request.payload or {}))
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
-  db: DbModule = request.app.state.db
-  email_request = get_user_by_email_request(email=payload.provider_email)
-  res = await db.run(email_request)
-  if res.rows:
-    raise HTTPException(status_code=409, detail="Email already registered")
-  create_request = create_from_provider_request(
+  providers: UserProvidersModule = request.app.state.user_providers
+  row = await providers.create_from_provider(
     provider=payload.provider,
     provider_identifier=payload.provider_identifier,
     provider_email=payload.provider_email,
     provider_displayname=payload.provider_displayname,
     provider_profile_image=payload.provider_profile_image,
   )
-  res = await db.run(create_request)
-  row = res.rows[0] if res.rows else None
   return RPCResponse(op=rpc_request.op, payload=row, version=rpc_request.version)
 

--- a/server/modules/user_providers_module.py
+++ b/server/modules/user_providers_module.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import uuid
+
+from fastapi import FastAPI, HTTPException
+
+from server.modules import BaseModule
+from server.modules.auth_module import AuthModule
+from server.modules.db_module import DbModule
+from server.modules.env_module import EnvModule
+from server.modules.oauth_module import OauthModule
+from server.registry.system.config import get_config_request
+from server.registry.users.content.profile import (
+  get_profile_request,
+  update_if_unedited_request,
+)
+from server.registry.users.security.identities import (
+  create_from_provider_request,
+  get_by_provider_identifier_request,
+  get_user_by_email_request,
+  link_provider_request,
+  set_provider_request,
+  unlink_last_provider_request,
+  unlink_provider_request,
+)
+from server.registry.users.security.sessions import revoke_provider_tokens_request
+
+
+_CLIENT_ID_ERRORS = {
+  "google": "Google OAuth client_id not configured",
+  "discord": "Discord OAuth client_id not configured",
+  "microsoft": "Microsoft OAuth client_id not configured",
+}
+
+_CLIENT_SECRET_ENV = {
+  "google": ("GOOGLE_AUTH_SECRET", "Google OAuth client_secret not configured"),
+  "discord": ("DISCORD_AUTH_SECRET", "Discord OAuth client_secret not configured"),
+  "microsoft": ("MICROSOFT_AUTH_SECRET", "Microsoft OAuth client_secret not configured"),
+}
+
+_REDIRECT_ERRORS = {
+  "google": "Google OAuth redirect URI not configured",
+  "discord": "Discord OAuth redirect URI not configured",
+  "microsoft": "Microsoft OAuth redirect URI not configured",
+}
+
+
+class UserProvidersModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+    self.auth: AuthModule | None = None
+    self.oauth: OauthModule | None = None
+    self.env: EnvModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.auth = self.app.state.auth
+    await self.auth.on_ready()
+    self.oauth = self.app.state.oauth
+    await self.oauth.on_ready()
+    self.env = self.app.state.env
+    await self.env.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    self.db = None
+    self.auth = None
+    self.oauth = None
+    self.env = None
+
+  async def set_provider(
+    self,
+    guid: str,
+    provider: str,
+    *,
+    code: str | None = None,
+    id_token: str | None = None,
+    access_token: str | None = None,
+  ) -> None:
+    id_token, access_token, profile = await self._authenticate_provider(
+      provider,
+      code=code,
+      id_token=id_token,
+      access_token=access_token,
+    )
+    assert self.db, "database module not initialised"
+    request = set_provider_request(guid=guid, provider=provider)
+    await self.db.run(request)
+    if profile:
+      await self._update_profile_from_login(guid, profile)
+
+  async def link_provider(
+    self,
+    guid: str,
+    provider: str,
+    *,
+    code: str | None = None,
+    id_token: str | None = None,
+    access_token: str | None = None,
+  ) -> None:
+    provider_uid, _, _ = await self._authenticate_provider(
+      provider,
+      code=code,
+      id_token=id_token,
+      access_token=access_token,
+      require_login=True,
+    )
+    provider_uid = self._normalize_provider_identifier(provider_uid)
+    assert self.db, "database module not initialised"
+    lookup_request = get_by_provider_identifier_request(
+      provider=provider,
+      provider_identifier=provider_uid,
+    )
+    res = await self.db.run(lookup_request)
+    if res.rows and str(res.rows[0].get("guid")) != str(guid):
+      raise HTTPException(status_code=409, detail="Provider already linked")
+    link_request = link_provider_request(
+      guid=guid,
+      provider=provider,
+      provider_identifier=provider_uid,
+    )
+    await self.db.run(link_request)
+
+  async def unlink_provider(
+    self,
+    guid: str,
+    provider: str,
+    *,
+    new_default: str | None = None,
+  ) -> None:
+    assert self.db, "database module not initialised"
+    profile_request = get_profile_request(guid=guid)
+    res_profile = await self.db.run(profile_request)
+    default_provider = res_profile.rows[0].get("default_provider") if res_profile.rows else None
+    unlink_request = unlink_provider_request(guid=guid, provider=provider)
+    res = await self.db.run(unlink_request)
+    remaining = res.rows[0].get("providers_remaining") if res.rows else 0
+    if remaining == 0:
+      await self.unlink_last_provider(guid=guid, provider=provider)
+      return
+    if provider == default_provider:
+      if not new_default:
+        raise HTTPException(status_code=400, detail="new_default required")
+      set_request = set_provider_request(guid=guid, provider=new_default)
+      await self.db.run(set_request)
+      revoke_request = revoke_provider_tokens_request(guid=guid, provider=provider)
+      await self.db.run(revoke_request)
+
+  async def unlink_last_provider(self, guid: str, provider: str) -> None:
+    assert self.db, "database module not initialised"
+    request = unlink_last_provider_request(guid=guid, provider=provider)
+    await self.db.run(request)
+
+  async def get_by_provider_identifier(self, provider: str, provider_identifier: str):
+    assert self.db, "database module not initialised"
+    request = get_by_provider_identifier_request(
+      provider=provider,
+      provider_identifier=provider_identifier,
+    )
+    res = await self.db.run(request)
+    return res.rows[0] if res.rows else None
+
+  async def create_from_provider(
+    self,
+    provider: str,
+    provider_identifier: str,
+    provider_email: str,
+    provider_displayname: str | None,
+    provider_profile_image: str | None,
+  ):
+    assert self.db, "database module not initialised"
+    email_request = get_user_by_email_request(email=provider_email)
+    res = await self.db.run(email_request)
+    if res.rows:
+      raise HTTPException(status_code=409, detail="Email already registered")
+    create_request = create_from_provider_request(
+      provider=provider,
+      provider_identifier=provider_identifier,
+      provider_email=provider_email,
+      provider_displayname=provider_displayname,
+      provider_profile_image=provider_profile_image,
+    )
+    res = await self.db.run(create_request)
+    return res.rows[0] if res.rows else None
+
+  async def _authenticate_provider(
+    self,
+    provider: str,
+    *,
+    code: str | None,
+    id_token: str | None,
+    access_token: str | None,
+    require_login: bool = False,
+  ):
+    if provider not in ("google", "discord", "microsoft"):
+      raise HTTPException(status_code=400, detail="Unsupported auth provider")
+    auth = self._require_auth()
+    oauth = self._require_oauth()
+    strategy = getattr(auth, "providers", {}).get(provider)
+    if not strategy or not getattr(strategy, "audience", None):
+      raise HTTPException(status_code=500, detail=_CLIENT_ID_ERRORS[provider])
+    if code:
+      client_id = getattr(strategy, "audience")
+      client_secret = self._get_client_secret(provider)
+      redirect_uri = await self._get_redirect_uri(provider)
+      id_token, access_token = await oauth.exchange_code_for_tokens(
+        code,
+        client_id,
+        client_secret,
+        redirect_uri,
+        provider,
+      )
+      if provider in ("google", "microsoft") and not id_token:
+        raise HTTPException(status_code=400, detail="Missing id_token")
+      if provider == "discord" and not access_token:
+        raise HTTPException(status_code=400, detail="access_token required")
+    else:
+      if provider == "discord" and not access_token:
+        raise HTTPException(status_code=400, detail="access_token required")
+      if provider == "microsoft" and (not id_token or not access_token):
+        raise HTTPException(status_code=400, detail="id_token and access_token required")
+    if require_login:
+      guid, profile, payload = await auth.handle_auth_login(provider, id_token, access_token)
+      return guid, profile, payload
+    profile = None
+    if access_token or id_token:
+      _, profile, _ = await auth.handle_auth_login(provider, id_token, access_token)
+    return id_token, access_token, profile
+
+  def _require_auth(self) -> AuthModule:
+    assert self.auth, "auth module not initialised"
+    return self.auth
+
+  def _require_oauth(self) -> OauthModule:
+    assert self.oauth, "oauth module not initialised"
+    return self.oauth
+
+  def _require_env(self) -> EnvModule:
+    assert self.env, "env module not initialised"
+    return self.env
+
+  def _require_db(self) -> DbModule:
+    assert self.db, "database module not initialised"
+    return self.db
+
+  def _get_client_secret(self, provider: str) -> str:
+    env_module = self._require_env()
+    env_key, error_message = _CLIENT_SECRET_ENV[provider]
+    try:
+      secret = env_module.get(env_key)
+    except RuntimeError:
+      secret = None
+    if not secret:
+      raise HTTPException(status_code=500, detail=error_message)
+    return secret
+
+  async def _get_redirect_uri(self, provider: str) -> str:
+    db = self._require_db()
+    res = await db.run(get_config_request("Hostname"))
+    if not res.rows:
+      raise HTTPException(status_code=500, detail=_REDIRECT_ERRORS[provider])
+    return res.rows[0]["value"]
+
+  async def _update_profile_from_login(self, guid: str, profile: dict) -> None:
+    raw_email = (profile.get("email") or "").strip()
+    raw_name = (profile.get("username") or "").strip()
+    display_name = raw_name or (raw_email.split("@")[0] if raw_email else "User")
+    db = self._require_db()
+    request = update_if_unedited_request(
+      guid=guid,
+      email=raw_email,
+      display_name=display_name,
+    )
+    await db.run(request)
+
+  def _normalize_provider_identifier(self, pid: str) -> str:
+    try:
+      return str(uuid.UUID(pid))
+    except ValueError:
+      return str(uuid.uuid5(uuid.NAMESPACE_URL, pid))
+

--- a/tests/test_user_providers_module.py
+++ b/tests/test_user_providers_module.py
@@ -1,0 +1,379 @@
+import asyncio
+from types import SimpleNamespace
+import uuid
+
+import pytest
+from fastapi import FastAPI, HTTPException
+
+from server.modules.user_providers_module import UserProvidersModule
+from server.registry.types import DBRequest
+from server.registry.system.config import get_config_request
+from server.registry.users.content.profile import (
+  get_profile_request,
+  update_if_unedited_request,
+)
+from server.registry.users.security.identities import (
+  create_from_provider_request,
+  get_by_provider_identifier_request,
+  get_user_by_email_request,
+  link_provider_request,
+  set_provider_request,
+  unlink_last_provider_request,
+  unlink_provider_request,
+)
+from server.registry.users.security.sessions import revoke_provider_tokens_request
+
+
+class DBRes:
+  def __init__(self, rows=None, rowcount=0):
+    self.rows = rows or []
+    self.rowcount = rowcount
+
+
+def _normalize_db_call(op, args=None):
+  if isinstance(op, DBRequest):
+    args = op.params
+    op = op.op
+  return op, args or {}
+
+
+class ReadyStub:
+  async def on_ready(self):
+    return None
+
+
+class DummyDb(ReadyStub):
+  def __init__(self):
+    self.calls = []
+    self._handlers = {}
+
+  def respond(self, op: str, handler):
+    self._handlers[op] = handler
+
+  async def run(self, op, args=None):
+    key, params = _normalize_db_call(op, args)
+    self.calls.append((key, params))
+    handler = self._handlers.get(key)
+    if handler:
+      return handler(params)
+    return DBRes()
+
+
+class DummyAuth(ReadyStub):
+  def __init__(self, providers=None, login_result=None):
+    self.providers = providers or {}
+    self.login_result = login_result or ("pid", {"email": "", "username": ""}, {})
+    self.logins = []
+
+  async def handle_auth_login(self, provider, id_token, access_token):
+    self.logins.append((provider, id_token, access_token))
+    return self.login_result
+
+
+class DummyOauth(ReadyStub):
+  def __init__(self, result=("id", "access")):
+    self.result = result
+    self.calls = []
+
+  async def exchange_code_for_tokens(self, code, client_id, client_secret, redirect_uri, provider):
+    self.calls.append((code, client_id, client_secret, redirect_uri, provider))
+    return self.result
+
+
+class DummyEnv(ReadyStub):
+  def __init__(self, values=None):
+    self.values = values or {}
+
+  def get(self, key):
+    if key not in self.values:
+      raise RuntimeError(f"missing env {key}")
+    return self.values[key]
+
+
+def build_module(db=None, auth=None, oauth=None, env=None):
+  app = FastAPI()
+  db = db or DummyDb()
+  auth = auth or DummyAuth()
+  oauth = oauth or DummyOauth()
+  env = env or DummyEnv()
+  app.state.db = db
+  app.state.auth = auth
+  app.state.oauth = oauth
+  app.state.env = env
+  module = UserProvidersModule(app)
+  asyncio.run(module.startup())
+  return module, db, auth, oauth, env
+
+
+def test_set_provider_calls_db_updates_profile():
+  auth = DummyAuth(
+    providers={"microsoft": SimpleNamespace(audience="client")},
+    login_result=("pid", {"email": "e", "username": "n"}, {}),
+  )
+  module, db, *_ = build_module(auth=auth)
+  asyncio.run(
+    module.set_provider(
+      guid="u1",
+      provider="microsoft",
+      id_token="id",
+      access_token="acc",
+    )
+  )
+  set_req = set_provider_request(guid="u1", provider="microsoft")
+  update_req = update_if_unedited_request(guid="u1", email="e", display_name="n")
+  assert (set_req.op, set_req.params) in db.calls
+  assert (update_req.op, update_req.params) in db.calls
+  asyncio.run(module.shutdown())
+
+
+def test_set_provider_defaults_blank_profile():
+  auth = DummyAuth(
+    providers={"microsoft": SimpleNamespace(audience="client")},
+    login_result=("pid", {"email": "", "username": ""}, {}),
+  )
+  module, db, *_ = build_module(auth=auth)
+  asyncio.run(
+    module.set_provider(
+      guid="u1",
+      provider="microsoft",
+      id_token="id",
+      access_token="acc",
+    )
+  )
+  update_req = update_if_unedited_request(guid="u1", email="", display_name="User")
+  assert (update_req.op, update_req.params) in db.calls
+  asyncio.run(module.shutdown())
+
+
+def test_link_provider_google_normalizes_identifier():
+  auth = DummyAuth(
+    providers={"google": SimpleNamespace(audience="client-id")},
+    login_result=("google-id", {}, {}),
+  )
+  oauth = DummyOauth(result=("id", "acc"))
+  env = DummyEnv({"GOOGLE_AUTH_SECRET": "secret"})
+  db = DummyDb()
+  config_req = get_config_request("Hostname")
+  db.respond(config_req.op, lambda _: DBRes(rows=[{"value": "redirect"}]))
+  module, db, *_ = build_module(db=db, auth=auth, oauth=oauth, env=env)
+  asyncio.run(
+    module.link_provider(
+      guid="u1",
+      provider="google",
+      code="authcode",
+    )
+  )
+  expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "google-id"))
+  link_req = link_provider_request(
+    guid="u1",
+    provider="google",
+    provider_identifier=expected,
+  )
+  assert (link_req.op, link_req.params) in db.calls
+  asyncio.run(module.shutdown())
+
+
+def test_link_provider_discord_normalizes_identifier():
+  auth = DummyAuth(
+    providers={"discord": SimpleNamespace(audience="client-id")},
+    login_result=("discord-id", {}, {}),
+  )
+  oauth = DummyOauth(result=(None, "acc"))
+  env = DummyEnv({"DISCORD_AUTH_SECRET": "secret"})
+  db = DummyDb()
+  config_req = get_config_request("Hostname")
+  db.respond(config_req.op, lambda _: DBRes(rows=[{"value": "redirect"}]))
+  module, db, *_ = build_module(db=db, auth=auth, oauth=oauth, env=env)
+  asyncio.run(
+    module.link_provider(
+      guid="u1",
+      provider="discord",
+      code="authcode",
+    )
+  )
+  expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "discord-id"))
+  link_req = link_provider_request(
+    guid="u1",
+    provider="discord",
+    provider_identifier=expected,
+  )
+  assert (link_req.op, link_req.params) in db.calls
+  asyncio.run(module.shutdown())
+
+
+def test_link_provider_microsoft_normalizes_identifier():
+  auth = DummyAuth(
+    providers={"microsoft": SimpleNamespace(audience="client-id")},
+    login_result=("ms-id", {}, {}),
+  )
+  module, db, *_ = build_module(auth=auth)
+  asyncio.run(
+    module.link_provider(
+      guid="u1",
+      provider="microsoft",
+      id_token="id",
+      access_token="acc",
+    )
+  )
+  expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "ms-id"))
+  link_req = link_provider_request(
+    guid="u1",
+    provider="microsoft",
+    provider_identifier=expected,
+  )
+  assert (link_req.op, link_req.params) in db.calls
+  asyncio.run(module.shutdown())
+
+
+def test_unlink_non_default_provider_retains_tokens():
+  db = DummyDb()
+  profile_req = get_profile_request(guid="u1")
+  db.respond(profile_req.op, lambda _: DBRes(rows=[{"default_provider": "microsoft"}]))
+  unlink_req = unlink_provider_request(guid="u1", provider="google")
+  db.respond(unlink_req.op, lambda _: DBRes(rows=[{"providers_remaining": 1}], rowcount=1))
+  module, db, *_ = build_module(db=db)
+  asyncio.run(
+    module.unlink_provider(
+      guid="u1",
+      provider="google",
+    )
+  )
+  revoke_req = revoke_provider_tokens_request(guid="u1", provider="google")
+  assert revoke_req.op not in [op for op, _ in db.calls]
+  asyncio.run(module.shutdown())
+
+
+def test_unlink_default_provider_without_new_default_raises():
+  db = DummyDb()
+  profile_req = get_profile_request(guid="u1")
+  db.respond(profile_req.op, lambda _: DBRes(rows=[{"default_provider": "google"}]))
+  unlink_req = unlink_provider_request(guid="u1", provider="google")
+  db.respond(unlink_req.op, lambda _: DBRes(rows=[{"providers_remaining": 1}], rowcount=1))
+  module, *_ = build_module(db=db)
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(
+      module.unlink_provider(
+        guid="u1",
+        provider="google",
+      )
+    )
+  assert exc.value.status_code == 400
+  asyncio.run(module.shutdown())
+
+
+def test_unlink_default_provider_sets_new_default_and_revokes_tokens():
+  db = DummyDb()
+  profile_req = get_profile_request(guid="u1")
+  db.respond(profile_req.op, lambda _: DBRes(rows=[{"default_provider": "google"}]))
+  unlink_req = unlink_provider_request(guid="u1", provider="google")
+  db.respond(unlink_req.op, lambda _: DBRes(rows=[{"providers_remaining": 1}], rowcount=1))
+  module, db, *_ = build_module(db=db)
+  asyncio.run(
+    module.unlink_provider(
+      guid="u1",
+      provider="google",
+      new_default="microsoft",
+    )
+  )
+  set_req = set_provider_request(guid="u1", provider="microsoft")
+  revoke_req = revoke_provider_tokens_request(guid="u1", provider="google")
+  assert (set_req.op, set_req.params) in db.calls
+  assert (revoke_req.op, revoke_req.params) in db.calls
+  asyncio.run(module.shutdown())
+
+
+def test_unlink_last_provider_soft_deletes_and_revokes():
+  db = DummyDb()
+  profile_req = get_profile_request(guid="u1")
+  db.respond(profile_req.op, lambda _: DBRes(rows=[{"default_provider": "google"}]))
+  unlink_req = unlink_provider_request(guid="u1", provider="google")
+  db.respond(unlink_req.op, lambda _: DBRes(rows=[{"providers_remaining": 0}], rowcount=1))
+  last_req = unlink_last_provider_request(guid="u1", provider="google")
+  db.respond(last_req.op, lambda _: DBRes([], 1))
+  module, db, *_ = build_module(db=db)
+  asyncio.run(
+    module.unlink_provider(
+      guid="u1",
+      provider="google",
+    )
+  )
+  assert (last_req.op, last_req.params) in db.calls
+  revoke_req = revoke_provider_tokens_request(guid="u1", provider="google")
+  assert revoke_req.op not in [op for op, _ in db.calls]
+  asyncio.run(module.shutdown())
+
+
+def test_create_from_provider_checks_email_conflict():
+  db = DummyDb()
+  email_req = get_user_by_email_request(email="exists@example.com")
+  db.respond(email_req.op, lambda _: DBRes(rows=[{"guid": "u1"}]))
+  module, *_ = build_module(db=db)
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(
+      module.create_from_provider(
+        provider="google",
+        provider_identifier="pid",
+        provider_email="exists@example.com",
+        provider_displayname="Name",
+        provider_profile_image=None,
+      )
+    )
+  assert exc.value.status_code == 409
+  asyncio.run(module.shutdown())
+
+
+def test_create_from_provider_returns_row():
+  db = DummyDb()
+  email_req = get_user_by_email_request(email="new@example.com")
+  db.respond(email_req.op, lambda _: DBRes(rows=[]))
+  create_req = create_from_provider_request(
+    provider="google",
+    provider_identifier="pid",
+    provider_email="new@example.com",
+    provider_displayname="Name",
+    provider_profile_image=None,
+  )
+  db.respond(create_req.op, lambda params: DBRes(rows=[{"guid": "u1"}]))
+  module, db, *_ = build_module(db=db)
+  row = asyncio.run(
+    module.create_from_provider(
+      provider="google",
+      provider_identifier="pid",
+      provider_email="new@example.com",
+      provider_displayname="Name",
+      provider_profile_image=None,
+    )
+  )
+  assert row == {"guid": "u1"}
+  asyncio.run(module.shutdown())
+
+
+def test_get_by_provider_identifier_returns_row():
+  db = DummyDb()
+  lookup_req = get_by_provider_identifier_request(provider="google", provider_identifier="pid")
+  db.respond(lookup_req.op, lambda params: DBRes(rows=[{"guid": "u1"}]))
+  module, db, *_ = build_module(db=db)
+  row = asyncio.run(
+    module.get_by_provider_identifier(
+      provider="google",
+      provider_identifier="pid",
+    )
+  )
+  assert row == {"guid": "u1"}
+  asyncio.run(module.shutdown())
+
+
+def test_set_provider_missing_provider_config_raises():
+  auth = DummyAuth(providers={})
+  module, *_ = build_module(auth=auth)
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(
+      module.set_provider(
+        guid="u1",
+        provider="google",
+        code="code",
+      )
+    )
+  assert exc.value.status_code == 500
+  asyncio.run(module.shutdown())
+

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -1,482 +1,223 @@
 import asyncio
-import importlib.util
-import pathlib
-import sys
-import types
 from types import SimpleNamespace
-import uuid
-from datetime import datetime, timezone, timedelta
-from server.modules.providers.auth.google_provider import GoogleAuthProvider
-from server.modules.providers.auth.microsoft_provider import MicrosoftAuthProvider
-from fastapi import FastAPI
-from server.registry.types import DBRequest
-
-from server.modules.oauth_module import OauthModule
 
 import pytest
 from fastapi import HTTPException
-from server.registry.users.content.profile import (
-  get_profile_request,
-  set_profile_image_request,
-  update_if_unedited_request,
-)
 
-PROFILE_GET_REQUEST = get_profile_request(guid="")
-PROFILE_IMAGE_REQUEST = set_profile_image_request(guid="", provider="", image_b64=None)
-UPDATE_IF_UNEDITED_REQUEST = update_if_unedited_request(
-  guid="",
-  email=None,
-  display_name=None,
-)
+from server.models import RPCRequest, RPCResponse
+
+from rpc.users.providers import services as user_services
+from rpc.auth.providers import services as auth_services
 
 
-def _normalize_db_call(op, args=None):
-  if hasattr(op, "op") and hasattr(op, "params"):
-    return op.op, op.params
-  return op, args
-
-# stub rpc package
-pkg = types.ModuleType("rpc")
-pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / "rpc")]
-sys.modules.setdefault("rpc", pkg)
-
-spec = importlib.util.spec_from_file_location("server.models", "server/models.py")
-models = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(models)
-RPCRequest = models.RPCRequest
-RPCResponse = models.RPCResponse
-sys.modules["server.models"] = models
-
-# stub server packages
-server_pkg = types.ModuleType("server")
-modules_pkg = types.ModuleType("server.modules")
-db_module_pkg = types.ModuleType("server.modules.db_module")
-class DbModule: ...
-db_module_pkg.DbModule = DbModule
-modules_pkg.db_module = db_module_pkg
-server_pkg.modules = modules_pkg
-models_pkg = types.ModuleType("server.models")
-class AuthContext:
-  def __init__(self, **data):
-    self.role_mask = 0
-    self.__dict__.update(data)
-models_pkg.AuthContext = AuthContext
-server_pkg.models = models_pkg
-
-sys.modules.setdefault("server", server_pkg)
-sys.modules.setdefault("server.modules", modules_pkg)
-sys.modules.setdefault("server.modules.db_module", db_module_pkg)
-sys.modules.setdefault("server.models", models_pkg)
-
-# load real helpers then override for service import
-real_helpers_spec = importlib.util.spec_from_file_location("rpc.helpers", "rpc/helpers.py")
-real_helpers = importlib.util.module_from_spec(real_helpers_spec)
-real_helpers_spec.loader.exec_module(real_helpers)
-
-helpers_stub = types.ModuleType("rpc.helpers")
-async def _stub(request):
-  raise NotImplementedError
-helpers_stub.unbox_request = _stub
-sys.modules["rpc.helpers"] = helpers_stub
-
-# import services with stubbed helpers
-svc_spec = importlib.util.spec_from_file_location("rpc.users.providers.services", "rpc/users/providers/services.py")
-svc_mod = importlib.util.module_from_spec(svc_spec)
-svc_spec.loader.exec_module(svc_mod)
-
-# restore real helpers
-sys.modules["rpc.helpers"] = real_helpers
-
-users_providers_set_provider_v1 = svc_mod.users_providers_set_provider_v1
-users_providers_link_provider_v1 = svc_mod.users_providers_link_provider_v1
-users_providers_unlink_provider_v1 = svc_mod.users_providers_unlink_provider_v1
-
-class DBRes:
-  def __init__(self, rows=None, rowcount=0):
-    self.rows = rows or []
-    self.rowcount = rowcount
-
-class DummyDb:
+class DummyModule:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args=None):
-    if isinstance(op, DBRequest):
-      args = op.params
-      op = op.op
-    args = args or {}
-    key, params = _normalize_db_call(op, args)
-    self.calls.append((key, params))
-    return DBRes()
+    self.get_result = None
+    self.create_result = None
 
-class DummyState:
-  def __init__(self, db, auth=None, env=None):
-    self.db = db
-    if auth is not None:
-      self.auth = auth
-    if env is not None:
-      self.env = env
-    self.oauth = OauthModule(FastAPI())
-    if hasattr(self, 'auth'):
-      self.oauth.auth = self.auth
-    self.oauth.db = self.db
+  async def set_provider(self, guid, provider, *, code=None, id_token=None, access_token=None):
+    self.calls.append(("set", {
+      "guid": guid,
+      "provider": provider,
+      "code": code,
+      "id_token": id_token,
+      "access_token": access_token,
+    }))
 
-class DummyApp:
-  def __init__(self, state):
-    self.state = state
+  async def link_provider(self, guid, provider, *, code=None, id_token=None, access_token=None):
+    self.calls.append(("link", {
+      "guid": guid,
+      "provider": provider,
+      "code": code,
+      "id_token": id_token,
+      "access_token": access_token,
+    }))
+
+  async def unlink_provider(self, guid, provider, *, new_default=None):
+    self.calls.append(("unlink", {
+      "guid": guid,
+      "provider": provider,
+      "new_default": new_default,
+    }))
+
+  async def get_by_provider_identifier(self, provider, provider_identifier):
+    self.calls.append(("get", {
+      "provider": provider,
+      "provider_identifier": provider_identifier,
+    }))
+    return self.get_result
+
+  async def create_from_provider(
+    self,
+    provider,
+    provider_identifier,
+    provider_email,
+    provider_displayname,
+    provider_profile_image,
+  ):
+    self.calls.append(("create", {
+      "provider": provider,
+      "provider_identifier": provider_identifier,
+      "provider_email": provider_email,
+      "provider_displayname": provider_displayname,
+      "provider_profile_image": provider_profile_image,
+    }))
+    return self.create_result
+
+  async def unlink_last_provider(self, guid, provider):
+    self.calls.append(("unlink_last", {
+      "guid": guid,
+      "provider": provider,
+    }))
+
 
 class DummyRequest:
-  def __init__(self, state):
-    self.app = DummyApp(state)
+  def __init__(self, module):
+    self.app = SimpleNamespace(state=SimpleNamespace(user_providers=module))
     self.headers = {}
 
 
-def test_set_provider_calls_db():
-  async def fake_get(request):
-    rpc = RPCRequest(
-      op="urn:users:providers:set_provider:1",
-      payload={"provider": "microsoft", "id_token": "id", "access_token": "acc"},
-      version=1,
-    )
-    return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.unbox_request = fake_get
-  db = DummyDb()
-  class DummyAuth:
-    def __init__(self):
-      self.providers = {"microsoft": SimpleNamespace(audience="client")}
-    async def handle_auth_login(self, provider, id_token, access_token):
-      return "pid", {"email": "e", "username": "n"}, {}
-  req = DummyRequest(DummyState(db, auth=DummyAuth()))
-  resp = asyncio.run(users_providers_set_provider_v1(req))
-  assert ("db:users:security_identities:set_provider:1", {"guid": "u1", "provider": "microsoft"}) in db.calls
-  expected_update = update_if_unedited_request(
-    guid="u1",
-    email="e",
-    display_name="n",
+def make_rpc_request(op, payload=None, version=1):
+  return RPCRequest(op=op, payload=payload or {}, version=version)
+
+
+def stub_unbox(module, rpc_request, auth_ctx=None):
+  async def fake_unbox(request):
+    return rpc_request, auth_ctx or SimpleNamespace(user_guid="user-1"), None
+  return fake_unbox
+
+
+def restore(module, attr, value):
+  setattr(module, attr, value)
+
+
+def test_set_provider_delegates_to_module():
+  module = DummyModule()
+  req = DummyRequest(module)
+  rpc_request = make_rpc_request(
+    "urn:users:providers:set_provider:1",
+    {"provider": "microsoft", "id_token": "id", "access_token": "acc"},
   )
-  assert (expected_update.op, expected_update.params) in db.calls
+  original = user_services.unbox_request
+  user_services.unbox_request = stub_unbox(user_services, rpc_request)
+  try:
+    resp = asyncio.run(user_services.users_providers_set_provider_v1(req))
+  finally:
+    restore(user_services, "unbox_request", original)
   assert isinstance(resp, RPCResponse)
+  assert resp.op == rpc_request.op
+  assert resp.version == 1
   assert resp.payload["provider"] == "microsoft"
+  assert module.calls[0][0] == "set"
+  assert module.calls[0][1]["guid"] == "user-1"
 
 
-def test_set_provider_missing_provider_raises():
-  async def fake_get(request):
-    rpc = RPCRequest(op="urn:users:providers:set_provider:1", payload={}, version=1)
-    return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.unbox_request = fake_get
-  db = DummyDb()
-  req = DummyRequest(DummyState(db))
-  with pytest.raises(HTTPException) as exc:
-    asyncio.run(users_providers_set_provider_v1(req))
-  assert exc.value.status_code == 400
-
-
-def test_set_provider_defaults_blank_profile():
-  async def fake_get(request):
-    rpc = RPCRequest(
-      op="urn:users:providers:set_provider:1",
-      payload={"provider": "microsoft", "id_token": "id", "access_token": "acc"},
-      version=1,
-    )
-    return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.unbox_request = fake_get
-  db = DummyDb()
-  class DummyAuth:
-    def __init__(self):
-      self.providers = {"microsoft": SimpleNamespace(audience="client")}
-    async def handle_auth_login(self, provider, id_token, access_token):
-      return "pid", {"email": "", "username": ""}, {}
-  req = DummyRequest(DummyState(db, auth=DummyAuth()))
-  asyncio.run(users_providers_set_provider_v1(req))
-  expected_update = update_if_unedited_request(
-    guid="u1",
-    email="",
-    display_name="User",
+def test_link_provider_requires_code_for_google():
+  module = DummyModule()
+  req = DummyRequest(module)
+  rpc_request = make_rpc_request(
+    "urn:users:providers:link_provider:1",
+    {"provider": "google"},
   )
-  assert (expected_update.op, expected_update.params) in db.calls
-
-
-def test_link_provider_google_normalizes_identifier():
-  async def fake_get(request):
-    rpc = RPCRequest(
-      op="urn:users:providers:link_provider:1",
-      payload={"provider": "google", "code": "authcode"},
-      version=1,
-    )
-    return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.unbox_request = fake_get
-
-  async def fake_exchange(code, client_id, client_secret, redirect_uri, provider):
-    assert provider == "google"
-    return "id", "acc"
-
-  class DummyAuth:
-    def __init__(self):
-      provider = GoogleAuthProvider(api_id="client-id", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
-
-      async def fake_fetch_jwks():
-        provider._jwks = {"keys": []}
-        provider._jwks_fetched_at = datetime.now(timezone.utc)
-
-      provider.fetch_jwks = fake_fetch_jwks
-      asyncio.run(provider.startup())
-      self.providers = {"google": provider}
-
-    async def handle_auth_login(self, provider, id_token, access_token):
-      return "google-id", {}, {}
-
-  class DummyDb:
-    def __init__(self):
-      self.calls = []
-    async def run(self, op, args=None):
-      if isinstance(op, DBRequest):
-        args = op.params
-        op = op.op
-      args = args or {}
-      key, params = _normalize_db_call(op, args)
-      self.calls.append((key, params))
-      if key == "db:system:config:get_config:1":
-        config_key = params.get("key") if isinstance(params, dict) else None
-        if config_key == "Hostname":
-          return DBRes(rows=[{"value": "redirect"}])
-      return DBRes()
-
-    async def get_google_api_secret(self):
-      return "secret"
-
-  class DummyEnv:
-    async def on_ready(self):
-      return None
-    def get(self, k):
-      assert k == "GOOGLE_AUTH_SECRET"
-      return "secret"
-
-  db = DummyDb()
-  auth = DummyAuth()
-  env = DummyEnv()
-  req = DummyRequest(DummyState(db, auth, env))
-  req.app.state.oauth.exchange_code_for_tokens = fake_exchange
-  asyncio.run(users_providers_link_provider_v1(req))
-  expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "google-id"))
-  assert ("db:users:security_identities:link_provider:1", {"guid": "u1", "provider": "google", "provider_identifier": expected}) in db.calls
-  asyncio.run(auth.providers["google"].shutdown())
-
-
-def test_link_provider_discord_normalizes_identifier():
-  async def fake_get(request):
-    rpc = RPCRequest(
-      op="urn:users:providers:link_provider:1",
-      payload={"provider": "discord", "code": "authcode"},
-      version=1,
-    )
-    return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.unbox_request = fake_get
-
-  async def fake_exchange(code, client_id, client_secret, redirect_uri, provider):
-    assert provider == "discord"
-    return None, "acc"
-
-  class DummyAuth:
-    def __init__(self):
-      class Provider:
-        audience = "client-id"
-        requires_id_token = False
-      self.providers = {"discord": Provider()}
-
-    async def handle_auth_login(self, provider, id_token, access_token):
-      return "discord-id", {}, {}
-
-  class DummyDb:
-    def __init__(self):
-      self.calls = []
-    async def run(self, op, args=None):
-      if isinstance(op, DBRequest):
-        args = op.params
-        op = op.op
-      args = args or {}
-      self.calls.append((op, args))
-      if op == "db:system:config:get_config:1":
-        key = args["key"]
-        if key == "Hostname":
-          return DBRes(rows=[{"value": "redirect"}])
-      return DBRes()
-
-  class DummyEnv:
-    async def on_ready(self):
-      return None
-    def get(self, k):
-      assert k == "DISCORD_AUTH_SECRET"
-      return "secret"
-
-  db = DummyDb()
-  auth = DummyAuth()
-  env = DummyEnv()
-  req = DummyRequest(DummyState(db, auth, env))
-  req.app.state.oauth.exchange_code_for_tokens = fake_exchange
-  asyncio.run(users_providers_link_provider_v1(req))
-  expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "discord-id"))
-  assert (
-    "db:users:security_identities:link_provider:1",
-    {"guid": "u1", "provider": "discord", "provider_identifier": expected},
-  ) in db.calls
-
-
-def test_link_provider_microsoft_normalizes_identifier():
-  async def fake_get(request):
-    rpc = RPCRequest(
-      op="urn:users:providers:link_provider:1",
-      payload={"provider": "microsoft", "id_token": "id", "access_token": "acc"},
-      version=1,
-    )
-    return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.unbox_request = fake_get
-
-  class DummyAuth:
-    def __init__(self):
-      provider = MicrosoftAuthProvider(api_id="client-id", jwks_uri="uri", jwks_expiry=timedelta(minutes=1))
-
-      async def fake_fetch_jwks():
-        provider._jwks = {"keys": []}
-        provider._jwks_fetched_at = datetime.now(timezone.utc)
-
-      provider.fetch_jwks = fake_fetch_jwks
-      asyncio.run(provider.startup())
-      self.providers = {"microsoft": provider}
-
-    async def handle_auth_login(self, provider, id_token, access_token):
-      return "ms-id", {}, {}
-
-  class DummyDb:
-    def __init__(self):
-      self.calls = []
-    async def run(self, op, args=None):
-      if isinstance(op, DBRequest):
-        args = op.params
-        op = op.op
-      args = args or {}
-      key, params = _normalize_db_call(op, args)
-      self.calls.append((key, params))
-      return DBRes()
-
-  db = DummyDb()
-  auth = DummyAuth()
-  req = DummyRequest(DummyState(db, auth))
-  asyncio.run(users_providers_link_provider_v1(req))
-  expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "ms-id"))
-  assert ("db:users:security_identities:link_provider:1", {"guid": "u1", "provider": "microsoft", "provider_identifier": expected}) in db.calls
-  asyncio.run(auth.providers["microsoft"].shutdown())
-
-
-def test_unlink_non_default_provider_retains_tokens():
-  async def fake_get(request):
-    rpc = RPCRequest(op="urn:users:providers:unlink_provider:1", payload={"provider": "google"}, version=1)
-    return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.unbox_request = fake_get
-
-  class LocalDb(DummyDb):
-    async def run(self, op, args=None):
-      if isinstance(op, DBRequest):
-        args = op.params
-        op = op.op
-      args = args or {}
-      key, params = _normalize_db_call(op, args)
-      self.calls.append((key, params))
-      if key == PROFILE_GET_REQUEST.op:
-        return DBRes(rows=[{"default_provider": "microsoft"}])
-      if key == "db:users:security_identities:unlink_provider:1":
-        return DBRes(rows=[{"providers_remaining": 1}], rowcount=1)
-      return DBRes()
-
-  db = LocalDb()
-  req = DummyRequest(DummyState(db))
-  asyncio.run(users_providers_unlink_provider_v1(req))
-  assert ("db:users:security_sessions:revoke_provider_tokens:1", {"guid": "u1", "provider": "google"}) not in db.calls
-  assert not any(op == "db:users:security_sessions:revoke_all_device_tokens:1" for op, _ in db.calls)
-  assert not any(op == "db:users:security_identities:soft_delete_account:1" for op, _ in db.calls)
-
-
-
-def test_unlink_default_provider_without_new_default_raises():
-  async def fake_get(request):
-    rpc = RPCRequest(op="urn:users:providers:unlink_provider:1", payload={"provider": "google"}, version=1)
-    return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.unbox_request = fake_get
-
-  class LocalDb(DummyDb):
-    async def run(self, op, args=None):
-      if isinstance(op, DBRequest):
-        args = op.params
-        op = op.op
-      args = args or {}
-      key, params = _normalize_db_call(op, args)
-      self.calls.append((key, params))
-      if key == PROFILE_GET_REQUEST.op:
-        return DBRes(rows=[{"default_provider": "google"}])
-      if key == "db:users:security_identities:unlink_provider:1":
-        return DBRes(rows=[{"providers_remaining": 1}], rowcount=1)
-      return DBRes()
-
-  db = LocalDb()
-  req = DummyRequest(DummyState(db))
+  original = user_services.unbox_request
+  user_services.unbox_request = stub_unbox(user_services, rpc_request)
   with pytest.raises(HTTPException):
-    asyncio.run(users_providers_unlink_provider_v1(req))
-  assert not any(op == "db:users:security_identities:set_provider:1" for op, _ in db.calls)
-  assert not any(op == "db:users:security_sessions:revoke_provider_tokens:1" for op, _ in db.calls)
+    asyncio.run(user_services.users_providers_link_provider_v1(req))
+  restore(user_services, "unbox_request", original)
+  assert not module.calls
 
 
-def test_unlink_default_provider_sets_new_default_and_revokes_tokens():
-  async def fake_get(request):
-    rpc = RPCRequest(op="urn:users:providers:unlink_provider:1", payload={"provider": "google", "new_default": "microsoft"}, version=1)
-    return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.unbox_request = fake_get
-
-  class LocalDb(DummyDb):
-    async def run(self, op, args=None):
-      if isinstance(op, DBRequest):
-        args = op.params
-        op = op.op
-      args = args or {}
-      key, params = _normalize_db_call(op, args)
-      self.calls.append((key, params))
-      if key == PROFILE_GET_REQUEST.op:
-        return DBRes(rows=[{"default_provider": "google"}])
-      if key == "db:users:security_identities:unlink_provider:1":
-        return DBRes(rows=[{"providers_remaining": 1}], rowcount=1)
-      return DBRes()
-
-  db = LocalDb()
-  req = DummyRequest(DummyState(db))
-  asyncio.run(users_providers_unlink_provider_v1(req))
-  assert ("db:users:security_identities:set_provider:1", {"guid": "u1", "provider": "microsoft"}) in db.calls
-  assert ("db:users:security_sessions:revoke_provider_tokens:1", {"guid": "u1", "provider": "google"}) in db.calls
-  assert not any(op == "db:users:security_sessions:revoke_all_device_tokens:1" for op, _ in db.calls)
-  assert not any(op == "db:users:security_identities:soft_delete_account:1" for op, _ in db.calls)
+def test_link_provider_delegates_to_module():
+  module = DummyModule()
+  req = DummyRequest(module)
+  rpc_request = make_rpc_request(
+    "urn:users:providers:link_provider:1",
+    {"provider": "discord", "code": "auth"},
+  )
+  original = user_services.unbox_request
+  user_services.unbox_request = stub_unbox(user_services, rpc_request)
+  try:
+    resp = asyncio.run(user_services.users_providers_link_provider_v1(req))
+  finally:
+    restore(user_services, "unbox_request", original)
+  assert resp.payload == {"provider": "discord"}
+  assert module.calls[0][0] == "link"
+  assert module.calls[0][1]["guid"] == "user-1"
 
 
-def test_unlink_last_provider_soft_deletes_and_revokes():
-  async def fake_get(request):
-    rpc = RPCRequest(op="urn:users:providers:unlink_provider:1", payload={"provider": "google"}, version=1)
-    return rpc, SimpleNamespace(user_guid="u1"), None
-  svc_mod.unbox_request = fake_get
+def test_unlink_provider_delegates_to_module():
+  module = DummyModule()
+  req = DummyRequest(module)
+  rpc_request = make_rpc_request(
+    "urn:users:providers:unlink_provider:1",
+    {"provider": "google", "new_default": "microsoft"},
+  )
+  original = user_services.unbox_request
+  user_services.unbox_request = stub_unbox(user_services, rpc_request)
+  try:
+    resp = asyncio.run(user_services.users_providers_unlink_provider_v1(req))
+  finally:
+    restore(user_services, "unbox_request", original)
+  assert resp.payload == {"provider": "google"}
+  assert module.calls[0] == ("unlink", {"guid": "user-1", "provider": "google", "new_default": "microsoft"})
 
-  class LocalDb(DummyDb):
-    async def run(self, op, args=None):
-      if isinstance(op, DBRequest):
-        args = op.params
-        op = op.op
-      args = args or {}
-      key, params = _normalize_db_call(op, args)
-      self.calls.append((key, params))
-      if key == PROFILE_GET_REQUEST.op:
-        return DBRes(rows=[{"default_provider": "google"}])
-      if key == "db:users:security_identities:unlink_provider:1":
-        return DBRes(rows=[{"providers_remaining": 0}], rowcount=1)
-      if key == "db:users:security_identities:unlink_last_provider:1":
-        return DBRes([], 1)
-      return DBRes()
 
-  db = LocalDb()
-  req = DummyRequest(DummyState(db))
-  asyncio.run(users_providers_unlink_provider_v1(req))
-  assert ("db:users:security_identities:unlink_last_provider:1", {"guid": "u1", "provider": "google"}) in db.calls
-  assert not any(op == "db:users:security_sessions:revoke_provider_tokens:1" for op, _ in db.calls)
+def test_get_by_provider_identifier_returns_module_value():
+  module = DummyModule()
+  module.get_result = {"guid": "user-1"}
+  req = DummyRequest(module)
+  rpc_request = make_rpc_request(
+    "urn:users:providers:get_by_provider_identifier:1",
+    {"provider": "google", "provider_identifier": "pid"},
+  )
+  original = user_services.unbox_request
+  user_services.unbox_request = stub_unbox(user_services, rpc_request, auth_ctx=None)
+  try:
+    resp = asyncio.run(user_services.users_providers_get_by_provider_identifier_v1(req))
+  finally:
+    restore(user_services, "unbox_request", original)
+  assert resp.payload == {"guid": "user-1"}
+  assert module.calls[0][0] == "get"
+
+
+def test_create_from_provider_returns_module_value():
+  module = DummyModule()
+  module.create_result = {"guid": "user-1"}
+  req = DummyRequest(module)
+  rpc_request = make_rpc_request(
+    "urn:users:providers:create_from_provider:1",
+    {
+      "provider": "google",
+      "provider_identifier": "pid",
+      "provider_email": "user@example.com",
+      "provider_displayname": "User",
+      "provider_profile_image": None,
+    },
+  )
+  original = user_services.unbox_request
+  user_services.unbox_request = stub_unbox(user_services, rpc_request, auth_ctx=None)
+  try:
+    resp = asyncio.run(user_services.users_providers_create_from_provider_v1(req))
+  finally:
+    restore(user_services, "unbox_request", original)
+  assert resp.payload == {"guid": "user-1"}
+  assert module.calls[0][0] == "create"
+
+
+def test_auth_unlink_last_provider_delegates_to_module():
+  module = DummyModule()
+  req = DummyRequest(module)
+  rpc_request = make_rpc_request(
+    "urn:auth:providers:unlink_last_provider:1",
+    {"guid": "u1", "provider": "google"},
+  )
+  original = auth_services.unbox_request
+  auth_services.unbox_request = stub_unbox(auth_services, rpc_request, auth_ctx=None)
+  try:
+    resp = asyncio.run(auth_services.auth_providers_unlink_last_provider_v1(req))
+  finally:
+    restore(auth_services, "unbox_request", original)
+  assert resp.payload == {"ok": True}
+  assert module.calls[0] == ("unlink_last", {"guid": "u1", "provider": "google"})
 


### PR DESCRIPTION
## Summary
- add a dedicated user providers module that centralizes provider authentication, linking, and unlinking helpers
- update the auth and user provider RPC services to delegate to the module facade
- add focused module tests and simplify service tests to mock the module interface

## Testing
- pytest tests/test_user_providers_module.py tests/test_users_providers_services.py


------
https://chatgpt.com/codex/tasks/task_e_68e462bb99948325996e112296c8c2e6