### PR TITLE
Add MSSQL registry support for Discord guilds

### DIFF
--- a/server/registry/system/__init__.py
+++ b/server/registry/system/__init__.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from . import assistant, config, public, roles, routes
+from . import assistant, config, discord, public, roles, routes
 
 if TYPE_CHECKING:
   from server.registry import RegistryRouter
 
 __all__ = [
   "config",
+  "discord",
   "public",
   "register",
   "roles",
@@ -22,6 +23,7 @@ def register(router: "RegistryRouter") -> None:
   domain = router.domain("system")
   assistant.register(domain)
   config.register(domain.subdomain("config"))
+  discord.register(domain)
   public.register(domain)
   roles.register(domain.subdomain("roles"))
   routes.register(domain.subdomain("routes"))

--- a/server/registry/system/discord/__init__.py
+++ b/server/registry/system/discord/__init__.py
@@ -1,0 +1,20 @@
+"""Discord registry bindings for the system domain."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from . import guilds
+
+if TYPE_CHECKING:
+  from server.registry import DomainRouter
+
+__all__ = [
+  "guilds",
+  "register",
+]
+
+
+def register(domain: "DomainRouter") -> None:
+  discord_router = domain.subdomain("discord")
+  guilds.register(discord_router.subdomain("guilds"))

--- a/server/registry/system/discord/guilds/__init__.py
+++ b/server/registry/system/discord/guilds/__init__.py
@@ -1,0 +1,80 @@
+"""Discord guild registry helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from server.registry.types import DBRequest
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "get_guild_request",
+  "list_guilds_request",
+  "register",
+  "upsert_guild_request",
+]
+
+
+_DEF_PROVIDER_KEY = "db:system:discord_guilds"
+
+
+def _normalise_identifier(value: str | int | None) -> str | None:
+  if value is None:
+    return None
+  return str(value)
+
+
+def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
+  return DBRequest(op=op, params=params or {})
+
+
+def upsert_guild_request(
+  *,
+  guild_id: str | int,
+  name: str,
+  joined_on: datetime | str | None = None,
+  member_count: int | None = None,
+  owner_id: str | int | None = None,
+  region: str | None = None,
+  left_on: datetime | str | None = None,
+  notes: str | None = None,
+) -> DBRequest:
+  params: dict[str, Any] = {
+    "guild_id": _normalise_identifier(guild_id),
+    "name": name,
+  }
+  if joined_on is not None:
+    params["joined_on"] = joined_on
+  if member_count is not None:
+    params["member_count"] = member_count
+  owner_id = _normalise_identifier(owner_id)
+  if owner_id is not None:
+    params["owner_id"] = owner_id
+  if region is not None:
+    params["region"] = region
+  if left_on is not None:
+    params["left_on"] = left_on
+  if notes is not None:
+    params["notes"] = notes
+  return _request(f"{_DEF_PROVIDER_KEY}:upsert_guild:1", params)
+
+
+def get_guild_request(*, guild_id: str | int) -> DBRequest:
+  params = {"guild_id": _normalise_identifier(guild_id)}
+  return _request(f"{_DEF_PROVIDER_KEY}:get_guild:1", params)
+
+
+def list_guilds_request(*, include_inactive: bool = True) -> DBRequest:
+  params: dict[str, Any] = {}
+  if not include_inactive:
+    params["include_inactive"] = False
+  return _request(f"{_DEF_PROVIDER_KEY}:list_guilds:1", params)
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function("upsert_guild", version=1)
+  router.add_function("get_guild", version=1)
+  router.add_function("list_guilds", version=1)

--- a/server/registry/system/discord/guilds/mssql.py
+++ b/server/registry/system/discord/guilds/mssql.py
@@ -1,0 +1,135 @@
+"""Discord guild queries for MSSQL."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from server.registry.providers.mssql import run_json_many, run_json_one
+from server.registry.types import DBResponse
+
+__all__ = [
+  "get_guild_v1",
+  "list_guilds_v1",
+  "upsert_guild_v1",
+]
+
+
+async def upsert_guild_v1(args: dict[str, Any]) -> DBResponse:
+  guild_id = str(args["guild_id"])
+  name = args["name"]
+  joined_on = args.get("joined_on")
+  member_count = args.get("member_count")
+  owner_id = args.get("owner_id")
+  if owner_id is not None:
+    owner_id = str(owner_id)
+  region = args.get("region")
+  left_on = args.get("left_on")
+  notes = args.get("notes")
+  sql = """
+    MERGE discord_guilds AS target
+    USING (
+      SELECT
+        ? AS element_guild_id,
+        ? AS element_name,
+        ? AS element_joined_on,
+        ? AS element_member_count,
+        ? AS element_owner_id,
+        ? AS element_region,
+        ? AS element_left_on,
+        ? AS element_notes
+    ) AS source
+    ON target.element_guild_id = source.element_guild_id
+    WHEN MATCHED THEN
+      UPDATE SET
+        element_name = source.element_name,
+        element_member_count = source.element_member_count,
+        element_owner_id = source.element_owner_id,
+        element_region = source.element_region,
+        element_left_on = source.element_left_on,
+        element_notes = source.element_notes,
+        element_joined_on = COALESCE(source.element_joined_on, target.element_joined_on)
+    WHEN NOT MATCHED THEN
+      INSERT (
+        element_guild_id,
+        element_name,
+        element_joined_on,
+        element_member_count,
+        element_owner_id,
+        element_region,
+        element_left_on,
+        element_notes
+      ) VALUES (
+        source.element_guild_id,
+        source.element_name,
+        COALESCE(source.element_joined_on, SYSUTCDATETIME()),
+        source.element_member_count,
+        source.element_owner_id,
+        source.element_region,
+        source.element_left_on,
+        source.element_notes
+      )
+    OUTPUT
+      inserted.recid,
+      inserted.element_guild_id,
+      inserted.element_name,
+      inserted.element_joined_on,
+      inserted.element_member_count,
+      inserted.element_owner_id,
+      inserted.element_region,
+      inserted.element_left_on,
+      inserted.element_notes
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  params = (
+    guild_id,
+    name,
+    joined_on,
+    member_count,
+    owner_id,
+    region,
+    left_on,
+    notes,
+  )
+  return await run_json_one(sql, params)
+
+
+async def get_guild_v1(args: dict[str, Any]) -> DBResponse:
+  guild_id = str(args["guild_id"])
+  sql = """
+    SELECT
+      recid,
+      element_guild_id,
+      element_name,
+      element_joined_on,
+      element_member_count,
+      element_owner_id,
+      element_region,
+      element_left_on,
+      element_notes
+    FROM discord_guilds
+    WHERE element_guild_id = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (guild_id,))
+
+
+async def list_guilds_v1(args: dict[str, Any]) -> DBResponse:
+  include_inactive = args.get("include_inactive", True)
+  sql = """
+    SELECT
+      recid,
+      element_guild_id,
+      element_name,
+      element_joined_on,
+      element_member_count,
+      element_owner_id,
+      element_region,
+      element_left_on,
+      element_notes
+    FROM discord_guilds
+  """
+  params: list[Any] = []
+  if not include_inactive:
+    sql += "\n    WHERE element_left_on IS NULL"
+  sql += "\n    ORDER BY element_joined_on DESC\n    FOR JSON PATH, INCLUDE_NULL_VALUES;"
+  return await run_json_many(sql, tuple(params))


### PR DESCRIPTION
## Summary
- register the new system.discord guild registry subtree
- add request helpers and MSSQL queries to upsert and select discord_guilds rows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e922bf65cc83259f300eabbc8bd95b