### PR TITLE
Refactor DB request usage to new DBRequest API

### DIFF
--- a/rpc/auth/discord/services.py
+++ b/rpc/auth/discord/services.py
@@ -11,6 +11,8 @@ from server.modules.env_module import EnvModule
 from server.modules.auth_module import AuthModule
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
+from server.registry.system.config import get_config_request
+from server.registry.types import DBRequest
 from .models import AuthDiscordOauthLogin1, AuthDiscordOauthLoginPayload1
 
 
@@ -52,7 +54,7 @@ async def auth_discord_oauth_login_v1(request: Request):
   if not client_secret:
     raise HTTPException(status_code=500, detail="DISCORD_AUTH_SECRET not configured")
 
-  res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+  res_redirect = await db.run(get_config_request(key="Hostname"))
   if not res_redirect.rows:
     raise HTTPException(status_code=500, detail="Discord OAuth redirect URI not configured")
   redirect_uri = res_redirect.rows[0]["value"]
@@ -88,18 +90,26 @@ async def auth_discord_oauth_login_v1(request: Request):
   new_img = profile.get("profilePicture")
   if new_img and new_img != user.get("profile_image"):
     await db.run(
-      "db:users:profile:set_profile_image:1",
-      {"guid": user_guid, "image_b64": new_img, "provider": provider},
+      DBRequest(
+        op="db:users:profile:set_profile_image:1",
+        payload={
+          "guid": user_guid,
+          "image_b64": new_img,
+          "provider": provider,
+        },
+      ),
     )
     user["profile_image"] = new_img
   if user.get("provider_name") == "discord":
     res_prof = await db.run(
-      "db:users:profile:update_if_unedited:1",
-      {
-        "guid": user_guid,
-        "email": profile["email"],
-        "display_name": profile["username"],
-      },
+      DBRequest(
+        op="db:users:profile:update_if_unedited:1",
+        payload={
+          "guid": user_guid,
+          "email": profile["email"],
+          "display_name": profile["username"],
+        },
+      ),
     )
     if res_prof.rows:
       updated = res_prof.rows[0]

--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -9,6 +9,8 @@ from server.modules.env_module import EnvModule
 from server.modules.auth_module import AuthModule
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
+from server.registry.system.config import get_config_request
+from server.registry.types import DBRequest
 from .models import AuthGoogleOauthLogin1, AuthGoogleOauthLoginPayload1
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
@@ -56,7 +58,7 @@ async def auth_google_oauth_login_v1(request: Request):
     raise HTTPException(status_code=500, detail="GOOGLE_AUTH_SECRET not configured")
 
   # Require redirect_uri from system config
-  res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+  res_redirect = await db.run(get_config_request(key="Hostname"))
   if not res_redirect.rows:
       raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
   redirect_uri = res_redirect.rows[0]["value"]
@@ -94,18 +96,26 @@ async def auth_google_oauth_login_v1(request: Request):
   new_img = profile.get("profilePicture")
   if new_img and new_img != user.get("profile_image"):
     await db.run(
-      "db:users:profile:set_profile_image:1",
-      {"guid": user_guid, "image_b64": new_img, "provider": provider},
+      DBRequest(
+        op="db:users:profile:set_profile_image:1",
+        payload={
+          "guid": user_guid,
+          "image_b64": new_img,
+          "provider": provider,
+        },
+      ),
     )
     user["profile_image"] = new_img
   if user.get("provider_name") == "google":
     res_prof = await db.run(
-      "db:users:profile:update_if_unedited:1",
-      {
-        "guid": user_guid,
-        "email": profile["email"],
-        "display_name": profile["username"],
-      },
+      DBRequest(
+        op="db:users:profile:update_if_unedited:1",
+        payload={
+          "guid": user_guid,
+          "email": profile["email"],
+          "display_name": profile["username"],
+        },
+      ),
     )
     if res_prof.rows:
       updated = res_prof.rows[0]

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -9,6 +9,7 @@ from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
+from server.registry.types import DBRequest
 from .models import AuthMicrosoftOauthLogin1
 
 
@@ -68,18 +69,26 @@ async def auth_microsoft_oauth_login_v1(request: Request):
   new_img = profile.get("profilePicture")
   if new_img != user.get("profile_image"):
     await db.run(
-      "db:users:profile:set_profile_image:1",
-      {"guid": user_guid, "image_b64": new_img, "provider": provider},
+      DBRequest(
+        op="db:users:profile:set_profile_image:1",
+        payload={
+          "guid": user_guid,
+          "image_b64": new_img,
+          "provider": provider,
+        },
+      ),
     )
     user["profile_image"] = new_img
   if user.get("provider_name") == "microsoft":
     res_prof = await db.run(
-      "db:users:profile:update_if_unedited:1",
-      {
-        "guid": user_guid,
-        "email": profile["email"],
-        "display_name": profile["username"],
-      },
+      DBRequest(
+        op="db:users:profile:update_if_unedited:1",
+        payload={
+          "guid": user_guid,
+          "email": profile["email"],
+          "display_name": profile["username"],
+        },
+      ),
     )
     if res_prof.rows:
       updated = res_prof.rows[0]

--- a/rpc/auth/providers/services.py
+++ b/rpc/auth/providers/services.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.db_module import DbModule
+from server.registry.auth.providers import unlink_last_provider_request
 
 from .models import AuthProvidersUnlinkLastProvider1
 
@@ -16,7 +17,6 @@ async def auth_providers_unlink_last_provider_v1(request: Request):
     raise HTTPException(status_code=400, detail=str(e))
   db: DbModule = request.app.state.db
   await db.run(
-    rpc_request.op,
-    {"guid": payload.guid, "provider": payload.provider},
+    unlink_last_provider_request(guid=payload.guid, provider=payload.provider),
   )
   return RPCResponse(op=rpc_request.op, payload={"ok": True}, version=rpc_request.version)

--- a/rpc/service/routes/services.py
+++ b/rpc/service/routes/services.py
@@ -5,6 +5,7 @@ from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.db_module import DbModule
 from server.modules.auth_module import AuthModule
+from server.registry.types import DBRequest
 from .models import (
   ServiceRoutesRouteItem1,
   ServiceRoutesList1,
@@ -21,7 +22,9 @@ async def service_routes_get_routes_v1(request: Request):
   )
   db: DbModule = request.app.state.db
   auth: AuthModule = request.app.state.auth
-  res = await db.run("db:service:routes:get_routes:1", {})
+  res = await db.run(
+    DBRequest(op="db:service:routes:get_routes:1", payload={}),
+  )
   routes = []
   for row in res.rows:
     mask = int(row.get("element_roles", 0))
@@ -58,13 +61,18 @@ async def service_routes_upsert_route_v1(request: Request):
   db: DbModule = request.app.state.db
   auth: AuthModule = request.app.state.auth
   mask = auth.names_to_mask(payload.required_roles)
-  await db.run("db:service:routes:upsert_route:1", {
-    "path": payload.path,
-    "name": payload.name,
-    "icon": payload.icon,
-    "sequence": payload.sequence,
-    "roles": mask,
-  })
+  await db.run(
+    DBRequest(
+      op="db:service:routes:upsert_route:1",
+      payload={
+        "path": payload.path,
+        "name": payload.name,
+        "icon": payload.icon,
+        "sequence": payload.sequence,
+        "roles": mask,
+      },
+    ),
+  )
   logging.debug(
     "[service_routes_upsert_route_v1] upserted route %s",
     payload.path,
@@ -86,7 +94,12 @@ async def service_routes_delete_route_v1(request: Request):
   )
   payload = ServiceRoutesDeleteRoute1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run("db:service:routes:delete_route:1", {"path": payload.path})
