### PR TITLE
docs: document selective dependency maintenance workflow

### DIFF
--- a/docs/package-maintenance-guide.md
+++ b/docs/package-maintenance-guide.md
@@ -1,0 +1,175 @@
+# Package Maintenance Guide
+
+This guide explains how to review, upgrade, and roll back selective dependency groups for the Elideus Group project when working from a Windows Command Prompt. It complements the automation already present in `dev.cmd`, `run_tests.py`, and the new `scripts/dependency_health.py` helper.
+
+## 1. Preparation
+
+1. Open **Developer Command Prompt for VS** or **Windows Terminal (Command Prompt tab)**.
+2. Ensure required tooling is installed and available on `PATH`:
+   - `git`, `python`/`py`, and `pip`.
+   - `node` and `npm` (Node 18 LTS).
+3. Sync to the latest default branch and confirm a clean working tree:
+   ```cmd
+   git pull
+   git status
+   ```
+4. Create a working branch for dependency maintenance:
+   ```cmd
+   git checkout -b chore/dependency-review-YYYYMMDD
+   ```
+
+## 2. Inventory Existing Dependencies
+
+### 2.1 Interactive overview
+
+Run the interactive helper from the repository root:
+```cmd
+py scripts\dependency_health.py
+```
+Key features:
+- Lists Python packages from `requirements.txt` and `requirements-dev.txt`.
+- Lists Node dependencies from `frontend\package.json`.
+- Executes `pip list --outdated` and `npm outdated` on demand.
+- Highlights targeted package groups (`MUI`, `ATProto`, `React`, `FastAPI stack`, `async IO helpers`) so upgrades can be scoped to logical bundles.
+
+For a non-interactive snapshot that you can paste into an issue comment:
+```cmd
+py scripts\dependency_health.py --non-interactive
+```
+Add `--skip-outdated` when running in limited-network environments to skip `pip list --outdated` and `npm outdated` calls.
+
+### 2.2 Manual indexing (Python)
+
+Use the Python launcher (`py`) to inspect installed versions inside your virtual environment:
+```cmd
+py -m pip list
+py -m pip list --outdated --format=columns
+```
+To view available versions for a single package (example: `fastapi`):
+```cmd
+py -m pip index versions fastapi
+```
+Repeat for each security-critical package: `fastapi`, `uvicorn`, `gunicorn`, `aiohttp`, `asyncpg`, `atproto`, and `python-jose`.
+
+### 2.3 Manual indexing (Node)
+
+From the `frontend` directory:
+```cmd
+cd frontend
+npm ls --depth=0
+npm outdated
+```
+For a focused package family:
+```cmd
+npm view @mui/material versions --json
+npm view @atproto/api versions --json
+npm view react versions --json
+```
+Return to the repository root when finished:
+```cmd
+cd ..
+```
+
+## 3. Planning Selective Upgrades
+
+Only upgrade cohesive sets of packages to minimize regressions.
+
+### 3.1 Node upgrade bundles
+
+| Bundle | Packages | Recommended command |
+| --- | --- | --- |
+| **MUI & Emotion** | `@mui/material`, `@mui/icons-material`, `@emotion/react`, `@emotion/styled` | `npm install @mui/material@latest @mui/icons-material@latest @emotion/react@latest @emotion/styled@latest`
+| **ATProto SDK** | `@atproto/api`, `@atproto/crypto`, `@atproto/identity`, `@atproto/lexicon`, `@atproto/xrpc` | `npm install @atproto/api@latest @atproto/crypto@latest @atproto/identity@latest @atproto/lexicon@latest @atproto/xrpc@latest`
+| **React Core** | `react`, `react-dom`, `react-router-dom` | `npm install react@latest react-dom@latest react-router-dom@latest`
+
+Usage notes:
+- Run the commands from `frontend`. Add `--save-exact` if a lockfile must pin patch versions manually.
+- After installing, inspect the generated `package-lock.json` diff to ensure only the targeted bundle changed.
+- Rebuild generated frontend assets only after dependency tests pass (`npm run build`).
+
+### 3.2 Python upgrade bundles
+
+| Bundle | Packages | Recommended command |
+| --- | --- | --- |
+| **FastAPI runtime trio** | `fastapi`, `uvicorn`, `gunicorn` | `py -m pip install --upgrade fastapi uvicorn gunicorn`
+| **Async IO helpers** | `aiohttp`, `aiofiles`, `aioodbc`, `asyncpg` | `py -m pip install --upgrade aiohttp aiofiles aioodbc asyncpg`
+| **ATProto client** | `atproto` | `py -m pip install --upgrade atproto`
+
+Usage notes:
+- Activate the project’s virtual environment before running upgrades.
+- Capture currently installed versions first: `py -m pip freeze > logs\freeze-before.txt`.
+- After upgrading, export a comparison snapshot: `py -m pip freeze > logs\freeze-after.txt`.
+- If a package introduces breaking changes, revert the bundle and investigate before reattempting.
+
+## 4. Verification Checklist
+
+After each bundle upgrade:
+
+1. **Lockfiles and requirement files**
+   - Ensure `frontend\package.json` and `frontend\package-lock.json` updates are limited to the intended packages.
+   - For Python, verify `requirements*.txt` only change when you explicitly edit them; otherwise leave them untouched if unpinned.
+
+2. **Static analysis & tests**
+   ```cmd
+   npm run lint
+   npm run type-check
+   npm test
+   py -m venv .venv && call .venv\Scripts\activate && py scripts\run_tests.py
+   ```
+   If the project already uses a virtual environment, reuse it instead of creating a new one.
+
+3. **Application smoke tests**
+   - Launch the backend: `py main.py` (or via Docker if applicable).
+   - Launch the frontend dev server: `npm run dev` (inspect login/auth flows touched by the upgrade bundle).
+
+4. **Security audits**
+   ```cmd
+   npm audit
+   py -m pip install --upgrade pip
+   py -m pip install pip-audit
+   py -m pip_audit
+   ```
+   Resolve or document high-severity findings before closing the maintenance task.
+
+## 5. Rolling Back Changes
+
+If an upgrade causes regressions:
+
+1. Restore specific files from Git:
+   ```cmd
+   git checkout -- frontend\package.json frontend\package-lock.json
+   git checkout -- requirements.txt requirements-dev.txt
+   ```
+2. To discard all local changes in the branch:
+   ```cmd
+   git reset --hard HEAD
+   git clean -fd
+   ```
+3. If a commit was already made, revert it:
+   ```cmd
+   git log --oneline
+   git revert <commit-sha>
+   ```
+4. Use `git reflog` to recover previous states if you accidentally reset the branch.
+
+## 6. Documenting and Merging
+
+1. Summarize upgrade details in `ARCHITECTURE.md` or team notes if behavior changes.
+2. Commit with clear scope (one bundle per commit when possible):
+   ```cmd
+   git add frontend\package.json frontend\package-lock.json
+   git commit -m "chore(frontend): upgrade mui bundle"
+   ```
+3. Run `git status` to confirm a clean tree before opening a pull request.
+4. Use `make_pr` tooling or the standard GitHub flow to create the PR. Include:
+   - A changelog of bundles upgraded.
+   - Test evidence (`npm lint`, `npm test`, `pytest`).
+   - Notes about outstanding advisories or pinned packages.
+
+## 7. Ongoing Maintenance Cadence
+
+- Perform a dependency triage every two weeks, or sooner if security advisories are published.
+- Use Renovate (configured in `renovate.json`) as an alerting source but continue to batch manual upgrades into the bundles listed above.
+- Track upstream change logs for `fastapi`, `atproto`, and `@mui/*` packages to anticipate breaking changes.
+
+By following these steps, you can confidently maintain the project’s dependency stack, ship security fixes promptly, and keep rollback procedures ready whenever regressions appear.

