### PR TITLE
Update DB module calls and tests to use DBRequest objects

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -46,9 +46,17 @@ class DbModule(BaseModule):
 
     self._provider = provider_cls(**cfg)
 
-  async def run(self, op: str, args: Dict[str, Any]) -> DBResponse:
+  async def run(
+    self,
+    request: DBRequest | str,
+    args: Dict[str, Any] | None = None,
+  ) -> DBResponse:
     assert self._provider, "db_module not initialized"
-    request = DBRequest(op=op, payload=args)
+    if isinstance(request, str):
+      request = DBRequest(op=request, payload=args or {})
+    elif args is not None:
+      raise TypeError("args cannot be provided when passing a DBRequest instance")
+    op = request.op
     out = await self._provider.run(request)
     if isinstance(out, DBResponse):
       if not out.op:
@@ -71,7 +79,9 @@ class DbModule(BaseModule):
     await self.init(provider=self.provider, **cfg)
     assert self._provider
     await self._provider.startup()
-    res = await self.run("db:system:config:get_config:1", {"key": "LoggingLevel"})
+    res = await self.run(
+      DBRequest(op="db:system:config:get_config:1", payload={"key": "LoggingLevel"})
+    )
     val = res.rows[0]["value"] if res.rows else "0"
     try:
       self.logging_level = int(val)
@@ -86,13 +96,17 @@ class DbModule(BaseModule):
       self._provider = None
 
   async def get_ms_api_id(self) -> str:
-    res = await self.run("db:system:config:get_config:1", {"key": "MsApiId"})
+    res = await self.run(
+      DBRequest(op="db:system:config:get_config:1", payload={"key": "MsApiId"})
+    )
     if not res.rows:
       raise ValueError("Missing config value for key: MsApiId")
     return res.rows[0]["value"]
 
   async def get_google_client_id(self) -> str:
-    res = await self.run("db:system:config:get_config:1", {"key": "GoogleClientId"})
+    res = await self.run(
+      DBRequest(op="db:system:config:get_config:1", payload={"key": "GoogleClientId"})
+    )
     value = res.rows[0]["value"] if res.rows else None
     logging.debug("[DbModule] GoogleClientId=%s", value)
     if not value:
@@ -109,7 +123,9 @@ class DbModule(BaseModule):
     return value
 
   async def get_discord_client_id(self) -> str:
-    res = await self.run("db:system:config:get_config:1", {"key": "DiscordClientId"})
+    res = await self.run(
+      DBRequest(op="db:system:config:get_config:1", payload={"key": "DiscordClientId"})
+    )
     value = res.rows[0]["value"] if res.rows else None
     logging.debug("[DbModule] DiscordClientId=%s", value)
     if not value:
@@ -117,45 +133,59 @@ class DbModule(BaseModule):
     return value
 
   async def get_auth_providers(self) -> list[str]:
-    res = await self.run("db:system:config:get_config:1", {"key": "AuthProviders"})
+    res = await self.run(
+      DBRequest(op="db:system:config:get_config:1", payload={"key": "AuthProviders"})
+    )
     value = res.rows[0]["value"] if res.rows else None
     if value is None:
       raise ValueError("Missing config value for key: AuthProviders")
     return [p.strip() for p in value.split(',') if p.strip()]
 
   async def get_jwks_cache_time(self) -> int:
-    res = await self.run("db:system:config:get_config:1", {"key": "JwksCacheTime"})
+    res = await self.run(
+      DBRequest(op="db:system:config:get_config:1", payload={"key": "JwksCacheTime"})
+    )
     value = res.rows[0]["value"] if res.rows else None
     if value is None:
       raise ValueError("Missing config value for key: JwksCacheTime")
     return int(value)
 
   async def list_storage_cache(self, user_guid: str) -> list[Dict[str, Any]]:
-    res = await self.run("db:storage:cache:list:1", {"user_guid": user_guid})
+    res = await self.run(
+      DBRequest(op="db:storage:cache:list:1", payload={"user_guid": user_guid})
+    )
     return res.rows
 
   async def replace_storage_cache(self, user_guid: str, items: list[Dict[str, Any]]):
     await self.run(
-      "db:storage:cache:replace_user:1",
-      {"user_guid": user_guid, "items": items},
+      DBRequest(
+        op="db:storage:cache:replace_user:1",
+        payload={"user_guid": user_guid, "items": items},
+      )
     )
 
   async def user_exists(self, user_guid: str) -> bool:
