### PR TITLE
Switch role modules to system role DB operations

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -14,7 +14,11 @@ from server.modules.providers.auth.microsoft_provider import MicrosoftAuthProvid
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.providers.auth.discord_provider import DiscordAuthProvider
 from server.modules.discord_bot_module import DiscordBotModule
-from server.registry.system.roles import list_roles_request
+from server.registry.system.roles import (
+  delete_role_request,
+  list_roles_request,
+  upsert_role_request,
+)
 from server.registry.types import DBRequest
 
 DEFAULT_SESSION_TOKEN_EXPIRY = 15 # minutes
@@ -54,24 +58,12 @@ class RoleCache:
 
   async def upsert_role(self, name: str, mask: int, display: str | None):
     await self.db.run(
-      DBRequest(
-        op="db:security:roles:upsert_role:1",
-        payload={
-          "name": name,
-          "mask": mask,
-          "display": display,
-        },
-      ),
+      upsert_role_request(name=name, mask=mask, display=display),
     )
     await self.refresh_role_cache()
 
   async def delete_role(self, name: str):
-    await self.db.run(
-      DBRequest(
-        op="db:security:roles:delete_role:1",
-        payload={"name": name},
-      ),
-    )
+    await self.db.run(delete_role_request(name=name))
     await self.refresh_role_cache()
 
   def mask_to_names(self, mask: int) -> list[str]:

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -3,8 +3,13 @@ from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.auth_module import AuthModule
 from server.modules.discord_bot_module import DiscordBotModule
-from server.registry.system.roles import list_roles_request
-from server.registry.types import DBRequest
+from server.registry.system.roles import (
+  add_role_member_request,
+  get_role_members_request,
+  get_role_non_members_request,
+  list_roles_request,
+  remove_role_member_request,
+)
 
 
 class RoleAdminModule(BaseModule):
@@ -53,18 +58,8 @@ class RoleAdminModule(BaseModule):
     return roles
 
   async def get_role_members(self, role: str) -> tuple[list[dict], list[dict]]:
