### PR TITLE
Use finance credits registry for support updates

### DIFF
--- a/server/modules/providers/database/mssql_provider/registry.py
+++ b/server/modules/providers/database/mssql_provider/registry.py
@@ -434,11 +434,6 @@ def _support_users_set_credits(args: Dict[str, Any]):
   return (DbRunMode.EXEC, sql, (credits, guid))
 
 
-@register("db:support:users:set_credits:1")
-def _db_support_users_set_credits(args: Dict[str, Any]):
-  return _support_users_set_credits(args)
-
-
 @register("db:storage:files:set_gallery:1")
 def _storage_files_set_gallery(args: Dict[str, Any]):
   guid = str(UUID(args["user_guid"]))

--- a/server/modules/user_admin_module.py
+++ b/server/modules/user_admin_module.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
+from server.registry.finance.credits import set_credits_request
 from server.registry.types import DBRequest
 
 
@@ -43,12 +44,7 @@ class UserAdminModule(BaseModule):
     return credits
 
   async def set_credits(self, guid: str, credits: int) -> None:
-    await self.db.run(
-      DBRequest(
-        op="db:support:users:set_credits:1",
-        payload={"guid": guid, "credits": credits},
-      ),
-    )
+    await self.db.run(set_credits_request(guid=guid, credits=credits))
 
   async def reset_display(self, guid: str) -> None:
     await self.db.run(

--- a/server/registry/finance/credits/__init__.py
+++ b/server/registry/finance/credits/__init__.py
@@ -6,10 +6,13 @@ from typing import Any, TYPE_CHECKING
 
 from server.registry.types import DBRequest
 
+from .model import SetCreditsParams
+
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
 
 __all__ = [
+  "SetCreditsParams",
   "register",
   "set_credits_request",
 ]
@@ -20,7 +23,7 @@ def _request(name: str, params: dict[str, Any]) -> DBRequest:
 
 
 def set_credits_request(*, guid: str, credits: int) -> DBRequest:
-  params = {"guid": guid, "credits": credits}
+  params: SetCreditsParams = {"guid": guid, "credits": credits}
   return _request("set", params)
 
 

--- a/server/registry/finance/credits/model.py
+++ b/server/registry/finance/credits/model.py
@@ -1,0 +1,16 @@
+"""Typed request contracts for finance credit registry operations."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+__all__ = [
+  "SetCreditsParams",
+]
+
+
+class SetCreditsParams(TypedDict):
+  """Parameters required to update a user's credit balance."""
+
+  guid: str
+  credits: int

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -1,9 +1,10 @@
-from uuid import uuid4
 import asyncio
 import importlib.util
 import pathlib
 import sys
 import types
+from typing import Any
+from uuid import uuid4
 import pytest
 
 # stub server package
@@ -16,6 +17,75 @@ modules_pkg.__path__ = [str(root_path / "server/modules")]
 sys.modules.setdefault("server.modules", modules_pkg)
 providers_pkg = types.ModuleType("server.modules.providers")
 providers_pkg.__path__ = [str(root_path / "server/modules/providers")]
+
+
+class _BaseProvider:
+  def __init__(self, **config):
+    self.config = config
+
+
+class _LifecycleProvider(_BaseProvider):
+  async def startup(self):
+    return None
+
+  async def shutdown(self):
+    return None
+
+
+class _AuthProviderBase(_LifecycleProvider):
+  async def verify_id_token(self, id_token, access_token=None):
+    return {}
+
+  async def fetch_user_profile(self, access_token):
+    return {}
+
+  def extract_guid(self, payload):
+    if isinstance(payload, dict):
+      return payload.get("guid")
+    return None
+
+
+class _DbProviderBase(_LifecycleProvider):
+  async def run(self, request):
+    raise NotImplementedError
+
+
+class _AuthProvider(_AuthProviderBase):
+  def __init__(self, *, audience=None, issuer=None, jwks_uri=None, algorithm="RS256", jwks_expiry=None):
+    super().__init__(audience=audience, issuer=issuer, jwks_uri=jwks_uri, algorithm=algorithm, jwks_expiry=jwks_expiry)
+    self.audience = audience
+    self.issuer = issuer
+    self.jwks_uri = jwks_uri
+    self.algorithm = algorithm
+    self.jwks_expiry = jwks_expiry
+
+
+providers_pkg.BaseProvider = _BaseProvider
+providers_pkg.LifecycleProvider = _LifecycleProvider
+providers_pkg.AuthProviderBase = _AuthProviderBase
+providers_pkg.DbProviderBase = _DbProviderBase
+providers_pkg.AuthProvider = _AuthProvider
+
+
+class _BaseModule:
+  def __init__(self, app=None):
+    self.app = app
+    self._ready = False
+
+  async def startup(self):
+    self._ready = True
+
+  async def shutdown(self):
+    self._ready = False
+
+  def mark_ready(self):
+    self._ready = True
+
+  async def on_ready(self):
+    return self._ready
+
+
+modules_pkg.BaseModule = _BaseModule
 class _DbRunMode:
   ROW_ONE = "row_one"
   ROW_MANY = "row_many"
@@ -71,9 +141,23 @@ class _DBResponse:
       return list(data)
     return [data]
 
+class _DBRequest:
+  def __init__(self, *, op: str, payload=None, params=None):
+    self.op = op
+    source = payload if payload is not None else params or {}
+    self.payload = dict(source)
+
+  @property
+  def params(self):
+    return self.payload
+
 registry_types_pkg.DBResponse = _DBResponse
+registry_types_pkg.DBRequest = _DBRequest
 sys.modules.setdefault("server.registry.types", registry_types_pkg)
 registry_pkg.types = registry_types_pkg
+providers_pkg.DBRequest = _DBRequest
+providers_pkg.DBResponse = _DBResponse
+providers_pkg.DBResult = _DBResponse
 registry_users_pkg = types.ModuleType("server.registry.users")
 registry_users_pkg.__path__ = [str(root_path / "server/registry/users")]
 sys.modules.setdefault("server.registry.users", registry_users_pkg)
@@ -119,6 +203,14 @@ spec_content_profile = importlib.util.spec_from_file_location(
 content_profile_mssql = importlib.util.module_from_spec(spec_content_profile)
 sys.modules["server.registry.users.content.profile.mssql"] = content_profile_mssql
 spec_content_profile.loader.exec_module(content_profile_mssql)
+
+spec_finance_credits = importlib.util.spec_from_file_location(
+  "server.registry.finance.credits.mssql",
+  root_path / "server/registry/finance/credits/mssql.py",
+)
+finance_credits_mssql = importlib.util.module_from_spec(spec_finance_credits)
+sys.modules["server.registry.finance.credits.mssql"] = finance_credits_mssql
+spec_finance_credits.loader.exec_module(finance_credits_mssql)
 
 def test_mssql_get_by_provider_identifier_uses_user_view():
   handler = get_mssql_handler("db:users:providers:get_by_provider_identifier:1")
@@ -175,12 +267,18 @@ def test_mssql_discord_get_security_uses_security_view():
   assert "auth_providers" in sql
 
 
-def test_mssql_support_users_set_credits_updates_table():
-  handler = get_mssql_handler("db:support:users:set_credits:1")
-  mode, sql, params = handler({"guid": "gid", "credits": 10})
-  assert mode == "exec"
-  assert "update users_credits" in sql.lower()
-  assert params == (10, "gid")
+def test_finance_credits_set_updates_table(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_exec(sql, params):
+    captured["sql"] = sql
+    captured["params"] = tuple(params)
+    return registry_types_pkg.DBResponse()
+
+  monkeypatch.setattr(finance_credits_mssql, "run_exec", fake_run_exec)
+  asyncio.run(finance_credits_mssql.set_credits_v1({"guid": "gid", "credits": 10}))
+  assert "update users_credits" in captured["sql"].lower()
+  assert captured["params"] == (10, "gid")
 
 
 def test_fetch_rows_returns_empty_on_error(monkeypatch):


### PR DESCRIPTION
## Summary
- route user admin credit updates through the finance credits registry helper and typed request params
- remove the legacy db:support handler and extend finance registry helpers with typed contracts
- update provider query tests to exercise the finance credits MSSQL implementation and expand stubbed provider classes

## Testing
- pytest tests/test_provider_queries.py tests/test_account_user_services.py tests/test_support_services.py

------
https://chatgpt.com/codex/tasks/task_e_68f66050f63083259ee24fc2c2f2deb0