-    res = await self.run("db:users:account:exists:1", {"user_guid": user_guid})
+    res = await self.run(
+      DBRequest(op="db:users:account:exists:1", payload={"user_guid": user_guid})
+    )
     return bool(res.rows)
 
   async def upsert_storage_cache(self, item: Dict[str, Any]) -> DBResponse:
-    return await self.run("db:storage:cache:upsert:1", item)
+    return await self.run(DBRequest(op="db:storage:cache:upsert:1", payload=item))
 
   async def delete_storage_cache(self, user_guid: str, path: str, filename: str):
     await self.run(
-      "db:storage:cache:delete:1",
-      {"user_guid": user_guid, "path": path, "filename": filename},
+      DBRequest(
+        op="db:storage:cache:delete:1",
+        payload={"user_guid": user_guid, "path": path, "filename": filename},
+      )
     )
 
   async def delete_storage_cache_folder(self, user_guid: str, path: str):
     await self.run(
-      "db:storage:cache:delete_folder:1",
-      {"user_guid": user_guid, "path": path},
+      DBRequest(
+        op="db:storage:cache:delete_folder:1",
+        payload={"user_guid": user_guid, "path": path},
+      )
     )
 

--- a/tests/test_account_role_services.py
+++ b/tests/test_account_role_services.py
@@ -1,5 +1,6 @@
 import types, sys, pathlib, asyncio, importlib
 from fastapi import HTTPException
+from server.registry.models import DBRequest
 
 # stub rpc package and load required modules
 root_path = pathlib.Path(__file__).resolve().parent.parent
@@ -41,14 +42,10 @@ class DummyDb:
     self.non_members = non_members or []
     self.roles = roles or []
 
-  async def run(self, request, payload=None):
-    if isinstance(request, str):
-      op = request
-      args = payload or {}
-    else:
-      op = request.op
-      args = request.payload
-    self.calls.append((op, args))
+  async def run(self, request):
+    assert isinstance(request, DBRequest)
+    op = request.op
+    self.calls.append(request)
     if op == "db:security:roles:get_role_members:1":
       return DBRes(self.members, len(self.members))
     if op == "db:security:roles:get_role_non_members:1":
@@ -72,15 +69,19 @@ class RoleCache:
     self.upsert_args = (name, mask, display)
     if self.db:
       await self.db.run(
-        "db:security:roles:upsert_role:1",
-        {"name": name, "mask": mask, "display": display},
+        DBRequest(
+          op="db:security:roles:upsert_role:1",
+          payload={"name": name, "mask": mask, "display": display},
+        )
       )
     await self.refresh_role_cache()
 
   async def delete_role(self, name):
     self.delete_args = name
     if self.db:
-      await self.db.run("db:security:roles:delete_role:1", {"name": name})
+      await self.db.run(
+        DBRequest(op="db:security:roles:delete_role:1", payload={"name": name})
+      )
     await self.refresh_role_cache()
 
   async def refresh_user_roles(self, guid):
@@ -107,7 +108,7 @@ class DummyRoleAdmin:
       raise HTTPException(status_code=403, detail="Forbidden")
 
   async def list_roles(self, actor_mask: int | None = None):