+  await db.run(
+    DBRequest(
+      op="db:service:routes:delete_route:1",
+      payload={"path": payload.path},
+    ),
+  )
   logging.debug(
     "[service_routes_delete_route_v1] deleted route %s",
     payload.path,

--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -3,6 +3,7 @@ from fastapi import HTTPException, Request
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.db_module import DbModule
+from server.registry.types import DBRequest
 from .models import (
   UsersProfileProfile1,
   UsersProfileSetDisplay1,
@@ -27,7 +28,12 @@ async def users_profile_get_profile_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   db: DbModule = request.app.state.db
-  res = await db.run("db:users:profile:get_profile:1", {"guid": user_guid})
+  res = await db.run(
+    DBRequest(
+      op="db:users:profile:get_profile:1",
+      payload={"guid": user_guid},
+    ),
+  )
   if not res.rows:
     raise HTTPException(status_code=404, detail="Profile not found")
   row = res.rows[0]
@@ -51,10 +57,15 @@ async def users_profile_set_display_v1(request: Request):
 
   payload = UsersProfileSetDisplay1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run("db:users:profile:set_display:1", {
-    "guid": user_guid,
-    "display_name": payload.display_name,
-  })
+  await db.run(
+    DBRequest(
+      op="db:users:profile:set_display:1",
+      payload={
+        "guid": user_guid,
+        "display_name": payload.display_name,
+      },
+    ),
+  )
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -69,10 +80,15 @@ async def users_profile_set_optin_v1(request: Request):
 
   payload = UsersProfileSetOptin1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run("db:users:profile:set_optin:1", {
-    "guid": user_guid,
-    "display_email": payload.display_email,
-  })
+  await db.run(
+    DBRequest(
+      op="db:users:profile:set_optin:1",
+      payload={
+        "guid": user_guid,
+        "display_email": payload.display_email,
+      },
+    ),
+  )
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -86,7 +102,12 @@ async def users_profile_get_roles_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   db: DbModule = request.app.state.db
-  res = await db.run("db:users:profile:get_roles:1", {"guid": user_guid})
+  res = await db.run(
+    DBRequest(
+      op="db:users:profile:get_roles:1",
+      payload={"guid": user_guid},
+    ),
+  )
   roles = int(res.rows[0].get("element_roles", 0)) if res.rows else 0
   payload = UsersProfileRoles1(roles=roles)
   return RPCResponse(
@@ -103,11 +124,16 @@ async def users_profile_set_profile_image_v1(request: Request):
 
   payload = UsersProfileSetProfileImage1(**(rpc_request.payload or {}))
   db: DbModule = request.app.state.db
-  await db.run("db:users:profile:set_profile_image:1", {
-    "guid": user_guid,
-    "image_b64": payload.image_b64,
-    "provider": payload.provider,
-  })
+  await db.run(
+    DBRequest(
+      op="db:users:profile:set_profile_image:1",
+      payload={
+        "guid": user_guid,
+        "image_b64": payload.image_b64,
+        "provider": payload.provider,
+      },
+    ),
+  )
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -6,6 +6,19 @@ from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 from server.modules.db_module import DbModule
+from server.modules.oauth_module import OauthModule
+from server.registry.auth.providers import unlink_last_provider_request
+from server.registry.auth.session import revoke_provider_tokens_request
+from server.registry.system.config import get_config_request
+from server.registry.types import DBRequest
+from server.registry.users.providers import (
+  create_from_provider_request,
+  get_by_provider_identifier_request,
+  get_user_by_email_request,
+  link_provider_request,
+  set_provider_request,
+  unlink_provider_request,
+)
 from .models import (
   UsersProvidersSetProvider1,
   UsersProvidersLinkProvider1,
@@ -13,7 +26,6 @@ from .models import (
   UsersProvidersGetByProviderIdentifier1,
   UsersProvidersCreateFromProvider1,
 )
-from server.modules.oauth_module import OauthModule
 
 
 def normalize_provider_identifier(pid: str) -> str:
@@ -43,7 +55,7 @@ async def users_providers_set_provider_v1(request: Request):
         client_secret = env.get("GOOGLE_AUTH_SECRET")
         if not client_secret:
           raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
-        res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+        res_redirect = await db.run(get_config_request(key="Hostname"))
         if not res_redirect.rows:
           raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
         redirect_uri = res_redirect.rows[0]["value"]
@@ -68,7 +80,7 @@ async def users_providers_set_provider_v1(request: Request):
         client_secret = env.get("DISCORD_AUTH_SECRET")
         if not client_secret:
           raise HTTPException(status_code=500, detail="Discord OAuth client_secret not configured")
-        res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+        res_redirect = await db.run(get_config_request(key="Hostname"))
         if not res_redirect.rows:
           raise HTTPException(status_code=500, detail="Discord OAuth redirect URI not configured")
         redirect_uri = res_redirect.rows[0]["value"]
@@ -93,7 +105,7 @@ async def users_providers_set_provider_v1(request: Request):
         client_secret = env.get("MICROSOFT_AUTH_SECRET")
         if not client_secret:
           raise HTTPException(status_code=500, detail="Microsoft OAuth client_secret not configured")
-        res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+        res_redirect = await db.run(get_config_request(key="Hostname"))
         if not res_redirect.rows:
           raise HTTPException(status_code=500, detail="Microsoft OAuth redirect URI not configured")
         redirect_uri = res_redirect.rows[0]["value"]
@@ -114,11 +126,7 @@ async def users_providers_set_provider_v1(request: Request):
       raise HTTPException(status_code=400, detail="Unsupported auth provider")
     _, profile, _ = await auth.handle_auth_login(payload.provider, id_token, access_token)
   await db.run(
-    "db:users:providers:set_provider:1",
-    {
-      "guid": auth_ctx.user_guid,
-      "provider": payload.provider,
-    },
+    set_provider_request(guid=auth_ctx.user_guid, provider=payload.provider),
   )
   if profile:
     raw_email = (profile.get("email") or "").strip()
@@ -126,12 +134,14 @@ async def users_providers_set_provider_v1(request: Request):
     email = raw_email
     display_name = raw_name or (raw_email.split("@")[0] if raw_email else "User")
     await db.run(
-      "db:users:profile:update_if_unedited:1",
-      {
-        "guid": auth_ctx.user_guid,
-        "email": email,
-        "display_name": display_name,
-      },
+      DBRequest(
+        op="db:users:profile:update_if_unedited:1",
+        payload={
+          "guid": auth_ctx.user_guid,
+          "email": email,
+          "display_name": display_name,
+        },
+      ),
     )
   return RPCResponse(
     op=rpc_request.op,
@@ -159,7 +169,7 @@ async def users_providers_link_provider_v1(request: Request):
     client_secret = env.get("GOOGLE_AUTH_SECRET")
     if not client_secret:
       raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
-    res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+    res_redirect = await db.run(get_config_request(key="Hostname"))
     if not res_redirect.rows:
       raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
     redirect_uri = res_redirect.rows[0]["value"]
@@ -182,7 +192,7 @@ async def users_providers_link_provider_v1(request: Request):
       client_secret = env.get("DISCORD_AUTH_SECRET")
       if not client_secret:
         raise HTTPException(status_code=500, detail="Discord OAuth client_secret not configured")
-      res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+      res_redirect = await db.run(get_config_request(key="Hostname"))
       if not res_redirect.rows:
         raise HTTPException(status_code=500, detail="Discord OAuth redirect URI not configured")
       redirect_uri = res_redirect.rows[0]["value"]
@@ -208,7 +218,7 @@ async def users_providers_link_provider_v1(request: Request):
       client_secret = env.get("MICROSOFT_AUTH_SECRET")
       if not client_secret:
         raise HTTPException(status_code=500, detail="Microsoft OAuth client_secret not configured")
-      res_redirect = await db.run("db:system:config:get_config:1", {"key": "Hostname"})
+      res_redirect = await db.run(get_config_request(key="Hostname"))
       if not res_redirect.rows:
         raise HTTPException(status_code=500, detail="Microsoft OAuth redirect URI not configured")
       redirect_uri = res_redirect.rows[0]["value"]
@@ -231,18 +241,19 @@ async def users_providers_link_provider_v1(request: Request):
   provider_uid, _, _ = await auth.handle_auth_login(payload.provider, id_token, access_token)
   provider_uid = normalize_provider_identifier(provider_uid)
   res = await db.run(
-    "db:users:providers:get_by_provider_identifier:1",
-    {"provider": payload.provider, "provider_identifier": provider_uid},
+    get_by_provider_identifier_request(
+      provider=payload.provider,
+      provider_identifier=provider_uid,
+    ),
   )
   if res.rows and res.rows[0].get("guid") != auth_ctx.user_guid:
     raise HTTPException(status_code=409, detail="Provider already linked")
   await db.run(
-    "db:users:providers:link_provider:1",
-    {
-      "guid": auth_ctx.user_guid,
-      "provider": payload.provider,
-      "provider_identifier": provider_uid,
-    },
+    link_provider_request(
+      guid=auth_ctx.user_guid,
+      provider=payload.provider,
+      provider_identifier=provider_uid,
+    ),
   )
   return RPCResponse(op=rpc_request.op, payload={"provider": payload.provider}, version=rpc_request.version)
 
@@ -254,30 +265,34 @@ async def users_providers_unlink_provider_v1(request: Request):
     raise HTTPException(status_code=400, detail=str(e))
   db: DbModule = request.app.state.db
   res_prof = await db.run(
-    "db:users:profile:get_profile:1",
-    {"guid": auth_ctx.user_guid},
+    DBRequest(
+      op="db:users:profile:get_profile:1",
+      payload={"guid": auth_ctx.user_guid},
+    ),
   )
   default_provider = res_prof.rows[0].get("default_provider") if res_prof.rows else None
   res = await db.run(
-    "db:users:providers:unlink_provider:1",
-    {"guid": auth_ctx.user_guid, "provider": payload.provider},
+    unlink_provider_request(guid=auth_ctx.user_guid, provider=payload.provider),
   )
   remaining = res.rows[0].get("providers_remaining") if res.rows else 0
   if remaining == 0:
     await db.run(
-      "db:auth:providers:unlink_last_provider:1",
-      {"guid": auth_ctx.user_guid, "provider": payload.provider},
+      unlink_last_provider_request(
+        guid=auth_ctx.user_guid,
+        provider=payload.provider,
+      ),
     )
   elif payload.provider == default_provider:
     if not payload.new_default:
       raise HTTPException(status_code=400, detail="new_default required")
     await db.run(
-      "db:users:providers:set_provider:1",
-      {"guid": auth_ctx.user_guid, "provider": payload.new_default},
+      set_provider_request(guid=auth_ctx.user_guid, provider=payload.new_default),
     )
     await db.run(
-      "db:auth:session:revoke_provider_tokens:1",
-      {"guid": auth_ctx.user_guid, "provider": payload.provider},
+      revoke_provider_tokens_request(
+        guid=auth_ctx.user_guid,
+        provider=payload.provider,
+      ),
     )
   return RPCResponse(op=rpc_request.op, payload={"provider": payload.provider}, version=rpc_request.version)
 
@@ -289,8 +304,7 @@ async def users_providers_get_by_provider_identifier_v1(request: Request):
     raise HTTPException(status_code=400, detail=str(e))
   db: DbModule = request.app.state.db
   res = await db.run(
-    "db:users:providers:get_by_provider_identifier:1",
-    payload.model_dump(),
+    get_by_provider_identifier_request(**payload.model_dump()),
   )
   row = res.rows[0] if res.rows else None
   return RPCResponse(op=rpc_request.op, payload=row, version=rpc_request.version)
@@ -303,14 +317,12 @@ async def users_providers_create_from_provider_v1(request: Request):
     raise HTTPException(status_code=400, detail=str(e))
   db: DbModule = request.app.state.db
   res = await db.run(
-    "db:users:providers:get_user_by_email:1",
-    {"email": payload.provider_email},
+    get_user_by_email_request(email=payload.provider_email),
   )
   if res.rows:
     raise HTTPException(status_code=409, detail="Email already registered")
   res = await db.run(
-    "db:users:providers:create_from_provider:1",
-    payload.model_dump(),
+    create_from_provider_request(**payload.model_dump()),
   )
   row = res.rows[0] if res.rows else None
   return RPCResponse(op=rpc_request.op, payload=row, version=rpc_request.version)

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -14,6 +14,8 @@ from server.modules.providers.auth.microsoft_provider import MicrosoftAuthProvid
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.providers.auth.discord_provider import DiscordAuthProvider
 from server.modules.discord_bot_module import DiscordBotModule
+from server.registry.system.roles import list_roles_request
+from server.registry.types import DBRequest
 
 DEFAULT_SESSION_TOKEN_EXPIRY = 15 # minutes
 DEFAULT_ROTATION_TOKEN_EXPIRY = 90 # days
@@ -30,7 +32,7 @@ class RoleCache:
   async def load_roles(self):
     logging.debug("[RoleCache] Loading roles from database")
     try:
-      result = await self.db.run("db:system:roles:list:1", {})
+      result = await self.db.run(list_roles_request())
     except Exception as e:
       logging.error("[RoleCache] Failed to load roles: %s", e)
       return
@@ -52,15 +54,23 @@ class RoleCache:
 
   async def upsert_role(self, name: str, mask: int, display: str | None):
     await self.db.run(
-      "db:security:roles:upsert_role:1",
-      {"name": name, "mask": mask, "display": display},
+      DBRequest(
+        op="db:security:roles:upsert_role:1",
+        payload={
+          "name": name,
+          "mask": mask,
+          "display": display,
+        },
+      ),
     )
     await self.refresh_role_cache()
 
   async def delete_role(self, name: str):
     await self.db.run(
-      "db:security:roles:delete_role:1",
-      {"name": name},
+      DBRequest(
+        op="db:security:roles:delete_role:1",
+        payload={"name": name},
+      ),
     )
     await self.refresh_role_cache()
 
@@ -83,7 +93,9 @@ class RoleCache:
       logging.debug("[RoleCache] Returning cached roles for %s", guid)
       return self._user_roles[guid]
     logging.debug("[RoleCache] Fetching roles for %s", guid)
-    res = await self.db.run("db:users:profile:get_roles:1", {"guid": guid})
+    res = await self.db.run(
+      DBRequest(op="db:users:profile:get_roles:1", payload={"guid": guid}),
+    )
     mask = int(res.rows[0].get("element_roles", 0)) if res.rows else 0
     names = self.mask_to_names(mask)
     self._user_roles[guid] = (names, mask)
@@ -254,7 +266,9 @@ class AuthModule(BaseModule):
     if not guid or not session_guid or not device_guid:
       raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Subject not found", headers={"WWW-Authenticate": "Bearer"})
 
-    res = await self.db.run("db:users:session:get_rotkey:1", {"guid": guid})
+    res = await self.db.run(
+      DBRequest(op="db:users:session:get_rotkey:1", payload={"guid": guid}),
+    )
     rotkey = res.rows[0].get("rotkey") if res.rows else None
     derived_secret = f"{self.jwt_secret}:{rotkey}:{guid}:{session_guid}:{device_guid}" if rotkey else None
     try:
@@ -325,7 +339,12 @@ class AuthModule(BaseModule):
     return self.role_cache.get_role_names(exclude_registered)
 
   async def get_discord_user_security(self, discord_id: str) -> tuple[str, list[str], int]:
-    res = await self.db.run("db:auth:discord:get_security:1", {"discord_id": discord_id})
+    res = await self.db.run(
+      DBRequest(
+        op="db:auth:discord:get_security:1",
+        payload={"discord_id": discord_id},
+      ),
+    )
     if not res.rows:
       return "", [], 0
     row = res.rows[0]

--- a/server/modules/bsky_module.py
+++ b/server/modules/bsky_module.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from atproto import AsyncClient as AsyncBskyClient, client_utils
 from fastapi import FastAPI
 
+from server.registry.system.config import get_config_request
 from . import BaseModule
 from .db_module import DbModule
 
@@ -43,7 +44,7 @@ class BskyModule(BaseModule):
   async def _load_optional_config(self, key: str) -> str:
     if not self.db:
       raise RuntimeError("BskyModule requires database module")
-    res = await self.db.run("db:system:config:get_config:1", {"key": key})
+    res = await self.db.run(get_config_request(key=key))
     if not res.rows:
       return ""
     return res.rows[0].get("value") or ""

--- a/server/modules/discord_bot_module.py
+++ b/server/modules/discord_bot_module.py
@@ -18,6 +18,7 @@ except ImportError:  # pragma: no cover - non-Windows platforms
 from . import BaseModule
 from .env_module import EnvModule
 from .db_module import DbModule
+from server.registry.system.config import get_config_request
 
 from server.helpers.logging import configure_discord_logging, remove_discord_logging, update_logging_level
 from server.routers.discord_events import register_discord_event_handlers
@@ -75,7 +76,7 @@ class DiscordBotModule(BaseModule):
       register_discord_event_handlers(self)
       update_logging_level(self.db.logging_level)
       configure_discord_logging(self)
-      res = await self.db.run("db:system:config:get_config:1", {"key": "DiscordSyschan"})
+      res = await self.db.run(get_config_request(key="DiscordSyschan"))
       if not res.rows:
         raise ValueError("Missing config value for key: DiscordSyschan")
       self.syschan = int(res.rows[0]["value"] or 0)

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -12,6 +12,21 @@ except Exception:
   DEFAULT_SESSION_TOKEN_EXPIRY = 15
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
+from server.registry.auth.oauth import (
+  relink_discord_request,
+  relink_google_request,
+  relink_microsoft_request,
+)
+from server.registry.auth.session import (
+  create_session_request,
+  update_device_token_request,
+)
+from server.registry.types import DBRequest
+from server.registry.users.providers import (
+  create_from_provider_request,
+  get_any_by_provider_identifier_request,
+  get_by_provider_identifier_request,
+)
 
 
 class OauthModule(BaseModule):
@@ -160,8 +175,10 @@ class OauthModule(BaseModule):
       checked.add(uid)
       logging.debug(f"[lookup_user] checking identifier={pid[:40]}")
       res = await self.db.run(
-        "db:users:providers:get_by_provider_identifier:1",
-        {"provider": provider, "provider_identifier": uid},
+        get_by_provider_identifier_request(
+          provider=provider,
+          provider_identifier=uid,
+        ),
       )
       if res.rows:
         logging.debug(f"[lookup_user] user found with identifier={pid[:40]}")
@@ -180,23 +197,29 @@ class OauthModule(BaseModule):
     logging.debug(f"[create_session] rotation_token={rotation_token[:40]}")
     now = datetime.now(timezone.utc)
     await self.db.run(
-      "db:users:session:set_rotkey:1",
-      {"guid": user_guid, "rotkey": rotation_token, "iat": now, "exp": rot_exp},
+      DBRequest(
+        op="db:users:session:set_rotkey:1",
+        payload={
+          "guid": user_guid,
+          "rotkey": rotation_token,
+          "iat": now,
+          "exp": rot_exp,
+        },
+      ),
     )
     roles, _ = await self.auth.get_user_roles(user_guid)
     session_exp = now + timedelta(minutes=DEFAULT_SESSION_TOKEN_EXPIRY)
     placeholder = uuid.uuid4().hex
     res = await self.db.run(
-      "db:auth:session:create_session:1",
-      {
-        "access_token": placeholder,
-        "expires": session_exp,
-        "fingerprint": fingerprint,
-        "user_agent": user_agent,
-        "ip_address": ip_address,
-        "user_guid": user_guid,
-        "provider": provider,
-      },
+      create_session_request(
+        access_token=placeholder,
+        expires=session_exp,
+        fingerprint=fingerprint,
+        user_guid=user_guid,
+        provider=provider,
+        user_agent=user_agent,
+        ip_address=ip_address,
+      ),
     )
     row = res.rows[0] if res.rows else {}
     session_guid = row.get("session_guid")
@@ -205,8 +228,7 @@ class OauthModule(BaseModule):
       user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp,
     )
     await self.db.run(
-      "db:auth:session:update_device_token:1",
-      {"device_guid": device_guid, "access_token": session_token},
+      update_device_token_request(device_guid=device_guid, access_token=session_token),
     )
     logging.debug(f"[create_session] session_token={session_token[:40]}")
     return session_token, session_exp, rotation_token, rot_exp
@@ -227,41 +249,61 @@ class OauthModule(BaseModule):
       needs_relink = True
     elif not user:
       await self.db.run(
-        "db:users:providers:get_any_by_provider_identifier:1",
-        {"provider": provider, "provider_identifier": provider_uid},
+        get_any_by_provider_identifier_request(
+          provider=provider,
+          provider_identifier=provider_uid,
+        ),
       )
       needs_relink = True
 
     if needs_relink:
-      res = await self.db.run(
-        f"db:auth:{provider}:oauth_relink:1",
-        {
-          "provider_identifier": provider_uid,
-          "email": profile["email"],
-          "display_name": profile["username"],
-          "profile_image": profile.get("profilePicture"),
-          "confirm": confirm,
-          "reauth_token": reauth_token,
-        },
-      )
+      relink_builders = {
+        "discord": relink_discord_request,
+        "google": relink_google_request,
+        "microsoft": relink_microsoft_request,
+      }
+      relink_builder = relink_builders.get(provider)
+      if relink_builder:
+        request = relink_builder(
+          provider_identifier=provider_uid,
+          email=profile["email"],
+          display_name=profile["username"],
+          profile_image=profile.get("profilePicture"),
+          confirm=confirm,
+          reauth_token=reauth_token,
+        )
+      else:
+        request = DBRequest(
+          op=f"db:auth:{provider}:oauth_relink:1",
+          payload={
+            "provider_identifier": provider_uid,
+            "email": profile["email"],
+            "display_name": profile["username"],
+            "profile_image": profile.get("profilePicture"),
+            "confirm": confirm,
+            "reauth_token": reauth_token,
+          },
+        )
+      res = await self.db.run(request)
       user = res.rows[0] if res.rows else None
 
     if not user:
       res = await self.db.run(
-        "db:users:providers:create_from_provider:1",
-        {
-          "provider": provider,
-          "provider_identifier": provider_uid,
-          "provider_email": profile["email"],
-          "provider_displayname": profile["username"],
-          "provider_profile_image": profile.get("profilePicture"),
-        },
+        create_from_provider_request(
+          provider=provider,
+          provider_identifier=provider_uid,
+          provider_email=profile["email"],
+          provider_displayname=profile["username"],
+          provider_profile_image=profile.get("profilePicture"),
+        ),
       )
       user = res.rows[0] if res.rows else None
       if not user:
         res = await self.db.run(
-          "db:users:providers:get_by_provider_identifier:1",
-          {"provider": provider, "provider_identifier": provider_uid},
+          get_by_provider_identifier_request(
+            provider=provider,
+            provider_identifier=provider_uid,
+          ),
         )
         user = res.rows[0] if res.rows else None
       if not user:

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -8,6 +8,8 @@ from openai import AsyncOpenAI
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
+from server.registry.system.config import get_config_request
+from server.registry.types import DBRequest
 
 if TYPE_CHECKING:  # pragma: no cover
   from .discord_output_module import DiscordOutputModule
@@ -87,7 +89,7 @@ class OpenaiModule(BaseModule):
 
   async def get_openai_token(self) -> str:
     assert self.db
-    res = await self.db.run("db:system:config:get_config:1", {"key": "OpenAIApiKey"})
+    res = await self.db.run(get_config_request(key="OpenAIApiKey"))
     if res.rows:
       return res.rows[0].get("value", "")
     return ""
@@ -103,7 +105,9 @@ class OpenaiModule(BaseModule):
     if not self.db:
       return None
     try:
-      res = await self.db.run("db:assistant:personas:get_by_name:1", {"name": name})
+      res = await self.db.run(
+        DBRequest(op="db:assistant:personas:get_by_name:1", payload={"name": name}),
+      )
       if res.rows:
         return res.rows[0]
     except Exception:
@@ -133,12 +137,16 @@ class OpenaiModule(BaseModule):
 
   async def list_models(self) -> List[Dict[str, Any]]:
     assert self.db
-    res = await self.db.run("db:assistant:models:list:1", {})
+    res = await self.db.run(
+      DBRequest(op="db:assistant:models:list:1", payload={}),
+    )
     return list(res.rows or [])
 
   async def list_personas(self) -> List[Dict[str, Any]]:
     assert self.db
-    res = await self.db.run("db:assistant:personas:list:1", {})
+    res = await self.db.run(
+      DBRequest(op="db:assistant:personas:list:1", payload={}),
+    )
     personas: List[Dict[str, Any]] = []
     for row in res.rows or []:
       personas.append({
@@ -167,7 +175,9 @@ class OpenaiModule(BaseModule):
     }
     if not payload["name"]:
       raise ValueError("name required")
-    await self.db.run("db:assistant:personas:upsert:1", payload)
+    await self.db.run(
+      DBRequest(op="db:assistant:personas:upsert:1", payload=payload),
+    )
 
   async def delete_persona(self, recid: int | None = None, name: str | None = None) -> None:
     assert self.db

--- a/server/modules/public_gallery_module.py
+++ b/server/modules/public_gallery_module.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
@@ -22,5 +23,7 @@ class PublicGalleryModule(BaseModule):
 
   async def list_public_files(self):
     assert self.db
-    res = await self.db.run("db:public:gallery:get_public_files:1", {})
+    res = await self.db.run(
+      DBRequest(op="db:public:gallery:get_public_files:1", payload={}),
+    )
     return res.rows

--- a/server/modules/public_links_module.py
+++ b/server/modules/public_links_module.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
@@ -22,9 +23,16 @@ class PublicLinksModule(BaseModule):
     self.db = None
 
   async def get_home_links(self):
-    res = await self.db.run("db:public:links:get_home_links:1", {})
+    res = await self.db.run(
+      DBRequest(op="db:public:links:get_home_links:1", payload={}),
+    )
     return res.rows
 
   async def get_navbar_routes(self, role_mask: int):
-    res = await self.db.run("db:public:links:get_navbar_routes:1", {"role_mask": role_mask})
+    res = await self.db.run(
+      DBRequest(
+        op="db:public:links:get_navbar_routes:1",
+        payload={"role_mask": role_mask},
+      ),
+    )
     return res.rows

--- a/server/modules/public_users_module.py
+++ b/server/modules/public_users_module.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
@@ -23,10 +24,17 @@ class PublicUsersModule(BaseModule):
 
   async def get_profile(self, guid: str):
     assert self.db
-    res = await self.db.run("db:public:users:get_profile:1", {"guid": guid})
+    res = await self.db.run(
+      DBRequest(op="db:public:users:get_profile:1", payload={"guid": guid}),
+    )
     return res.rows[0] if res.rows else None
 
   async def get_published_files(self, guid: str):
     assert self.db
-    res = await self.db.run("db:public:users:get_published_files:1", {"guid": guid})
+    res = await self.db.run(
+      DBRequest(
+        op="db:public:users:get_published_files:1",
+        payload={"guid": guid},
+      ),
+    )
     return res.rows

--- a/server/modules/public_vars_module.py
+++ b/server/modules/public_vars_module.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import asyncio, subprocess
 from fastapi import FastAPI
+from server.registry.types import DBRequest
 from . import BaseModule
 from .db_module import DbModule
 from .auth_module import AuthModule
@@ -40,15 +41,21 @@ class PublicVarsModule(BaseModule):
       return result.stdout, result.stderr
 
   async def get_version(self) -> str:
-    res = await self.db.run("db:public:vars:get_version:1", {})
+    res = await self.db.run(
+      DBRequest(op="db:public:vars:get_version:1", payload={}),
+    )
     return res.rows[0].get("version") if res.rows else ""
 
   async def get_hostname(self) -> str:
-    res = await self.db.run("db:public:vars:get_hostname:1", {})
+    res = await self.db.run(
+      DBRequest(op="db:public:vars:get_hostname:1", payload={}),
+    )
     return res.rows[0].get("hostname") if res.rows else ""
 
   async def get_repo(self) -> str:
-    res = await self.db.run("db:public:vars:get_repo:1", {})
+    res = await self.db.run(
+      DBRequest(op="db:public:vars:get_repo:1", payload={}),
+    )
     return res.rows[0].get("repo") if res.rows else ""
 
   async def get_ffmpeg_version(self) -> str:

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -3,6 +3,8 @@ from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.auth_module import AuthModule
 from server.modules.discord_bot_module import DiscordBotModule
+from server.registry.system.roles import list_roles_request
+from server.registry.types import DBRequest
 
 
 class RoleAdminModule(BaseModule):
@@ -34,7 +36,7 @@ class RoleAdminModule(BaseModule):
       raise HTTPException(status_code=403, detail="Forbidden")
 
   async def list_roles(self, actor_mask: int | None = None) -> list[dict]:
-    res = await self.db.run("db:system:roles:list:1", {})
+    res = await self.db.run(list_roles_request())
     roles = [
       {
         "name": r.get("name", ""),
@@ -51,8 +53,18 @@ class RoleAdminModule(BaseModule):
     return roles
 
   async def get_role_members(self, role: str) -> tuple[list[dict], list[dict]]:
-    mem_res = await self.db.run("db:security:roles:get_role_members:1", {"role": role})
-    non_res = await self.db.run("db:security:roles:get_role_non_members:1", {"role": role})
+    mem_res = await self.db.run(
+      DBRequest(
+        op="db:security:roles:get_role_members:1",
+        payload={"role": role},
+      ),
+    )
+    non_res = await self.db.run(
+      DBRequest(
+        op="db:security:roles:get_role_non_members:1",
+        payload={"role": role},
+      ),
+    )
     members = [
       {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
       for r in mem_res.rows
@@ -68,8 +80,10 @@ class RoleAdminModule(BaseModule):
       role_mask = self.auth.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
     await self.db.run(
-      "db:security:roles:add_role_member:1",
-      {"role": role, "user_guid": user_guid},
+      DBRequest(
+        op="db:security:roles:add_role_member:1",
+        payload={"role": role, "user_guid": user_guid},
+      ),
     )
     await self.auth.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
@@ -79,8 +93,10 @@ class RoleAdminModule(BaseModule):
       role_mask = self.auth.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
     await self.db.run(
-      "db:security:roles:remove_role_member:1",
-      {"role": role, "user_guid": user_guid},
+      DBRequest(
+        op="db:security:roles:remove_role_member:1",
+        payload={"role": role, "user_guid": user_guid},
+      ),
     )
     await self.auth.refresh_user_roles(user_guid)
     return await self.get_role_members(role)

--- a/server/modules/session_module.py
+++ b/server/modules/session_module.py
@@ -8,6 +8,13 @@ from server.modules.auth_module import AuthModule, DEFAULT_SESSION_TOKEN_EXPIRY
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
 from server.modules.discord_bot_module import DiscordBotModule
+from server.registry.auth.session import (
+  create_session_request,
+  revoke_device_token_request,
+  update_device_token_request,
+  update_session_request,
+)
+from server.registry.types import DBRequest
 
 
 class SessionModule(BaseModule):
@@ -65,8 +72,14 @@ class SessionModule(BaseModule):
     new_img = provider_profile.get("profilePicture")
     if new_img and new_img != user.get("profile_image"):
       await self.db.run(
-        "urn:users:profile:set_profile_image:1",
-        {"guid": user["guid"], "image_b64": new_img, "provider": provider},
+        DBRequest(
+          op="urn:users:profile:set_profile_image:1",
+          payload={
+            "guid": user["guid"],
+            "image_b64": new_img,
+            "provider": provider,
+          },
+        ),
       )
       user["profile_image"] = new_img
 
@@ -92,7 +105,9 @@ class SessionModule(BaseModule):
   ) -> str:
     data = self.auth.decode_rotation_token(rotation_token)
     user_guid = data["guid"]
-    stored = await self.db.run("db:users:session:get_rotkey:1", {"guid": user_guid})
+    stored = await self.db.run(
+      DBRequest(op="db:users:session:get_rotkey:1", payload={"guid": user_guid}),
+    )
     row = stored.rows[0] if stored.rows else None
     if not row or row.get("rotkey") != rotation_token:
       raise HTTPException(status_code=401, detail="Invalid rotation token")
@@ -103,16 +118,15 @@ class SessionModule(BaseModule):
     )
     placeholder = uuid.uuid4().hex
     res = await self.db.run(
-      "db:auth:session:create_session:1",
-      {
-        "access_token": placeholder,
-        "expires": session_exp,
-        "fingerprint": fingerprint,
-        "user_agent": user_agent,
-        "ip_address": ip_address,
-        "user_guid": user_guid,
-        "provider": provider,
-      },
+      create_session_request(
+        access_token=placeholder,
+        expires=session_exp,
+        fingerprint=fingerprint,
+        user_guid=user_guid,
+        provider=provider,
+        user_agent=user_agent,
+        ip_address=ip_address,
+      ),
     )
     row2 = res.rows[0] if res.rows else {}
     session_guid = row2.get("session_guid")
@@ -121,23 +135,21 @@ class SessionModule(BaseModule):
       user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp
     )
     await self.db.run(
-      "db:auth:session:update_device_token:1",
-      {"device_guid": device_guid, "access_token": session_token},
+      update_device_token_request(device_guid=device_guid, access_token=session_token),
     )
     return session_token
 
   async def invalidate_token(self, user_guid: str) -> None:
     now = datetime.now(timezone.utc)
     await self.db.run(
-      "db:users:session:set_rotkey:1",
-      {"guid": user_guid, "rotkey": "", "iat": now, "exp": now},
+      DBRequest(
+        op="db:users:session:set_rotkey:1",
+        payload={"guid": user_guid, "rotkey": "", "iat": now, "exp": now},
+      ),
     )
 
   async def logout_device(self, token: str) -> None:
-    await self.db.run(
-      "db:auth:session:revoke_device_token:1",
-      {"access_token": token},
-    )
+    await self.db.run(revoke_device_token_request(access_token=token))
 
   async def get_session(
     self,
@@ -146,7 +158,7 @@ class SessionModule(BaseModule):
     user_agent: str | None,
   ) -> dict:
     res = await self.db.run(
-      "db:auth:session:get_by_access_token:1", {"access_token": token}
+      DBRequest(op="db:auth:session:get_by_access_token:1", payload={"access_token": token}),
     )
     session = res.rows[0] if res.rows else None
     if not session:
@@ -166,8 +178,11 @@ class SessionModule(BaseModule):
 
     try:
       await self.db.run(
-        "db:auth:session:update_session:1",
-        {"access_token": token, "ip_address": ip_address, "user_agent": user_agent},
+        update_session_request(
+          access_token=token,
+          ip_address=ip_address,
+          user_agent=user_agent,
+        ),
       )
     except Exception as e:
       logging.error("[SessionModule.get_session] Failed to update session metadata: %s", e)

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -7,6 +7,8 @@ from uuid import UUID
 from azure.storage.blob.aio import BlobServiceClient
 from azure.storage.blob import ContentSettings
 from fastapi import FastAPI
+from server.registry.system.config import get_config_request
+from server.registry.types import DBRequest
 from . import BaseModule
 from .env_module import EnvModule
 from .db_module import DbModule
@@ -55,7 +57,7 @@ class StorageModule(BaseModule):
       logging.error("[StorageModule] Failed to load AZURE_BLOB_CONNECTION_STRING: %s", e)
 
     try:
-      res = await self.db.run("db:system:config:get_config:1", {"key": "StorageCacheTime"})
+      res = await self.db.run(get_config_request(key="StorageCacheTime"))
       value = res.rows[0]["value"] if res.rows else "15m"
       try:
         self.reindex_interval = self._parse_duration(value)
@@ -93,7 +95,7 @@ class StorageModule(BaseModule):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run("db:system:config:get_config:1", {"key": "AzureBlobContainerName"})
+    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -356,20 +358,24 @@ class StorageModule(BaseModule):
   async def list_public_files(self):
     """Return files marked as publicly accessible."""
     assert self.db
-    res = await self.db.run("db:storage:cache:list_public:1", {})
+    res = await self.db.run(
+      DBRequest(op="db:storage:cache:list_public:1", payload={}),
+    )
     return res.rows
 
   async def list_flagged_for_moderation(self):
     """Return files that have been reported for moderation review."""
     assert self.db
-    res = await self.db.run("db:storage:cache:list_reported:1", {})
+    res = await self.db.run(
+      DBRequest(op="db:storage:cache:list_reported:1", payload={}),
+    )
     return res.rows
 
   async def upload_files(self, user_guid: str, files):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run("db:system:config:get_config:1", {"key": "AzureBlobContainerName"})
+    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -430,7 +436,7 @@ class StorageModule(BaseModule):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run("db:system:config:get_config:1", {"key": "AzureBlobContainerName"})
+    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -462,23 +468,36 @@ class StorageModule(BaseModule):
   async def set_gallery(self, user_guid: str, name: str, gallery: bool):
     assert self.db
     await self.db.run(
-      "db:storage:files:set_gallery:1",
-      {"user_guid": user_guid, "name": name, "gallery": 1 if gallery else 0},
+      DBRequest(
+        op="db:storage:files:set_gallery:1",
+        payload={
+          "user_guid": user_guid,
+          "name": name,
+          "gallery": 1 if gallery else 0,
+        },
+      ),
     )
 
   async def report_file(self, user_guid: str, name: str):
     assert self.db
     path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
     await self.db.run(
-      "db:storage:cache:set_reported:1",
-      {"user_guid": user_guid, "path": path, "filename": filename, "reported": 1},
+      DBRequest(
+        op="db:storage:cache:set_reported:1",
+        payload={
+          "user_guid": user_guid,
+          "path": path,
+          "filename": filename,
+          "reported": 1,
+        },
+      ),
     )
 
   async def create_folder(self, user_guid: str, path: str):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run("db:system:config:get_config:1", {"key": "AzureBlobContainerName"})
+    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -529,7 +548,7 @@ class StorageModule(BaseModule):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run("db:system:config:get_config:1", {"key": "AzureBlobContainerName"})
+    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -569,7 +588,7 @@ class StorageModule(BaseModule):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run("db:system:config:get_config:1", {"key": "AzureBlobContainerName"})
+    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -816,7 +835,7 @@ class StorageModule(BaseModule):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run("db:system:config:get_config:1", {"key": "AzureBlobContainerName"})
+    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -882,7 +901,9 @@ class StorageModule(BaseModule):
 
   async def get_storage_stats(self):
     assert self.db
-    db_res = await self.db.run("db:storage:cache:count_rows:1", {})
+    db_res = await self.db.run(
+      DBRequest(op="db:storage:cache:count_rows:1", payload={}),
+    )
     db_rows = db_res.rows[0]["count"] if db_res.rows else 0
     if not self.connection_string:
       return {
@@ -892,7 +913,7 @@ class StorageModule(BaseModule):
         "user_folder_count": 0,
         "db_rows": db_rows,
       }
-    res = await self.db.run("db:system:config:get_config:1", {"key": "AzureBlobContainerName"})
+    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       return {

--- a/server/modules/system_config_module.py
+++ b/server/modules/system_config_module.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 import logging
 from fastapi import FastAPI
+from server.registry.system.config import (
+  delete_config_request,
+  get_configs_request,
+  upsert_config_request,
+)
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
@@ -29,7 +34,7 @@ class SystemConfigModule(BaseModule):
 
   async def get_configs(self, user_guid: str, roles: list[str]) -> SystemConfigList1:
     logging.debug("[system_config_get_configs_v1] user=%s roles=%s", user_guid, roles)
-    res = await self.db.run("db:system:config:get_configs:1", {})
+    res = await self.db.run(get_configs_request())
     items = [
       SystemConfigConfigItem1(
         key=row.get("element_key", ""),
@@ -52,8 +57,7 @@ class SystemConfigModule(BaseModule):
       value,
     )
     await self.db.run(
-      "db:system:config:upsert_config:1",
-      {"key": key, "value": value},
+      upsert_config_request(key=key, value=value),
     )
     logging.debug(
       "[system_config_upsert_config_v1] upserted config %s",
@@ -69,8 +73,7 @@ class SystemConfigModule(BaseModule):
       key,
     )
     await self.db.run(
-      "db:system:config:delete_config:1",
-      {"key": key},
+      delete_config_request(key),
     )
     logging.debug(
       "[system_config_delete_config_v1] deleted config %s",

--- a/server/modules/user_admin_module.py
+++ b/server/modules/user_admin_module.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
+from server.registry.types import DBRequest
 
 
 class UserAdminModule(BaseModule):
@@ -21,14 +22,18 @@ class UserAdminModule(BaseModule):
     pass
 
   async def get_displayname(self, guid: str) -> str:
-    res = await self.db.run("db:users:profile:get_profile:1", {"guid": guid})
+    res = await self.db.run(
+      DBRequest(op="db:users:profile:get_profile:1", payload={"guid": guid}),
+    )
     if not res.rows:
       raise HTTPException(status_code=404, detail="Profile not found")
     row = res.rows[0]
     return row.get("display_name", "")
 
   async def get_credits(self, guid: str) -> int:
-    res = await self.db.run("db:users:profile:get_profile:1", {"guid": guid})
+    res = await self.db.run(
+      DBRequest(op="db:users:profile:get_profile:1", payload={"guid": guid}),
+    )
     if not res.rows:
       raise HTTPException(status_code=404, detail="Profile not found")
     row = res.rows[0]
@@ -39,12 +44,16 @@ class UserAdminModule(BaseModule):
 
   async def set_credits(self, guid: str, credits: int) -> None:
     await self.db.run(
-      "db:support:users:set_credits:1",
-      {"guid": guid, "credits": credits},
+      DBRequest(
+        op="db:support:users:set_credits:1",
+        payload={"guid": guid, "credits": credits},
+      ),
     )
 
   async def reset_display(self, guid: str) -> None:
     await self.db.run(
-      "db:users:profile:set_display:1",
-      {"guid": guid, "display_name": "Default User"},
+      DBRequest(
+        op="db:users:profile:set_display:1",
+        payload={"guid": guid, "display_name": "Default User"},
+      ),
     )

--- a/server/routers/discord_events.py
+++ b/server/routers/discord_events.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from discord.ext import commands
+from server.registry.system.config import get_config_request
 
 if TYPE_CHECKING:  # pragma: no cover - runtime import cycle guard
   from server.modules.discord_bot_module import DiscordBotModule
@@ -24,9 +25,9 @@ def _register_on_ready_handler(bot_module: "DiscordBotModule", bot: commands.Bot
   async def on_ready():
     channel = bot.get_channel(bot_module.syschan)
     if channel:
-      res = await bot_module.db.run("db:system:config:get_config:1", {"key": "Version"})
+      res = await bot_module.db.run(get_config_request(key="Version"))
       version = res.rows[0]["value"] if res.rows else None
-      name_res = await bot_module.db.run("db:system:config:get_config:1", {"key": "BotName"})
+      name_res = await bot_module.db.run(get_config_request(key="BotName"))
       bot_name = name_res.rows[0]["value"] if name_res.rows else None
       msg = f"{(bot_name or 'TheOracleGPT-Dev')} Online. Version: {version or 'unknown'}"
       if await bot_module._try_send_channel(channel.id, msg):

--- a/tests/test_account_role_services.py
+++ b/tests/test_account_role_services.py
@@ -41,7 +41,13 @@ class DummyDb:
     self.non_members = non_members or []
     self.roles = roles or []
 
-  async def run(self, op, args):
+  async def run(self, request, payload=None):
+    if isinstance(request, str):
+      op = request
+      args = payload or {}
+    else:
+      op = request.op
+      args = request.payload
     self.calls.append((op, args))
     if op == "db:security:roles:get_role_members:1":
       return DBRes(self.members, len(self.members))

--- a/tests/test_auth_discord_link_by_email.py
+++ b/tests/test_auth_discord_link_by_email.py
@@ -34,7 +34,12 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([], 0)

--- a/tests/test_auth_google_email_exists.py
+++ b/tests/test_auth_google_email_exists.py
@@ -36,7 +36,12 @@ class DummyDb:
   def __init__(self):
     self.calls = []
     self.linked = False
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       if self.linked:

--- a/tests/test_auth_google_existing_user_lookup.py
+++ b/tests/test_auth_google_existing_user_lookup.py
@@ -38,7 +38,12 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)

--- a/tests/test_auth_google_link_by_email.py
+++ b/tests/test_auth_google_link_by_email.py
@@ -41,7 +41,12 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([], 0)

--- a/tests/test_auth_google_oauth_login_creation.py
+++ b/tests/test_auth_google_oauth_login_creation.py
@@ -38,7 +38,12 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       if len([c for c in self.calls if c[0] == op]) == 1:

--- a/tests/test_auth_google_profile_image_update.py
+++ b/tests/test_auth_google_profile_image_update.py
@@ -38,7 +38,12 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)

--- a/tests/test_auth_google_profile_refresh.py
+++ b/tests/test_auth_google_profile_refresh.py
@@ -28,10 +28,24 @@ class DummyDb:
   def __init__(self, allow_update):
     self.calls = []
     self.allow_update = allow_update
-  async def run(self, op, args):
+
+  async def run(self, request, payload=None):
+    if isinstance(request, str):
+      op = request
+      args = payload or {}
+    else:
+      op = request.op
+      args = request.payload
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
-      return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "provider_name": "google" }], 1)
+      return DBRes([
+        {
+          "guid": "user-guid",
+          "display_name": "User",
+          "credits": 0,
+          "provider_name": "google",
+        }
+      ], 1)
     if op == "db:users:profile:update_if_unedited:1":
       if self.allow_update:
         return DBRes([{ "display_name": args["display_name"], "email": args["email"] }], 1)

--- a/tests/test_auth_google_relink_unlinked.py
+++ b/tests/test_auth_google_relink_unlinked.py
@@ -35,7 +35,12 @@ class DummyDb:
   def __init__(self):
     self.calls = []
     self._get_by_count = 0
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       self._get_by_count += 1

--- a/tests/test_auth_google_soft_undelete.py
+++ b/tests/test_auth_google_soft_undelete.py
@@ -43,7 +43,12 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([

--- a/tests/test_auth_microsoft_email_exists.py
+++ b/tests/test_auth_microsoft_email_exists.py
@@ -26,7 +26,12 @@ class DummyDb:
   def __init__(self):
     self.calls = []
     self.linked = False
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       if self.linked:

--- a/tests/test_auth_microsoft_home_account_lookup.py
+++ b/tests/test_auth_microsoft_home_account_lookup.py
@@ -26,7 +26,12 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0 }], 1)

--- a/tests/test_auth_microsoft_link_by_email.py
+++ b/tests/test_auth_microsoft_link_by_email.py
@@ -31,7 +31,12 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([], 0)

--- a/tests/test_auth_microsoft_oauth_login_creation.py
+++ b/tests/test_auth_microsoft_oauth_login_creation.py
@@ -24,7 +24,12 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       if len([c for c in self.calls if c[0] == op]) == 1:

--- a/tests/test_auth_microsoft_profile_image_clear.py
+++ b/tests/test_auth_microsoft_profile_image_clear.py
@@ -24,7 +24,12 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)

--- a/tests/test_auth_microsoft_profile_image_update.py
+++ b/tests/test_auth_microsoft_profile_image_update.py
@@ -24,7 +24,12 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "profile_image": "old" }], 1)

