### PR TITLE
Add registries for account enablements, actions, and system service pages

### DIFF
--- a/server/registry/account/__init__.py
+++ b/server/registry/account/__init__.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from . import accounts, content, oauth, providers, session
+from . import actions, accounts, content, enablements, oauth, providers, session
 
 if TYPE_CHECKING:
   from server.registry import RegistryRouter
 
 __all__ = [
+  "actions",
   "accounts",
   "content",
+  "enablements",
   "providers",
   "register",
   "session",
@@ -25,6 +27,8 @@ def register(router: "RegistryRouter") -> None:
     domain.subdomain("accounts"),
     legacy_op_segment="account",
   )
+  actions.register(domain.subdomain("actions"))
+  enablements.register(domain.subdomain("enablements"))
   providers.register(domain.subdomain("providers"))
   oauth.register(domain.subdomain("oauth"))
   session.register(domain.subdomain("session"))

--- a/server/registry/account/actions/__init__.py
+++ b/server/registry/account/actions/__init__.py
@@ -1,0 +1,88 @@
+"""Account user action log registry helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from server.registry.types import DBRequest
+
+from .model import (
+  ListUserActionsParams,
+  LogUserActionParams,
+  UpdateUserActionParams,
+  UserActionLogRecord,
+)
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "list_user_actions_request",
+  "log_user_action_request",
+  "register",
+  "update_user_action_request",
+  "ListUserActionsParams",
+  "LogUserActionParams",
+  "UpdateUserActionParams",
+  "UserActionLogRecord",
+]
+
+_OP_PREFIX = "db:account:actions"
+
+
+def _op(name: str) -> str:
+  return f"{_OP_PREFIX}:{name}:1"
+
+
+def list_user_actions_request(
+  *,
+  users_guid: str,
+  action_recid: int | None = None,
+  limit: int | None = None,
+) -> DBRequest:
+  params: ListUserActionsParams = {"users_guid": users_guid}
+  if action_recid is not None:
+    params["action_recid"] = action_recid
+  if limit is not None:
+    params["limit"] = limit
+  return DBRequest(op=_op("list_by_user"), params=params)
+
+
+def log_user_action_request(
+  *,
+  recid: int,
+  users_guid: str,
+  action_recid: int,
+  element_url: str | None = None,
+  element_notes: str | None = None,
+) -> DBRequest:
+  params: LogUserActionParams = {
+    "recid": recid,
+    "users_guid": users_guid,
+    "action_recid": action_recid,
+  }
+  if element_url is not None:
+    params["element_url"] = element_url
+  if element_notes is not None:
+    params["element_notes"] = element_notes
+  return DBRequest(op=_op("log"), params=params)
+
+
+def update_user_action_request(
+  *,
+  recid: int,
+  element_url: str | None = None,
+  element_notes: str | None = None,
+) -> DBRequest:
+  params: UpdateUserActionParams = {"recid": recid}
+  if element_url is not None:
+    params["element_url"] = element_url
+  if element_notes is not None:
+    params["element_notes"] = element_notes
+  return DBRequest(op=_op("update"), params=params)
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function("list_by_user", version=1)
+  router.add_function("log", version=1)
+  router.add_function("update", version=1)

--- a/server/registry/account/actions/model.py
+++ b/server/registry/account/actions/model.py
@@ -1,0 +1,43 @@
+"""Typed contracts for user action log registry operations."""
+
+from __future__ import annotations
+
+from typing import NotRequired, TypedDict
+
+__all__ = [
+  "ListUserActionsParams",
+  "LogUserActionParams",
+  "UpdateUserActionParams",
+  "UserActionLogRecord",
+]
+
+
+class UserActionLogRecord(TypedDict, total=False):
+  recid: int
+  users_guid: str
+  action_recid: int
+  action_label: str | None
+  action_description: str | None
+  element_url: str | None
+  element_logged_on: str
+  element_notes: str | None
+
+
+class ListUserActionsParams(TypedDict):
+  users_guid: str
+  action_recid: NotRequired[int | None]
+  limit: NotRequired[int | None]
+
+
+class LogUserActionParams(TypedDict):
+  recid: int
+  users_guid: str
+  action_recid: int
+  element_url: NotRequired[str | None]
+  element_notes: NotRequired[str | None]
+
+
+class UpdateUserActionParams(TypedDict):
+  recid: int
+  element_url: NotRequired[str | None]
+  element_notes: NotRequired[str | None]

--- a/server/registry/account/actions/mssql.py
+++ b/server/registry/account/actions/mssql.py
@@ -1,0 +1,97 @@
+"""MSSQL helpers for user action log operations."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from server.registry.providers.mssql import run_exec, run_json_many
+from server.registry.types import DBResponse
+
+__all__ = [
+  "list_by_user_v1",
+  "log_v1",
+  "update_v1",
+]
+
+
+async def list_by_user_v1(params: dict[str, Any]) -> DBResponse:
+  guid = str(UUID(str(params["users_guid"])))
+  filters = ["ual.users_guid = ?"]
+  args: list[Any] = [guid]
+
+  action_recid = params.get("action_recid")
+  if action_recid is not None:
+    filters.append("ual.action_recid = ?")
+    args.append(int(action_recid))
+
+  where_clause = " AND ".join(filters)
+  order_clause = "ORDER BY ual.element_logged_on DESC"
+  fetch_clause = ""
+
+  limit = params.get("limit")
+  if limit is not None:
+    limit_value = int(limit)
+    if limit_value > 0:
+      fetch_clause = " OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY"
+      args.append(limit_value)
+
+  sql = f"""
+    SELECT
+      ual.recid,
+      ual.users_guid,
+      ual.action_recid,
+      aa.action_label,
+      aa.action_description,
+      ual.element_url,
+      ual.element_logged_on,
+      ual.element_notes
+    FROM users_actions_log ual
+    LEFT JOIN account_actions aa ON aa.recid = ual.action_recid
+    WHERE {where_clause}
+    {order_clause}{fetch_clause}
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql, tuple(args))
+
+
+async def log_v1(params: dict[str, Any]) -> DBResponse:
+  recid = int(params["recid"])
+  guid = str(UUID(str(params["users_guid"])))
+  action_recid = int(params["action_recid"])
+  element_url = params.get("element_url")
+  element_notes = params.get("element_notes")
+  sql = """
+    INSERT INTO users_actions_log (
+      recid,
+      users_guid,
+      action_recid,
+      element_url,
+      element_notes
+    ) VALUES (?, ?, ?, ?, ?);
+  """
+  return await run_exec(sql, (recid, guid, action_recid, element_url, element_notes))
+
+
+async def update_v1(params: dict[str, Any]) -> DBResponse:
+  recid = int(params["recid"])
+  assignments: list[str] = []
+  args: list[Any] = []
+
+  if "element_url" in params:
+    assignments.append("element_url = ?")
+    args.append(params.get("element_url"))
+  if "element_notes" in params:
+    assignments.append("element_notes = ?")
+    args.append(params.get("element_notes"))
+
+  if not assignments:
+    return DBResponse()
+
+  args.append(recid)
+  sql = f"""
+    UPDATE users_actions_log
+    SET {", ".join(assignments)}
+    WHERE recid = ?;
+  """
+  return await run_exec(sql, tuple(args))

--- a/server/registry/account/enablements/__init__.py
+++ b/server/registry/account/enablements/__init__.py
@@ -1,0 +1,51 @@
+"""Account enablements registry helpers."""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from server.registry.types import DBRequest
+
+from .model import (
+  UpsertUserEnablementsParams,
+  UserEnablementsRecord,
+)
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "get_user_enablements_request",
+  "register",
+  "upsert_user_enablements_request",
+  "UpsertUserEnablementsParams",
+  "UserEnablementsRecord",
+]
+
+_OP_PREFIX = "db:account:enablements"
+
+
+def _op(name: str) -> str:
+  return f"{_OP_PREFIX}:{name}:1"
+
+
+def get_user_enablements_request(*, users_guid: str) -> DBRequest:
+  params: dict[str, Any] = {"users_guid": users_guid}
+  return DBRequest(op=_op("get_by_user"), params=params)
+
+
+def upsert_user_enablements_request(
+  *,
+  users_guid: str,
+  element_enablements: str,
+) -> DBRequest:
+  params: UpsertUserEnablementsParams = {
+    "users_guid": users_guid,
+    "element_enablements": element_enablements,
+  }
+  return DBRequest(op=_op("upsert"), params=params)
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function("get_by_user", version=1)
+  router.add_function("upsert", version=1)

--- a/server/registry/account/enablements/model.py
+++ b/server/registry/account/enablements/model.py
@@ -1,0 +1,22 @@
+"""Typed contracts for user enablement registry operations."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+__all__ = [
+  "UpsertUserEnablementsParams",
+  "UserEnablementsRecord",
+]
+
+
+class UserEnablementsRecord(TypedDict, total=False):
+  users_guid: str
+  element_enablements: str
+  created_on: str
+  modified_on: str
+
+
+class UpsertUserEnablementsParams(TypedDict):
+  users_guid: str
+  element_enablements: str