-    res = await self.db.run("db:system:roles:list:1", {})
+    res = await self.db.run(DBRequest(op="db:system:roles:list:1", payload={}))
     roles = [
       {
         "name": r.get("name", ""),
@@ -124,8 +125,12 @@ class DummyRoleAdmin:
     return roles
 
   async def get_role_members(self, role):
-    mem_res = await self.db.run("db:security:roles:get_role_members:1", {"role": role})
-    non_res = await self.db.run("db:security:roles:get_role_non_members:1", {"role": role})
+    mem_res = await self.db.run(
+      DBRequest(op="db:security:roles:get_role_members:1", payload={"role": role})
+    )
+    non_res = await self.db.run(
+      DBRequest(op="db:security:roles:get_role_non_members:1", payload={"role": role})
+    )
     members = [
       {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
       for r in mem_res.rows
@@ -141,8 +146,10 @@ class DummyRoleAdmin:
       role_mask = self.auth.role_cache.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
     await self.db.run(
-      "db:security:roles:add_role_member:1",
-      {"role": role, "user_guid": user_guid},
+      DBRequest(
+        op="db:security:roles:add_role_member:1",
+        payload={"role": role, "user_guid": user_guid},
+      )
     )
     await self.auth.role_cache.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
@@ -152,8 +159,10 @@ class DummyRoleAdmin:
       role_mask = self.auth.role_cache.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
     await self.db.run(
-      "db:security:roles:remove_role_member:1",
-      {"role": role, "user_guid": user_guid},
+      DBRequest(
+        op="db:security:roles:remove_role_member:1",
+        payload={"role": role, "user_guid": user_guid},
+      )
     )
     await self.auth.role_cache.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
@@ -213,7 +222,10 @@ def test_add_and_remove_member():
   helpers.unbox_request = fake_get_add
   svc_mod.unbox_request = fake_get_add
   resp = asyncio.run(account_role_add_role_member_v1(req))
-  assert any(op == "db:security:roles:add_role_member:1" for op, _ in db.calls)
+  assert any(
+    call.op == "db:security:roles:add_role_member:1"
+    for call in db.calls
+  )
   assert resp.payload["members"] == [{"guid": "u1", "displayName": "User 1"}]
   assert resp.payload["nonMembers"] == [{"guid": "u2", "displayName": "User 2"}]
 
@@ -236,7 +248,10 @@ def test_add_and_remove_member():
   helpers.unbox_request = fake_get_remove
   svc_mod.unbox_request = fake_get_remove
   resp2 = asyncio.run(account_role_remove_role_member_v1(req))
-  assert any(op == "db:security:roles:remove_role_member:1" for op, _ in db.calls)
+  assert any(
+    call.op == "db:security:roles:remove_role_member:1"
+    for call in db.calls
+  )
   assert resp2.payload["members"] == []
   assert resp2.payload["nonMembers"] == [
     {"guid": "u1", "displayName": "User 1"},
@@ -263,11 +278,12 @@ def test_upsert_and_delete_role():
   svc_mod.unbox_request = fake_upsert
   resp = asyncio.run(account_role_upsert_role_v1(req))
   assert auth.role_cache.upsert_args == ("ROLE_NEW", 8, "New")
-  assert (
-    "db:security:roles:upsert_role:1",
-    {"name": "ROLE_NEW", "mask": 8, "display": "New"},
-  ) in db.calls
-  assert isinstance(resp, models_mod.RPCResponse)
+  assert any(
+    call.op == "db:security:roles:upsert_role:1"
+    and call.payload == {"name": "ROLE_NEW", "mask": 8, "display": "New"}
+    for call in db.calls
+  )
+  assert isinstance(resp, svc_mod.RPCResponse)
 
   db.calls.clear()
 
@@ -284,8 +300,12 @@ def test_upsert_and_delete_role():
   svc_mod.unbox_request = fake_delete
   resp2 = asyncio.run(account_role_delete_role_v1(req))
   assert auth.role_cache.delete_args == "ROLE_NEW"
-  assert ("db:security:roles:delete_role:1", {"name": "ROLE_NEW"}) in db.calls
-  assert isinstance(resp2, models_mod.RPCResponse)
+  assert any(
+    call.op == "db:security:roles:delete_role:1"
+    and call.payload == {"name": "ROLE_NEW"}
+    for call in db.calls
+  )
+  assert isinstance(resp2, svc_mod.RPCResponse)
 
 
 def test_get_roles_filters_by_mask():

--- a/tests/test_db_module_api_ids.py
+++ b/tests/test_db_module_api_ids.py
@@ -3,15 +3,17 @@ from fastapi import FastAPI
 
 from server.modules.db_module import DbModule
 from server.modules.providers import DBResult
+from server.registry.models import DBRequest
 
 
 def test_get_google_client_id():
   app = FastAPI()
   db = DbModule(app)
 
-  async def fake_run(op, args):
-    assert op == "db:system:config:get_config:1"
-    assert args == {"key": "GoogleClientId"}
+  async def fake_run(request):
+    assert isinstance(request, DBRequest)
+    assert request.op == "db:system:config:get_config:1"
+    assert request.payload == {"key": "GoogleClientId"}
     return DBResult(rows=[{"value": "gid"}], rowcount=1)
 
   db.run = fake_run
@@ -35,9 +37,10 @@ def test_get_discord_client_id():
   app = FastAPI()
   db = DbModule(app)
 
-  async def fake_run(op, args):
-    assert op == "db:system:config:get_config:1"
-    assert args == {"key": "DiscordClientId"}
+  async def fake_run(request):
+    assert isinstance(request, DBRequest)
+    assert request.op == "db:system:config:get_config:1"
+    assert request.payload == {"key": "DiscordClientId"}
     return DBResult(rows=[{"value": "dcid"}], rowcount=1)
 
   db.run = fake_run
@@ -48,9 +51,10 @@ def test_get_ms_api_id():
   app = FastAPI()
   db = DbModule(app)
 
-  async def fake_run(op, args):
-    assert op == "db:system:config:get_config:1"
-    assert args == {"key": "MsApiId"}
+  async def fake_run(request):
+    assert isinstance(request, DBRequest)
+    assert request.op == "db:system:config:get_config:1"
+    assert request.payload == {"key": "MsApiId"}
     return DBResult(rows=[{"value": "mid"}], rowcount=1)
 
   db.run = fake_run
@@ -61,9 +65,10 @@ def test_get_auth_providers():
   app = FastAPI()
   db = DbModule(app)
 
-  async def fake_run(op, args):
-    assert op == "db:system:config:get_config:1"
-    assert args == {"key": "AuthProviders"}
+  async def fake_run(request):
+    assert isinstance(request, DBRequest)
+    assert request.op == "db:system:config:get_config:1"
+    assert request.payload == {"key": "AuthProviders"}
     return DBResult(rows=[{"value": "microsoft,google,discord"}], rowcount=1)
 
   db.run = fake_run
@@ -74,9 +79,10 @@ def test_get_jwks_cache_time():
   app = FastAPI()
   db = DbModule(app)
 
-  async def fake_run(op, args):
-    assert op == "db:system:config:get_config:1"
-    assert args == {"key": "JwksCacheTime"}
+  async def fake_run(request):
+    assert isinstance(request, DBRequest)
+    assert request.op == "db:system:config:get_config:1"
+    assert request.payload == {"key": "JwksCacheTime"}
     return DBResult(rows=[{"value": "45"}], rowcount=1)
 
   db.run = fake_run

--- a/tests/test_service_roles_services.py
+++ b/tests/test_service_roles_services.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import sys
 
 import pytest
+from server.registry.models import DBRequest
 
 # stub rpc package and load required modules
 root_path = pathlib.Path(__file__).resolve().parent.parent
@@ -76,14 +77,10 @@ class DummyDb:
     self.members = members or []
     self.non_members = non_members or []
 
-  async def run(self, request, payload=None):
-    if isinstance(request, str):
-      op = request
-      args = payload or {}
-    else:
-      op = request.op
-      args = request.payload
-    self.calls.append((op, args))
+  async def run(self, request):
+    assert isinstance(request, DBRequest)
+    op = request.op
+    self.calls.append(request)
     if op == "db:security:roles:get_role_members:1":
       return DBRes(self.members, len(self.members))
     if op == "db:security:roles:get_role_non_members:1":
@@ -111,15 +108,19 @@ class RoleCache:
     self.upsert_args = (name, mask, display)
     if self.db:
       await self.db.run(
-        "db:security:roles:upsert_role:1",
-        {"name": name, "mask": mask, "display": display},
+        DBRequest(
+          op="db:security:roles:upsert_role:1",
+          payload={"name": name, "mask": mask, "display": display},
+        )
       )
     await self.refresh_role_cache()
 
   async def delete_role(self, name):
     self.delete_args = name
     if self.db:
-      await self.db.run("db:security:roles:delete_role:1", {"name": name})
+      await self.db.run(
+        DBRequest(op="db:security:roles:delete_role:1", payload={"name": name})
+      )
     await self.refresh_role_cache()
 
   def get_role_names(self, exclude_registered=False):
@@ -168,7 +169,7 @@ class DummyRoleAdmin:
     self.auth = auth
 
   async def list_roles(self):
-    res = await self.db.run("db:system:roles:list:1", {})
+    res = await self.db.run(DBRequest(op="db:system:roles:list:1", payload={}))
     return [
       {
         "name": r.get("name", ""),
@@ -271,10 +272,11 @@ def test_upsert_role_calls_db_and_loads_roles():
   resp = asyncio.run(service_roles_upsert_role_v1(req))
   assert isinstance(resp, RPCResponse)
   assert auth.role_cache.upsert_args == ("ROLE_NEW", 4, "New")
-  assert (
-    "db:security:roles:upsert_role:1",
-    {"name": "ROLE_NEW", "mask": 4, "display": "New"},
-  ) in db.calls
+  assert any(
+    call.op == "db:security:roles:upsert_role:1"
+    and call.payload == {"name": "ROLE_NEW", "mask": 4, "display": "New"}
+    for call in db.calls
+  )
   assert auth.role_cache.loaded
 
 
@@ -295,10 +297,11 @@ def test_delete_role_calls_db_and_loads_roles():
   resp = asyncio.run(svc_mod.service_roles_delete_role_v1(req))
   assert isinstance(resp, RPCResponse)
   assert auth.role_cache.delete_args == "ROLE_OLD"
-  assert (
-    "db:security:roles:delete_role:1",
-    {"name": "ROLE_OLD"},
-  ) in db.calls
+  assert any(
+    call.op == "db:security:roles:delete_role:1"
+    and call.payload == {"name": "ROLE_OLD"}
+    for call in db.calls
+  )
   assert auth.role_cache.loaded
 
 

--- a/tests/test_system_roles_services.py
+++ b/tests/test_system_roles_services.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.requests import Request
+from server.registry.models import DBRequest
 
 # Stub rpc package
 pkg = types.ModuleType('rpc')
@@ -43,13 +44,20 @@ class RoleCache:
   async def upsert_role(self, name, mask, display):
     self.upsert_args = (name, mask, display)
     if self.db:
-      await self.db.run('db:security:roles:upsert_role:1', {'name': name, 'mask': mask, 'display': display})
+      await self.db.run(
+        DBRequest(
+          op='db:security:roles:upsert_role:1',
+          payload={'name': name, 'mask': mask, 'display': display},
+        )
+      )
     await self.refresh_role_cache()
 
   async def delete_role(self, name):
     self.delete_args = name
     if self.db:
-      await self.db.run('db:security:roles:delete_role:1', {'name': name})
+      await self.db.run(
+        DBRequest(op='db:security:roles:delete_role:1', payload={'name': name})
+      )
     await self.refresh_role_cache()
 
 class AuthModule:
@@ -112,14 +120,10 @@ class DummyDb:
   def __init__(self):
     self.calls = []
 
-  async def run(self, request, payload=None):
-    if isinstance(request, str):
-      op = request
-      args = payload or {}
-    else:
-      op = request.op
-      args = request.payload
-    self.calls.append((op, args))
+  async def run(self, request):
+    assert isinstance(request, DBRequest)
+    op = request.op
+    self.calls.append(request)
     if op == 'db:system:roles:list:1':
       rows = [{'name': 'ROLE_FOO', 'mask': 1, 'display': 'Foo'}]
       return SimpleNamespace(rows=rows, rowcount=1)
@@ -137,7 +141,7 @@ class DummyRoleAdmin:
     self.auth = auth
 
   async def list_roles(self):
-    res = await self.db.run('db:system:roles:list:1', {})
+    res = await self.db.run(DBRequest(op='db:system:roles:list:1', payload={}))
     return [
       {
         'name': r.get('name', ''),
@@ -179,13 +183,24 @@ def test_get_roles_service():
   assert data['payload'] == {
     'roles': [{'name': 'ROLE_FOO', 'mask': '1', 'display': 'Foo'}]
   }
-  assert ('db:system:roles:list:1', {}) in db.calls
+  assert any(
+    call.op == 'db:system:roles:list:1' and call.payload == {}
+    for call in db.calls
+  )
 
 def test_upsert_and_delete_role_service():
   resp = client.post('/rpc', json={'op': 'urn:system:roles:upsert_role:1', 'payload': {'name': 'ROLE_FOO', 'mask': '1', 'display': 'Foo'}})
   assert resp.status_code == 200
   resp = client.post('/rpc', json={'op': 'urn:system:roles:delete_role:1', 'payload': {'name': 'ROLE_FOO'}})
   assert resp.status_code == 200
-  assert ('db:security:roles:upsert_role:1', {'name': 'ROLE_FOO', 'mask': 1, 'display': 'Foo'}) in db.calls
-  assert ('db:security:roles:delete_role:1', {'name': 'ROLE_FOO'}) in db.calls
+  assert any(
+    call.op == 'db:security:roles:upsert_role:1'
+    and call.payload == {'name': 'ROLE_FOO', 'mask': 1, 'display': 'Foo'}
+    for call in db.calls
+  )
+  assert any(
+    call.op == 'db:security:roles:delete_role:1'
+    and call.payload == {'name': 'ROLE_FOO'}
+    for call in db.calls
+  )
   assert auth.role_cache.refreshed


### PR DESCRIPTION
## Summary
- update `DbModule.run` and call sites to accept `DBRequest` instances
- adjust database-related tests to build `DBRequest` objects and assert against their payloads

## Testing
- pytest tests/test_db_module_api_ids.py tests/test_system_roles_services.py tests/test_service_roles_services.py tests/test_account_role_services.py


------
https://chatgpt.com/codex/tasks/task_e_68f3d3e7eb548325a600e77cf611cce1