### PR TITLE
Add environment selection for mssql CLI

### DIFF
--- a/scripts/mssql_cli.py
+++ b/scripts/mssql_cli.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
+import argparse
 import asyncio
 import subprocess
 
-from scriptlib import apply_schema, bump_version, connect, dump_data, dump_schema
+from scriptlib import apply_schema, bump_version, connect, dump_data, dump_schema, select_environment
 
 
 def _commit_and_tag(version: str, schema_file: str) -> None:
@@ -129,12 +130,32 @@ async def interactive_console(conn):
         except Exception as e2:
           print(f'Error: {e2}')
 
-async def main():
+def parse_args():
+  parser = argparse.ArgumentParser(description='Interactive MSSQL CLI tool')
+  parser.add_argument(
+    '-e',
+    '--env',
+    choices=['prod', 'test'],
+    default='test',
+    help='Select environment configuration (default: test)',
+  )
+  return parser.parse_args()
+
+
+async def run_cli():
   conn = await connect()
   try:
     await interactive_console(conn)
   finally:
     await conn.close()
 
+
+def main():
+  args = parse_args()
+  select_environment(args.env)
+  print(f"Using {args.env} environment configuration")
+  asyncio.run(run_cli())
+
+
 if __name__ == '__main__':
-  asyncio.run(main())
+  main()

--- a/scripts/scriptlib.py
+++ b/scripts/scriptlib.py
@@ -15,6 +15,23 @@ from pydantic import BaseModel
 
 dotenv.load_dotenv()
 
+
+def select_environment(environment: str) -> None:
+  """Configure environment variables for the requested execution environment."""
+  env = environment.lower()
+  if env not in {'prod', 'test'}:
+    raise ValueError("environment must be 'prod' or 'test'")
+  suffix = '' if env == 'prod' else '_DEV'
+  overrides = {
+    'AZURE_SQL_CONNECTION_STRING': f'AZURE_SQL_CONNECTION_STRING{suffix}',
+    'DISCORD_SECRET': f'DISCORD_SECRET{suffix}',
+  }
+  for target, source in overrides.items():
+    value = os.getenv(source)
+    if not value:
+      raise RuntimeError(f"Environment variable {source} not set for {env} environment")
+    os.environ[target] = value
+
 # Root of the repository relative to this file
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 


### PR DESCRIPTION
## Summary
- add an --env/-e flag to the MSSQL CLI script so local runs default to the test configuration while allowing prod selection
- centralize environment switching in scriptlib to map shared connection string and secret variables

## Testing
- python scripts/mssql_cli.py --help

------
https://chatgpt.com/codex/tasks/task_e_68e9b546d9a8832593f6e4ffd05a68ee