--- a/tests/test_auth_microsoft_profile_refresh.py
+++ b/tests/test_auth_microsoft_profile_refresh.py
@@ -30,10 +30,24 @@ class DummyDb:
   def __init__(self, allow_update):
     self.calls = []
     self.allow_update = allow_update
-  async def run(self, op, args):
+
+  async def run(self, request, payload=None):
+    if isinstance(request, str):
+      op = request
+      args = payload or {}
+    else:
+      op = request.op
+      args = request.payload
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
-      return DBRes([{ "guid": "user-guid", "display_name": "User", "credits": 0, "provider_name": "microsoft" }], 1)
+      return DBRes([
+        {
+          "guid": "user-guid",
+          "display_name": "User",
+          "credits": 0,
+          "provider_name": "microsoft",
+        }
+      ], 1)
     if op == "db:users:profile:update_if_unedited:1":
       if self.allow_update:
         return DBRes([{ "display_name": args["display_name"], "email": args["email"] }], 1)

--- a/tests/test_auth_microsoft_relink_unlinked.py
+++ b/tests/test_auth_microsoft_relink_unlinked.py
@@ -25,7 +25,12 @@ class DummyDb:
   def __init__(self):
     self.calls = []
     self._get_by_count = 0
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:providers:get_by_provider_identifier:1":
       self._get_by_count += 1

