### PR TITLE
Add service routes module wrapper

### DIFF
--- a/rpc/service/routes/services.py
+++ b/rpc/service/routes/services.py
@@ -1,22 +1,21 @@
-from fastapi import Request
+from __future__ import annotations
+
 import logging
 
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
+
+from typing import TYPE_CHECKING
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.db_module import DbModule
-from server.modules.auth_module import AuthModule
-from server.registry.system.routes import (
-  delete_route_request,
-  get_routes_request,
-  upsert_route_request,
-)
 from .models import (
   ServiceRoutesRouteItem1,
   ServiceRoutesList1,
   ServiceRoutesDeleteRoute1,
 )
+
+if TYPE_CHECKING:
+  from server.modules.service_routes_module import ServiceRoutesModule
 
 
 async def service_routes_get_routes_v1(request: Request):
@@ -26,22 +25,9 @@ async def service_routes_get_routes_v1(request: Request):
     auth_ctx.user_guid,
     auth_ctx.roles,
   )
-  db: DbModule = request.app.state.db
-  auth: AuthModule = request.app.state.auth
-  db_request = get_routes_request()
-  res = await db.run(db_request)
-  routes = []
-  for row in res.rows:
-    mask = int(row.get("element_roles", 0))
-    roles = auth.mask_to_names(mask)
-    item = ServiceRoutesRouteItem1(
-      path=row.get("element_path", ""),
-      name=row.get("element_name", ""),
-      icon=row.get("element_icon"),
-      sequence=int(row.get("element_sequence", 0)),
-      required_roles=roles,
-    )
-    routes.append(item)
+  routes_mod: ServiceRoutesModule = request.app.state.service_routes
+  route_dicts = await routes_mod.list_routes()
+  routes = [ServiceRoutesRouteItem1(**route) for route in route_dicts]
   payload = ServiceRoutesList1(routes=routes)
   logging.debug(
     "[service_routes_get_routes_v1] returning %d routes",
@@ -63,20 +49,18 @@ async def service_routes_upsert_route_v1(request: Request):
     rpc_request.payload,
   )
   payload = ServiceRoutesRouteItem1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  auth: AuthModule = request.app.state.auth
+  routes_mod: ServiceRoutesModule = request.app.state.service_routes
   try:
-    mask = auth.names_to_mask(payload.required_roles)
+    route_dict = await routes_mod.upsert_route(
+      path=payload.path,
+      name=payload.name,
+      icon=payload.icon,
+      sequence=payload.sequence,
+      required_roles=payload.required_roles,
+    )
   except KeyError as exc:
     raise HTTPException(status_code=400, detail=str(exc)) from exc
-  db_request = upsert_route_request(
-    path=payload.path,
-    name=payload.name,
-    icon=payload.icon,
-    sequence=payload.sequence,
-    roles=mask,
-  )
-  await db.run(db_request)
+  payload = ServiceRoutesRouteItem1(**route_dict)
   logging.debug(
     "[service_routes_upsert_route_v1] upserted route %s",
     payload.path,
@@ -97,9 +81,9 @@ async def service_routes_delete_route_v1(request: Request):
     rpc_request.payload,
   )
   payload = ServiceRoutesDeleteRoute1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  db_request = delete_route_request(payload.path)
