### PR TITLE
Ensure user profile auth providers are returned as JSON arrays

### DIFF
--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -39,9 +39,8 @@ async def users_profile_get_profile_v1(request: Request):
   row = res.rows[0]
   row["guid"] = str(row.get("guid", ""))
   auth_providers = row.get("auth_providers")
-  if isinstance(auth_providers, str):
-    import json
-    row["auth_providers"] = json.loads(auth_providers) if auth_providers else []
+  if not auth_providers:
+    row["auth_providers"] = []
   profile = UsersProfileProfile1(**row)
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -283,14 +283,16 @@ def _users_profile(args: Dict[str, Any]):
         v.credits,
         v.profile_image_base64 AS profile_image,
         v.provider_name AS default_provider,
-        (
-          SELECT
-            ap.element_name AS name,
-            ap.element_display AS display
-          FROM users_auth ua
-          JOIN auth_providers ap ON ap.recid = ua.providers_recid
-          WHERE ua.users_guid = v.user_guid AND ua.element_linked = 1
-          FOR JSON PATH
+        JSON_QUERY(
+          (
+            SELECT
+              ap.element_name AS name,
+              ap.element_display AS display
+            FROM users_auth ua
+            JOIN auth_providers ap ON ap.recid = ua.providers_recid
+            WHERE ua.users_guid = v.user_guid AND ua.element_linked = 1
+            FOR JSON PATH
+          )
         ) AS auth_providers
       FROM vw_account_user_profile v
       WHERE v.user_guid = ?;

--- a/server/registry/users/content/profile/mssql.py
+++ b/server/registry/users/content/profile/mssql.py
@@ -30,14 +30,16 @@ async def get_profile_v1(args: dict[str, Any]) -> DBResponse:
       v.credits,
       v.profile_image_base64 AS profile_image,
       v.provider_name AS default_provider,
-      (
-        SELECT
-          ap.element_name AS name,
-          ap.element_display AS display
-        FROM users_auth ua
-        JOIN auth_providers ap ON ap.recid = ua.providers_recid
-        WHERE ua.users_guid = v.user_guid AND ua.element_linked = 1
-        FOR JSON PATH
+      JSON_QUERY(
+        (
+          SELECT
+            ap.element_name AS name,
+            ap.element_display AS display
+          FROM users_auth ua
+          JOIN auth_providers ap ON ap.recid = ua.providers_recid
+          WHERE ua.users_guid = v.user_guid AND ua.element_linked = 1
+          FOR JSON PATH
+        )
       ) AS auth_providers
     FROM vw_account_user_profile v
     WHERE v.user_guid = ?

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -65,6 +65,7 @@ def test_mssql_get_profile_uses_profile_view():
   assert "vw_account_user_profile" in sql
   assert "v.credits" in sql
   assert "users_credits" not in sql
+  assert "json_query" in sql
 
 def test_mssql_get_rotkey_queries_users_and_providers():
   handler = get_mssql_handler("db:users:session:get_rotkey:1")

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -60,6 +60,7 @@ svc_spec.loader.exec_module(svc_mod)
 # restore real helpers for other tests
 sys.modules["rpc.helpers"] = real_helpers
 
+users_profile_get_profile_v1 = svc_mod.users_profile_get_profile_v1
 users_profile_get_roles_v1 = svc_mod.users_profile_get_roles_v1
 users_profile_set_profile_image_v1 = svc_mod.users_profile_set_profile_image_v1
 
@@ -79,6 +80,22 @@ class DummyDb:
     elif args is None:
       args = {}
     self.calls.append((op, args))
+    if op == "db:users:profile:get_profile:1":
+      return DBRes([
+        {
+          "guid": args.get("guid"),
+          "display_name": "Test User",
+          "email": "user@example.com",
+          "display_email": True,
+          "credits": 10,
+          "profile_image": None,
+          "default_provider": "microsoft",
+          "auth_providers": [
+            {"name": "microsoft", "display": "Microsoft"},
+            {"name": "google", "display": "Google"},
+          ],
+        }
+      ], 1)
     if op == "db:users:profile:get_roles:1":
       return DBRes([{"element_roles": self.roles}], 1)
     if op == "db:users:profile:set_profile_image:1":
@@ -109,6 +126,23 @@ def test_get_roles_service_returns_mask():
   assert isinstance(resp, RPCResponse)
   assert resp.payload["roles"] == 5
   assert ("db:users:profile:get_roles:1", {"guid": "u1"}) in db.calls
+
+
+def test_get_profile_returns_structured_auth_providers():
+  async def fake_get(request):
+    rpc = RPCRequest(op="urn:users:profile:get_profile:1", payload=None, version=1)
+    return rpc, SimpleNamespace(user_guid="user-guid"), None
+  svc_mod.unbox_request = fake_get
+  db = DummyDb()
+  req = DummyRequest(DummyState(db))
+  resp = asyncio.run(users_profile_get_profile_v1(req))
+  assert isinstance(resp, RPCResponse)
+  assert resp.payload["guid"] == "user-guid"
+  providers = resp.payload["auth_providers"]
+  assert isinstance(providers, list)
+  assert providers[0]["name"] == "microsoft"
+  assert providers[1]["display"] == "Google"
+  assert ("db:users:profile:get_profile:1", {"guid": "user-guid"}) in db.calls
 
 def test_set_profile_image_calls_db():
   async def fake_img(request):


### PR DESCRIPTION
## Summary
- use JSON_QUERY in MSSQL profile queries so auth provider lists are emitted as JSON arrays
- update the profile RPC service to consume the structured provider list without json.loads
- add regression tests covering the SQL text and RPC payload shape

## Testing
- pytest tests/test_provider_queries.py tests/test_users_profile_services.py

------
https://chatgpt.com/codex/tasks/task_e_68f3db2095848325a185ee25d25fbab8