--- a/server/registry/account/enablements/mssql.py
+++ b/server/registry/account/enablements/mssql.py
@@ -1,0 +1,51 @@
+"""MSSQL helpers for user enablement registry operations."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from server.registry.providers.mssql import run_exec, run_json_one
+from server.registry.types import DBResponse
+
+__all__ = [
+  "get_by_user_v1",
+  "upsert_v1",
+]
+
+
+async def get_by_user_v1(params: dict[str, Any]) -> DBResponse:
+  guid = str(UUID(str(params["users_guid"])))
+  sql = """
+    SELECT TOP 1
+      ue.users_guid,
+      ue.element_enablements,
+      ue.created_on,
+      ue.modified_on
+    FROM users_enablements ue
+    WHERE ue.users_guid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return await run_json_one(sql, (guid,))
+
+
+async def upsert_v1(params: dict[str, Any]) -> DBResponse:
+  guid = str(UUID(str(params["users_guid"])))
+  enablements = str(params["element_enablements"])
+  updated = await run_exec(
+    """
+    UPDATE users_enablements
+    SET element_enablements = ?, modified_on = SYSUTCDATETIME()
+    WHERE users_guid = ?;
+    """,
+    (enablements, guid),
+  )
+  if updated.rowcount == 0:
+    return await run_exec(
+      """
+      INSERT INTO users_enablements (users_guid, element_enablements)
+      VALUES (?, ?);
+      """,
+      (guid, enablements),
+    )
+  return updated

