### PR TITLE
Reintroduce environment selector to mssql_cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We are building this site primarily using [Codex](https://chatgpt.com/codex). Th
 
 ### CLI Utilities
 Several helper scripts in the `scripts` directory manage the project database and data entities:
-- `mssql_cli.py` provides similar features for Azure SQL using the `AZURE_SQL_CONNECTION_STRING` environment variable.
+- `mssql_cli.py` provides similar features for Azure SQL. Pass `--env prod` to target production or rely on the default `--env test`, which reads the `AZURE_SQL_CONNECTION_STRING_DEV` and `DISCORD_SECRET_DEV` environment variables and maps them to their production counterparts for the session.
 - `run_tests.py` executes various test, generate, and update operations for build automation. It increments the build version directly in the Azure SQL database.
     - Requires `DATABASE_PROVIDER` and the `AZURE_SQL_CONNECTION_STRING` environment variable for MSSQL.
 - `run_dbsync.py` applies pending upgrade SQL in the `scripts` directory, records the most recent script in `system_config`, and flags the build to export a refreshed schema dump.

--- a/scripts/mssql_cli.py
+++ b/scripts/mssql_cli.py
@@ -1,6 +1,38 @@
 from __future__ import annotations
-import asyncio, subprocess, pyodbc
+import argparse, asyncio, os, subprocess, pyodbc
 from scriptlib import connect, dump_schema, apply_schema, dump_data, bump_version
+
+
+def _ensure_env_var(name: str, env: str) -> None:
+  if env == 'test':
+    source = f'{name}_DEV'
+    value = os.getenv(source)
+    if not value:
+      raise RuntimeError(f'{source} not set')
+    os.environ[name] = value
+  else:
+    value = os.getenv(name)
+    if not value:
+      raise RuntimeError(f'{name} not set')
+
+
+def _configure_environment(env: str) -> None:
+  if env not in {'test', 'prod'}:
+    raise ValueError(f"Unknown environment '{env}'")
+  _ensure_env_var('AZURE_SQL_CONNECTION_STRING', env)
+  _ensure_env_var('DISCORD_SECRET', env)
+
+
+def _parse_args() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(description='Interactive MSSQL management CLI')
+  parser.add_argument(
+    '-e',
+    '--env',
+    default='test',
+    choices=['test', 'prod'],
+    help='Environment to target (default: test)',
+  )
+  return parser.parse_args()
 
 
 def _commit_and_tag(version: str, schema_file: str) -> None:
@@ -115,7 +147,8 @@ async def interactive_console(conn):
           print(f'Error: {e2}')
 
 async def main():
-  # register converter right before connecting
+  args = _parse_args()
+  _configure_environment(args.env)
   pyodbc.add_output_converter(-16, _wide_to_str)
   conn = await connect()
   try:


### PR DESCRIPTION
## Summary
- add a --env/-e flag to mssql_cli with a default test target that maps _DEV environment variables
- validate required environment variables for each mode before connecting and reuse the values during the session
- update the CLI utilities documentation to explain the restored environment selection

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea2941b51c8325b458809224fb938e