### PR TITLE
Return JSON payloads from assistant MSSQL handlers

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -1373,9 +1373,10 @@ def _assistant_personas_get_by_name(args: Dict[str, Any]):
       vp.element_modified_on
     FROM vw_personas vp
     JOIN assistant_personas ap ON ap.element_name = vp.persona_name
-    WHERE vp.persona_name = ?;
+    WHERE vp.persona_name = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (DbRunMode.ROW_ONE, sql, (name,))
+  return (DbRunMode.JSON_ONE, sql, (name,))
 
 @register("urn:assistant:models:list:1")
 def _assistant_models_list(_: Dict[str, Any]):
@@ -1496,9 +1497,12 @@ def _db_assistant_personas_delete(args: Dict[str, Any]):
 def _assistant_models_get_by_name(args: Dict[str, Any]):
   name = args["name"]
   sql = """
-    SELECT recid FROM assistant_models WHERE element_name = ?;
+    SELECT recid
+    FROM assistant_models
+    WHERE element_name = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
-  return (DbRunMode.ROW_ONE, sql, (name,))
+  return (DbRunMode.JSON_ONE, sql, (name,))
 
 @register("db:assistant:conversations:insert:1")
 def _assistant_conversations_insert(args: Dict[str, Any]):
@@ -1521,10 +1525,11 @@ def _assistant_conversations_insert(args: Dict[str, Any]):
       element_output,
       element_tokens
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
-    SELECT SCOPE_IDENTITY() AS recid;
+    SELECT CAST(SCOPE_IDENTITY() AS BIGINT) AS recid
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
   return (
-    DbRunMode.ROW_ONE,
+    DbRunMode.JSON_ONE,
     sql,
     (
       personas_recid,
@@ -1565,10 +1570,11 @@ def _assistant_conversations_find_recent(args: Dict[str, Any]):
       AND ((element_channel_id = ?) OR (element_channel_id IS NULL AND ? IS NULL))
       AND ((element_user_id = ?) OR (element_user_id IS NULL AND ? IS NULL))
       AND element_created_on >= DATEADD(second, -?, SYSDATETIMEOFFSET())
-    ORDER BY element_created_on DESC;
+    ORDER BY element_created_on DESC
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
   return (
-    DbRunMode.ROW_ONE,
+    DbRunMode.JSON_ONE,
     sql,
     (
       personas_recid,

--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -44,13 +44,14 @@ def test_assistant_conversations_insert(monkeypatch):
     'tokens': 5,
   }
 
-  async def fake_fetch_rows(sql, params, *, one=False, stream=False):
-    assert one
+  async def fake_fetch_json(sql, params, *, many=False):
+    assert not many
     assert "INSERT INTO assistant_conversations" in sql
+    assert "FOR JSON PATH" in sql
     assert params == (1, 2, '1', '2', '3', 'hi', '', 5)
     return DBResult(rows=[{'recid': 9}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, 'fetch_rows', fake_fetch_rows)
+  monkeypatch.setattr(mssql_provider, 'fetch_json', fake_fetch_json)
 
   res = asyncio.run(provider.run('db:assistant:conversations:insert:1', args))
   assert res.rows == [{'recid': 9}]
@@ -68,14 +69,15 @@ def test_assistant_conversations_find_recent(monkeypatch):
     'window_seconds': 120,
   }
 
-  async def fake_fetch_rows(sql, params, *, one=False, stream=False):
-    assert one
+  async def fake_fetch_json(sql, params, *, many=False):
+    assert not many
     assert "SELECT TOP 1 recid" in sql
     assert "DATEADD" in sql
+    assert "FOR JSON PATH" in sql
     assert params == (1, 2, 'hi', '1', '1', '2', '2', '3', '3', 120)
     return DBResult(rows=[{'recid': 5}], rowcount=1)
 
-  monkeypatch.setattr(mssql_provider, 'fetch_rows', fake_fetch_rows)
+  monkeypatch.setattr(mssql_provider, 'fetch_json', fake_fetch_json)
 
   res = asyncio.run(provider.run('db:assistant:conversations:find_recent:1', args))
   assert res.rows == [{'recid': 5}]

--- a/tests/test_mssql_personas_registry.py
+++ b/tests/test_mssql_personas_registry.py
@@ -6,9 +6,10 @@ def test_persona_lookup_query_targets_element_name():
   handler = registry.get_handler("db:assistant:personas:get_by_name:1")
   mode, sql, params = handler({"name": "stark"})
 
-  assert mode is DbRunMode.ROW_ONE
+  assert mode is DbRunMode.JSON_ONE
   assert "FROM vw_personas vp" in sql
   assert "JOIN assistant_personas ap ON ap.element_name = vp.persona_name" in sql
-  assert "WHERE vp.persona_name = ?;" in sql
+  assert "WHERE vp.persona_name = ?" in sql
+  assert "FOR JSON PATH" in sql
   assert "vp.model_name AS element_model" in sql
   assert params == ("stark",)


### PR DESCRIPTION
## Summary
- update assistant persona and conversation MSSQL registry handlers to return JSON payloads
- align assistant-related unit tests with the JSON run modes

## Testing
- pytest tests/test_mssql_personas_registry.py tests/test_db_assistant_conversations.py tests/test_openai_module.py

------
https://chatgpt.com/codex/tasks/task_e_68f4046c96b48325929269fbeab58ff6