### PR TITLE
Fix guild sync script imports

### DIFF
--- a/scripts/sync_discord_guilds.py
+++ b/scripts/sync_discord_guilds.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime
 
 import discord
 from fastapi import FastAPI
+
+from scriptlib import REPO_ROOT
+
+if REPO_ROOT not in sys.path:
+  sys.path.insert(0, REPO_ROOT)
 
 from server.helpers.logging import configure_root_logging
 from server.modules.db_module import DbModule


### PR DESCRIPTION
## Summary
- ensure the Discord guild sync script loads application modules by adding the repo root to `sys.path`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e950de181483258bb36e78d36d4ad3