--- a/tests/test_bsky_module.py
+++ b/tests/test_bsky_module.py
@@ -19,7 +19,12 @@ class DummyDb(BaseModule):
   async def shutdown(self):
     pass
 
-  async def run(self, op: str, args: dict):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     class Res:
       def __init__(self, rows):
         self.rows = rows

--- a/tests/test_discord_events_router.py
+++ b/tests/test_discord_events_router.py
@@ -35,7 +35,12 @@ class DummyDb:
     self.values = values
     self.calls: list[tuple[str, dict]] = []
 
-  async def run(self, op: str, args: dict):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     value = self.values.get(args.get("key"))
     rows = [{"value": value}] if value is not None else []

--- a/tests/test_discord_module.py
+++ b/tests/test_discord_module.py
@@ -31,7 +31,12 @@ class DummyDb(BaseModule):
   async def shutdown(self):
     pass
 
-  async def run(self, op: str, args: dict):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     class Res:
       def __init__(self, rows):
         self.rows = rows

--- a/tests/test_google_services_helpers.py
+++ b/tests/test_google_services_helpers.py
@@ -35,7 +35,12 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:auth:session:create_session:1":
       return SimpleNamespace(rows=[{"session_guid": "sess", "device_guid": "dev"}])

--- a/tests/test_microsoft_services_helpers.py
+++ b/tests/test_microsoft_services_helpers.py
@@ -22,7 +22,12 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:auth:session:create_session:1":
       return SimpleNamespace(rows=[{"session_guid": "sess", "device_guid": "dev"}])

