### PR TITLE
Pluralize users account registry operations

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -175,7 +175,7 @@ class DbModule(BaseModule):
 
   async def user_exists(self, user_guid: str) -> bool:
     res = await self.run(
-      DBRequest(op="db:users:account:exists:1", payload={"user_guid": user_guid})
+      DBRequest(op="db:users:accounts:exists:1", payload={"user_guid": user_guid})
     )
     return bool(res.rows)
 

--- a/server/registry/users/__init__.py
+++ b/server/registry/users/__init__.py
@@ -21,6 +21,9 @@ __all__ = [
 def register(router: "RegistryRouter") -> None:
   domain = router.domain("users")
   content.register(domain)
-  accounts.register(domain.subdomain("accounts", op_segment="account"))
+  accounts.register(
+    domain.subdomain("accounts"),
+    legacy_op_segment="account",
+  )
   providers.register(domain.subdomain("providers"))
   session.register(domain.subdomain("session"))

--- a/server/registry/users/accounts/__init__.py
+++ b/server/registry/users/accounts/__init__.py
@@ -35,16 +35,42 @@ def get_security_profile_request(
     params["provider_identifier"] = provider_identifier
   if discord_id is not None:
     params["discord_id"] = discord_id
-  return DBRequest(op="db:users:account:get_security_profile:1", params=params)
+  return DBRequest(op="db:users:accounts:get_security_profile:1", params=params)
 
 
 def account_exists_request(user_guid: str) -> DBRequest:
   return DBRequest(
-    op="db:users:account:exists:1",
+    op="db:users:accounts:exists:1",
     params={"user_guid": user_guid},
   )
 
 
-def register(router: "SubdomainRouter") -> None:
+def register(
+  router: "SubdomainRouter",
+  *,
+  legacy_op_segment: str | None = None,
+) -> None:
   router.add_function("get_security_profile", version=1)
   router.add_function("account_exists", version=1)
+
+  if legacy_op_segment:
+    # Temporary compatibility alias while dependents migrate off singular ops.
+    from server.registry import SubdomainRouter as _SubdomainRouter
+
+    legacy_router = _SubdomainRouter(
+      router._registry,
+      router._domain,
+      router._module_components,
+      (legacy_op_segment,),
+      provider=router._provider,
+    )
+    legacy_router.add_function(
+      "get_security_profile",
+      version=1,
+      implementation="get_security_profile",
+    )
+    legacy_router.add_function(
+      "account_exists",
+      version=1,
+      implementation="account_exists",
+    )

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -64,7 +64,7 @@ def test_account_security_filters_by_provider(monkeypatch):
   monkeypatch.setattr(accounts_mssql, "run_json_one", fake_run_json_one)
 
   provider_identifier = str(uuid4())
-  handler = get_handler("db:users:account:get_security_profile:1")
+  handler = get_handler("db:users:accounts:get_security_profile:1")
   asyncio.run(
     handler({
       "provider": "microsoft",
@@ -90,7 +90,7 @@ def test_account_security_filters_by_discord(monkeypatch):
 
   monkeypatch.setattr(accounts_mssql, "run_json_one", fake_run_json_one)
 
-  handler = get_handler("db:users:account:get_security_profile:1")
+  handler = get_handler("db:users:accounts:get_security_profile:1")
   asyncio.run(handler({"discord_id": "42"}))
   sql = captured["sql"].lower()
   assert "vw_user_session_security" in sql


### PR DESCRIPTION
## Summary
- pluralize the users account registry operations to use the `db:users:accounts:*` identifier
- register a temporary alias for the legacy singular operation names
- update modules and tests to reference the new operation path

## Testing
- pytest tests/test_provider_queries.py

------
https://chatgpt.com/codex/tasks/task_e_68f7b401118483258c53b06f0afefe80