-    mem_res = await self.db.run(
-      DBRequest(
-        op="db:security:roles:get_role_members:1",
-        payload={"role": role},
-      ),
-    )
-    non_res = await self.db.run(
-      DBRequest(
-        op="db:security:roles:get_role_non_members:1",
-        payload={"role": role},
-      ),
-    )
+    mem_res = await self.db.run(get_role_members_request(role))
+    non_res = await self.db.run(get_role_non_members_request(role))
     members = [
       {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
       for r in mem_res.rows
@@ -79,12 +74,7 @@ class RoleAdminModule(BaseModule):
     if actor_mask is not None:
       role_mask = self.auth.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
-    await self.db.run(
-      DBRequest(
-        op="db:security:roles:add_role_member:1",
-        payload={"role": role, "user_guid": user_guid},
-      ),
-    )
+    await self.db.run(add_role_member_request(role, user_guid))
     await self.auth.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 
@@ -92,12 +82,7 @@ class RoleAdminModule(BaseModule):
     if actor_mask is not None:
       role_mask = self.auth.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
-    await self.db.run(
-      DBRequest(
-        op="db:security:roles:remove_role_member:1",
-        payload={"role": role, "user_guid": user_guid},
-      ),
-    )
+    await self.db.run(remove_role_member_request(role, user_guid))
     await self.auth.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 

--- a/tests/test_account_role_services.py
+++ b/tests/test_account_role_services.py
@@ -46,9 +46,9 @@ class DummyDb:
     assert isinstance(request, DBRequest)
     op = request.op
     self.calls.append(request)
-    if op == "db:security:roles:get_role_members:1":
+    if op == "db:system:roles:get_role_members:1":
       return DBRes(self.members, len(self.members))
-    if op == "db:security:roles:get_role_non_members:1":
+    if op == "db:system:roles:get_role_non_members:1":
       return DBRes(self.non_members, len(self.non_members))
     if op == "db:system:roles:list:1":
       return DBRes(self.roles, len(self.roles))
@@ -70,7 +70,7 @@ class RoleCache:
     if self.db:
       await self.db.run(
         DBRequest(
-          op="db:security:roles:upsert_role:1",
+          op="db:system:roles:upsert_role:1",
           payload={"name": name, "mask": mask, "display": display},
         )
       )
@@ -80,7 +80,7 @@ class RoleCache:
     self.delete_args = name
     if self.db:
       await self.db.run(
-        DBRequest(op="db:security:roles:delete_role:1", payload={"name": name})
+        DBRequest(op="db:system:roles:delete_role:1", payload={"name": name})
       )
     await self.refresh_role_cache()
 
@@ -126,10 +126,10 @@ class DummyRoleAdmin:
 
   async def get_role_members(self, role):
     mem_res = await self.db.run(
-      DBRequest(op="db:security:roles:get_role_members:1", payload={"role": role})
+      DBRequest(op="db:system:roles:get_role_members:1", payload={"role": role})
     )
     non_res = await self.db.run(
-      DBRequest(op="db:security:roles:get_role_non_members:1", payload={"role": role})
+      DBRequest(op="db:system:roles:get_role_non_members:1", payload={"role": role})
     )
     members = [
       {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
@@ -147,7 +147,7 @@ class DummyRoleAdmin:
       self._ensure_can_manage(actor_mask, role_mask)
     await self.db.run(
       DBRequest(
-        op="db:security:roles:add_role_member:1",
+        op="db:system:roles:add_role_member:1",
         payload={"role": role, "user_guid": user_guid},
       )
     )
@@ -160,7 +160,7 @@ class DummyRoleAdmin:
       self._ensure_can_manage(actor_mask, role_mask)
     await self.db.run(
       DBRequest(
-        op="db:security:roles:remove_role_member:1",
+        op="db:system:roles:remove_role_member:1",
         payload={"role": role, "user_guid": user_guid},
       )
     )
@@ -223,7 +223,7 @@ def test_add_and_remove_member():
   svc_mod.unbox_request = fake_get_add
   resp = asyncio.run(account_role_add_role_member_v1(req))
   assert any(
-    call.op == "db:security:roles:add_role_member:1"
+    call.op == "db:system:roles:add_role_member:1"
     for call in db.calls
   )
   assert resp.payload["members"] == [{"guid": "u1", "displayName": "User 1"}]
@@ -249,7 +249,7 @@ def test_add_and_remove_member():
   svc_mod.unbox_request = fake_get_remove
   resp2 = asyncio.run(account_role_remove_role_member_v1(req))
   assert any(
-    call.op == "db:security:roles:remove_role_member:1"
+    call.op == "db:system:roles:remove_role_member:1"
     for call in db.calls
   )
   assert resp2.payload["members"] == []
@@ -279,7 +279,7 @@ def test_upsert_and_delete_role():
   resp = asyncio.run(account_role_upsert_role_v1(req))
   assert auth.role_cache.upsert_args == ("ROLE_NEW", 8, "New")
   assert any(
-    call.op == "db:security:roles:upsert_role:1"
+    call.op == "db:system:roles:upsert_role:1"
     and call.payload == {"name": "ROLE_NEW", "mask": 8, "display": "New"}
     for call in db.calls
   )
@@ -301,7 +301,7 @@ def test_upsert_and_delete_role():
   resp2 = asyncio.run(account_role_delete_role_v1(req))
   assert auth.role_cache.delete_args == "ROLE_NEW"
   assert any(
-    call.op == "db:security:roles:delete_role:1"
+    call.op == "db:system:roles:delete_role:1"
     and call.payload == {"name": "ROLE_NEW"}
     for call in db.calls
   )

--- a/tests/test_service_roles_services.py
+++ b/tests/test_service_roles_services.py
@@ -81,9 +81,9 @@ class DummyDb:
     assert isinstance(request, DBRequest)
     op = request.op
     self.calls.append(request)
-    if op == "db:security:roles:get_role_members:1":
+    if op == "db:system:roles:get_role_members:1":
       return DBRes(self.members, len(self.members))
-    if op == "db:security:roles:get_role_non_members:1":
+    if op == "db:system:roles:get_role_non_members:1":
       return DBRes(self.non_members, len(self.non_members))
     return DBRes()
 
@@ -109,7 +109,7 @@ class RoleCache:
     if self.db:
       await self.db.run(
         DBRequest(
-          op="db:security:roles:upsert_role:1",
+          op="db:system:roles:upsert_role:1",
           payload={"name": name, "mask": mask, "display": display},
         )
       )
@@ -119,7 +119,7 @@ class RoleCache:
     self.delete_args = name
     if self.db:
       await self.db.run(
-        DBRequest(op="db:security:roles:delete_role:1", payload={"name": name})
+        DBRequest(op="db:system:roles:delete_role:1", payload={"name": name})
       )
     await self.refresh_role_cache()
 
@@ -273,7 +273,7 @@ def test_upsert_role_calls_db_and_loads_roles():
   assert isinstance(resp, RPCResponse)
   assert auth.role_cache.upsert_args == ("ROLE_NEW", 4, "New")
   assert any(
-    call.op == "db:security:roles:upsert_role:1"
+    call.op == "db:system:roles:upsert_role:1"
     and call.payload == {"name": "ROLE_NEW", "mask": 4, "display": "New"}
     for call in db.calls
   )
@@ -298,7 +298,7 @@ def test_delete_role_calls_db_and_loads_roles():
   assert isinstance(resp, RPCResponse)
   assert auth.role_cache.delete_args == "ROLE_OLD"
   assert any(
-    call.op == "db:security:roles:delete_role:1"
+    call.op == "db:system:roles:delete_role:1"
     and call.payload == {"name": "ROLE_OLD"}
     for call in db.calls
   )

--- a/tests/test_system_roles_services.py
+++ b/tests/test_system_roles_services.py
@@ -46,7 +46,7 @@ class RoleCache:
     if self.db:
       await self.db.run(
         DBRequest(
-          op='db:security:roles:upsert_role:1',
+          op='db:system:roles:upsert_role:1',
           payload={'name': name, 'mask': mask, 'display': display},
         )
       )
@@ -56,7 +56,7 @@ class RoleCache:
     self.delete_args = name
     if self.db:
       await self.db.run(
-        DBRequest(op='db:security:roles:delete_role:1', payload={'name': name})
+        DBRequest(op='db:system:roles:delete_role:1', payload={'name': name})
       )
     await self.refresh_role_cache()
 
@@ -127,9 +127,9 @@ class DummyDb:
     if op == 'db:system:roles:list:1':
       rows = [{'name': 'ROLE_FOO', 'mask': 1, 'display': 'Foo'}]
       return SimpleNamespace(rows=rows, rowcount=1)
-    if op == 'db:security:roles:upsert_role:1':
+    if op == 'db:system:roles:upsert_role:1':
       return SimpleNamespace(rows=[], rowcount=1)
-    if op == 'db:security:roles:delete_role:1':
+    if op == 'db:system:roles:delete_role:1':
       return SimpleNamespace(rows=[], rowcount=1)
     raise AssertionError(f'unexpected op {op}')
 
@@ -194,12 +194,12 @@ def test_upsert_and_delete_role_service():
   resp = client.post('/rpc', json={'op': 'urn:system:roles:delete_role:1', 'payload': {'name': 'ROLE_FOO'}})
   assert resp.status_code == 200
   assert any(
-    call.op == 'db:security:roles:upsert_role:1'
+    call.op == 'db:system:roles:upsert_role:1'
     and call.payload == {'name': 'ROLE_FOO', 'mask': 1, 'display': 'Foo'}
     for call in db.calls
   )
   assert any(
-    call.op == 'db:security:roles:delete_role:1'
+    call.op == 'db:system:roles:delete_role:1'
     and call.payload == {'name': 'ROLE_FOO'}
     for call in db.calls
   )


### PR DESCRIPTION
## Summary
- update auth and role admin modules to use the new db:system:roles registry bindings
- align role service tests with the updated database operation identifiers

## Testing
- pytest tests/test_account_role_services.py tests/test_system_roles_services.py tests/test_service_roles_services.py

------
https://chatgpt.com/codex/tasks/task_e_68f7a519aaf083259b49efbd870ca7ef