### PR TITLE
Add users session registry bindings and MSSQL handlers

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -21,6 +21,7 @@ from server.registry.system.roles import (
 )
 from server.registry.types import DBRequest
 from server.registry.users.accounts import get_security_profile_request
+from server.registry.users.session import get_rotkey_request
 
 DEFAULT_SESSION_TOKEN_EXPIRY = 15 # minutes
 DEFAULT_ROTATION_TOKEN_EXPIRY = 90 # days
@@ -259,9 +260,7 @@ class AuthModule(BaseModule):
     if not guid or not session_guid or not device_guid:
       raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Subject not found", headers={"WWW-Authenticate": "Bearer"})
 
-    res = await self.db.run(
-      DBRequest(op="db:users:session:get_rotkey:1", payload={"guid": guid}),
-    )
+    res = await self.db.run(get_rotkey_request(guid=guid))
     rotkey = res.rows[0].get("rotkey") if res.rows else None
     derived_secret = f"{self.jwt_secret}:{rotkey}:{guid}:{session_guid}:{device_guid}" if rotkey else None
     try:

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -27,6 +27,7 @@ from server.registry.users.providers import (
   get_any_by_provider_identifier_request,
   get_by_provider_identifier_request,
 )
+from server.registry.users.session import set_rotkey_request
 
 
 class OauthModule(BaseModule):
@@ -197,14 +198,11 @@ class OauthModule(BaseModule):
     logging.debug(f"[create_session] rotation_token={rotation_token[:40]}")
     now = datetime.now(timezone.utc)
     await self.db.run(
-      DBRequest(
-        op="db:users:session:set_rotkey:1",
-        payload={
-          "guid": user_guid,
-          "rotkey": rotation_token,
-          "iat": now,
-          "exp": rot_exp,
-        },
+      set_rotkey_request(
+        guid=user_guid,
+        rotkey=rotation_token,
+        iat=now,
+        exp=rot_exp,
       ),
     )
     roles, _ = await self.auth.get_user_roles(user_guid)

--- a/server/modules/session_module.py
+++ b/server/modules/session_module.py
@@ -15,6 +15,7 @@ from server.registry.auth.session import (
   update_session_request,
 )
 from server.registry.types import DBRequest
+from server.registry.users.session import get_rotkey_request, set_rotkey_request
 
 
 class SessionModule(BaseModule):
@@ -105,9 +106,7 @@ class SessionModule(BaseModule):
   ) -> str:
     data = self.auth.decode_rotation_token(rotation_token)
     user_guid = data["guid"]
-    stored = await self.db.run(
-      DBRequest(op="db:users:session:get_rotkey:1", payload={"guid": user_guid}),
-    )
+    stored = await self.db.run(get_rotkey_request(guid=user_guid))
     row = stored.rows[0] if stored.rows else None
     if not row or row.get("rotkey") != rotation_token:
       raise HTTPException(status_code=401, detail="Invalid rotation token")
@@ -142,10 +141,7 @@ class SessionModule(BaseModule):
   async def invalidate_token(self, user_guid: str) -> None:
     now = datetime.now(timezone.utc)
     await self.db.run(
-      DBRequest(
-        op="db:users:session:set_rotkey:1",
-        payload={"guid": user_guid, "rotkey": "", "iat": now, "exp": now},
-      ),
+      set_rotkey_request(guid=user_guid, rotkey="", iat=now, exp=now),
     )
 
   async def logout_device(self, token: str) -> None:

--- a/server/registry/users/__init__.py
+++ b/server/registry/users/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from . import accounts, content, providers
+from . import accounts, content, providers, session
 
 if TYPE_CHECKING:
   from server.registry import RegistryRouter
@@ -14,6 +14,7 @@ __all__ = [
   "content",
   "providers",
   "register",
+  "session",
 ]
 
 
@@ -22,3 +23,4 @@ def register(router: "RegistryRouter") -> None:
   content.register(domain)
   accounts.register(domain.subdomain("accounts", op_segment="account"))
   providers.register(domain.subdomain("providers"))
+  session.register(domain.subdomain("session"))

