### PR TITLE
Introduce DBRequest/DBResponse models for database providers

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -9,7 +9,7 @@ import logging
 from . import BaseModule
 from .env_module import EnvModule
 from .providers import DbProviderBase
-from .providers import DBResult
+from .providers import DBRequest, DBResponse
 from server.helpers.logging import update_logging_level
 
 
@@ -46,13 +46,20 @@ class DbModule(BaseModule):
 
     self._provider = provider_cls(**cfg)
 
-  async def run(self, op: str, args: Dict[str, Any]) -> DBResult:
+  async def run(self, op: str, args: Dict[str, Any]) -> DBResponse:
     assert self._provider, "db_module not initialized"
-    out = await self._provider.run(op, args)
-    # normalize to DBResult
-    if isinstance(out, DBResult):
+    request = DBRequest(op=op, payload=args)
+    out = await self._provider.run(request)
+    if isinstance(out, DBResponse):
+      if not out.op:
+        out.attach_op(op)
       return out
-    return DBResult(**out)  # expects {"rows":[...], "rowcount":N}
+    if isinstance(out, dict):
+      rows = out.get("rows")
+      rowcount = out.get("rowcount")
+      payload = out.get("payload", rows)
+      return DBResponse(op=op, payload=payload, rowcount=rowcount)
+    raise TypeError(f"Unexpected database response type: {type(out)!r}")
 
   async def startup(self):
     env: EnvModule = self.app.state.env
@@ -137,7 +144,7 @@ class DbModule(BaseModule):
     res = await self.run("db:users:account:exists:1", {"user_guid": user_guid})
     return bool(res.rows)
 
-  async def upsert_storage_cache(self, item: Dict[str, Any]) -> DBResult:
+  async def upsert_storage_cache(self, item: Dict[str, Any]) -> DBResponse:
     return await self.run("db:storage:cache:upsert:1", item)
 
   async def delete_storage_cache(self, user_guid: str, path: str, filename: str):

--- a/server/modules/providers/__init__.py
+++ b/server/modules/providers/__init__.py
@@ -12,7 +12,7 @@ from fastapi import HTTPException, status
 from jose import jwt
 import logging
 
