### PR TITLE
Use accounts security profile request for Discord lookups

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -20,6 +20,7 @@ from server.registry.system.roles import (
   upsert_role_request,
 )
 from server.registry.types import DBRequest
+from server.registry.users.accounts import get_security_profile_request
 
 DEFAULT_SESSION_TOKEN_EXPIRY = 15 # minutes
 DEFAULT_ROTATION_TOKEN_EXPIRY = 90 # days
@@ -332,10 +333,7 @@ class AuthModule(BaseModule):
 
   async def get_discord_user_security(self, discord_id: str) -> tuple[str, list[str], int]:
     res = await self.db.run(
-      DBRequest(
-        op="db:auth:discord:get_security:1",
-        payload={"discord_id": discord_id},
-      ),
+      get_security_profile_request(discord_id=discord_id),
     )
     if not res.rows:
       return "", [], 0


### PR DESCRIPTION
## Summary
- update the authentication module to fetch Discord security profiles through the accounts registry request
- confirm the MSSQL security profile query already normalizes Discord identifiers

## Testing
- not run (explain why)

------
https://chatgpt.com/codex/tasks/task_e_68f7a709f8488325a831796d542bc172