### PR TITLE
Document Discord in-process RPC path and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,9 @@ The OpenAI module records conversation details whenever `!summarize` is executed
 - Outbound Discord messages are buffered through an internal asyncio queue that respects the module's chunking and rate-limiting rules. Use `queue_channel_message` and `queue_user_message` helpers to enqueue work.
 - Successful deliveries update per-channel, per-user, and aggregate throughput metrics. Call `get_throughput_snapshot()` to inspect counters and timestamps for monitoring or diagnostics.
 
-### Discord Bot RPC Configuration
+### Discord Bot RPC Dispatch
 
-Discord bot commands now invoke the public RPC surface over HTTP instead of dispatching operations in-process. Bot operators must provide credentials so the adapter can reach the FastAPI service. Store these entries in the system configuration table (`system.config` domain):
+Discord bot commands now execute RPC handlers entirely in-process. The `DiscordBotModule.call_rpc` helper resolves the target handler from the shared dispatcher (`rpc.HANDLERS`) and fabricates a lightweight request object that mirrors the FastAPI ingress. Instead of HTTP credentials, the module loads Discord identity details through the shared auth provider (`DiscordAuthModule` or `app.state.auth`). The resulting `AuthContext` and Discord metadata are attached to the synthetic request state so downstream handlers observe the same security guarantees they expect from HTTP traffic.
 
-| Key | Description |
-| --- | ----------- |
-| `DiscordRpcBaseUrl` | Root URL of the API (for example `https://api.example.com`). The adapter appends `/rpc` automatically when issuing requests. |
-| `DiscordRpcToken` | Bearer token that authorizes the bot to call Discord RPC domains. Rotate this credential using the same procedure as other service tokens. |
-| `DiscordRpcSigningSecret` | Optional secret for validating inbound Discord webhook calls. |
-
-Restart the Discord worker after updating these settings so that the updated credentials are reloaded. The bot now records Discord context metadata on the RPC request state, ensuring downstream handlers can authorize calls without relying on HTTP headers. Legacy `X-Discord-*` headers remain available only for guarded webhook integrations.
+Because identity is derived from Discord lookups, no additional RPC configuration entries (such as `DiscordRpcBaseUrl`, `DiscordRpcToken`, or `DiscordRpcSigningSecret`) are required. Ensure the Discord security tables remain in sync so the lookup performed by `get_discord_user_security` can resolve every bot user before dispatching commands.
 

--- a/tests/test_discord_module.py
+++ b/tests/test_discord_module.py
@@ -1,5 +1,4 @@
 import asyncio, logging
-import pytest
 from fastapi import FastAPI
 from server.registry.types import DBRequest
 
@@ -12,9 +11,6 @@ class DummyEnv(BaseModule):
     super().__init__(app)
     self._env = {
       "DISCORD_SECRET": "secret",
-      "DISCORD_RPC_BASE_URL": "https://api.example.com",
-      "DISCORD_RPC_TOKEN": "token",
-      "DISCORD_RPC_SIGNING_SECRET": "signing",
     }
 
   async def startup(self):
@@ -51,13 +47,7 @@ class DummyDb(BaseModule):
       key = args.get("key")
       if key == "DiscordSyschan":
         return Res([{ "value": "123" }])
-      if key == "DiscordRpcBaseUrl":
-        return Res([{ "value": "https://api.example.com" }])
-      if key == "DiscordRpcToken":
-        return Res([{ "value": "token" }])
-      if key == "DiscordRpcSigningSecret":
-        return Res([{ "value": "signing" }])
-    return Res([])
+      return Res([])
 
 
 class DummyBot:
@@ -115,7 +105,7 @@ def test_discord_module_startup_single_owner(monkeypatch, caplog):
     return lock_attempts["count"] == 1
   
   def fake_release(self):
-      self._lock_handle = None
+    self._lock_handle = None
 
   monkeypatch.setattr(DiscordBotModule, "_init_discord_bot", fake_init)
   monkeypatch.setattr(DiscordBotModule, "_try_lock_file", fake_try_lock)
@@ -145,42 +135,3 @@ def test_discord_module_startup_single_owner(monkeypatch, caplog):
 
   asyncio.run(module1.shutdown())
   asyncio.run(module2.shutdown())
-
-
-def test_discord_module_startup_without_rpc_config(monkeypatch, caplog):
-  app = FastAPI()
-  app.state.env = DummyEnv(app)
-  app.state.db = DummyDbMissingRpc(app)
-  asyncio.run(app.state.env.startup())
-  asyncio.run(app.state.db.startup())
-
-  def fake_init(self, prefix: str):
-    return DummyBot()
-
-  def fake_try_lock(self, handle):
-    return True
-
-  def fake_release(self):
-    self._lock_handle = None
-
-  monkeypatch.setattr(DiscordBotModule, "_init_discord_bot", fake_init)
-  monkeypatch.setattr(DiscordBotModule, "_try_lock_file", fake_try_lock)
-  monkeypatch.setattr(DiscordBotModule, "_release_bot_lock", fake_release)
-
-  module = DiscordBotModule(app)
-
-  with caplog.at_level(logging.WARNING):
-    asyncio.run(module.startup())
-
-  assert module.rpc_base_url is None
-  assert module.rpc_token is None
-  assert module.rpc_signing_secret is None
-  warning_messages = [record.message for record in caplog.records]
-  assert any("RPC base URL/token missing" in msg for msg in warning_messages)
-  assert any("RPC signing secret missing" in msg for msg in warning_messages)
-
-  with pytest.raises(RuntimeError):
-    asyncio.run(module.call_rpc("urn:test:ops:trigger:1"))
-
-  asyncio.run(module.shutdown())
-

