### PR TITLE
Ensure pnpm is available during CI builds

### DIFF
--- a/.github/workflows/elideus_elideus-group-test.yml
+++ b/.github/workflows/elideus_elideus-group-test.yml
@@ -36,8 +36,10 @@ jobs:
         cache: 'pnpm'
         cache-dependency-path: frontend/pnpm-lock.yaml
 
-    - name: Enable Corepack
-      run: corepack enable
+    - name: Enable Corepack and install pnpm
+      run: |
+        corepack enable
+        corepack prepare pnpm@9 --activate
 
     - name: Install Node dependencies
       run: |

--- a/.github/workflows/main_elideus-group.yml
+++ b/.github/workflows/main_elideus-group.yml
@@ -37,8 +37,10 @@ jobs:
         cache: 'pnpm'
         cache-dependency-path: frontend/pnpm-lock.yaml
 
-    - name: Enable Corepack
-      run: corepack enable
+    - name: Enable Corepack and install pnpm
+      run: |
+        corepack enable
+        corepack prepare pnpm@9 --activate
 
     - name: Install Node dependencies
       run: |

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -32,8 +32,10 @@ jobs:
         cache: 'pnpm'
         cache-dependency-path: frontend/pnpm-lock.yaml
 
-    - name: Enable Corepack
-      run: corepack enable
+    - name: Enable Corepack and install pnpm
+      run: |
+        corepack enable
+        corepack prepare pnpm@9 --activate
 
     - name: Install Node dependencies
       run: |


### PR DESCRIPTION
## Summary
- update all workflows to prepare pnpm via Corepack before installing frontend dependencies

## Testing
- not run (CI configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68ebe6dbbf08832586495a09a1db3b85