### PR TITLE
Guard Discord guild upsert from recid payloads

### DIFF
--- a/server/registry/system/discord/guilds/mssql.py
+++ b/server/registry/system/discord/guilds/mssql.py
@@ -15,6 +15,8 @@ __all__ = [
 
 
 async def upsert_guild_v1(args: dict[str, Any]) -> DBResponse:
+  args = dict(args)
+  args.pop("recid", None)
   guild_id = str(args["guild_id"])
   name = args["name"]
   joined_on = args.get("joined_on")

--- a/tests/test_sync_discord_guilds.py
+++ b/tests/test_sync_discord_guilds.py
@@ -80,6 +80,7 @@ def test_synchronize_guilds_upserts_each_guild():
   assert first.params["member_count"] == 5
   assert first.params["owner_id"] == "42"
   assert first.params["region"] == "us"
+  assert "recid" not in first.params
 
 
 def test_synchronize_guilds_skips_duplicate_ids():


### PR DESCRIPTION
## Summary
- drop any recid field from the Discord guild upsert arguments before constructing the query
- ensure the synchronisation test asserts that recid is never sent to the database request

## Testing
- pytest tests/test_sync_discord_guilds.py *(fails: ModuleNotFoundError: No module named 'scriptlib')*


------
https://chatgpt.com/codex/tasks/task_e_68e95b209fe48325917c5607dbc2d9ae