--- a/tests/test_discord_rpc_client.py
+++ b/tests/test_discord_rpc_client.py
@@ -1,17 +1,13 @@
 import asyncio
 from types import SimpleNamespace
 
+import pytest
 from fastapi import FastAPI
 
 from server.modules.discord_bot_module import DiscordBotModule
 
 
-async def _capture_handler(parts, request, captured):
-  captured['request'] = request
-  return SimpleNamespace(payload={'ok': True}, op='urn:test:ops:trigger:1', version=1)
-
-
-def test_call_rpc_attaches_discord_metadata():
+def test_call_rpc_populates_auth_context_and_metadata():
   app = FastAPI()
   module = DiscordBotModule(app)
 
@@ -19,16 +15,17 @@ def test_call_rpc_attaches_discord_metadata():
 
   class StubAuth:
     async def get_discord_user_security(self, discord_id: str):
-      return (f'user-{discord_id}', ['ROLE_REGISTERED'], 0x1)
+      return (f'user-{discord_id}', ['ROLE_REGISTERED'], 0x7)
 
   app.state.auth = StubAuth()
 
   captured: dict[str, SimpleNamespace] = {}
 
-  original_handlers = rpc.HANDLERS.copy()
+  original_handlers = dict(rpc.HANDLERS)
 
   async def _handler(parts, request):
-    return await _capture_handler(parts, request, captured)
+    captured['request'] = request
+    return SimpleNamespace(payload={'ok': True}, op='urn:test:ops:trigger:1', version=1)
 
   rpc.HANDLERS['test'] = _handler
 
@@ -41,14 +38,56 @@ def test_call_rpc_attaches_discord_metadata():
       )
     )
   finally:
-    rpc.HANDLERS = original_handlers
+    rpc.HANDLERS.clear()
+    rpc.HANDLERS.update(original_handlers)
 
   assert hasattr(response, 'payload')
   assert response.payload['ok'] is True
 
   request = captured['request']
-  metadata = getattr(request.state, 'discord_metadata', None)
+  rpc_request = request.state.rpc_request
+  auth_ctx = request.state.auth_ctx
+  metadata = request.state.discord_metadata
+
+  assert rpc_request.user_guid == 'user-7'
+  assert rpc_request.roles == ['ROLE_REGISTERED']
+  assert rpc_request.role_mask == 0x7
+  assert auth_ctx.user_guid == 'user-7'
+  assert auth_ctx.roles == ['ROLE_REGISTERED']
+  assert auth_ctx.role_mask == 0x7
   assert metadata == {'user_id': '7', 'guild_id': '9', 'channel_id': '11'}
   assert request.headers['x-discord-id'] == '7'
   assert request.headers['x-discord-guild-id'] == '9'
   assert request.headers['x-discord-channel-id'] == '11'
+
+
+def test_call_rpc_requires_user_metadata():
+  app = FastAPI()
+  module = DiscordBotModule(app)
+
+  import rpc
+
+  class StubAuth:
+    async def get_discord_user_security(self, discord_id: str):
+      return ('guid', ['ROLE_REGISTERED'], 1)
+
+  app.state.auth = StubAuth()
+
+  with pytest.raises(RuntimeError, match='Discord user metadata is required'):
+    asyncio.run(module.call_rpc('urn:test:ops:trigger:1'))
+
+
+def test_call_rpc_raises_when_security_profile_missing():
+  app = FastAPI()
+  module = DiscordBotModule(app)
+
+  import rpc
+
+  class StubAuth:
+    async def get_discord_user_security(self, discord_id: str):
+      return ('', [], 0)
+
+  app.state.auth = StubAuth()
+
+  with pytest.raises(RuntimeError, match='No security profile for Discord user'):
+    asyncio.run(module.call_rpc('urn:test:ops:trigger:1', metadata={'user_id': '999'}))

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -1,13 +1,32 @@
 import asyncio
+import importlib
+import importlib.util
+import pathlib
+import sys
 from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
 
-from server.models import RPCRequest, RPCResponse
+ROOT = pathlib.Path(__file__).resolve().parent.parent
 
-from rpc.users.providers import services as user_services
-from rpc.auth.providers import services as auth_services
+
+def _load_models():
+  spec = importlib.util.spec_from_file_location('server.models', ROOT / 'server/models.py')
+  mod = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(mod)
+  sys.modules['server.models'] = mod
+  return mod
+
+
+models = _load_models()
+RPCRequest = models.RPCRequest
+RPCResponse = models.RPCResponse
+
+user_services = importlib.import_module('rpc.users.providers.services')
+user_services = importlib.reload(user_services)
+auth_services = importlib.import_module('rpc.auth.providers.services')
+auth_services = importlib.reload(auth_services)
 
 
 class DummyModule:


### PR DESCRIPTION
## Summary
- document the Discord bot's in-process RPC dispatch flow and drop legacy HTTP configuration references
- refresh Discord module and user provider tests to avoid RPC config dependencies and ensure consistent model loading
- add Discord RPC client unit coverage for metadata enrichment and missing identity guardrails

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e7d79dbe208325ae90e82c8b1e5868