### PR TITLE
Cast sys metadata text columns to NVARCHAR(4000)

### DIFF
--- a/scripts/scriptlib.py
+++ b/scripts/scriptlib.py
@@ -217,9 +217,9 @@ async def list_tables(conn):
 async def list_views(conn):
   async with conn.cursor() as cur:
     await cur.execute(
-      """SELECT SCHEMA_NAME(v.schema_id) AS view_schema,
-                v.name AS view_name,
-                CONVERT(NVARCHAR(MAX), m.definition) AS view_definition
+      """SELECT CAST(SCHEMA_NAME(v.schema_id) AS NVARCHAR(4000)) AS view_schema,
+                CAST(v.name AS NVARCHAR(4000)) AS view_name,
+                CAST(m.definition AS NVARCHAR(4000)) AS view_definition
            FROM sys.views v
            JOIN sys.sql_modules m ON v.object_id = m.object_id
           WHERE SCHEMA_NAME(v.schema_id)='dbo'
@@ -234,8 +234,8 @@ async def list_views(conn):
 async def list_view_dependencies(conn):
   async with conn.cursor() as cur:
     await cur.execute(
-      """SELECT OBJECT_NAME(d.referencing_id) AS view_name,
-                OBJECT_NAME(d.referenced_id) AS ref_name
+      """SELECT CAST(OBJECT_NAME(d.referencing_id) AS NVARCHAR(4000)) AS view_name,
+                CAST(OBJECT_NAME(d.referenced_id) AS NVARCHAR(4000)) AS ref_name
            FROM sys.sql_expression_dependencies d
            JOIN sys.views v ON d.referencing_id = v.object_id
            JOIN sys.views r ON d.referenced_id = r.object_id
@@ -249,20 +249,20 @@ async def list_view_dependencies(conn):
 async def list_columns(conn, schema: str, table: str):
   async with conn.cursor() as cur:
     await cur.execute(
-      """SELECT c.name AS column_name,
-                t.name AS data_type,
+      """SELECT CAST(c.name AS NVARCHAR(4000)) AS column_name,
+                CAST(t.name AS NVARCHAR(4000)) AS data_type,
                 c.max_length,
                 c.precision,
                 c.scale,
                 c.is_nullable,
-                CONVERT(NVARCHAR(MAX), dc.definition) AS default_definition,
+                CAST(dc.definition AS NVARCHAR(4000)) AS default_definition,
                 ic.seed_value,
                 ic.increment_value,
                 c.is_identity,
                 c.is_rowguidcol,
-                CONVERT(NVARCHAR(MAX), cc.definition) AS computed_definition,
+                CAST(cc.definition AS NVARCHAR(4000)) AS computed_definition,
                 cc.is_persisted,
-                c.collation_name
+                CAST(c.collation_name AS NVARCHAR(4000)) AS collation_name
            FROM sys.columns c
            JOIN sys.types t
              ON c.user_type_id = t.user_type_id
@@ -303,7 +303,7 @@ async def list_columns(conn, schema: str, table: str):
 async def list_primary_key(conn, schema: str, table: str):
   async with conn.cursor() as cur:
     await cur.execute(
-      """SELECT c.name AS column_name
+      """SELECT CAST(c.name AS NVARCHAR(4000)) AS column_name
            FROM sys.index_columns ic
            JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id
            JOIN sys.indexes i ON ic.object_id = i.object_id AND ic.index_id = i.index_id
@@ -318,11 +318,11 @@ async def list_primary_key(conn, schema: str, table: str):
 async def list_foreign_keys(conn, schema: str, table: str):
   async with conn.cursor() as cur:
     await cur.execute(
-      """SELECT fk.name AS constraint_name,
-                COL_NAME(fkc.parent_object_id, fkc.parent_column_id) AS column_name,
-                OBJECT_SCHEMA_NAME(fkc.referenced_object_id) AS ref_schema,
-                OBJECT_NAME(fkc.referenced_object_id) AS ref_table,
-                COL_NAME(fkc.referenced_object_id, fkc.referenced_column_id) AS ref_column
+      """SELECT CAST(fk.name AS NVARCHAR(4000)) AS constraint_name,
+                CAST(COL_NAME(fkc.parent_object_id, fkc.parent_column_id) AS NVARCHAR(4000)) AS column_name,
+                CAST(OBJECT_SCHEMA_NAME(fkc.referenced_object_id) AS NVARCHAR(4000)) AS ref_schema,
+                CAST(OBJECT_NAME(fkc.referenced_object_id) AS NVARCHAR(4000)) AS ref_table,
+                CAST(COL_NAME(fkc.referenced_object_id, fkc.referenced_column_id) AS NVARCHAR(4000)) AS ref_column
            FROM sys.foreign_key_columns fkc
            JOIN sys.foreign_keys fk ON fkc.constraint_object_id = fk.object_id
           WHERE fkc.parent_object_id = OBJECT_ID(?)
@@ -350,14 +350,14 @@ async def list_foreign_keys(conn, schema: str, table: str):
 async def list_indexes(conn, schema: str, table: str):
   async with conn.cursor() as cur:
     await cur.execute(
-      """SELECT i.name AS index_name,
+      """SELECT CAST(i.name AS NVARCHAR(4000)) AS index_name,
                 i.is_unique AS is_unique,
-                CONVERT(NVARCHAR(MAX), i.filter_definition) AS filter_definition,
+                CAST(i.filter_definition AS NVARCHAR(4000)) AS filter_definition,
                 ic.is_descending_key AS is_descending,
                 ic.is_included_column AS is_included,
                 ic.key_ordinal AS key_ordinal,
                 ic.index_column_id AS index_column_id,
-                c.name AS column_name
+                CAST(c.name AS NVARCHAR(4000)) AS column_name
            FROM sys.indexes i
            JOIN sys.index_columns ic
              ON i.object_id = ic.object_id AND i.index_id = ic.index_id
@@ -398,10 +398,10 @@ async def list_indexes(conn, schema: str, table: str):
 async def list_constraints(conn, schema: str, table: str):
   async with conn.cursor() as cur:
     await cur.execute(
-      """SELECT kc.name AS constraint_name,
-                kc.type AS constraint_type,
+      """SELECT CAST(kc.name AS NVARCHAR(4000)) AS constraint_name,
+                CAST(kc.type AS NVARCHAR(4000)) AS constraint_type,
                 ic.key_ordinal,
-                c.name AS column_name
+                CAST(c.name AS NVARCHAR(4000)) AS column_name
            FROM sys.key_constraints kc
            JOIN sys.tables t ON kc.parent_object_id = t.object_id
            JOIN sys.schemas s ON t.schema_id = s.schema_id
@@ -442,8 +442,8 @@ async def list_constraints(conn, schema: str, table: str):
 async def list_check_constraints(conn, schema: str, table: str):
   async with conn.cursor() as cur:
     await cur.execute(
-      """SELECT cc.CONSTRAINT_NAME AS constraint_name,
-                CONVERT(NVARCHAR(MAX), cc.definition) AS definition,
+      """SELECT CAST(cc.CONSTRAINT_NAME AS NVARCHAR(4000)) AS constraint_name,
+                CAST(cc.definition AS NVARCHAR(4000)) AS definition,
                 cc.is_not_trusted,
                 cc.is_disabled
            FROM sys.check_constraints cc


### PR DESCRIPTION
## Summary
- cast MSSQL sys catalog string fields to NVARCHAR(4000) to avoid missing column errors
- remove NVARCHAR(MAX) conversions in schema introspection queries to prevent SQL_WLONGVARCHAR results

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e9b9ae14408325813665ea64c04fea