--- a/server/registry/account/session/__init__.py
+++ b/server/registry/account/session/__init__.py
@@ -17,7 +17,9 @@ __all__ = [
   "revoke_all_device_tokens_request",
   "revoke_device_token_request",
   "revoke_provider_tokens_request",
+  "get_security_snapshot_request",
   "set_rotkey_request",
+  "list_session_snapshots_request",
   "update_device_token_request",
   "update_session_request",
 ]
@@ -25,6 +27,14 @@ __all__ = [
 
 def _request(name: str, params: dict[str, Any]) -> DBRequest:
   return DBRequest(op=f"db:account:session:{name}:1", params=params)
+
+
+def list_session_snapshots_request(*, guid: str) -> DBRequest:
+  return _request("list_snapshots", {"guid": guid})
+
+
+def get_security_snapshot_request(*, guid: str) -> DBRequest:
+  return _request("get_security_snapshot", {"guid": guid})
 
 
 def create_session_request(
@@ -124,3 +134,5 @@ def register(router: "SubdomainRouter") -> None:
   router.add_function("revoke_provider_tokens", version=1)
   router.add_function("get_rotkey", version=1)
   router.add_function("set_rotkey", version=1)
+  router.add_function("list_snapshots", version=1)
+  router.add_function("get_security_snapshot", version=1)

--- a/server/registry/account/session/mssql.py
+++ b/server/registry/account/session/mssql.py
@@ -7,12 +7,14 @@ from uuid import UUID, uuid4
 
 from server.modules.providers.database.mssql_provider.logic import transaction
 from server.registry.account.providers.mssql import get_auth_provider_recid
-from server.registry.providers.mssql import run_exec, run_json_one
+from server.registry.providers.mssql import run_exec, run_json_many, run_json_one
 from server.registry.types import DBResponse
 
 __all__ = [
   "create_session_v1",
   "get_rotkey_v1",
+  "get_security_snapshot_v1",
+  "list_snapshots_v1",
   "revoke_all_device_tokens_v1",
   "revoke_device_token_v1",
   "revoke_provider_tokens_v1",
@@ -215,3 +217,60 @@ async def set_rotkey_v1(args: dict[str, Any]) -> DBResponse:
     WHERE element_guid = ?;
   """
   return await run_exec(sql, (rotkey, iat, exp, guid))
+
+
+async def list_snapshots_v1(params: dict[str, Any]) -> DBResponse:
+  guid = str(UUID(params["guid"]))
+  sql = """
+    SELECT
+      aus.user_guid,
+      aus.user_roles,
+      aus.user_created_on,
+      aus.user_modified_on,
+      aus.element_rotkey,
+      aus.element_rotkey_iat,
+      aus.element_rotkey_exp,
+      aus.session_guid,
+      aus.session_created_on,
+      aus.session_modified_on,
+      aus.device_guid,
+      aus.device_created_on,
+      aus.device_modified_on,
+      aus.element_token,
+      aus.element_token_iat,
+      aus.element_token_exp,
+      aus.element_revoked_at,
+      aus.element_device_fingerprint,
+      aus.element_user_agent,
+      aus.element_ip_last_seen
+    FROM vw_account_user_sessions aus
+    WHERE aus.user_guid = ?
+    ORDER BY aus.session_created_on DESC, aus.device_created_on DESC
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql, (guid,))
+
+
+async def get_security_snapshot_v1(params: dict[str, Any]) -> DBResponse:
+  guid = str(UUID(params["guid"]))
+  sql = """
+    SELECT
+      aus.user_guid,
+      aus.element_rotkey,
+      aus.element_rotkey_iat,
+      aus.element_rotkey_exp,
+      aus.session_guid,
+      aus.device_guid,
+      aus.element_token,
+      aus.element_token_iat,
+      aus.element_token_exp,
+      aus.element_revoked_at,
+      aus.element_device_fingerprint,
+      aus.element_user_agent,
+      aus.element_ip_last_seen
+    FROM vw_account_user_security aus
+    WHERE aus.user_guid = ?
+    ORDER BY aus.element_token_iat DESC
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql, (guid,))

--- a/server/registry/system/__init__.py
+++ b/server/registry/system/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from . import config, conversations, guilds, links, models, personas, public_users, roles, routes, vars
+from . import config, conversations, guilds, links, models, personas, public_users, roles, routes, service_pages, vars
 
 if TYPE_CHECKING:
   from server.registry import RegistryRouter
@@ -15,11 +15,12 @@ __all__ = [
   "guilds",
   "links",
   "models",
-  "public_users",
   "personas",
+  "public_users",
   "register",
   "roles",
   "routes",
+  "service_pages",
   "vars",
 ]
 
@@ -35,4 +36,5 @@ def register(router: "RegistryRouter") -> None:
   roles.register(domain.subdomain("roles"))
   routes.register(domain.subdomain("routes"))
   public_users.register(domain.subdomain("public_users"))
+  service_pages.register(domain.subdomain("service_pages"))
   vars.register(domain.subdomain("vars"))

--- a/server/registry/system/service_pages/__init__.py
+++ b/server/registry/system/service_pages/__init__.py
@@ -1,0 +1,128 @@
+"""System service page registry helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from server.registry.types import DBRequest
+
+from .model import (
+  CreateServicePageParams,
+  DeleteServicePageParams,
+  GetServicePageByRouteParams,
+  GetServicePageParams,
+  ListServicePagesParams,
+  ServicePageRecord,
+  UpdateServicePageParams,
+)
+
+if TYPE_CHECKING:
+  from server.registry import SubdomainRouter
+
+__all__ = [
+  "create_service_page_request",
+  "delete_service_page_request",
+  "get_service_page_by_route_request",
+  "get_service_page_request",
+  "list_service_pages_request",
+  "register",
+  "update_service_page_request",
+  "CreateServicePageParams",
+  "DeleteServicePageParams",
+  "GetServicePageByRouteParams",
+  "GetServicePageParams",
+  "ListServicePagesParams",
+  "ServicePageRecord",
+  "UpdateServicePageParams",
+]
+
+_OP_PREFIX = "db:system:service_pages"
+
+
+def _op(name: str) -> str:
+  return f"{_OP_PREFIX}:{name}:1"
+
+
+def list_service_pages_request(*, include_inactive: bool = True) -> DBRequest:
+  params: ListServicePagesParams = {}
+  if not include_inactive:
+    params["element_is_active"] = True
+  return DBRequest(op=_op("list"), params=params)
+
+
+def get_service_page_request(*, recid: int) -> DBRequest:
+  params: GetServicePageParams = {"recid": recid}
+  return DBRequest(op=_op("get"), params=params)
+
+
+def get_service_page_by_route_request(
+  *,
+  route_name: str,
+  active_only: bool = True,
+) -> DBRequest:
+  params: GetServicePageByRouteParams = {"element_route_name": route_name}
+  if active_only:
+    params["element_is_active"] = True
+  return DBRequest(op=_op("get_by_route"), params=params)
+
+
+def create_service_page_request(
+  *,
+  recid: int,
+  route_name: str,
+  page_blob: str,
+  created_by: str,
+  modified_by: str,
+  version: int | None = None,
+  is_active: bool | None = None,
+) -> DBRequest:
+  params: CreateServicePageParams = {
+    "recid": recid,
+    "element_route_name": route_name,
+    "element_pageblob": page_blob,
+    "element_created_by": created_by,
+    "element_modified_by": modified_by,
+  }
+  if version is not None:
+    params["element_version"] = version
+  if is_active is not None:
+    params["element_is_active"] = is_active
+  return DBRequest(op=_op("create"), params=params)
+
+
+def update_service_page_request(
+  *,
+  recid: int,
+  modified_by: str,
+  route_name: str | None = None,
+  page_blob: str | None = None,
+  version: int | None = None,
+  is_active: bool | None = None,
+) -> DBRequest:
+  params: UpdateServicePageParams = {
+    "recid": recid,
+    "element_modified_by": modified_by,
+  }
+  if route_name is not None:
+    params["element_route_name"] = route_name
+  if page_blob is not None:
+    params["element_pageblob"] = page_blob
+  if version is not None:
+    params["element_version"] = version
+  if is_active is not None:
+    params["element_is_active"] = is_active
+  return DBRequest(op=_op("update"), params=params)
+
+
+def delete_service_page_request(*, recid: int) -> DBRequest:
+  params: DeleteServicePageParams = {"recid": recid}
+  return DBRequest(op=_op("delete"), params=params)
+
+
+def register(router: "SubdomainRouter") -> None:
+  router.add_function("list", version=1)
+  router.add_function("get", version=1)
+  router.add_function("get_by_route", version=1)
+  router.add_function("create", version=1)
+  router.add_function("update", version=1)
+  router.add_function("delete", version=1)

--- a/server/registry/system/service_pages/model.py
+++ b/server/registry/system/service_pages/model.py
@@ -1,0 +1,63 @@
+"""Typed contracts for service page registry operations."""
+
+from __future__ import annotations
+
+from typing import NotRequired, TypedDict
+
+__all__ = [
+  "CreateServicePageParams",
+  "DeleteServicePageParams",
+  "GetServicePageByRouteParams",
+  "GetServicePageParams",
+  "ListServicePagesParams",
+  "ServicePageRecord",
+  "UpdateServicePageParams",
+]
+
+
+class ServicePageRecord(TypedDict, total=False):
+  recid: int
+  element_route_name: str
+  element_pageblob: str
+  element_version: int
+  element_created_on: str
+  element_modified_on: str
+  element_created_by: str
+  element_modified_by: str
+  element_is_active: bool
+
+
+class ListServicePagesParams(TypedDict, total=False):
+  element_is_active: NotRequired[bool]
+
+
+class GetServicePageParams(TypedDict):
+  recid: int
+
+
+class GetServicePageByRouteParams(TypedDict):
+  element_route_name: str
+  element_is_active: NotRequired[bool]
+
+
+class CreateServicePageParams(TypedDict):
+  recid: int
+  element_route_name: str
+  element_pageblob: str
+  element_created_by: str
+  element_modified_by: str
+  element_version: NotRequired[int]
+  element_is_active: NotRequired[bool]
+
+
+class UpdateServicePageParams(TypedDict):
+  recid: int
+  element_modified_by: str
+  element_route_name: NotRequired[str]
+  element_pageblob: NotRequired[str]
+  element_version: NotRequired[int]
+  element_is_active: NotRequired[bool]
+
+
+class DeleteServicePageParams(TypedDict):
+  recid: int

--- a/server/registry/system/service_pages/mssql.py
+++ b/server/registry/system/service_pages/mssql.py
@@ -1,0 +1,162 @@
+"""MSSQL helpers for service page registry operations."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from server.registry.providers.mssql import run_exec, run_json_many, run_json_one
+from server.registry.types import DBResponse
+
+__all__ = [
+  "create_v1",
+  "delete_v1",
+  "get_by_route_v1",
+  "get_v1",
+  "list_v1",
+  "update_v1",
+]
+
+
+def _to_bool_flag(value: Any) -> int:
+  return 1 if bool(value) else 0
+
+
+async def list_v1(params: dict[str, Any]) -> DBResponse:
+  filters: list[str] = []
+  args: list[Any] = []
+
+  if "element_is_active" in params:
+    filters.append("sp.element_is_active = ?")
+    args.append(_to_bool_flag(params["element_is_active"]))
+
+  where_clause = ""
+  if filters:
+    where_clause = "WHERE " + " AND ".join(filters)
+
+  sql = f"""
+    SELECT
+      sp.recid,
+      sp.element_route_name,
+      sp.element_pageblob,
+      sp.element_version,
+      sp.element_created_on,
+      sp.element_modified_on,
+      sp.element_created_by,
+      sp.element_modified_by,
+      sp.element_is_active
+    FROM service_pages sp
+    {where_clause}
+    ORDER BY sp.element_route_name, sp.element_version DESC
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql, tuple(args))
+
+
+async def get_v1(params: dict[str, Any]) -> DBResponse:
+  recid = int(params["recid"])
+  sql = """
+    SELECT
+      sp.recid,
+      sp.element_route_name,
+      sp.element_pageblob,
+      sp.element_version,
+      sp.element_created_on,
+      sp.element_modified_on,
+      sp.element_created_by,
+      sp.element_modified_by,
+      sp.element_is_active
+    FROM service_pages sp
+    WHERE sp.recid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return await run_json_one(sql, (recid,))
+
+
+async def get_by_route_v1(params: dict[str, Any]) -> DBResponse:
+  route_name = str(params["element_route_name"])
+  filters = ["sp.element_route_name = ?"]
+  args: list[Any] = [route_name]
+
+  if "element_is_active" in params:
+    filters.append("sp.element_is_active = ?")
+    args.append(_to_bool_flag(params["element_is_active"]))
+
+  where_clause = " AND ".join(filters)
+  sql = f"""
+    SELECT TOP 1
+      sp.recid,
+      sp.element_route_name,
+      sp.element_pageblob,
+      sp.element_version,
+      sp.element_created_on,
+      sp.element_modified_on,
+      sp.element_created_by,
+      sp.element_modified_by,
+      sp.element_is_active
+    FROM service_pages sp
+    WHERE {where_clause}
+    ORDER BY sp.element_version DESC, sp.element_modified_on DESC
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return await run_json_one(sql, tuple(args))
+
+
+async def create_v1(params: dict[str, Any]) -> DBResponse:
+  recid = int(params["recid"])
+  route_name = str(params["element_route_name"])
+  page_blob = str(params["element_pageblob"])
+  version = int(params.get("element_version", 1))
+  created_by = str(UUID(str(params["element_created_by"])))
+  modified_by = str(UUID(str(params["element_modified_by"])))
+  is_active = _to_bool_flag(params.get("element_is_active", True))
+  sql = """
+    INSERT INTO service_pages (
+      recid,
+      element_route_name,
+      element_pageblob,
+      element_version,
+      element_created_by,
+      element_modified_by,
+      element_is_active
+    ) VALUES (?, ?, ?, ?, ?, ?, ?);
+  """
+  return await run_exec(
+    sql,
+    (recid, route_name, page_blob, version, created_by, modified_by, is_active),
+  )
+
+
+async def update_v1(params: dict[str, Any]) -> DBResponse:
+  recid = int(params["recid"])
+  modified_by = str(UUID(str(params["element_modified_by"])))
+
+  assignments: list[str] = ["element_modified_by = ?", "element_modified_on = SYSUTCDATETIME()"]
+  args: list[Any] = [modified_by]
+
+  if "element_route_name" in params:
+    assignments.append("element_route_name = ?")
+    args.append(str(params["element_route_name"]))
+  if "element_pageblob" in params:
+    assignments.append("element_pageblob = ?")
+    args.append(str(params["element_pageblob"]))
+  if "element_version" in params:
+    assignments.append("element_version = ?")
+    args.append(int(params["element_version"]))
+  if "element_is_active" in params:
+    assignments.append("element_is_active = ?")
+    args.append(_to_bool_flag(params["element_is_active"]))
+
+  sql = f"""
+    UPDATE service_pages
+    SET {", ".join(assignments)}
+    WHERE recid = ?;
+  """
+  args.append(recid)
+  return await run_exec(sql, tuple(args))
+
+
+async def delete_v1(params: dict[str, Any]) -> DBResponse:
+  recid = int(params["recid"])
+  sql = "DELETE FROM service_pages WHERE recid = ?;"
+  return await run_exec(sql, (recid,))

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -7,9 +7,13 @@ import pytest
 from server.registry import get_handler
 from server.registry.finance.credits import mssql as finance_credits_mssql
 from server.registry.types import DBResponse
+from server.registry.account.actions import mssql as actions_mssql
 from server.registry.account.accounts import mssql as accounts_mssql
+from server.registry.account.enablements import mssql as enablements_mssql
 from server.registry.account.profile import mssql as profile_mssql
 from server.registry.account.providers import mssql as users_providers_mssql
+from server.registry.account.session import mssql as session_mssql
+from server.registry.system.service_pages import mssql as service_pages_mssql
 from server.modules.providers.database.mssql_provider import db_helpers
 
 
@@ -97,6 +101,244 @@ def test_account_security_filters_by_discord(monkeypatch):
   assert "auth_providers" in sql
   assert "ua.element_identifier" in sql
   assert any(param == "discord" for param in captured["params"])
+
+
+def test_account_enablements_get_by_user_uses_table(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_json_one(sql, params):
+    captured["sql"] = sql
+    captured["params"] = tuple(params)
+    return DBResponse()
+
+  monkeypatch.setattr(enablements_mssql, "run_json_one", fake_run_json_one)
+
+  guid = str(uuid4())
+  handler = get_handler("db:account:enablements:get_by_user:1")
+  asyncio.run(handler({"users_guid": guid}))
+  sql = captured["sql"].lower()
+  assert "from users_enablements" in sql
+  assert "for json path" in sql
+  assert captured["params"] == (guid,)
+
+
+def test_account_enablements_upsert_inserts_when_missing(monkeypatch):
+  calls: list[tuple[str, tuple[Any, ...]]] = []
+
+  async def fake_run_exec(sql, params):
+    calls.append((sql, tuple(params)))
+    if "update users_enablements" in sql.lower():
+      return DBResponse(rowcount=0)
+    return DBResponse(rowcount=1)
+
+  monkeypatch.setattr(enablements_mssql, "run_exec", fake_run_exec)
+
+  guid = str(uuid4())
+  asyncio.run(
+    enablements_mssql.upsert_v1({
+      "users_guid": guid,
+      "element_enablements": "111",
+    })
+  )
+
+  sql_calls = [sql.lower() for sql, _ in calls]
+  assert any("update users_enablements" in sql for sql in sql_calls)
+  assert any("insert into users_enablements" in sql for sql in sql_calls)
+
+
+def test_account_actions_list_by_user_joins_actions(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_json_many(sql, params):
+    captured["sql"] = sql
+    captured["params"] = tuple(params)
+    return DBResponse()
+
+  monkeypatch.setattr(actions_mssql, "run_json_many", fake_run_json_many)
+
+  guid = str(uuid4())
+  handler = get_handler("db:account:actions:list_by_user:1")
+  asyncio.run(handler({"users_guid": guid, "limit": 5}))
+  sql = captured["sql"].lower()
+  assert "from users_actions_log" in sql
+  assert "left join account_actions" in sql
+  assert "fetch next ? rows only" in sql
+  assert captured["params"][-1] == 5
+
+
+def test_account_actions_log_inserts_log_table(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_exec(sql, params):
+    captured["sql"] = sql
+    captured["params"] = tuple(params)
+    return DBResponse()
+
+  monkeypatch.setattr(actions_mssql, "run_exec", fake_run_exec)
+
+  guid = str(uuid4())
+  asyncio.run(
+    actions_mssql.log_v1({
+      "recid": 100,
+      "users_guid": guid,
+      "action_recid": 42,
+    })
+  )
+
+  sql = captured["sql"].lower()
+  assert "insert into users_actions_log" in sql
+  assert captured["params"][:3] == (100, guid, 42)
+
+
+def test_account_actions_update_builds_dynamic_assignments(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_exec(sql, params):
+    captured["sql"] = sql
+    captured["params"] = tuple(params)
+    return DBResponse()
+
+  monkeypatch.setattr(actions_mssql, "run_exec", fake_run_exec)
+
+  asyncio.run(
+    actions_mssql.update_v1({
+      "recid": 10,
+      "element_url": "https://example", 
+      "element_notes": "note",
+    })
+  )
+
+  sql = captured["sql"].lower()
+  assert "update users_actions_log" in sql
+  assert "element_url = ?" in sql
+  assert "element_notes = ?" in sql
+  assert captured["params"][-1] == 10
+
+
+def test_account_session_list_snapshots_uses_view(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_json_many(sql, params):
+    captured["sql"] = sql
+    captured["params"] = tuple(params)
+    return DBResponse()
+
+  monkeypatch.setattr(session_mssql, "run_json_many", fake_run_json_many)
+
+  guid = str(uuid4())
+  handler = get_handler("db:account:session:list_snapshots:1")
+  asyncio.run(handler({"guid": guid}))
+  sql = captured["sql"].lower()
+  assert "vw_account_user_sessions" in sql
+  assert "for json path" in sql
+
+
+def test_account_session_security_snapshot_uses_view(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_json_many(sql, params):
+    captured["sql"] = sql
+    captured["params"] = tuple(params)
+    return DBResponse()
+
+  monkeypatch.setattr(session_mssql, "run_json_many", fake_run_json_many)
+
+  guid = str(uuid4())
+  handler = get_handler("db:account:session:get_security_snapshot:1")
+  asyncio.run(handler({"guid": guid}))
+  sql = captured["sql"].lower()
+  assert "vw_account_user_security" in sql
+  assert "order by" in sql
+
+
+def test_service_pages_list_filters_active(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_json_many(sql, params):
+    captured["sql"] = sql
+    captured["params"] = tuple(params)
+    return DBResponse()
+
+  monkeypatch.setattr(service_pages_mssql, "run_json_many", fake_run_json_many)
+
+  handler = get_handler("db:system:service_pages:list:1")
+  asyncio.run(handler({"element_is_active": True}))
+  sql = captured["sql"].lower()
+  assert "from service_pages" in sql
+  assert "element_is_active = ?" in sql
+  assert captured["params"] == (1,)
+
+
+def test_service_pages_create_inserts_table(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_exec(sql, params):
+    captured["sql"] = sql
+    captured["params"] = tuple(params)
+    return DBResponse()
+
+  monkeypatch.setattr(service_pages_mssql, "run_exec", fake_run_exec)
+
+  guid = str(uuid4())
+  asyncio.run(
+    service_pages_mssql.create_v1({
+      "recid": 5,
+      "element_route_name": "home",
+      "element_pageblob": "<p>hi</p>",
+      "element_version": 3,
+      "element_created_by": guid,
+      "element_modified_by": guid,
+      "element_is_active": False,
+    })
+  )
+
+  sql = captured["sql"].lower()
+  assert "insert into service_pages" in sql
+  assert captured["params"][0] == 5
+  assert captured["params"][-1] == 0
+
+
+def test_service_pages_update_sets_modified_fields(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_exec(sql, params):
+    captured["sql"] = sql
+    captured["params"] = tuple(params)
+    return DBResponse()
+
+  monkeypatch.setattr(service_pages_mssql, "run_exec", fake_run_exec)
+
+  guid = str(uuid4())
+  asyncio.run(
+    service_pages_mssql.update_v1({
+      "recid": 8,
+      "element_modified_by": guid,
+      "element_pageblob": "<p>updated</p>",
+      "element_is_active": True,
+    })
+  )
+
+  sql = captured["sql"].lower()
+  assert "update service_pages" in sql
+  assert "element_modified_on = sysutcdatetime()" in sql
+  assert captured["params"][0] == guid
+  assert captured["params"][-1] == 8
+
+
+def test_service_pages_delete_uses_table(monkeypatch):
+  captured: dict[str, Any] = {}
+
+  async def fake_run_exec(sql, params):
+    captured["sql"] = sql
+    captured["params"] = tuple(params)
+    return DBResponse()
+
+  monkeypatch.setattr(service_pages_mssql, "run_exec", fake_run_exec)
+
+  asyncio.run(service_pages_mssql.delete_v1({"recid": 12}))
+  sql = captured["sql"].lower()
+  assert "delete from service_pages" in sql
+  assert captured["params"] == (12,)
 
 
 def test_finance_credits_set_updates_table(monkeypatch):


### PR DESCRIPTION
## Summary
- add account.enablements registry and provider for users_enablements operations with typed contracts
- add account.actions registry for users_actions_log lookup and mutation flows
- introduce a system.service_pages registry with CRUD helpers and wire it into domain registration alongside view-based session snapshots
- expand provider query tests to cover the new registry SQL surfaces

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f83b6d9f9083258ac52e7f7370aa96