-  await db.run(db_request)
+  routes_mod: ServiceRoutesModule = request.app.state.service_routes
+  result = await routes_mod.delete_route(payload.path)
+  payload = ServiceRoutesDeleteRoute1(**result)
   logging.debug(
     "[service_routes_delete_route_v1] deleted route %s",
     payload.path,

--- a/server/modules/service_routes_module.py
+++ b/server/modules/service_routes_module.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+
+from server.modules import BaseModule
+from server.modules.auth_module import AuthModule
+from server.modules.db_module import DbModule
+from server.registry.system.routes import (
+  delete_route_request,
+  get_routes_request,
+  upsert_route_request,
+)
+
+
+class ServiceRoutesModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+    self.auth: AuthModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.auth = self.app.state.auth
+    await self.auth.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    self.db = None
+    self.auth = None
+
+  async def list_routes(self) -> list[dict[str, Any]]:
+    assert self.db, "database module not initialised"
+    assert self.auth, "auth module not initialised"
+    request = get_routes_request()
+    res = await self.db.run(request)
+    routes: list[dict[str, Any]] = []
+    for row in res.rows:
+      mask = int(row.get("element_roles", 0))
+      routes.append({
+        "path": row.get("element_path", ""),
+        "name": row.get("element_name", ""),
+        "icon": row.get("element_icon"),
+        "sequence": int(row.get("element_sequence", 0)),
+        "required_roles": self.auth.mask_to_names(mask),
+      })
+    return routes
+
+  async def upsert_route(
+    self,
+    *,
+    path: str,
+    name: str,
+    icon: str | None,
+    sequence: int,
+    required_roles: list[str],
+  ) -> dict[str, Any]:
+    assert self.db, "database module not initialised"
+    assert self.auth, "auth module not initialised"
+    mask = self.auth.names_to_mask(required_roles)
+    request = upsert_route_request(
+      path=path,
+      name=name,
+      icon=icon,
+      sequence=sequence,
+      roles=mask,
+    )
+    await self.db.run(request)
+    return {
+      "path": path,
+      "name": name,
+      "icon": icon,
+      "sequence": sequence,
+      "required_roles": required_roles,
+    }
+
+  async def delete_route(self, path: str) -> dict[str, str]:
+    assert self.db, "database module not initialised"
+    request = delete_route_request(path)
+    await self.db.run(request)
+    return {"path": path}

--- a/tests/test_service_routes_module.py
+++ b/tests/test_service_routes_module.py
@@ -1,0 +1,120 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from server.registry.types import DBRequest
+from server.modules.service_routes_module import ServiceRoutesModule
+
+
+class DummyDb:
+  def __init__(self, rows=None):
+    self.rows = rows or []
+    self.calls: list[tuple[str, dict[str, object]]] = []
+
+  async def on_ready(self):
+    pass
+
+  async def run(self, request: DBRequest):
+    assert isinstance(request, DBRequest)
+    self.calls.append((request.op, request.params))
+    if request.op == 'db:system:routes:get_routes:1':
+      return SimpleNamespace(rows=self.rows, rowcount=len(self.rows))
+    return SimpleNamespace(rows=[], rowcount=1)
+
+
+class DummyAuth:
+  def __init__(self, roles=None):
+    self.roles = roles or {'ROLE_SERVICE_ADMIN': 1}
+
+  async def on_ready(self):
+    pass
+
+  def mask_to_names(self, mask: int) -> list[str]:
+    return [name for name, bit in self.roles.items() if mask & bit]
+
+  def names_to_mask(self, names: list[str]) -> int:
+    mask = 0
+    for name in names:
+      mask |= self.roles[name]
+    return mask
+
+
+async def make_module(rows=None, roles=None):
+  db = DummyDb(rows)
+  auth = DummyAuth(roles)
+  app_state = SimpleNamespace(db=db, auth=auth)
+  app = SimpleNamespace(state=app_state)
+  mod = ServiceRoutesModule(app)
+  await mod.startup()
+  return mod, db, auth
+
+
+def test_list_routes_translates_role_masks():
+  rows = [{
+    'element_path': '/admin',
+    'element_name': 'Admin',
+    'element_icon': 'shield',
+    'element_sequence': 10,
+    'element_roles': 3,
+  }]
+  roles = {'ROLE_SERVICE_ADMIN': 1, 'ROLE_EDITOR': 2}
+  mod, db, _ = asyncio.run(make_module(rows, roles))
+  routes = asyncio.run(mod.list_routes())
+  assert routes == [{
+    'path': '/admin',
+    'name': 'Admin',
+    'icon': 'shield',
+    'sequence': 10,
+    'required_roles': ['ROLE_SERVICE_ADMIN', 'ROLE_EDITOR'],
+  }]
+  assert db.calls == [('db:system:routes:get_routes:1', {})]
+
+
+def test_upsert_route_converts_role_names():
+  roles = {'ROLE_SERVICE_ADMIN': 1, 'ROLE_EDITOR': 2}
+  mod, db, _ = asyncio.run(make_module([], roles))
+  result = asyncio.run(mod.upsert_route(
+    path='/admin',
+    name='Admin',
+    icon='shield',
+    sequence=5,
+    required_roles=['ROLE_SERVICE_ADMIN'],
+  ))
+  assert result == {
+    'path': '/admin',
+    'name': 'Admin',
+    'icon': 'shield',
+    'sequence': 5,
+    'required_roles': ['ROLE_SERVICE_ADMIN'],
+  }
+  assert db.calls == [(
+    'db:system:routes:upsert_route:1',
+    {
+      'path': '/admin',
+      'name': 'Admin',
+      'icon': 'shield',
+      'sequence': 5,
+      'roles': 1,
+    },
+  )]
+
+
+def test_upsert_route_invalid_role_raises_key_error():
+  roles = {'ROLE_SERVICE_ADMIN': 1}
+  mod, _, _ = asyncio.run(make_module([], roles))
+  with pytest.raises(KeyError):
+    asyncio.run(mod.upsert_route(
+      path='/admin',
+      name='Admin',
+      icon=None,
+      sequence=1,
+      required_roles=['ROLE_UNKNOWN'],
+    ))
+
+
+def test_delete_route_calls_db():
+  mod, db, _ = asyncio.run(make_module([], {'ROLE_SERVICE_ADMIN': 1}))
+  result = asyncio.run(mod.delete_route('/admin'))
+  assert result == {'path': '/admin'}
+  assert db.calls == [('db:system:routes:delete_route:1', {'path': '/admin'})]

--- a/tests/test_service_routes_services.py
+++ b/tests/test_service_routes_services.py
@@ -1,9 +1,11 @@
-import types, sys, pathlib
+import pathlib
+import sys
+import types
 from types import SimpleNamespace
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.requests import Request
-from server.registry.types import DBRequest
 
 # Stub rpc packages
 pkg = types.ModuleType('rpc')
@@ -18,55 +20,9 @@ rpc_service_routes_pkg = types.ModuleType('rpc.service.routes')
 rpc_service_routes_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc/service/routes')]
 sys.modules.setdefault('rpc.service.routes', rpc_service_routes_pkg)
 
-# Stub server modules
+# Stub server models
 server_pkg = types.ModuleType('server')
-modules_pkg = types.ModuleType('server.modules')
-db_module_pkg = types.ModuleType('server.modules.db_module')
-auth_module_pkg = types.ModuleType('server.modules.auth_module')
 models_pkg = types.ModuleType('server.models')
-
-
-class DbModule:
-  pass
-
-
-db_module_pkg.DbModule = DbModule
-modules_pkg.db_module = db_module_pkg
-
-
-class RoleCache:
-  def __init__(self):
-    self.roles = {'ROLE_SERVICE_ADMIN': 1}
-
-  def mask_to_names(self, mask):
-    return [name for name, bit in self.roles.items() if mask & bit]
-
-  def names_to_mask(self, names):
-    mask = 0
-    missing = [n for n in names if n not in self.roles]
-    if missing:
-      raise KeyError(f"Undefined roles: {', '.join(missing)}")
-    for n in names:
-      mask |= self.roles[n]
-    return mask
-
-class AuthModule:
-  def __init__(self):
-    self.role_cache = RoleCache()
-
-  @property
-  def roles(self):
-    return self.role_cache.roles
-
-  def mask_to_names(self, mask):
-    return self.role_cache.mask_to_names(mask)
-
-  def names_to_mask(self, names):
-    return self.role_cache.names_to_mask(names)
-
-
-auth_module_pkg.AuthModule = AuthModule
-modules_pkg.auth_module = auth_module_pkg
 
 
 class RPCResponse:
@@ -75,15 +31,15 @@ class RPCResponse:
     self.__dict__.update(data)
 
 
+def ensure_json_serializable(value, *, field_name):
+  return value
+
+
 models_pkg.RPCResponse = RPCResponse
-models_pkg.ensure_json_serializable = lambda value, *, field_name: value
-server_pkg.modules = modules_pkg
+models_pkg.ensure_json_serializable = ensure_json_serializable
 server_pkg.models = models_pkg
 
 sys.modules.setdefault('server', server_pkg)
-sys.modules.setdefault('server.modules', modules_pkg)
-sys.modules.setdefault('server.modules.db_module', db_module_pkg)
-sys.modules.setdefault('server.modules.auth_module', auth_module_pkg)
 sys.modules.setdefault('server.models', models_pkg)
 
 import importlib.util
@@ -101,48 +57,55 @@ service_routes_upsert_route_v1 = svc.service_routes_upsert_route_v1
 service_routes_delete_route_v1 = svc.service_routes_delete_route_v1
 
 
+def _make_auth_context():
+  return SimpleNamespace(user_guid='u1', roles=['ROLE_SERVICE_ADMIN'])
+
+
 async def fake_unbox(request: Request):
   body = await request.json()
   op = body.get('op')
   payload = body.get('payload')
   rpc_req = SimpleNamespace(op=op, payload=payload, version=1)
-  auth_ctx = SimpleNamespace(user_guid='u1', roles=['ROLE_SERVICE_ADMIN'])
-  return rpc_req, auth_ctx, None
+  return rpc_req, _make_auth_context(), None
 
 
 svc.unbox_request = fake_unbox
 
 
-class DummyDb:
+class DummyServiceRoutesModule:
   def __init__(self):
-    self.calls = []
+    self.list_calls = 0
+    self.upsert_calls: list[dict[str, object]] = []
+    self.delete_calls: list[str] = []
 
-  async def run(self, op, args=None):
-    if isinstance(op, DBRequest):
-      args = op.params
-      op = op.op
-    args = args or {}
-    self.calls.append((op, args))
-    if op == 'db:system:routes:get_routes:1':
-      rows = [{
-        'element_path': '/a',
-        'element_name': 'A',
-        'element_icon': 'home',
-        'element_sequence': 1,
-        'element_roles': 1,
-      }]
-      return SimpleNamespace(rows=rows, rowcount=1)
-    if op in ('db:system:routes:upsert_route:1', 'db:system:routes:delete_route:1'):
-      return SimpleNamespace(rows=[], rowcount=1)
-    raise AssertionError(f'unexpected op {op}')
+  async def list_routes(self):
+    self.list_calls += 1
+    return [
+      {
+        'path': '/a',
+        'name': 'A',
+        'icon': 'home',
+        'sequence': 1,
+        'required_roles': ['ROLE_SERVICE_ADMIN'],
+      }
+    ]
+
+  async def upsert_route(self, **route):
+    self.upsert_calls.append(route)
+    return route
+
+  async def delete_route(self, path: str):
+    self.delete_calls.append(path)
+    return {'path': path}
 
 
-db = DummyDb()
-auth = AuthModule()
+class FailingServiceRoutesModule(DummyServiceRoutesModule):
+  async def upsert_route(self, **route):
+    raise KeyError('Undefined roles: ROLE_UNKNOWN')
+
 
 app = FastAPI()
-app.state.db = db
-app.state.auth = auth
+app.state.service_routes = DummyServiceRoutesModule()
 
 
 @app.post('/rpc')
@@ -158,10 +121,13 @@ async def rpc_endpoint(request: Request):
   raise AssertionError('unexpected op')
 
 
-client = TestClient(app)
+def _make_client():
+  return TestClient(app)
 
 
 def test_get_routes_service():
+  client = _make_client()
+  app.state.service_routes = DummyServiceRoutesModule()
   resp = client.post('/rpc', json={'op': 'urn:service:routes:get_routes:1', 'version': 1})
   assert resp.status_code == 200
   data = resp.json()
@@ -174,10 +140,13 @@ def test_get_routes_service():
       'required_roles': ['ROLE_SERVICE_ADMIN'],
     }]
   }
