### PR TITLE
Fix schema name handling in scriptlib table schema helper

### DIFF
--- a/scripts/scriptlib.py
+++ b/scripts/scriptlib.py
@@ -411,16 +411,16 @@ async def list_check_constraints(conn, schema: str, table: str):
   return result
 
 
-async def _table_schema(conn, schema: str, table: str):
-  columns = await list_columns(conn, schema, table)
-  primary_key = await list_primary_key(conn, schema, table)
-  foreign_keys = await list_foreign_keys(conn, schema, table)
-  indexes = await list_indexes(conn, schema, table)
-  constraints = await list_constraints(conn, schema, table)
-  check_constraints = await list_check_constraints(conn, schema, table)
+async def _table_schema(conn, schema_name: str, table: str):
+  columns = await list_columns(conn, schema_name, table)
+  primary_key = await list_primary_key(conn, schema_name, table)
+  foreign_keys = await list_foreign_keys(conn, schema_name, table)
+  indexes = await list_indexes(conn, schema_name, table)
+  constraints = await list_constraints(conn, schema_name, table)
+  check_constraints = await list_check_constraints(conn, schema_name, table)
   return {
-    'schema': schema,
-    'name': _qualify(schema, table),
+    'schema': schema_name,
+    'name': _qualify(schema_name, table),
     'table': table,
     'columns': columns,
     'primary_key': primary_key,


### PR DESCRIPTION
## Summary
- update `_table_schema` to accept a `schema_name` argument and use it in downstream helper calls
- ensure the returned schema metadata includes the raw schema and qualified table name based on the provided schema

## Testing
- python scripts/mssql_cli.py <<'EOF'
update version patch
EOF

------
https://chatgpt.com/codex/tasks/task_e_68e9abf96de88325b84ca295b67334b1