--- a/scripts/dependency_health.py
+++ b/scripts/dependency_health.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Interactive dependency inspection utility for selective package maintenance."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FRONTEND_DIR = REPO_ROOT / "frontend"
+PACKAGE_JSON_PATH = FRONTEND_DIR / "package.json"
+PYTHON_REQUIREMENT_PATHS = [
+  REPO_ROOT / "requirements.txt",
+  REPO_ROOT / "requirements-dev.txt",
+]
+
+NODE_GROUPS: Dict[str, Dict[str, Iterable[str]]] = {
+  "mui": {
+    "label": "MUI and Emotion styling",
+    "packages": [
+      "@mui/material",
+      "@mui/icons-material",
+      "@emotion/react",
+      "@emotion/styled",
+    ],
+  },
+  "atproto": {
+    "label": "ATProto client SDK",
+    "packages": [
+      "@atproto/api",
+      "@atproto/crypto",
+      "@atproto/identity",
+      "@atproto/lexicon",
+      "@atproto/xrpc",
+    ],
+  },
+  "react": {
+    "label": "React core runtime",
+    "packages": [
+      "react",
+      "react-dom",
+      "react-router-dom",
+    ],
+  },
+}
+
+PYTHON_GROUPS: Dict[str, Dict[str, Iterable[str]]] = {
+  "atproto": {
+    "label": "ATProto Python client",
+    "packages": ["atproto"],
+  },
+  "fastapi-stack": {
+    "label": "FastAPI runtime trio",
+    "packages": ["fastapi", "uvicorn", "gunicorn"],
+  },
+  "async-io": {
+    "label": "Async IO helpers",
+    "packages": ["aiohttp", "aiofiles", "aioodbc", "asyncpg"],
+  },
+}
+
+
+def read_package_json() -> Dict[str, Dict[str, str]]:
+  if not PACKAGE_JSON_PATH.exists():
+    raise FileNotFoundError(f"Missing package.json at {PACKAGE_JSON_PATH}")
+  with PACKAGE_JSON_PATH.open("r", encoding="utf-8") as handle:
+    return json.load(handle)
+
+
+def read_python_requirements() -> Dict[str, List[str]]:
+  results: Dict[str, List[str]] = {}
+  for path in PYTHON_REQUIREMENT_PATHS:
+    if not path.exists():
+      continue
+    name = path.name
+    packages: List[str] = []
+    with path.open("r", encoding="utf-8") as handle:
+      for raw_line in handle:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+          continue
+        packages.append(line)
+    results[name] = packages
+  return results
+
+
+def run_command(command: List[str], cwd: Optional[Path] = None) -> subprocess.CompletedProcess[str]:
+  return subprocess.run(
+    command,
+    cwd=str(cwd) if cwd else None,
+    capture_output=True,
+    text=True,
+    check=False,
+  )
+
+
+def load_pip_outdated(python_executable: str) -> Dict[str, Dict[str, str]]:
+  command = [python_executable, "-m", "pip", "list", "--outdated", "--format", "json"]
+  result = run_command(command, cwd=REPO_ROOT)
+  if result.returncode != 0:
+    raise RuntimeError(
+      f"pip outdated command failed with code {result.returncode}: {result.stderr.strip()}"
+    )
+  try:
+    data = json.loads(result.stdout)
+  except json.JSONDecodeError as error:
+    raise RuntimeError("Unable to parse pip outdated output") from error
+  return {entry["name"].lower(): entry for entry in data}
+
+
+def load_npm_outdated(npm_executable: str) -> Dict[str, Dict[str, str]]:
+  command = [npm_executable, "outdated", "--json"]
+  result = run_command(command, cwd=FRONTEND_DIR)
+  if result.returncode not in (0, 1):
+    raise RuntimeError(
+      f"npm outdated command failed with code {result.returncode}: {result.stderr.strip()}"
+    )
+  if not result.stdout.strip():
+    return {}
+  try:
+    data = json.loads(result.stdout)
+  except json.JSONDecodeError as error:
+    raise RuntimeError("Unable to parse npm outdated output") from error
+  return {name.lower(): values for name, values in data.items()}
+
+
+def print_python_summary(requirements: Dict[str, List[str]]) -> None:
+  print("\nPython requirement files:")
+  for name, packages in requirements.items():
+    print(f"  {name} ({len(packages)} entries)")
+    for package in packages:
+      print(f"    - {package}")
+
+
+def print_node_summary(package_json: Dict[str, Dict[str, str]]) -> None:
+  print("\nNode dependency overview:")
+  for section in ("dependencies", "devDependencies"):
+    entries = package_json.get(section, {})
+    print(f"  {section} ({len(entries)} entries)")
+    for name, version in entries.items():
+      print(f"    - {name}: {version}")
+
+
+def print_group_status(
+  label: str,
+  group_packages: Iterable[str],
+  outdated_index: Dict[str, Dict[str, str]],
+  note: str,
+) -> None:
+  print(f"\n[{label}] {note}")
+  for package in group_packages:
+    entry = outdated_index.get(package.lower())
+    if not entry:
+      print(f"  ✓ {package} is up to date or pinned manually")
+      continue
+    latest = entry.get("latest") or entry.get("latestVersion")
+    current = entry.get("current") or entry.get("installed")
+    wanted = entry.get("wanted") or entry.get("latest")
+    print(f"  • {package} → current: {current}, wanted: {wanted}, latest: {latest}")
+
+
+def inspect_groups(
+  node_outdated: Dict[str, Dict[str, str]],
+  python_outdated: Dict[str, Dict[str, str]],
+) -> None:
+  print("\nTargeted group status:")
+  for key, config in NODE_GROUPS.items():
+    print_group_status(
+      label=f"Node :: {config['label']} ({key})",
+      group_packages=config["packages"],
+      outdated_index=node_outdated,
+      note="Run npm install within frontend/ to update as a bundle.",
+    )
+  for key, config in PYTHON_GROUPS.items():
+    print_group_status(
+      label=f"Python :: {config['label']} ({key})",
+      group_packages=config["packages"],
+      outdated_index=python_outdated,
+      note="Use py -m pip install --upgrade while in a virtual environment.",
+    )
+
+
+def determine_python_default() -> str:
+  if os.name == "nt":
+    return "py"
+  return sys.executable
+
+
+def run_interactive(python_executable: str, npm_executable: str) -> None:
+  requirements = read_python_requirements()
+  package_json = read_package_json()
+  node_outdated: Dict[str, Dict[str, str]] = {}
+  python_outdated: Dict[str, Dict[str, str]] = {}
+  options = {
+    "1": "Show Python requirement entries",
+    "2": "Show Node dependency entries",
+    "3": "Refresh pip outdated report",
+    "4": "Refresh npm outdated report",
+    "5": "Review targeted package groups",
+    "6": "Quit",
+  }
+  while True:
+    print("\nDependency maintenance menu:")
+    for key, label in options.items():
+      print(f"  {key}. {label}")
+    choice = input("Select an option: ").strip()
+    if choice == "1":
+      print_python_summary(requirements)
+    elif choice == "2":
+      print_node_summary(package_json)
+    elif choice == "3":
+      try:
+        python_outdated = load_pip_outdated(python_executable)
+        print("\nUpdated pip outdated cache.")
+      except Exception as error:
+        print(f"\nUnable to refresh pip data: {error}")
+    elif choice == "4":
+      try:
+        node_outdated = load_npm_outdated(npm_executable)
+        print("\nUpdated npm outdated cache.")
+      except Exception as error:
+        print(f"\nUnable to refresh npm data: {error}")
+    elif choice == "5":
+      inspect_groups(node_outdated, python_outdated)
+    elif choice == "6":
+      print("Exiting.")
+      return
+    else:
+      print("Unknown option. Please choose a valid number.")
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument(
+    "--python",
+    dest="python_executable",
+    default=determine_python_default(),
+    help="Python launcher to use for pip commands (default: %(default)s)",
+  )
+  parser.add_argument(
+    "--npm",
+    dest="npm_executable",
+    default="npm",
+    help="npm executable to use (default: %(default)s)",
+  )
+  parser.add_argument(
+    "--non-interactive",
+    action="store_true",
+    help="Print summaries and exit without menu prompts.",
+  )
+  parser.add_argument(
+    "--skip-outdated",
+    action="store_true",
+    help="Do not execute pip/npm outdated checks in non-interactive mode.",
+  )
+  args = parser.parse_args()
+  requirements = read_python_requirements()
+  package_json = read_package_json()
+  if args.non_interactive:
+    print_python_summary(requirements)
+    print_node_summary(package_json)
+    python_outdated: Dict[str, Dict[str, str]] = {}
+    node_outdated: Dict[str, Dict[str, str]] = {}
+    if args.skip_outdated:
+      print("\nSkipping pip and npm outdated checks by request.")
+    else:
+      try:
+        python_outdated = load_pip_outdated(args.python_executable)
+      except Exception as error:
+        print(f"\nUnable to refresh pip data: {error}")
+      try:
+        node_outdated = load_npm_outdated(args.npm_executable)
+      except Exception as error:
+        print(f"\nUnable to refresh npm data: {error}")
+    inspect_groups(node_outdated, python_outdated)
+    return
+  run_interactive(args.python_executable, args.npm_executable)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Summary
- add a Windows-focused guide for reviewing and upgrading selective dependency bundles
- introduce an interactive `scripts/dependency_health.py` helper with targeted group analysis and non-interactive reporting options

## Testing
- `python scripts/dependency_health.py --non-interactive --skip-outdated`


------
https://chatgpt.com/codex/tasks/task_e_68e9b7a5025c83259f5b166af58ec5aa