### PR TITLE
Handle missing cursor descriptions in MSSQL CLI schema dumps

### DIFF
--- a/scripts/scriptlib.py
+++ b/scripts/scriptlib.py
@@ -197,14 +197,14 @@ async def _fetch_json(cur):
 
 
 async def _fetch_dicts(cur):
-  description = cur.description
+  description = getattr(cur, 'description', None)
   rows = await cur.fetchall()
   if not rows:
     logger.debug('_fetch_dicts returned 0 rows')
     return []
   if description is None:
     try:
-      description = cur.description
+      description = getattr(cur, 'description', None)
     except Exception as exc:
       logger.debug('Failed to read cursor description after fetch: %s', exc)
       description = None


### PR DESCRIPTION
## Summary
- guard `_fetch_dicts` against cursors that omit the `description` attribute so schema dumps can proceed without raising AttributeError

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e9c1a834e0832584af428b56b49a76