--- a/server/registry/users/session/__init__.py
+++ b/server/registry/users/session/__init__.py
@@ -1,0 +1,51 @@
+"""Session registry helpers for the users domain."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, TYPE_CHECKING
+
+from server.registry.types import DBRequest
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "get_rotkey_request",
+  "register",
+  "set_rotkey_request",
+]
+
+
+def _request(op: str, params: dict[str, Any]) -> DBRequest:
+  return DBRequest(op=op, params=params)
+
+
+def get_rotkey_request(*, guid: str) -> DBRequest:
+  return _request(
+    "db:users:session:get_rotkey:1",
+    {"guid": guid},
+  )
+
+
+def set_rotkey_request(
+  *,
+  guid: str,
+  rotkey: str,
+  iat: datetime,
+  exp: datetime,
+) -> DBRequest:
+  return _request(
+    "db:users:session:set_rotkey:1",
+    {
+      "guid": guid,
+      "rotkey": rotkey,
+      "iat": iat,
+      "exp": exp,
+    },
+  )
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function("get_rotkey", version=1)
+  router.add_function("set_rotkey", version=1)

--- a/server/registry/users/session/mssql.py
+++ b/server/registry/users/session/mssql.py
@@ -1,0 +1,74 @@
+"""MSSQL-backed handlers for user session registry operations."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from server.registry.providers.mssql import run_exec, run_json_one
+from server.registry.types import DBResponse
+
+__all__ = [
+  "get_rotkey_v1",
+  "set_rotkey_v1",
+]
+
+
+async def get_rotkey_v1(params: dict[str, Any]) -> DBResponse:
+  guid = str(UUID(params["guid"]))
+  sql = """
+    SELECT TOP 1
+      au.element_guid AS user_guid,
+      au.element_rotkey AS rotkey,
+      au.element_rotkey_iat AS rotkey_iat,
+      au.element_rotkey_exp AS rotkey_exp,
+      ap.element_name AS provider_name,
+      ap.element_display AS provider_display,
+      latest.session_guid,
+      latest.session_created_on,
+      latest.session_modified_on,
+      latest.device_guid,
+      latest.device_token,
+      latest.device_token_iat,
+      latest.device_token_exp,
+      latest.revoked_at,
+      latest.device_fingerprint,
+      latest.user_agent,
+      latest.ip_last_seen
+    FROM account_users au
+    LEFT JOIN auth_providers ap ON ap.recid = au.providers_recid
+    OUTER APPLY (
+      SELECT TOP 1
+        us.element_guid AS session_guid,
+        us.element_created_on AS session_created_on,
+        us.element_modified_on AS session_modified_on,
+        sd.element_guid AS device_guid,
+        sd.element_token AS device_token,
+        sd.element_token_iat AS device_token_iat,
+        sd.element_token_exp AS device_token_exp,
+        sd.element_revoked_at AS revoked_at,
+        sd.element_device_fingerprint AS device_fingerprint,
+        sd.element_user_agent AS user_agent,
+        sd.element_ip_last_seen AS ip_last_seen
+      FROM users_sessions us
+      JOIN sessions_devices sd ON sd.sessions_guid = us.element_guid
+      WHERE us.users_guid = au.element_guid
+      ORDER BY sd.element_token_iat DESC
+    ) latest
+    WHERE au.element_guid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return await run_json_one(sql, (guid,))
+
+
+async def set_rotkey_v1(args: dict[str, Any]) -> DBResponse:
+  guid = str(UUID(args["guid"]))
+  rotkey = args["rotkey"]
+  iat = args["iat"]
+  exp = args["exp"]
+  sql = """
+    UPDATE account_users
+    SET element_rotkey = ?, element_rotkey_iat = ?, element_rotkey_exp = ?
+    WHERE element_guid = ?;
+  """
+  return await run_exec(sql, (rotkey, iat, exp, guid))


### PR DESCRIPTION
## Summary
- add a users.session registry package with request builders for rotation key operations
- implement MSSQL handlers for fetching and updating session rotation key data and register the subdomain
- update auth, oauth, and session modules to use the new registry helpers

## Testing
- pytest tests/test_auth_google_oauth_login_creation.py

------
https://chatgpt.com/codex/tasks/task_e_68f7af9da27083258927728fca844c30