### PR TITLE
Return JSON results for MSSQL OAuth relink operations

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -319,44 +319,65 @@ def _db_auth_unlink_last_provider(args: Dict[str, Any]):
   return _auth_unlink_last_provider(args)
 
 @register("urn:auth:microsoft:oauth_relink:1")
-def _auth_ms_oauth_relink(args: Dict[str, Any]):
-    identifier = str(UUID(args["provider_identifier"]))
-    email = args.get("email")
-    display = args.get("display_name")
-    img = args.get("profile_image", "")
-    sql = "EXEC auth_oauth_relink @provider='microsoft', @identifier=?, @email=?, @display=?, @image=?;"
-    return (DbRunMode.ROW_ONE, sql, (identifier, email, display, img))
+async def _auth_ms_oauth_relink(args: Dict[str, Any]):
+  identifier = str(UUID(args["provider_identifier"]))
+  email = args.get("email")
+  display = args.get("display_name")
+  img = args.get("profile_image", "")
+  await exec_query(
+    "EXEC auth_oauth_relink @provider='microsoft', @identifier=?, @email=?, @display=?, @image=?;",
+    (identifier, email, display, img),
+  )
+  _, sql, params = _users_select({
+    "provider": "microsoft",
+    "provider_identifier": identifier,
+  })
+  return await fetch_json(sql, params)
 
 @register("db:auth:microsoft:oauth_relink:1")
-def _db_auth_ms_oauth_relink(args: Dict[str, Any]):
-  return _auth_ms_oauth_relink(args)
+async def _db_auth_ms_oauth_relink(args: Dict[str, Any]):
+  return await _auth_ms_oauth_relink(args)
 
 @register("urn:auth:google:oauth_relink:1")
-def _auth_google_oauth_relink(args: Dict[str, Any]):
-    identifier = str(UUID(args["provider_identifier"]))
-    email = args.get("email")
-    display = args.get("display_name")
-    img = args.get("profile_image", "")
-    sql = "EXEC auth_oauth_relink @provider='google', @identifier=?, @email=?, @display=?, @image=?;"
-    return (DbRunMode.ROW_ONE, sql, (identifier, email, display, img))
+async def _auth_google_oauth_relink(args: Dict[str, Any]):
+  identifier = str(UUID(args["provider_identifier"]))
+  email = args.get("email")
+  display = args.get("display_name")
+  img = args.get("profile_image", "")
+  await exec_query(
+    "EXEC auth_oauth_relink @provider='google', @identifier=?, @email=?, @display=?, @image=?;",
+    (identifier, email, display, img),
+  )
+  _, sql, params = _users_select({
+    "provider": "google",
+    "provider_identifier": identifier,
+  })
+  return await fetch_json(sql, params)
 
 @register("db:auth:google:oauth_relink:1")
-def _db_auth_google_oauth_relink(args: Dict[str, Any]):
-  return _auth_google_oauth_relink(args)
+async def _db_auth_google_oauth_relink(args: Dict[str, Any]):
+  return await _auth_google_oauth_relink(args)
 
 @register("urn:auth:discord:oauth_relink:1")
-def _auth_discord_oauth_relink(args: Dict[str, Any]):
-    raw_id = args["provider_identifier"]
-    identifier = str(UUID(str(uuid5(NAMESPACE_URL, f"discord:{raw_id}"))))
-    email = args.get("email")
-    display = args.get("display_name")
-    img = args.get("profile_image", "")
-    sql = "EXEC auth_oauth_relink @provider='discord', @identifier=?, @email=?, @display=?, @image=?;"
-    return (DbRunMode.ROW_ONE, sql, (identifier, email, display, img))
+async def _auth_discord_oauth_relink(args: Dict[str, Any]):
+  raw_id = args["provider_identifier"]
+  identifier = str(UUID(str(uuid5(NAMESPACE_URL, f"discord:{raw_id}"))))
+  email = args.get("email")
+  display = args.get("display_name")
+  img = args.get("profile_image", "")
+  await exec_query(
+    "EXEC auth_oauth_relink @provider='discord', @identifier=?, @email=?, @display=?, @image=?;",
+    (identifier, email, display, img),
+  )
+  _, sql, params = _users_select({
+    "provider": "discord",
+    "provider_identifier": identifier,
+  })
+  return await fetch_json(sql, params)
 
 @register("db:auth:discord:oauth_relink:1")
-def _db_auth_discord_oauth_relink(args: Dict[str, Any]):
-  return _auth_discord_oauth_relink(args)
+async def _db_auth_discord_oauth_relink(args: Dict[str, Any]):
+  return await _auth_discord_oauth_relink(args)
 
 @register("urn:auth:discord:get_security:1")
 def _auth_discord_get_security(args: Dict[str, Any]):


### PR DESCRIPTION
## Summary
- execute the `auth_oauth_relink` procedure and then fetch the refreshed user profile as JSON for each provider
- switch the Microsoft, Google, and Discord relink handlers to async JSON responses to align with downstream callers

## Testing
- pytest tests/test_auth_google_link_by_email.py tests/test_auth_google_soft_undelete.py tests/test_auth_google_relink_unlinked.py tests/test_auth_discord_link_by_email.py tests/test_auth_microsoft_link_by_email.py tests/test_auth_microsoft_email_exists.py tests/test_auth_microsoft_relink_unlinked.py tests/test_auth_google_email_exists.py


------
https://chatgpt.com/codex/tasks/task_e_68f3f2f4d1f48325930f5470b99445ea