### PR TITLE
Fix scriptlib cursor description access for schema dump

### DIFF
--- a/scripts/scriptlib.py
+++ b/scripts/scriptlib.py
@@ -197,11 +197,27 @@ async def _fetch_json(cur):
 
 
 async def _fetch_dicts(cur):
+  description = cur.description
   rows = await cur.fetchall()
   if not rows:
     logger.debug('_fetch_dicts returned 0 rows')
     return []
-  cols = [d[0] for d in cur.description]
+  if description is None:
+    try:
+      description = cur.description
+    except Exception as exc:
+      logger.debug('Failed to read cursor description after fetch: %s', exc)
+      description = None
+  if not description:
+    result = [
+      {f'column_{idx}': value for idx, value in enumerate(row)} for row in rows
+    ]
+    logger.debug(
+      '_fetch_dicts could not determine column names; using positional keys for %d rows',
+      len(result),
+    )
+    return result
+  cols = [d[0] for d in description]
   result = [dict(zip(cols, row)) for row in rows]
   logger.debug('_fetch_dicts returning %d rows with columns %s', len(result), cols)
   return result


### PR DESCRIPTION
## Summary
- capture the cursor description before fetching rows in `_fetch_dicts`
- add fallbacks when the cursor metadata is unavailable so schema dumps continue

## Testing
- not run (database access not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e9bf2435ac8325a38c6a4c3fe0e023