--- a/tests/test_openai_module.py
+++ b/tests/test_openai_module.py
@@ -98,7 +98,12 @@ def test_fetch_chat_logs_conversation():
     def __init__(self):
       self.calls = []
 
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       self.calls.append((op, args))
       if op == "db:assistant:personas:get_by_name:1":
         return DBResult(
@@ -167,7 +172,12 @@ def test_log_conversation_end_warns_when_no_rows_updated(caplog):
   module = OpenaiModule(app)
 
   class DummyDB:
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       assert op == "db:assistant:conversations:update_output:1"
       assert args == {"recid": 99, "output_data": "done", "tokens": 3}
       return DBResult(rowcount=0)
@@ -201,7 +211,12 @@ def test_fetch_chat_reuses_existing_conversation():
       self.calls: list[tuple[str, dict]] = []
       self.insert_count = 0
 
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       self.calls.append((op, args))
       if op == "db:assistant:personas:get_by_name:1":
         return DBResult(
@@ -277,7 +292,12 @@ def test_persona_response_calls_openai():
     def __init__(self):
       self.calls = []
 
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       self.calls.append((op, args))
       if op == "db:assistant:personas:get_by_name:1":
         return DBResult(
@@ -345,7 +365,12 @@ def test_persona_response_missing_persona():
   module = OpenaiModule(app)
 
   class DummyDB:
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       if op == "db:assistant:personas:get_by_name:1":
         return DBResult(rows=[], rowcount=0)
       return DBResult()
@@ -362,7 +387,12 @@ def test_persona_response_stub_without_client():
   module = OpenaiModule(app)
 
   class DummyDB:
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       if op == "db:assistant:personas:get_by_name:1":
         return DBResult(
           rows=[{

--- a/tests/test_role_admin_module.py
+++ b/tests/test_role_admin_module.py
@@ -9,7 +9,12 @@ class DummyDb:
     self.roles = roles or []
   async def on_ready(self):
     pass
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     if op == "db:system:roles:list:1":
       return types.SimpleNamespace(rows=self.roles)
     return types.SimpleNamespace(rows=[])

--- a/tests/test_service_roles_services.py
+++ b/tests/test_service_roles_services.py
@@ -76,7 +76,13 @@ class DummyDb:
     self.members = members or []
     self.non_members = non_members or []
 
-  async def run(self, op, args):
+  async def run(self, request, payload=None):
+    if isinstance(request, str):
+      op = request
+      args = payload or {}
+    else:
+      op = request.op
+      args = request.payload
     self.calls.append((op, args))
     if op == "db:security:roles:get_role_members:1":
       return DBRes(self.members, len(self.members))

--- a/tests/test_service_routes_services.py
+++ b/tests/test_service_routes_services.py
@@ -111,7 +111,12 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, op: str, args: dict):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == 'db:service:routes:get_routes:1':
       rows = [{

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -32,7 +32,12 @@ class DummyDb(BaseModule):
   async def shutdown(self):
     pass
 
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     class Res:
       def __init__(self, rows):
         self.rows = rows
@@ -156,7 +161,12 @@ def test_reindex_indexes_files_and_folders(monkeypatch):
       self.existing = set()
     async def startup(self):
       self.mark_ready()
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       class Res:
         def __init__(self, rows):
           self.rows = rows
@@ -254,7 +264,12 @@ def test_reindex_skips_unknown_users(monkeypatch):
       self.checked = []
     async def startup(self):
       self.mark_ready()
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       class Res:
         def __init__(self, rows):
           self.rows = rows
@@ -337,7 +352,12 @@ def test_move_file_copies_and_updates_cache(monkeypatch):
       self.upserted = None
     async def startup(self):
       self.mark_ready()
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       class Res:
         def __init__(self, rows):
           self.rows = rows
@@ -420,7 +440,12 @@ def test_rename_file_preserves_public_flag(monkeypatch):
     async def startup(self):
       self.mark_ready()
 
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       class Res:
         def __init__(self, rows):
           self.rows = rows
@@ -549,7 +574,12 @@ def test_rename_folder_updates_nested_entries(monkeypatch):
     async def startup(self):
       self.mark_ready()
 
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       class Res:
         def __init__(self, rows):
           self.rows = rows
@@ -674,7 +704,12 @@ def test_rename_folder_updates_nested_entries(monkeypatch):
 
 def test_get_storage_stats_counts_all_folders(monkeypatch):
   class DummyDb:
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       class Res:
         def __init__(self, rows):
           self.rows = rows
@@ -744,7 +779,12 @@ def test_upload_files_sets_created_on(monkeypatch):
     def __init__(self):
       self.upserts = []
 
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       class Res:
         def __init__(self, rows):
           self.rows = rows
@@ -808,7 +848,12 @@ def test_create_folder_creates_marker_and_cache(monkeypatch):
       self.upserts = []
     async def startup(self):
       self.mark_ready()
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       class Res:
         def __init__(self, rows):
           self.rows = rows
@@ -878,7 +923,12 @@ def test_create_folder_creates_marker_and_cache(monkeypatch):
 
 def test_get_storage_stats_counts_user_folders(monkeypatch):
   class DummyDb:
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       class Res:
         def __init__(self, rows):
           self.rows = rows

--- a/tests/test_system_config_module.py
+++ b/tests/test_system_config_module.py
@@ -45,7 +45,12 @@ sys.modules['server.modules'] = modules_pkg
 
 db_module_pkg = types.ModuleType('server.modules.db_module')
 class DbModule:
-  async def run(self, op: str, args: dict):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     raise NotImplementedError
 
 db_module_pkg.DbModule = DbModule
@@ -65,7 +70,12 @@ class DummyDb(DbModule):
     self.calls = []
   async def on_ready(self):
     pass
-  async def run(self, op: str, args: dict):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == 'db:system:config:get_configs:1':
       rows = [{'element_key': 'LoggingLevel', 'element_value': '4'}]

--- a/tests/test_system_roles_services.py
+++ b/tests/test_system_roles_services.py
@@ -111,7 +111,14 @@ svc.unbox_request = fake_unbox
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op: str, args: dict):
+
+  async def run(self, request, payload=None):
+    if isinstance(request, str):
+      op = request
+      args = payload or {}
+    else:
+      op = request.op
+      args = request.payload
     self.calls.append((op, args))
     if op == 'db:system:roles:list:1':
       rows = [{'name': 'ROLE_FOO', 'mask': 1, 'display': 'Foo'}]

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -72,7 +72,12 @@ class DummyDb:
   def __init__(self, roles=0):
     self.calls = []
     self.roles = roles
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     if op == "db:users:profile:get_roles:1":
       return DBRes([{"element_roles": self.roles}], 1)

--- a/tests/test_users_providers_services.py
+++ b/tests/test_users_providers_services.py
@@ -79,7 +79,12 @@ class DBRes:
 class DummyDb:
   def __init__(self):
     self.calls = []
-  async def run(self, op, args):
+  async def run(self, op, args=None):
+    if not isinstance(op, str):
+      args = op.payload
+      op = op.op
+    elif args is None:
+      args = {}
     self.calls.append((op, args))
     return DBRes()
 
@@ -198,7 +203,12 @@ def test_link_provider_google_normalizes_identifier():
   class DummyDb:
     def __init__(self):
       self.calls = []
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       self.calls.append((op, args))
       if op == "db:system:config:get_config:1":
         key = args["key"]
@@ -254,7 +264,12 @@ def test_link_provider_discord_normalizes_identifier():
   class DummyDb:
     def __init__(self):
       self.calls = []
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       self.calls.append((op, args))
       if op == "db:system:config:get_config:1":
         key = args["key"]
@@ -310,7 +325,12 @@ def test_link_provider_microsoft_normalizes_identifier():
   class DummyDb:
     def __init__(self):
       self.calls = []
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       self.calls.append((op, args))
       return DBRes()
 
@@ -330,7 +350,12 @@ def test_unlink_non_default_provider_retains_tokens():
   svc_mod.unbox_request = fake_get
 
   class LocalDb(DummyDb):
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       self.calls.append((op, args))
       if op == "db:users:profile:get_profile:1":
         return DBRes(rows=[{"default_provider": "microsoft"}])
@@ -354,7 +379,12 @@ def test_unlink_default_provider_without_new_default_raises():
   svc_mod.unbox_request = fake_get
 
   class LocalDb(DummyDb):
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       self.calls.append((op, args))
       if op == "db:users:profile:get_profile:1":
         return DBRes(rows=[{"default_provider": "google"}])
@@ -377,7 +407,12 @@ def test_unlink_default_provider_sets_new_default_and_revokes_tokens():
   svc_mod.unbox_request = fake_get
 
   class LocalDb(DummyDb):
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       self.calls.append((op, args))
       if op == "db:users:profile:get_profile:1":
         return DBRes(rows=[{"default_provider": "google"}])
@@ -401,7 +436,12 @@ def test_unlink_last_provider_soft_deletes_and_revokes():
   svc_mod.unbox_request = fake_get
 
   class LocalDb(DummyDb):
-    async def run(self, op, args):
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
       self.calls.append((op, args))
       if op == "db:users:profile:get_profile:1":
         return DBRes(rows=[{"default_provider": "google"}])


### PR DESCRIPTION
## Summary
- replace string-based `db.run` calls in RPC services and server modules with `DBRequest` instances or registry helpers
- adjust module imports to rely on `server.registry` request builders and normalize response handling
- update tests and fakes to accept `DBRequest` objects when stubbing the database layer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f35dd7d86c8325ac71ebafe3af76a3