### PR TITLE
Return structured auth provider data in profile responses

### DIFF
--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -39,8 +39,10 @@ async def users_profile_get_profile_v1(request: Request):
   row = res.rows[0]
   row["guid"] = str(row.get("guid", ""))
   auth_providers = row.get("auth_providers")
-  if not auth_providers:
+  if auth_providers is None:
     row["auth_providers"] = []
+  elif not isinstance(auth_providers, list):
+    raise HTTPException(status_code=500, detail="Invalid auth provider payload")
   profile = UsersProfileProfile1(**row)
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -284,20 +284,24 @@ def _users_profile(args: Dict[str, Any]):
         v.profile_image_base64 AS profile_image,
         v.provider_name AS default_provider,
         JSON_QUERY(
-          (
-            SELECT
-              ap.element_name AS name,
-              ap.element_display AS display
-            FROM users_auth ua
-            JOIN auth_providers ap ON ap.recid = ua.providers_recid
-            WHERE ua.users_guid = v.user_guid AND ua.element_linked = 1
-            FOR JSON PATH
+          COALESCE(
+            (
+              SELECT
+                ap.element_name AS name,
+                ap.element_display AS display
+              FROM users_auth ua
+              JOIN auth_providers ap ON ap.recid = ua.providers_recid
+              WHERE ua.users_guid = v.user_guid AND ua.element_linked = 1
+              FOR JSON PATH
+            ),
+            '[]'
           )
         ) AS auth_providers
       FROM vw_account_user_profile v
-      WHERE v.user_guid = ?;
+      WHERE v.user_guid = ?
+      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
     """
-    return (DbRunMode.ROW_ONE, sql, (guid,))
+    return (DbRunMode.JSON_ONE, sql, (guid,))
 
 @register("urn:auth:providers:unlink_last_provider:1")
 def _auth_unlink_last_provider(args: Dict[str, Any]):

--- a/server/registry/users/content/profile/mssql.py
+++ b/server/registry/users/content/profile/mssql.py
@@ -31,14 +31,17 @@ async def get_profile_v1(args: dict[str, Any]) -> DBResponse:
       v.profile_image_base64 AS profile_image,
       v.provider_name AS default_provider,
       JSON_QUERY(
-        (
-          SELECT
-            ap.element_name AS name,
-            ap.element_display AS display
-          FROM users_auth ua
-          JOIN auth_providers ap ON ap.recid = ua.providers_recid
-          WHERE ua.users_guid = v.user_guid AND ua.element_linked = 1
-          FOR JSON PATH
+        COALESCE(
+          (
+            SELECT
+              ap.element_name AS name,
+              ap.element_display AS display
+            FROM users_auth ua
+            JOIN auth_providers ap ON ap.recid = ua.providers_recid
+            WHERE ua.users_guid = v.user_guid AND ua.element_linked = 1
+            FOR JSON PATH
+          ),
+          '[]'
         )
       ) AS auth_providers
     FROM vw_account_user_profile v

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -5,7 +5,6 @@ import pathlib
 import sys
 import types
 import pytest
-import server.modules.providers.database.mssql_provider  # ensure provider module loaded
 
 # stub server package
 root_path = pathlib.Path(__file__).resolve().parent.parent
@@ -17,6 +16,24 @@ modules_pkg.__path__ = [str(root_path / "server/modules")]
 sys.modules.setdefault("server.modules", modules_pkg)
 providers_pkg = types.ModuleType("server.modules.providers")
 providers_pkg.__path__ = [str(root_path / "server/modules/providers")]
+class _DbRunMode:
+  ROW_ONE = "row_one"
+  ROW_MANY = "row_many"
+  JSON_ONE = "json_one"
+  JSON_MANY = "json_many"
+  EXEC = "exec"
+
+
+class _DBResult:
+  def __init__(self, rows=None, rowcount=0, payload=None):
+    if rows is None:
+      rows = []
+    self.rows = rows
+    self.rowcount = rowcount
+    self.payload = payload if payload is not None else rows
+
+providers_pkg.DbRunMode = _DbRunMode
+providers_pkg.DBResult = _DBResult
 sys.modules.setdefault("server.modules.providers", providers_pkg)
 database_pkg = types.ModuleType("server.modules.providers.database")
 database_pkg.__path__ = [str(root_path / "server/modules/providers/database")]
@@ -24,6 +41,51 @@ sys.modules.setdefault("server.modules.providers.database", database_pkg)
 mssql_pkg = types.ModuleType("server.modules.providers.database.mssql_provider")
 mssql_pkg.__path__ = [str(root_path / "server/modules/providers/database/mssql_provider")]
 sys.modules.setdefault("server.modules.providers.database.mssql_provider", mssql_pkg)
+
+registry_pkg = types.ModuleType("server.registry")
+registry_pkg.__path__ = [str(root_path / "server/registry")]
+sys.modules.setdefault("server.registry", registry_pkg)
+registry_types_pkg = types.ModuleType("server.registry.types")
+registry_types_pkg.__path__ = [str(root_path / "server/registry")]
+
+class _DBResponse:
+  def __init__(self, *, op="", payload=None, rows=None, rowcount=None):
+    if rows is not None:
+      payload = [dict(row) for row in rows]
+      if rowcount is None:
+        rowcount = len(payload)
+    self.op = op
+    self.payload = [] if payload is None else payload
+    if rowcount is None:
+      rowcount = 0
+    self.rowcount = rowcount
+
+  @property
+  def rows(self):
+    data = self.payload
+    if data is None:
+      return []
+    if isinstance(data, list):
+      return data
+    if isinstance(data, (tuple, set)):
+      return list(data)
+    return [data]
+
+registry_types_pkg.DBResponse = _DBResponse
+sys.modules.setdefault("server.registry.types", registry_types_pkg)
+registry_pkg.types = registry_types_pkg
+registry_users_pkg = types.ModuleType("server.registry.users")
+registry_users_pkg.__path__ = [str(root_path / "server/registry/users")]
+sys.modules.setdefault("server.registry.users", registry_users_pkg)
+registry_users_content_pkg = types.ModuleType("server.registry.users.content")
+registry_users_content_pkg.__path__ = [str(root_path / "server/registry/users/content")]
+sys.modules.setdefault("server.registry.users.content", registry_users_content_pkg)
+registry_users_content_profile_pkg = types.ModuleType("server.registry.users.content.profile")
+registry_users_content_profile_pkg.__path__ = [str(root_path / "server/registry/users/content/profile")]
+sys.modules.setdefault("server.registry.users.content.profile", registry_users_content_profile_pkg)
+registry_providers_pkg = types.ModuleType("server.registry.providers")
+registry_providers_pkg.__path__ = [str(root_path / "server/registry/providers")]
+sys.modules.setdefault("server.registry.providers", registry_providers_pkg)
 
 spec_logic = importlib.util.spec_from_file_location(
   "server.modules.providers.database.mssql_provider.logic",
@@ -50,6 +112,14 @@ sys.modules["server.modules.providers.database.mssql_provider.registry"] = regis
 spec_registry.loader.exec_module(registry_mod)
 get_mssql_handler = registry_mod.get_handler
 
+spec_content_profile = importlib.util.spec_from_file_location(
+  "server.registry.users.content.profile.mssql",
+  root_path / "server/registry/users/content/profile/mssql.py",
+)
+content_profile_mssql = importlib.util.module_from_spec(spec_content_profile)
+sys.modules["server.registry.users.content.profile.mssql"] = content_profile_mssql
+spec_content_profile.loader.exec_module(content_profile_mssql)
+
 def test_mssql_get_by_provider_identifier_uses_user_view():
   handler = get_mssql_handler("db:users:providers:get_by_provider_identifier:1")
   _, sql, _ = handler({"provider": "microsoft", "provider_identifier": str(uuid4())})
@@ -66,6 +136,21 @@ def test_mssql_get_profile_uses_profile_view():
   assert "v.credits" in sql
   assert "users_credits" not in sql
   assert "json_query" in sql
+  assert "for json path, without_array_wrapper" in sql
+
+
+def test_registry_content_profile_query_uses_json(monkeypatch):
+  captured = {}
+
+  async def fake_run_json_one(sql, params):
+    captured["sql"] = sql
+    return content_profile_mssql.DBResponse()
+
+  monkeypatch.setattr(content_profile_mssql, "run_json_one", fake_run_json_one)
+  asyncio.run(content_profile_mssql.get_profile_v1({"guid": "gid"}))
+  sql = captured["sql"].lower()
+  assert "json_query" in sql
+  assert "for json path, without_array_wrapper" in sql
 
 def test_mssql_get_rotkey_queries_users_and_providers():
   handler = get_mssql_handler("db:users:session:get_rotkey:1")

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -9,8 +9,9 @@ import pytest
 from fastapi import HTTPException
 
 # stub rpc package
+root_path = pathlib.Path(__file__).resolve().parent.parent
 pkg = types.ModuleType("rpc")
-pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / "rpc")]
+pkg.__path__ = [str(root_path / "rpc")]
 sys.modules.setdefault("rpc", pkg)
 
 spec = importlib.util.spec_from_file_location("server.models", "server/models.py")
@@ -22,7 +23,13 @@ sys.modules["server.models"] = models
 
 # stub server packages for loading real helpers
 server_pkg = types.ModuleType("server")
+server_pkg.__path__ = [str(root_path / "server")]
 modules_pkg = types.ModuleType("server.modules")
+modules_pkg.__path__ = [str(root_path / "server/modules")]
+class BaseModule:
+  async def startup(self): ...
+  async def shutdown(self): ...
+modules_pkg.BaseModule = BaseModule
 db_module_pkg = types.ModuleType("server.modules.db_module")
 class DbModule: ...
 db_module_pkg.DbModule = DbModule
@@ -40,6 +47,52 @@ sys.modules.setdefault("server", server_pkg)
 sys.modules.setdefault("server.modules", modules_pkg)
 sys.modules.setdefault("server.modules.db_module", db_module_pkg)
 sys.modules.setdefault("server.models", models_pkg)
+
+registry_pkg = types.ModuleType("server.registry")
+registry_pkg.__path__ = [str(root_path / "server/registry")]
+registry_types_pkg = types.ModuleType("server.registry.types")
+registry_types_pkg.__path__ = [str(root_path / "server/registry")]
+
+class DBRequest:
+  def __init__(self, *, op, payload=None, params=None):
+    source = payload if payload is not None else params or {}
+    self.op = op
+    self.payload = dict(source)
+
+class DBResponse:
+  def __init__(self, *, op="", payload=None, rows=None, rowcount=None):
+    if rows is not None:
+      payload = [dict(row) for row in rows]
+      if rowcount is None:
+        rowcount = len(payload)
+    self.op = op
+    self.payload = [] if payload is None else payload
+    if rowcount is None:
+      rowcount = 0
+    self.rowcount = rowcount
+
+  @property
+  def rows(self):
+    data = self.payload
+    if data is None:
+      return []
+    if isinstance(data, list):
+      return data
+    if isinstance(data, (tuple, set)):
+      return list(data)
+    return [data]
+
+registry_types_pkg.DBRequest = DBRequest
+registry_types_pkg.DBResponse = DBResponse
+registry_pkg.types = registry_types_pkg
+sys.modules.setdefault("server.registry", registry_pkg)
+sys.modules.setdefault("server.registry.types", registry_types_pkg)
+
+auth_module_pkg = types.ModuleType("server.modules.auth_module")
+class AuthModule: ...
+auth_module_pkg.AuthModule = AuthModule
+modules_pkg.auth_module = auth_module_pkg
+sys.modules.setdefault("server.modules.auth_module", auth_module_pkg)
 
 # load real helpers then override for service import
 real_helpers_spec = importlib.util.spec_from_file_location("rpc.helpers", "rpc/helpers.py")
@@ -69,10 +122,19 @@ class DBRes:
     self.rows = rows or []
     self.rowcount = rowcount
 
+_DEFAULT_PROVIDERS = object()
+
+
 class DummyDb:
-  def __init__(self, roles=0):
+  def __init__(self, roles=0, auth_providers=_DEFAULT_PROVIDERS):
     self.calls = []
     self.roles = roles
+    if auth_providers is _DEFAULT_PROVIDERS:
+      auth_providers = [
+        {"name": "microsoft", "display": "Microsoft"},
+        {"name": "google", "display": "Google"},
+      ]
+    self.auth_providers = auth_providers
   async def run(self, op, args=None):
     if not isinstance(op, str):
       args = op.payload
@@ -90,10 +152,7 @@ class DummyDb:
           "credits": 10,
           "profile_image": None,
           "default_provider": "microsoft",
-          "auth_providers": [
-            {"name": "microsoft", "display": "Microsoft"},
-            {"name": "google", "display": "Google"},
-          ],
+          "auth_providers": self.auth_providers,
         }
       ], 1)
     if op == "db:users:profile:get_roles:1":
@@ -143,6 +202,30 @@ def test_get_profile_returns_structured_auth_providers():
   assert providers[0]["name"] == "microsoft"
   assert providers[1]["display"] == "Google"
   assert ("db:users:profile:get_profile:1", {"guid": "user-guid"}) in db.calls
+
+
+def test_get_profile_defaults_auth_providers_to_empty_list():
+  async def fake_get(request):
+    rpc = RPCRequest(op="urn:users:profile:get_profile:1", payload=None, version=1)
+    return rpc, SimpleNamespace(user_guid="user-guid"), None
+  svc_mod.unbox_request = fake_get
+  db = DummyDb(auth_providers=None)
+  req = DummyRequest(DummyState(db))
+  resp = asyncio.run(users_profile_get_profile_v1(req))
+  assert isinstance(resp, RPCResponse)
+  assert resp.payload["auth_providers"] == []
+
+
+def test_get_profile_raises_on_invalid_auth_providers_shape():
+  async def fake_get(request):
+    rpc = RPCRequest(op="urn:users:profile:get_profile:1", payload=None, version=1)
+    return rpc, SimpleNamespace(user_guid="user-guid"), None
+  svc_mod.unbox_request = fake_get
+  db = DummyDb(auth_providers="not-json")
+  req = DummyRequest(DummyState(db))
+  with pytest.raises(HTTPException) as exc:
+    asyncio.run(users_profile_get_profile_v1(req))
+  assert exc.value.status_code == 500
 
 def test_set_profile_image_calls_db():
   async def fake_img(request):


### PR DESCRIPTION
## Summary
- wrap profile auth provider lookups with JSON_QUERY/COALESCE so MSSQL returns JSON fragments instead of quoted strings
- consume provider arrays directly in the profile RPC and surface a 500 for unexpected payload types
- expand provider and RPC tests to cover JSON output, null handling, and SQL structure

## Testing
- pytest tests/test_users_profile_services.py tests/test_provider_queries.py

------
https://chatgpt.com/codex/tasks/task_e_68f3e1c0b1c083258c18d227aad07b37