### PR TITLE
Add Pydantic models for registry request contracts

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -17,6 +17,13 @@ from server.registry.users.cache import (
   replace_user_cache_request,
   upsert_cache_item_request,
 )
+from server.registry.users.cache.model import (
+  CacheItemKey,
+  DeleteCacheFolderParams,
+  ListCacheParams,
+  ReplaceUserCacheParams,
+  UpsertCacheItemParams,
+)
 from server.helpers.logging import update_logging_level
 
 
@@ -158,11 +165,13 @@ class DbModule(BaseModule):
     return int(value)
 
   async def list_storage_cache(self, user_guid: str) -> list[Dict[str, Any]]:
-    res = await self.run(list_cache_request(user_guid))
+    params = ListCacheParams(user_guid=user_guid)
+    res = await self.run(list_cache_request(params))
     return res.rows
 
   async def replace_storage_cache(self, user_guid: str, items: list[Dict[str, Any]]):
-    await self.run(replace_user_cache_request(user_guid, items))
+    params = ReplaceUserCacheParams(user_guid=user_guid, items=items)
+    await self.run(replace_user_cache_request(params))
 
   async def user_exists(self, user_guid: str) -> bool:
     res = await self.run(
@@ -171,11 +180,14 @@ class DbModule(BaseModule):
     return bool(res.rows)
 
   async def upsert_storage_cache(self, item: Dict[str, Any]) -> DBResponse:
-    return await self.run(upsert_cache_item_request(item))
+    params = UpsertCacheItemParams.model_validate(item)
+    return await self.run(upsert_cache_item_request(params))
 
   async def delete_storage_cache(self, user_guid: str, path: str, filename: str):
-    await self.run(delete_cache_item_request(user_guid, path, filename))
+    params = CacheItemKey(user_guid=user_guid, path=path, filename=filename)
+    await self.run(delete_cache_item_request(params))
 
   async def delete_storage_cache_folder(self, user_guid: str, path: str):
-    await self.run(delete_cache_folder_request(user_guid, path))
+    params = DeleteCacheFolderParams(user_guid=user_guid, path=path)
+    await self.run(delete_cache_folder_request(params))
 

--- a/server/modules/public_links_module.py
+++ b/server/modules/public_links_module.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from fastapi import FastAPI
 from server.registry.system.links import (
+  NavbarRoutesParams,
   get_home_links_request,
   get_navbar_routes_request,
 )
@@ -32,5 +33,7 @@ class PublicLinksModule(BaseModule):
 
   async def get_navbar_routes(self, role_mask: int):
     assert self.db
-    res = await self.db.run(get_navbar_routes_request(role_mask=role_mask))
+    res = await self.db.run(
+      get_navbar_routes_request(NavbarRoutesParams(role_mask=role_mask))
+    )
     return res.rows

--- a/server/modules/user_admin_module.py
+++ b/server/modules/user_admin_module.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, HTTPException
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
-from server.registry.finance.credits import set_credits_request
+from server.registry.finance.credits import SetCreditsParams, set_credits_request
 from server.registry.types import DBRequest
 
 
@@ -44,7 +44,9 @@ class UserAdminModule(BaseModule):
     return credits
 
   async def set_credits(self, guid: str, credits: int) -> None:
-    await self.db.run(set_credits_request(guid=guid, credits=credits))
+    await self.db.run(
+      set_credits_request(SetCreditsParams(guid=guid, credits=credits))
+    )
 
   async def reset_display(self, guid: str) -> None:
     await self.db.run(

--- a/server/registry/finance/credits/__init__.py
+++ b/server/registry/finance/credits/__init__.py
@@ -1,8 +1,12 @@
-"""Finance credits registry helpers."""
+"""Finance credits registry helpers.
+
+Requests in this package are described by Pydantic models to guarantee that
+service and provider implementations agree on the credit update contract.
+"""
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from server.registry.types import DBRequest
 
@@ -18,12 +22,16 @@ __all__ = [
 ]
 
 
-def _request(name: str, params: dict[str, Any]) -> DBRequest:
-  return DBRequest(op=f"db:finance:credits:{name}:1", params=params)
+def _request(name: str, params: SetCreditsParams) -> DBRequest:
+  return DBRequest(
+    op=f"db:finance:credits:{name}:1",
+    params=params.model_dump(),
+  )
 
 
-def set_credits_request(*, guid: str, credits: int) -> DBRequest:
-  params: SetCreditsParams = {"guid": guid, "credits": credits}
+def set_credits_request(params: SetCreditsParams) -> DBRequest:
+  """Build a ``set`` registry request using validated parameters."""
+
   return _request("set", params)
 
 

--- a/server/registry/finance/credits/model.py
+++ b/server/registry/finance/credits/model.py
@@ -1,16 +1,23 @@
-"""Typed request contracts for finance credit registry operations."""
+"""Pydantic models describing finance credit registry contracts.
+
+These models provide a single source of truth for registry requests so
+providers and services share a stable contract.  All parameters are validated
+eagerly which keeps database operations type-safe.
+"""
 
 from __future__ import annotations
 
-from typing import TypedDict
+from pydantic import BaseModel, ConfigDict
 
 __all__ = [
   "SetCreditsParams",
 ]
 
 
-class SetCreditsParams(TypedDict):
+class SetCreditsParams(BaseModel):
   """Parameters required to update a user's credit balance."""
+
+  model_config = ConfigDict(extra="forbid")
 
   guid: str
   credits: int

--- a/server/registry/system/links/__init__.py
+++ b/server/registry/system/links/__init__.py
@@ -1,8 +1,12 @@
-"""Public links registry bindings."""
+"""Public links registry bindings.
+
+Helpers in this module exchange validated Pydantic models so registries,
+providers, and services share consistent payload shapes for public link data.
+"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from server.registry.types import DBRequest
 
@@ -21,16 +25,16 @@ __all__ = [
 ]
 
 
-def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
-  return DBRequest(op=op, params=params or {})
+def _request(op: str, params: NavbarRoutesParams | None = None) -> DBRequest:
+  payload = params.model_dump(exclude_none=True) if params else {}
+  return DBRequest(op=op, params=payload)
 
 
 def get_home_links_request() -> DBRequest:
   return _request("db:system:public_links:get_home_links:1")
 
 
-def get_navbar_routes_request(*, role_mask: int) -> DBRequest:
-  params: NavbarRoutesParams = {"role_mask": role_mask}
+def get_navbar_routes_request(params: NavbarRoutesParams) -> DBRequest:
   return _request("db:system:public_links:get_navbar_routes:1", params)
 
 

--- a/server/registry/system/links/model.py
+++ b/server/registry/system/links/model.py
@@ -1,8 +1,8 @@
-"""Type contracts for system public link registry operations."""
+"""Pydantic models for system public link registry interactions."""
 
 from __future__ import annotations
 
-from typing import TypedDict
+from pydantic import BaseModel, ConfigDict
 
 __all__ = [
   "HomeLink",
@@ -11,15 +11,19 @@ __all__ = [
 ]
 
 
-class HomeLink(TypedDict):
+class HomeLink(BaseModel):
   """Metadata for a public home link."""
+
+  model_config = ConfigDict(extra="forbid")
 
   title: str
   url: str
 
 
-class NavbarRoute(TypedDict):
+class NavbarRoute(BaseModel):
   """Metadata for a public navigation route."""
+
+  model_config = ConfigDict(extra="forbid")
 
   path: str
   name: str
@@ -27,7 +31,9 @@ class NavbarRoute(TypedDict):
   sequence: int
 
 
-class NavbarRoutesParams(TypedDict, total=False):
+class NavbarRoutesParams(BaseModel):
   """Parameters for fetching navbar routes."""
 
-  role_mask: int
+  model_config = ConfigDict(extra="forbid")
+
+  role_mask: int | None = None

--- a/server/registry/system/links/mssql.py
+++ b/server/registry/system/links/mssql.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, Mapping
+
 from server.registry.providers.mssql import run_json_many
 from server.registry.types import DBResponse
 
@@ -25,8 +27,14 @@ async def get_home_links_v1(_: object) -> DBResponse:
   return await run_json_many(sql)
 
 
-async def get_navbar_routes_v1(args: NavbarRoutesParams) -> DBResponse:
-  mask = int(args.get("role_mask", 0))
+async def get_navbar_routes_v1(
+  args: Mapping[str, Any] | NavbarRoutesParams,
+) -> DBResponse:
+  params = (
+    args if isinstance(args, NavbarRoutesParams)
+    else NavbarRoutesParams.model_validate(args)
+  )
+  mask = int(params.role_mask or 0)
   sql = """
     SELECT
       element_path AS path,

--- a/server/registry/users/cache/__init__.py
+++ b/server/registry/users/cache/__init__.py
@@ -1,10 +1,25 @@
-"""Users cache registry bindings."""
+"""Users cache registry bindings.
+
+Request helpers in this package now accept validated Pydantic models defined in
+``model.py``.  Using those models keeps database contracts aligned across
+services and providers while providing eager validation for shared payloads.
+"""
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Mapping, TYPE_CHECKING
+from typing import Any, Dict, Mapping, TYPE_CHECKING
 
-from .model import ContentCacheItem, normalize_content_cache_item
+from .model import (
+  CacheItemKey,
+  ContentCacheItem,
+  DeleteCacheFolderParams,
+  ListCacheParams,
+  ReplaceUserCacheParams,
+  SetPublicParams,
+  SetReportedParams,
+  UpsertCacheItemParams,
+  normalize_content_cache_item,
+)
 
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
@@ -22,6 +37,13 @@ __all__ = [
   "upsert_cache_item_request",
   "count_rows_request",
   "ContentCacheItem",
+  "CacheItemKey",
+  "DeleteCacheFolderParams",
+  "ListCacheParams",
+  "ReplaceUserCacheParams",
+  "SetPublicParams",
+  "SetReportedParams",
+  "UpsertCacheItemParams",
   "normalize_content_cache_item",
 ]
 
@@ -31,18 +53,21 @@ def _normalize_cache_item_payload(
   *,
   default_user_guid: str | None = None,
 ) -> Dict[str, Any]:
-  if isinstance(item, ContentCacheItem):
-    payload = item.to_payload()
-  else:
-    payload = normalize_content_cache_item(item, default_user_guid=default_user_guid)
+  payload = normalize_content_cache_item(
+    item,
+    default_user_guid=default_user_guid,
+  )
   if default_user_guid and not payload.get("user_guid"):
     payload["user_guid"] = default_user_guid
   return payload
 
 
-def list_cache_request(user_guid: str):
+def list_cache_request(params: ListCacheParams) -> DBRequest:
   from server.registry.types import DBRequest
-  return DBRequest(op="db:users:cache:list:1", params={"user_guid": user_guid})
+  return DBRequest(
+    op="db:users:cache:list:1",
+    params=params.model_dump(),
+  )
 
 
 def list_public_request():
@@ -55,77 +80,45 @@ def list_reported_request():
   return DBRequest(op="db:users:cache:list_reported:1", params={})
 
 
-def replace_user_cache_request(user_guid: str, items: Iterable[Dict[str, Any]]):
+def replace_user_cache_request(params: ReplaceUserCacheParams) -> DBRequest:
   from server.registry.types import DBRequest
-  normalized = [
-    _normalize_cache_item_payload(item, default_user_guid=user_guid)
-    for item in items
-  ]
-  return DBRequest(op="db:users:cache:replace_user:1", params={
-    "user_guid": user_guid,
-    "items": normalized,
-  })
+  normalized_items = [item.model_dump() for item in params.items]
+  payload = params.model_dump()
+  payload["items"] = normalized_items
+  return DBRequest(op="db:users:cache:replace_user:1", params=payload)
 
 
-def upsert_cache_item_request(item: Dict[str, Any]):
+def upsert_cache_item_request(item: UpsertCacheItemParams | Dict[str, Any]):
   from server.registry.types import DBRequest
-  normalized = _normalize_cache_item_payload(item)
+  if isinstance(item, UpsertCacheItemParams):
+    normalized = item.model_dump()
+  else:
+    normalized = _normalize_cache_item_payload(item)
   return DBRequest(op="db:users:cache:upsert:1", params=normalized)
 
 
-def delete_cache_item_request(user_guid: str, path: str, filename: str):
+def delete_cache_item_request(params: CacheItemKey) -> DBRequest:
   from server.registry.types import DBRequest
-  return DBRequest(op="db:users:cache:delete:1", params={
-    "user_guid": user_guid,
-    "path": path,
-    "filename": filename,
-  })
+  return DBRequest(op="db:users:cache:delete:1", params=params.model_dump())
 
 
-def delete_cache_folder_request(user_guid: str, path: str):
+def delete_cache_folder_request(params: DeleteCacheFolderParams) -> DBRequest:
   from server.registry.types import DBRequest
-  return DBRequest(op="db:users:cache:delete_folder:1", params={
-    "user_guid": user_guid,
-    "path": path,
-  })
+  return DBRequest(op="db:users:cache:delete_folder:1", params=params.model_dump())
 
 
-def set_public_request(
-  user_guid: str,
-  *,
-  public: bool,
-  name: str | None = None,
-  path: str | None = None,
-  filename: str | None = None,
-):
+def set_public_request(params: SetPublicParams) -> DBRequest:
   from server.registry.types import DBRequest
-  params = {
-    "user_guid": user_guid,
-    "public": bool(public),
-  }
-  if name is not None:
-    params["name"] = name
-  if path is not None:
-    params["path"] = path
-  if filename is not None:
-    params["filename"] = filename
-  return DBRequest(op="db:users:cache:set_public:1", params=params)
+  payload = params.model_dump(exclude_none=True)
+  payload["public"] = 1 if params.public else 0
+  return DBRequest(op="db:users:cache:set_public:1", params=payload)
 
 
-def set_reported_request(
-  user_guid: str,
-  *,
-  path: str,
-  filename: str,
-  reported: bool = True,
-):
+def set_reported_request(params: SetReportedParams) -> DBRequest:
   from server.registry.types import DBRequest
-  return DBRequest(op="db:users:cache:set_reported:1", params={
-    "user_guid": user_guid,
-    "path": path,
-    "filename": filename,
-    "reported": bool(reported),
-  })
+  payload = params.model_dump()
+  payload["reported"] = 1 if params.reported else 0
+  return DBRequest(op="db:users:cache:set_reported:1", params=payload)
 
 
 def count_rows_request():

--- a/server/registry/users/cache/model.py
+++ b/server/registry/users/cache/model.py
@@ -1,12 +1,20 @@
-"""Data models for content cache operations."""
+"""Pydantic models for content cache registry interactions."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any, Mapping, MutableMapping, Sequence
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 __all__ = [
+  "CacheItemKey",
   "ContentCacheItem",
+  "DeleteCacheFolderParams",
+  "ListCacheParams",
+  "ReplaceUserCacheParams",
+  "SetPublicParams",
+  "SetReportedParams",
+  "UpsertCacheItemParams",
   "normalize_content_cache_item",
 ]
 
@@ -17,29 +25,10 @@ def _coerce_flag(value: Any) -> int:
   return 1 if bool(value) else 0
 
 
-def normalize_content_cache_item(item: Mapping[str, Any], *, default_user_guid: str | None = None) -> dict[str, Any]:
-  data = dict(item)
-  user_guid = data.get("user_guid") or default_user_guid
-  if not user_guid:
-    raise ValueError("user_guid is required for content cache items")
-  data["user_guid"] = user_guid
-  name = data.get("filename") or data.get("name")
-  if name is None:
-    raise ValueError("filename is required for content cache items")
-  data["filename"] = name
-  path = data.get("path")
-  data["path"] = path or ""
-  data.setdefault("content_type", "application/octet-stream")
-  data["public"] = _coerce_flag(data.get("public", 0))
-  data["reported"] = _coerce_flag(data.get("reported", 0))
-  if "moderation_recid" in data and data["moderation_recid"] == "":
-    data["moderation_recid"] = None
-  return data
-
-
-@dataclass(slots=True)
-class ContentCacheItem:
+class ContentCacheItem(BaseModel):
   """Typed representation of a content cache row."""
+
+  model_config = ConfigDict(extra="allow")
 
   user_guid: str
   filename: str
@@ -52,21 +41,138 @@ class ContentCacheItem:
   reported: int = 0
   moderation_recid: Any | None = None
 
+  @model_validator(mode="before")
   @classmethod
-  def from_mapping(cls, data: Mapping[str, Any]) -> "ContentCacheItem":
-    normalized = normalize_content_cache_item(data)
-    return cls(**normalized)
+  def _normalize(cls, value: Any) -> MutableMapping[str, Any]:
+    if isinstance(value, cls):
+      return value.model_dump()
+    if not isinstance(value, Mapping):
+      raise TypeError("ContentCacheItem expects a mapping of values")
+    data: MutableMapping[str, Any] = dict(value)
+    user_guid = data.get("user_guid") or data.get("users_guid")
+    if not user_guid:
+      raise ValueError("user_guid is required for content cache items")
+    data["user_guid"] = user_guid
+    name = data.get("filename") or data.get("name")
+    if name is None:
+      raise ValueError("filename is required for content cache items")
+    data["filename"] = name
+    data["path"] = data.get("path") or ""
+    data["content_type"] = data.get("content_type") or "application/octet-stream"
+    data["public"] = _coerce_flag(data.get("public", 0))
+    data["reported"] = _coerce_flag(data.get("reported", 0))
+    if data.get("moderation_recid") == "":
+      data["moderation_recid"] = None
+    return data
+
+  @classmethod
+  def from_mapping(
+    cls,
+    data: Mapping[str, Any],
+    *,
+    default_user_guid: str | None = None,
+  ) -> "ContentCacheItem":
+    payload = dict(data)
+    if default_user_guid and not payload.get("user_guid"):
+      payload["user_guid"] = default_user_guid
+    return cls.model_validate(payload)
 
   def to_payload(self) -> dict[str, Any]:
-    return normalize_content_cache_item({
-      "user_guid": self.user_guid,
-      "filename": self.filename,
-      "path": self.path,
-      "content_type": self.content_type,
-      "public": self.public,
-      "created_on": self.created_on,
-      "modified_on": self.modified_on,
-      "url": self.url,
-      "reported": self.reported,
-      "moderation_recid": self.moderation_recid,
-    })
+    return self.model_dump()
+
+
+class ListCacheParams(BaseModel):
+  """Parameters required to list a user's cached items."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  user_guid: str
+
+
+class CacheItemKey(BaseModel):
+  """Coordinates for identifying a cached item."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  user_guid: str
+  path: str = ""
+  filename: str
+
+
+class DeleteCacheFolderParams(BaseModel):
+  """Parameters required to delete every item within a folder."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  user_guid: str
+  path: str = ""
+
+
+class ReplaceUserCacheParams(BaseModel):
+  """Payload used to replace a user's cache rows with provided items."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  user_guid: str
+  items: list[ContentCacheItem] = Field(default_factory=list)
+
+  @model_validator(mode="before")
+  @classmethod
+  def _apply_defaults(cls, value: Any) -> Mapping[str, Any]:
+    if isinstance(value, cls):
+      return value.model_dump()
+    if not isinstance(value, Mapping):
+      raise TypeError("ReplaceUserCacheParams expects a mapping")
+    data = dict(value)
+    user_guid = data.get("user_guid")
+    raw_items: Sequence[Any] = data.get("items", [])
+    normalized: list[Any] = []
+    for item in raw_items:
+      if isinstance(item, Mapping):
+        payload = dict(item)
+        if user_guid and not payload.get("user_guid"):
+          payload["user_guid"] = user_guid
+        normalized.append(payload)
+      else:
+        normalized.append(item)
+    data["items"] = normalized
+    return data
+
+
+class UpsertCacheItemParams(ContentCacheItem):
+  """Validated payload for inserting or updating a cache item."""
+
+
+class SetPublicParams(BaseModel):
+  """Parameters used to toggle the public flag for a cached item."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  user_guid: str
+  public: bool
+  name: str | None = None
+  path: str | None = None
+  filename: str | None = None
+
+
+class SetReportedParams(CacheItemKey):
+  """Parameters used to toggle the reported flag for a cached item."""
+
+  reported: bool = True
+
+
+def normalize_content_cache_item(
+  item: Mapping[str, Any] | ContentCacheItem,
+  *,
+  default_user_guid: str | None = None,
+) -> dict[str, Any]:
+  """Normalize arbitrary cache data into the canonical payload shape."""
+
+  if isinstance(item, ContentCacheItem):
+    payload = item.model_dump()
+  else:
+    payload = dict(item)
+  if default_user_guid and not payload.get("user_guid"):
+    payload["user_guid"] = default_user_guid
+  normalized = ContentCacheItem.model_validate(payload)
+  return normalized.model_dump()


### PR DESCRIPTION
## Summary
- define pydantic request/response models for finance credits, system public links, and users cache registries
- update registry helpers and consuming modules to use the new models and document the contracts

## Testing
- pytest tests/test_public_links_service.py
- pytest tests/test_storage_cache_upsert.py

------
https://chatgpt.com/codex/tasks/task_e_68f79723eb3c83258f1f7e3c6460970d