-  assert ('db:system:routes:get_routes:1', {}) in db.calls
+  assert app.state.service_routes.list_calls == 1
 
 
 def test_upsert_and_delete_route_service():
+  client = _make_client()
+  module = DummyServiceRoutesModule()
+  app.state.service_routes = module
   upsert_payload = {
     'path': '/a',
     'name': 'A',
@@ -187,13 +156,23 @@ def test_upsert_and_delete_route_service():
   }
   resp = client.post('/rpc', json={'op': 'urn:service:routes:upsert_route:1', 'payload': upsert_payload, 'version': 1})
   assert resp.status_code == 200
+  assert module.upsert_calls == [upsert_payload]
   resp = client.post('/rpc', json={'op': 'urn:service:routes:delete_route:1', 'payload': {'path': '/a'}, 'version': 1})
   assert resp.status_code == 200
-  assert ('db:system:routes:upsert_route:1', {
+  assert module.delete_calls == ['/a']
+
+
+def test_upsert_route_invalid_role_returns_400():
+  client = _make_client()
+  app.state.service_routes = FailingServiceRoutesModule()
+  upsert_payload = {
     'path': '/a',
     'name': 'A',
     'icon': 'home',
     'sequence': 1,
-    'roles': 1,
-  }) in db.calls
-  assert ('db:system:routes:delete_route:1', {'path': '/a'}) in db.calls
+    'required_roles': ['ROLE_UNKNOWN'],
+  }
+  resp = client.post('/rpc', json={'op': 'urn:service:routes:upsert_route:1', 'payload': upsert_payload, 'version': 1})
+  assert resp.status_code == 400
+  data = resp.json()
+  assert data['detail'] == "'Undefined roles: ROLE_UNKNOWN'"


### PR DESCRIPTION
## Summary
- add a ServiceRoutesModule that wraps database requests and role mask translations for system routes
- update the service routes RPC handlers to delegate to the new module
- add module-focused tests and update service tests to mock the module interface

## Testing
- pytest tests/test_service_routes_module.py tests/test_service_routes_services.py

------
https://chatgpt.com/codex/tasks/task_e_68e465dd27e8832588fbba2a6724e7d3