### PR TITLE
Add Discord guild join logging and table proposal

### DIFF
--- a/scripts/discord_guilds_table_proposal.sql
+++ b/scripts/discord_guilds_table_proposal.sql
@@ -1,0 +1,14 @@
+-- Proposal: track Discord guilds the bot has joined.
+CREATE TABLE discord_guilds (
+  recid bigint NOT NULL,
+  element_guild_id nvarchar(32) NOT NULL,
+  element_name nvarchar(256) NOT NULL,
+  element_joined_on datetimeoffset DEFAULT (sysutcdatetime()) NOT NULL,
+  element_member_count int,
+  element_owner_id nvarchar(32),
+  element_region nvarchar(128),
+  element_left_on datetimeoffset,
+  element_notes nvarchar(1024),
+  PRIMARY KEY (recid)
+);
+CREATE UNIQUE INDEX UQ_discord_guilds_element_guild_id ON discord_guilds (element_guild_id);

--- a/server/routers/discord_events.py
+++ b/server/routers/discord_events.py
@@ -48,8 +48,16 @@ def _register_on_ready_handler(bot_module: "DiscordBotModule", bot: commands.Bot
 def _register_on_guild_join_handler(bot_module: "DiscordBotModule", bot: commands.Bot) -> None:
   @bot.event
   async def on_guild_join(guild):
+    message = f"Joined guild {guild.name} ({guild.id})"
+    if await bot_module._try_send_channel(bot_module.syschan, message):
+      logging.info(message)
+      return
     channel = bot.get_channel(bot_module.syschan)
     if channel:
-      logging.info(f"Joined guild {guild.name} ({guild.id})")
+      try:
+        await channel.send(message)
+        logging.info(message)
+      except Exception:
+        logging.exception("[DiscordBotModule] failed to send guild join message", extra={"guild_id": guild.id})
     else:
       logging.warning(f"[DiscordProvider] System channel not found when joining {guild.name}.")


### PR DESCRIPTION
## Summary
- send a guild join notification through the Discord logging channel with a fallback message
- add a SQL proposal for tracking Discord guilds that the bot joins

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e91ee371c483258fbb60c4c76f80a4