-from pydantic import BaseModel
+from server.registry.types import DBRequest, DBResponse, DBResult
 
 __all__ = [
   "AuthProvider",
@@ -20,14 +20,11 @@ __all__ = [
   "LifecycleProvider",
   "AuthProviderBase",
   "DbProviderBase",
+  "DBRequest",
+  "DBResponse",
   "DBResult",
   "DbRunMode",
 ]
-
-
-class DBResult(BaseModel):
-  rows: list[dict] = []
-  rowcount: int = 0
 
 
 class DbRunMode(str, Enum):
@@ -65,8 +62,21 @@ class AuthProviderBase(LifecycleProvider):
 
 
 class DbProviderBase(LifecycleProvider):
+  async def run(
+    self,
+    request: DBRequest | str,
+    args: Dict[str, Any] | None = None,
+  ) -> DBResponse:
+    if isinstance(request, str):
+      payload = args or {}
+      return await self._run(DBRequest(op=request, payload=payload))
+    return await self._run(request)
+
+  async def execute(self, op: str, args: Dict[str, Any]) -> DBResponse:
+    return await self.run(DBRequest(op=op, payload=args))
+
   @abstractmethod
-  async def run(self, op: str, args: Dict[str, Any]) -> DBResult: ...
+  async def _run(self, request: DBRequest) -> DBResponse: ...
 
 
 class AuthProvider(AuthProviderBase):

--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -1,7 +1,8 @@
 # providers/database/mssql_provider/__init__.py
 from typing import Any, Dict
 
-from ... import DbProviderBase, DBResult, DbRunMode
+from ... import DbProviderBase, DbRunMode
+from server.registry.types import DBRequest, DBResponse
 from .logic import init_pool, close_pool
 from .db_helpers import fetch_rows, fetch_json, exec_query
 from .registry import get_handler
@@ -14,21 +15,41 @@ class MssqlProvider(DbProviderBase):
   async def shutdown(self) -> None:
     await close_pool()
 
-  async def run(self, op: str, args: Dict[str, Any]) -> DBResult:
-    handler = get_handler(op)
-    spec = handler(args)
+  async def _run(self, request: DBRequest) -> DBResponse:
+    handler = get_handler(request.op)
+    spec = handler(request.payload)
+    result = await self._execute_spec(spec)
+    return self._normalize_response(request.op, result)
+
+  async def _execute_spec(self, spec: Any) -> Any:
     if hasattr(spec, "__await__"):
       return await spec
-    mode, sql, params = spec
-    if mode is DbRunMode.JSON_ONE:
-      return await fetch_json(sql, params)
-    if mode is DbRunMode.ROW_ONE:
-      return await fetch_rows(sql, params, one=True)
-    if mode is DbRunMode.ROW_MANY:
-      return await fetch_rows(sql, params)
-    if mode is DbRunMode.JSON_MANY:
-      return await fetch_json(sql, params, many=True)
-    if mode is DbRunMode.EXEC:
-      return await exec_query(sql, params)
-    raise ValueError(f"Unknown mode: {mode}")
+    if isinstance(spec, tuple) and len(spec) == 3:
+      mode, sql, params = spec
+      if mode is DbRunMode.JSON_ONE:
+        return await fetch_json(sql, params)
+      if mode is DbRunMode.ROW_ONE:
+        return await fetch_rows(sql, params, one=True)
+      if mode is DbRunMode.ROW_MANY:
+        return await fetch_rows(sql, params)
+      if mode is DbRunMode.JSON_MANY:
+        return await fetch_json(sql, params, many=True)
+      if mode is DbRunMode.EXEC:
+        return await exec_query(sql, params)
+      raise ValueError(f"Unknown mode: {mode}")
+    return spec
+
+  def _normalize_response(self, op: str, result: Any) -> DBResponse:
+    if isinstance(result, DBResponse):
+      if not result.op:
+        result.attach_op(op)
+      return result
+    if isinstance(result, dict):
+      rows = result.get("rows")
+      rowcount = result.get("rowcount")
+      payload = result.get("payload", rows)
+      return DBResponse(op=op, payload=payload, rowcount=rowcount)
+    if result is None:
+      return DBResponse(op=op, payload=[], rowcount=0)
+    raise TypeError(f"Unexpected MSSQL handler result type: {type(result)!r}")
 

--- a/server/registry/models.py
+++ b/server/registry/models.py
@@ -1,0 +1,109 @@
+"""Database registry models.
+
+These mirror the RPC request/response shapes while retaining backward
+compatibility with the existing ``DBResult`` helpers.  Requests carry an
+``op`` name and an arbitrary ``payload`` dictionary.  Responses standardize
+``op``/``payload`` and expose ``rows``/``rowcount`` aliases for existing
+callers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, Mapping, Sequence
+
+__all__ = ["DBRequest", "DBResponse", "DBResult"]
+
+
+class DBRequest:
+  """Representation of a database operation request."""
+
+  __slots__ = ("op", "payload")
+
+  def __init__(
+    self,
+    *,
+    op: str,
+    payload: Mapping[str, Any] | None = None,
+    params: Mapping[str, Any] | None = None,
+  ) -> None:
+    if not op:
+      raise ValueError("op is required for DBRequest")
+    source = payload if payload is not None else params
+    if source is None:
+      source = {}
+    self.op = op
+    # normalize to a mutable dict for convenience
+    self.payload: Dict[str, Any] = dict(source)
+
+  @property
+  def params(self) -> Dict[str, Any]:
+    """Alias retained for backwards compatibility."""
+
+    return self.payload
+
+  def copy(self) -> "DBRequest":
+    return DBRequest(op=self.op, payload=dict(self.payload))
+
+  def with_payload(self, data: Mapping[str, Any]) -> "DBRequest":
+    new = self.copy()
+    new.payload.update(data)
+    return new
+
+
+class DBResponse:
+  """Normalized database provider response."""
+
+  __slots__ = ("op", "payload", "rowcount")
+
+  def __init__(
+    self,
+    *,
+    op: str = "",
+    payload: Any | None = None,
+    rows: Sequence[Mapping[str, Any]] | None = None,
+    rowcount: int | None = None,
+  ) -> None:
+    if rows is not None:
+      payload = [dict(row) for row in rows]
+      if rowcount is None:
+        rowcount = len(payload)
+    self.op = op
+    if payload is None:
+      payload = []
+    self.payload = payload
+    if rowcount is None:
+      rowcount = 0
+    self.rowcount = rowcount
+
+  @property
+  def rows(self) -> list[Mapping[str, Any]]:
+    data = self.payload
+    if data is None:
+      return []
+    if isinstance(data, list):
+      return data
+    if isinstance(data, (tuple, set)):
+      return [dict(item) if isinstance(item, Mapping) else item for item in data]
+    if isinstance(data, Mapping):
+      return [data]
+    return [data]
+
+  def attach_op(self, op: str) -> "DBResponse":
+    self.op = op
+    return self
+
+  def model_dump(self) -> dict[str, Any]:
+    return {
+      "op": self.op,
+      "payload": self.payload,
+      "rowcount": self.rowcount,
+      "rows": self.rows,
+    }
+
+  # Backwards compatibility for helper usage expecting dict unpacking
+  def __iter__(self) -> Iterator[tuple[str, Any]]:  # type: ignore[override]
+    yield from {"rows": self.rows, "rowcount": self.rowcount}.items()
+
+
+# Historical name kept for downstream imports/tests.
+DBResult = DBResponse

--- a/server/registry/types.py
+++ b/server/registry/types.py
@@ -1,0 +1,7 @@
+"""Compatibility re-export for database registry models."""
+
+from __future__ import annotations
+
+from .models import DBRequest, DBResponse, DBResult
+
+__all__ = ["DBRequest", "DBResponse", "DBResult"]


### PR DESCRIPTION
## Summary
- add DBRequest and DBResponse models that mirror RPC-style envelopes and re-export them for registry callers
- update DbProviderBase and DbModule to operate on the new request/response contract while keeping backward-compatible entry points
- adapt the MSSQL provider to normalize handler outputs into DBResponse objects

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f138c4891c83258d75deee6764145d