### PR TITLE
Fix cursor usage in MSSQL schema dump

### DIFF
--- a/scripts/scriptlib.py
+++ b/scripts/scriptlib.py
@@ -334,7 +334,7 @@ async def list_columns(conn, schema: str, table: str):
           ORDER BY c.column_id""",
       (_qualify(schema, table),),
     )
-  rows = await _fetch_dicts(cur)
+    rows = await _fetch_dicts(cur)
   columns: list[dict] = []
   for row in rows:
     logger.debug(


### PR DESCRIPTION
## Summary
- keep the aioodbc cursor alive while fetching column metadata during schema dumps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9c51339c483258c0b2c43043152f2