### PR TITLE
Dump Discord guild data to stdout

### DIFF
--- a/scripts/direct_insert_discord_guilds.py
+++ b/scripts/direct_insert_discord_guilds.py
@@ -1,120 +1,29 @@
-"""Standalone utility to pull Discord guilds and insert them into SQL Server.
+"""Standalone utility to pull Discord guilds and dump the records to stdout.
 
-This script deliberately avoids any of the application server modules. It
-implements a tiny asynchronous connection pool on top of ``aioodbc`` and uses
-raw SQL statements to upsert guild metadata into the ``discord_guilds`` table.
+This variant exists for manual workflows where inserting into SQL Server is
+performed outside of the application runtime. It connects to Discord, gathers
+metadata for each guild the bot can access, normalises it to match the
+``discord_guilds`` schema, and prints the resulting payloads as JSON. The JSON
+output can then be used to craft manual ``INSERT`` statements or seed files.
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 import os
-from contextlib import asynccontextmanager, suppress
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Iterable, Sequence
+from typing import Sequence
 
-import aioodbc
 import discord
 from dotenv import load_dotenv
 
 
 LOGGER = logging.getLogger("scripts.direct_insert_discord_guilds")
-
-
-class ConnectionPool:
-  """Very small async connection pool for aioodbc connections."""
-
-  def __init__(
-    self,
-    dsn: str,
-    *,
-    max_size: int = 5,
-    timeout: float | None = 30.0,
-    autocommit: bool = True,
-  ) -> None:
-    if max_size <= 0:
-      raise ValueError("max_size must be positive")
-    self._dsn = dsn
-    self._max_size = max_size
-    self._timeout = timeout
-    self._autocommit = autocommit
-    self._available: asyncio.LifoQueue[aioodbc.Connection] = asyncio.LifoQueue(max_size)
-    self._created = 0
-    self._lock = asyncio.Lock()
-    self._closed = False
-    self._in_use: set[aioodbc.Connection] = set()
-
-  async def _create(self) -> aioodbc.Connection:
-    conn = await aioodbc.connect(dsn=self._dsn, autocommit=self._autocommit)
-    self._created += 1
-    return conn
-
-  async def _get_from_queue(self) -> aioodbc.Connection:
-    if self._timeout is None:
-      return await self._available.get()
-    return await asyncio.wait_for(self._available.get(), timeout=self._timeout)
-
-  async def _finalize(self, conn: aioodbc.Connection) -> None:
-    with suppress(Exception):
-      await conn.close()
-    if self._created:
-      self._created -= 1
-
-  @asynccontextmanager
-  async def connection(self) -> aioodbc.Connection:
-    conn = await self.acquire()
-    try:
-      yield conn
-    finally:
-      await self.release(conn)
-
-  async def acquire(self) -> aioodbc.Connection:
-    if self._closed:
-      raise RuntimeError("Connection pool is closed")
-    while True:
-      try:
-        conn = self._available.get_nowait()
-      except asyncio.QueueEmpty:
-        async with self._lock:
-          if self._closed:
-            raise RuntimeError("Connection pool is closed")
-          if self._created < self._max_size:
-            conn = await self._create()
-            break
-        conn = await self._get_from_queue()
-      if getattr(conn, "closed", False):
-        await self._finalize(conn)
-        continue
-      break
-    self._in_use.add(conn)
-    return conn
-
-  async def release(self, conn: aioodbc.Connection) -> None:
-    if conn not in self._in_use:
-      return
-    self._in_use.discard(conn)
-    if self._closed or getattr(conn, "closed", False):
-      await self._finalize(conn)
-      return
-    try:
-      self._available.put_nowait(conn)
-    except asyncio.QueueFull:
-      await self._finalize(conn)
-
-  async def close(self) -> None:
-    if self._closed:
-      return
-    self._closed = True
-    while not self._available.empty():
-      conn = await self._available.get()
-      await self._finalize(conn)
-    for conn in list(self._in_use):
-      with suppress(Exception):
-        await conn.close()
-    self._in_use.clear()
 
 
 @dataclass(slots=True)
@@ -125,90 +34,6 @@ class GuildRecord:
   member_count: int | None
   owner_id: str | None
   region: str | None
-
-
-UPSERT_SQL = """
-DECLARE @result TABLE (
-  recid BIGINT,
-  element_guild_id NVARCHAR(64),
-  element_name NVARCHAR(512),
-  element_joined_on DATETIME2(7),
-  element_member_count INT,
-  element_owner_id NVARCHAR(64),
-  element_region NVARCHAR(256),
-  element_left_on DATETIME2(7),
-  element_notes NVARCHAR(MAX)
-);
-
-UPDATE discord_guilds
-  SET
-    element_name = ?,
-    element_member_count = ?,
-    element_owner_id = ?,
-    element_region = ?,
-    element_left_on = ?,
-    element_notes = ?,
-    element_joined_on = COALESCE(?, element_joined_on)
-  OUTPUT
-    inserted.recid,
-    inserted.element_guild_id,
-    inserted.element_name,
-    inserted.element_joined_on,
-    inserted.element_member_count,
-    inserted.element_owner_id,
-    inserted.element_region,
-    inserted.element_left_on,
-    inserted.element_notes
-  INTO @result
-  WHERE element_guild_id = ?;
-
-IF @@ROWCOUNT = 0
-BEGIN
-  INSERT INTO discord_guilds (
-    element_guild_id,
-    element_name,
-    element_joined_on,
-    element_member_count,
-    element_owner_id,
-    element_region,
-    element_left_on,
-    element_notes
-  )
-  OUTPUT
-    inserted.recid,
-    inserted.element_guild_id,
-    inserted.element_name,
-    inserted.element_joined_on,
-    inserted.element_member_count,
-    inserted.element_owner_id,
-    inserted.element_region,
-    inserted.element_left_on,
-    inserted.element_notes
-  INTO @result
-  VALUES (
-    ?,
-    ?,
-    COALESCE(?, SYSUTCDATETIME()),
-    ?,
-    ?,
-    ?,
-    ?,
-    ?
-  );
-END;
-
-SELECT
-  recid,
-  element_guild_id,
-  element_name,
-  element_joined_on,
-  element_member_count,
-  element_owner_id,
-  element_region,
-  element_left_on,
-  element_notes
-FROM @result;
-"""
 
 
 def _normalise_joined_on(joined: datetime | None) -> datetime | None:
@@ -249,6 +74,19 @@ def build_guild_records(guilds: Sequence[discord.Guild]) -> list[GuildRecord]:
   return records
 
 
+def _record_to_payload(record: GuildRecord) -> dict[str, object]:
+  return {
+    "element_guild_id": record.guild_id,
+    "element_name": record.name,
+    "element_joined_on": record.joined_on.isoformat(timespec="seconds") if record.joined_on else None,
+    "element_member_count": record.member_count,
+    "element_owner_id": record.owner_id,
+    "element_region": record.region,
+    "element_left_on": None,
+    "element_notes": None,
+  }
+
+
 async def fetch_guilds(token: str) -> list[discord.Guild]:
   intents = discord.Intents.default()
   intents.guilds = True
@@ -272,35 +110,6 @@ async def fetch_guilds(token: str) -> list[discord.Guild]:
   return guilds
 
 
-async def upsert_guilds(pool: ConnectionPool, records: Iterable[GuildRecord]) -> int:
-  processed = 0
-  async with pool.connection() as conn:
-    async with conn.cursor() as cursor:
-      for record in records:
-        params = (
-          record.name,
-          record.member_count,
-          record.owner_id,
-          record.region,
-          None,
-          None,
-          record.joined_on,
-          record.guild_id,
-          record.guild_id,
-          record.name,
-          record.joined_on,
-          record.member_count,
-          record.owner_id,
-          record.region,
-          None,
-          None,
-        )
-        await cursor.execute(UPSERT_SQL, params)
-        await cursor.fetchall()
-        processed += 1
-  return processed
-
-
 def _configure_logging(level: str) -> None:
   logging.basicConfig(
     level=getattr(logging, level.upper(), logging.INFO),
@@ -309,9 +118,7 @@ def _configure_logging(level: str) -> None:
 
 
 def _parse_args() -> argparse.Namespace:
-  parser = argparse.ArgumentParser(description="Insert Discord guild metadata directly into SQL Server")
-  parser.add_argument("--max-pool-size", type=int, default=5, help="Maximum number of pooled SQL connections")
-  parser.add_argument("--timeout", type=float, default=30.0, help="Seconds to wait for a pooled connection")
+  parser = argparse.ArgumentParser(description="Dump Discord guild metadata for manual SQL insertion")
   parser.add_argument("--log-level", default="INFO", help="Logging level (default: INFO)")
   return parser.parse_args()
 
@@ -323,21 +130,15 @@ async def run(args: argparse.Namespace) -> None:
   token = os.environ.get("DISCORD_SECRET")
   if not token:
     raise RuntimeError("DISCORD_SECRET environment variable is required")
-  dsn = os.environ.get("AZURE_SQL_CONNECTION_STRING")
-  if not dsn:
-    raise RuntimeError("AZURE_SQL_CONNECTION_STRING environment variable is required")
+  guilds = await fetch_guilds(token)
+  records = build_guild_records(guilds)
+  if not records:
+    LOGGER.info("No guilds available to insert")
+    return
 
-  pool = ConnectionPool(dsn, max_size=args.max_pool_size, timeout=args.timeout)
-  try:
-    guilds = await fetch_guilds(token)
-    records = build_guild_records(guilds)
-    if not records:
-      LOGGER.info("No guilds available to insert")
-      return
-    processed = await upsert_guilds(pool, records)
-    LOGGER.info("Completed guild synchronisation: processed=%d", processed)
-  finally:
-    await pool.close()
+  payloads = [_record_to_payload(record) for record in records]
+  print(json.dumps(payloads, indent=2))
+  LOGGER.info("Prepared %d guild record(s) for manual insertion", len(payloads))
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- refactor the direct_insert_discord_guilds script to emit guild metadata as JSON instead of inserting into SQL Server
- remove the custom aioodbc connection pool and SQL upsert logic since manual insertion is now required
- streamline CLI arguments and documentation to reflect the data-dump workflow

## Testing
- not run (script change only)


------
https://chatgpt.com/codex/tasks/task_e_68e9763a3f8c8325986a1a4124585b3f