### PR TITLE
Refine registry payload models and validation

### DIFF
--- a/rpc/auth/discord/services.py
+++ b/rpc/auth/discord/services.py
@@ -11,7 +11,7 @@ from server.modules.env_module import EnvModule
 from server.modules.auth_module import AuthModule
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
-from server.registry.system.config import get_config_request
+from server.registry.system.config import ConfigKeyParams, get_config_request
 from server.registry.types import DBRequest
 from .models import AuthDiscordOauthLogin1, AuthDiscordOauthLoginPayload1
 
@@ -54,7 +54,7 @@ async def auth_discord_oauth_login_v1(request: Request):
   if not client_secret:
     raise HTTPException(status_code=500, detail="DISCORD_AUTH_SECRET not configured")
 
-  res_redirect = await db.run(get_config_request(key="Hostname"))
+  res_redirect = await db.run(get_config_request(ConfigKeyParams(key="Hostname")))
   if not res_redirect.rows:
     raise HTTPException(status_code=500, detail="Discord OAuth redirect URI not configured")
   redirect_uri = res_redirect.rows[0]["value"]

--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -9,7 +9,7 @@ from server.modules.env_module import EnvModule
 from server.modules.auth_module import AuthModule
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
-from server.registry.system.config import get_config_request
+from server.registry.system.config import ConfigKeyParams, get_config_request
 from server.registry.types import DBRequest
 from .models import AuthGoogleOauthLogin1, AuthGoogleOauthLoginPayload1
 from fastapi.responses import JSONResponse
@@ -58,7 +58,7 @@ async def auth_google_oauth_login_v1(request: Request):
     raise HTTPException(status_code=500, detail="GOOGLE_AUTH_SECRET not configured")
 
   # Require redirect_uri from system config
-  res_redirect = await db.run(get_config_request(key="Hostname"))
+  res_redirect = await db.run(get_config_request(ConfigKeyParams(key="Hostname")))
   if not res_redirect.rows:
       raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
   redirect_uri = res_redirect.rows[0]["value"]

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -8,10 +8,17 @@ from server.modules.auth_module import AuthModule
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
 from server.registry.account.providers import unlink_last_provider_request
-from server.registry.account.session import revoke_provider_tokens_request
-from server.registry.system.config import get_config_request
+from server.registry.account.session import RevokeProviderTokensParams, revoke_provider_tokens_request
+from server.registry.system.config import ConfigKeyParams, get_config_request
 from server.registry.types import DBRequest
 from server.registry.account.providers import (
+  CreateFromProviderParams,
+  GetUserByEmailParams,
+  LinkProviderParams,
+  ProviderIdentifierParams,
+  SetProviderParams,
+  UnlinkLastProviderParams,
+  UnlinkProviderParams,
   create_from_provider_request,
   get_by_provider_identifier_request,
   get_user_by_email_request,
@@ -55,7 +62,7 @@ async def users_providers_set_provider_v1(request: Request):
         client_secret = env.get("GOOGLE_AUTH_SECRET")
         if not client_secret:
           raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
-        res_redirect = await db.run(get_config_request(key="Hostname"))
+        res_redirect = await db.run(get_config_request(ConfigKeyParams(key="Hostname")))
         if not res_redirect.rows:
           raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
         redirect_uri = res_redirect.rows[0]["value"]
@@ -80,7 +87,7 @@ async def users_providers_set_provider_v1(request: Request):
         client_secret = env.get("DISCORD_AUTH_SECRET")
         if not client_secret:
           raise HTTPException(status_code=500, detail="Discord OAuth client_secret not configured")
-        res_redirect = await db.run(get_config_request(key="Hostname"))
+        res_redirect = await db.run(get_config_request(ConfigKeyParams(key="Hostname")))
         if not res_redirect.rows:
           raise HTTPException(status_code=500, detail="Discord OAuth redirect URI not configured")
         redirect_uri = res_redirect.rows[0]["value"]
@@ -105,7 +112,7 @@ async def users_providers_set_provider_v1(request: Request):
         client_secret = env.get("MICROSOFT_AUTH_SECRET")
         if not client_secret:
           raise HTTPException(status_code=500, detail="Microsoft OAuth client_secret not configured")
-        res_redirect = await db.run(get_config_request(key="Hostname"))
+        res_redirect = await db.run(get_config_request(ConfigKeyParams(key="Hostname")))
         if not res_redirect.rows:
           raise HTTPException(status_code=500, detail="Microsoft OAuth redirect URI not configured")
         redirect_uri = res_redirect.rows[0]["value"]
@@ -126,7 +133,7 @@ async def users_providers_set_provider_v1(request: Request):
       raise HTTPException(status_code=400, detail="Unsupported auth provider")
     _, profile, _ = await auth.handle_auth_login(payload.provider, id_token, access_token)
   await db.run(
-    set_provider_request(guid=auth_ctx.user_guid, provider=payload.provider),
+    set_provider_request(SetProviderParams(guid=auth_ctx.user_guid, provider=payload.provider)),
   )
   if profile:
     raw_email = (profile.get("email") or "").strip()
@@ -169,7 +176,7 @@ async def users_providers_link_provider_v1(request: Request):
     client_secret = env.get("GOOGLE_AUTH_SECRET")
     if not client_secret:
       raise HTTPException(status_code=500, detail="Google OAuth client_secret not configured")
-    res_redirect = await db.run(get_config_request(key="Hostname"))
+    res_redirect = await db.run(get_config_request(ConfigKeyParams(key="Hostname")))
     if not res_redirect.rows:
       raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
     redirect_uri = res_redirect.rows[0]["value"]
@@ -192,7 +199,7 @@ async def users_providers_link_provider_v1(request: Request):
       client_secret = env.get("DISCORD_AUTH_SECRET")
       if not client_secret:
         raise HTTPException(status_code=500, detail="Discord OAuth client_secret not configured")
-      res_redirect = await db.run(get_config_request(key="Hostname"))
+      res_redirect = await db.run(get_config_request(ConfigKeyParams(key="Hostname")))
       if not res_redirect.rows:
         raise HTTPException(status_code=500, detail="Discord OAuth redirect URI not configured")
       redirect_uri = res_redirect.rows[0]["value"]
@@ -218,7 +225,7 @@ async def users_providers_link_provider_v1(request: Request):
       client_secret = env.get("MICROSOFT_AUTH_SECRET")
       if not client_secret:
         raise HTTPException(status_code=500, detail="Microsoft OAuth client_secret not configured")
-      res_redirect = await db.run(get_config_request(key="Hostname"))
+      res_redirect = await db.run(get_config_request(ConfigKeyParams(key="Hostname")))
       if not res_redirect.rows:
         raise HTTPException(status_code=500, detail="Microsoft OAuth redirect URI not configured")
       redirect_uri = res_redirect.rows[0]["value"]
@@ -242,17 +249,18 @@ async def users_providers_link_provider_v1(request: Request):
   provider_uid = normalize_provider_identifier(provider_uid)
   res = await db.run(
     get_by_provider_identifier_request(
-      provider=payload.provider,
-      provider_identifier=provider_uid,
+      ProviderIdentifierParams(provider=payload.provider, provider_identifier=provider_uid),
     ),
   )
   if res.rows and res.rows[0].get("guid") != auth_ctx.user_guid:
     raise HTTPException(status_code=409, detail="Provider already linked")
   await db.run(
     link_provider_request(
-      guid=auth_ctx.user_guid,
-      provider=payload.provider,
-      provider_identifier=provider_uid,
+      LinkProviderParams(
+        guid=auth_ctx.user_guid,
+        provider=payload.provider,
+        provider_identifier=provider_uid,
+      ),
     ),
   )
   return RPCResponse(op=rpc_request.op, payload={"provider": payload.provider}, version=rpc_request.version)
@@ -272,26 +280,28 @@ async def users_providers_unlink_provider_v1(request: Request):
   )
   default_provider = res_prof.rows[0].get("default_provider") if res_prof.rows else None
   res = await db.run(
-    unlink_provider_request(guid=auth_ctx.user_guid, provider=payload.provider),
+    unlink_provider_request(
+      UnlinkProviderParams(guid=auth_ctx.user_guid, provider=payload.provider),
+    ),
   )
   remaining = res.rows[0].get("providers_remaining") if res.rows else 0
   if remaining == 0:
     await db.run(
       unlink_last_provider_request(
-        guid=auth_ctx.user_guid,
-        provider=payload.provider,
+        UnlinkLastProviderParams(guid=auth_ctx.user_guid, provider=payload.provider),
       ),
     )
   elif payload.provider == default_provider:
     if not payload.new_default:
       raise HTTPException(status_code=400, detail="new_default required")
     await db.run(
-      set_provider_request(guid=auth_ctx.user_guid, provider=payload.new_default),
+      set_provider_request(
+        SetProviderParams(guid=auth_ctx.user_guid, provider=payload.new_default),
+      ),
     )
     await db.run(
       revoke_provider_tokens_request(
-        guid=auth_ctx.user_guid,
-        provider=payload.provider,
+        RevokeProviderTokensParams(guid=auth_ctx.user_guid, provider=payload.provider),
       ),
     )
   return RPCResponse(op=rpc_request.op, payload={"provider": payload.provider}, version=rpc_request.version)
@@ -304,7 +314,9 @@ async def users_providers_get_by_provider_identifier_v1(request: Request):
     raise HTTPException(status_code=400, detail=str(e))
   db: DbModule = request.app.state.db
   res = await db.run(
-    get_by_provider_identifier_request(**payload.model_dump()),
+    get_by_provider_identifier_request(
+      ProviderIdentifierParams(**payload.model_dump()),
+    ),
   )
   row = res.rows[0] if res.rows else None
   return RPCResponse(op=rpc_request.op, payload=row, version=rpc_request.version)
@@ -317,12 +329,12 @@ async def users_providers_create_from_provider_v1(request: Request):
     raise HTTPException(status_code=400, detail=str(e))
   db: DbModule = request.app.state.db
   res = await db.run(
-    get_user_by_email_request(email=payload.provider_email),
+    get_user_by_email_request(GetUserByEmailParams(email=payload.provider_email)),
   )
   if res.rows:
     raise HTTPException(status_code=409, detail="Email already registered")
   res = await db.run(
-    create_from_provider_request(**payload.model_dump()),
+    create_from_provider_request(CreateFromProviderParams(**payload.model_dump())),
   )
   row = res.rows[0] if res.rows else None
   return RPCResponse(op=rpc_request.op, payload=row, version=rpc_request.version)

--- a/server/modules/bsky_module.py
+++ b/server/modules/bsky_module.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from atproto import AsyncClient as AsyncBskyClient, client_utils
 from fastapi import FastAPI
 
-from server.registry.system.config import get_config_request
+from server.registry.system.config import ConfigKeyParams, get_config_request
 from . import BaseModule
 from .db_module import DbModule
 
@@ -44,7 +44,7 @@ class BskyModule(BaseModule):
   async def _load_optional_config(self, key: str) -> str:
     if not self.db:
       raise RuntimeError("BskyModule requires database module")
-    res = await self.db.run(get_config_request(key=key))
+    res = await self.db.run(get_config_request(ConfigKeyParams(key=key)))
     if not res.rows:
       return ""
     return res.rows[0].get("value") or ""

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -24,6 +24,7 @@ from server.registry.account.cache.model import (
   ReplaceUserCacheParams,
   UpsertCacheItemParams,
 )
+from server.registry.system.config import ConfigKeyParams, get_config_request
 from server.helpers.logging import update_logging_level
 
 
@@ -93,9 +94,7 @@ class DbModule(BaseModule):
     await self.init(provider=self.provider, **cfg)
     assert self._provider
     await self._provider.startup()
-    res = await self.run(
-      DBRequest(op="db:system:config:get_config:1", payload={"key": "LoggingLevel"})
-    )
+    res = await self.run(get_config_request(ConfigKeyParams(key="LoggingLevel")))
     val = res.rows[0]["value"] if res.rows else "0"
     try:
       self.logging_level = int(val)
@@ -110,17 +109,13 @@ class DbModule(BaseModule):
       self._provider = None
 
   async def get_ms_api_id(self) -> str:
-    res = await self.run(
-      DBRequest(op="db:system:config:get_config:1", payload={"key": "MsApiId"})
-    )
+    res = await self.run(get_config_request(ConfigKeyParams(key="MsApiId")))
     if not res.rows:
       raise ValueError("Missing config value for key: MsApiId")
     return res.rows[0]["value"]
 
   async def get_google_client_id(self) -> str:
-    res = await self.run(
-      DBRequest(op="db:system:config:get_config:1", payload={"key": "GoogleClientId"})
-    )
+    res = await self.run(get_config_request(ConfigKeyParams(key="GoogleClientId")))
     value = res.rows[0]["value"] if res.rows else None
     logging.debug("[DbModule] GoogleClientId=%s", value)
     if not value:
@@ -137,9 +132,7 @@ class DbModule(BaseModule):
     return value
 
   async def get_discord_client_id(self) -> str:
-    res = await self.run(
-      DBRequest(op="db:system:config:get_config:1", payload={"key": "DiscordClientId"})
-    )
+    res = await self.run(get_config_request(ConfigKeyParams(key="DiscordClientId")))
     value = res.rows[0]["value"] if res.rows else None
     logging.debug("[DbModule] DiscordClientId=%s", value)
     if not value:
@@ -147,18 +140,14 @@ class DbModule(BaseModule):
     return value
 
   async def get_auth_providers(self) -> list[str]:
-    res = await self.run(
-      DBRequest(op="db:system:config:get_config:1", payload={"key": "AuthProviders"})
-    )
+    res = await self.run(get_config_request(ConfigKeyParams(key="AuthProviders")))
     value = res.rows[0]["value"] if res.rows else None
     if value is None:
       raise ValueError("Missing config value for key: AuthProviders")
     return [p.strip() for p in value.split(',') if p.strip()]
 
   async def get_jwks_cache_time(self) -> int:
-    res = await self.run(
-      DBRequest(op="db:system:config:get_config:1", payload={"key": "JwksCacheTime"})
-    )
+    res = await self.run(get_config_request(ConfigKeyParams(key="JwksCacheTime")))
     value = res.rows[0]["value"] if res.rows else None
     if value is None:
       raise ValueError("Missing config value for key: JwksCacheTime")

--- a/server/modules/discord_bot_module.py
+++ b/server/modules/discord_bot_module.py
@@ -18,7 +18,7 @@ except ImportError:  # pragma: no cover - non-Windows platforms
 from . import BaseModule
 from .env_module import EnvModule
 from .db_module import DbModule
-from server.registry.system.config import get_config_request
+from server.registry.system.config import ConfigKeyParams, get_config_request
 
 from server.helpers.logging import configure_discord_logging, remove_discord_logging, update_logging_level
 from server.routers.discord_events import register_discord_event_handlers
@@ -76,7 +76,7 @@ class DiscordBotModule(BaseModule):
       register_discord_event_handlers(self)
       update_logging_level(self.db.logging_level)
       configure_discord_logging(self)
-      res = await self.db.run(get_config_request(key="DiscordSyschan"))
+      res = await self.db.run(get_config_request(ConfigKeyParams(key="DiscordSyschan")))
       if not res.rows:
         raise ValueError("Missing config value for key: DiscordSyschan")
       self.syschan = int(res.rows[0]["value"] or 0)

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -18,16 +18,21 @@ from server.registry.account.oauth import (
   relink_microsoft_request,
 )
 from server.registry.account.session import (
+  CreateSessionParams,
+  SetRotkeyParams,
+  UpdateDeviceTokenParams,
   create_session_request,
+  set_rotkey_request,
   update_device_token_request,
 )
 from server.registry.types import DBRequest
 from server.registry.account.providers import (
+  CreateFromProviderParams,
+  ProviderIdentifierParams,
   create_from_provider_request,
   get_any_by_provider_identifier_request,
   get_by_provider_identifier_request,
 )
-from server.registry.account.session import set_rotkey_request
 
 
 class OauthModule(BaseModule):
@@ -177,8 +182,7 @@ class OauthModule(BaseModule):
       logging.debug(f"[lookup_user] checking identifier={pid[:40]}")
       res = await self.db.run(
         get_by_provider_identifier_request(
-          provider=provider,
-          provider_identifier=uid,
+          ProviderIdentifierParams(provider=provider, provider_identifier=uid),
         ),
       )
       if res.rows:
@@ -199,10 +203,7 @@ class OauthModule(BaseModule):
     now = datetime.now(timezone.utc)
     await self.db.run(
       set_rotkey_request(
-        guid=user_guid,
-        rotkey=rotation_token,
-        iat=now,
-        exp=rot_exp,
+        SetRotkeyParams(guid=user_guid, rotkey=rotation_token, iat=now, exp=rot_exp),
       ),
     )
     roles, _ = await self.auth.get_user_roles(user_guid)
@@ -210,13 +211,15 @@ class OauthModule(BaseModule):
     placeholder = uuid.uuid4().hex
     res = await self.db.run(
       create_session_request(
-        access_token=placeholder,
-        expires=session_exp,
-        fingerprint=fingerprint,
-        user_guid=user_guid,
-        provider=provider,
-        user_agent=user_agent,
-        ip_address=ip_address,
+        CreateSessionParams(
+          access_token=placeholder,
+          expires=session_exp,
+          fingerprint=fingerprint,
+          user_guid=user_guid,
+          provider=provider,
+          user_agent=user_agent,
+          ip_address=ip_address,
+        ),
       ),
     )
     row = res.rows[0] if res.rows else {}
@@ -226,7 +229,9 @@ class OauthModule(BaseModule):
       user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp,
     )
     await self.db.run(
-      update_device_token_request(device_guid=device_guid, access_token=session_token),
+      update_device_token_request(
+        UpdateDeviceTokenParams(device_guid=device_guid, access_token=session_token),
+      ),
     )
     logging.debug(f"[create_session] session_token={session_token[:40]}")
     return session_token, session_exp, rotation_token, rot_exp
@@ -248,8 +253,7 @@ class OauthModule(BaseModule):
     elif not user:
       await self.db.run(
         get_any_by_provider_identifier_request(
-          provider=provider,
-          provider_identifier=provider_uid,
+          ProviderIdentifierParams(provider=provider, provider_identifier=provider_uid),
         ),
       )
       needs_relink = True
@@ -288,19 +292,20 @@ class OauthModule(BaseModule):
     if not user:
       res = await self.db.run(
         create_from_provider_request(
-          provider=provider,
-          provider_identifier=provider_uid,
-          provider_email=profile["email"],
-          provider_displayname=profile["username"],
-          provider_profile_image=profile.get("profilePicture"),
+          CreateFromProviderParams(
+            provider=provider,
+            provider_identifier=provider_uid,
+            provider_email=profile["email"],
+            provider_displayname=profile["username"],
+            provider_profile_image=profile.get("profilePicture"),
+          ),
         ),
       )
       user = res.rows[0] if res.rows else None
       if not user:
         res = await self.db.run(
           get_by_provider_identifier_request(
-            provider=provider,
-            provider_identifier=provider_uid,
+            ProviderIdentifierParams(provider=provider, provider_identifier=provider_uid),
           ),
         )
         user = res.rows[0] if res.rows else None

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -8,7 +8,7 @@ from openai import AsyncOpenAI
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
-from server.registry.system.config import get_config_request
+from server.registry.system.config import ConfigKeyParams, get_config_request
 from server.registry.system.conversations import (
   find_recent_request,
   insert_conversation_request,
@@ -100,7 +100,7 @@ class OpenaiModule(BaseModule):
 
   async def get_openai_token(self) -> str:
     assert self.db
-    res = await self.db.run(get_config_request(key="OpenAIApiKey"))
+    res = await self.db.run(get_config_request(ConfigKeyParams(key="OpenAIApiKey")))
     if res.rows:
       return res.rows[0].get("value", "")
     return ""

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -4,6 +4,8 @@ from server.modules.db_module import DbModule
 from server.modules.auth_module import AuthModule
 from server.modules.discord_bot_module import DiscordBotModule
 from server.registry.system.roles import (
+  ModifyRoleMemberParams,
+  RoleScopeParams,
   add_role_member_request,
   get_role_members_request,
   get_role_non_members_request,
@@ -58,8 +60,8 @@ class RoleAdminModule(BaseModule):
     return roles
 
   async def get_role_members(self, role: str) -> tuple[list[dict], list[dict]]:
-    mem_res = await self.db.run(get_role_members_request(role))
-    non_res = await self.db.run(get_role_non_members_request(role))
+    mem_res = await self.db.run(get_role_members_request(RoleScopeParams(role=role)))
+    non_res = await self.db.run(get_role_non_members_request(RoleScopeParams(role=role)))
     members = [
       {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
       for r in mem_res.rows
@@ -74,7 +76,7 @@ class RoleAdminModule(BaseModule):
     if actor_mask is not None:
       role_mask = self.auth.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
-    await self.db.run(add_role_member_request(role, user_guid))
+    await self.db.run(add_role_member_request(ModifyRoleMemberParams(role=role, user_guid=user_guid)))
     await self.auth.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 
@@ -82,7 +84,7 @@ class RoleAdminModule(BaseModule):
     if actor_mask is not None:
       role_mask = self.auth.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
-    await self.db.run(remove_role_member_request(role, user_guid))
+    await self.db.run(remove_role_member_request(ModifyRoleMemberParams(role=role, user_guid=user_guid)))
     await self.auth.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 

--- a/server/modules/session_module.py
+++ b/server/modules/session_module.py
@@ -9,13 +9,20 @@ from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
 from server.modules.discord_bot_module import DiscordBotModule
 from server.registry.account.session import (
+  CreateSessionParams,
+  GuidParams,
+  RevokeDeviceTokenParams,
+  SetRotkeyParams,
+  UpdateDeviceTokenParams,
+  UpdateSessionParams,
   create_session_request,
+  get_rotkey_request,
   revoke_device_token_request,
+  set_rotkey_request,
   update_device_token_request,
   update_session_request,
 )
 from server.registry.types import DBRequest
-from server.registry.account.session import get_rotkey_request, set_rotkey_request
 
 
 class SessionModule(BaseModule):
@@ -106,7 +113,7 @@ class SessionModule(BaseModule):
   ) -> str:
     data = self.auth.decode_rotation_token(rotation_token)
     user_guid = data["guid"]
-    stored = await self.db.run(get_rotkey_request(guid=user_guid))
+    stored = await self.db.run(get_rotkey_request(GuidParams(guid=user_guid)))
     row = stored.rows[0] if stored.rows else None
     if not row or row.get("rotkey") != rotation_token:
       raise HTTPException(status_code=401, detail="Invalid rotation token")
@@ -118,13 +125,15 @@ class SessionModule(BaseModule):
     placeholder = uuid.uuid4().hex
     res = await self.db.run(
       create_session_request(
-        access_token=placeholder,
-        expires=session_exp,
-        fingerprint=fingerprint,
-        user_guid=user_guid,
-        provider=provider,
-        user_agent=user_agent,
-        ip_address=ip_address,
+        CreateSessionParams(
+          access_token=placeholder,
+          expires=session_exp,
+          fingerprint=fingerprint,
+          user_guid=user_guid,
+          provider=provider,
+          user_agent=user_agent,
+          ip_address=ip_address,
+        ),
       ),
     )
     row2 = res.rows[0] if res.rows else {}
@@ -134,18 +143,20 @@ class SessionModule(BaseModule):
       user_guid, rotation_token, session_guid, device_guid, roles, exp=session_exp
     )
     await self.db.run(
-      update_device_token_request(device_guid=device_guid, access_token=session_token),
+      update_device_token_request(
+        UpdateDeviceTokenParams(device_guid=device_guid, access_token=session_token),
+      ),
     )
     return session_token
 
   async def invalidate_token(self, user_guid: str) -> None:
     now = datetime.now(timezone.utc)
     await self.db.run(
-      set_rotkey_request(guid=user_guid, rotkey="", iat=now, exp=now),
+      set_rotkey_request(SetRotkeyParams(guid=user_guid, rotkey="", iat=now, exp=now)),
     )
 
   async def logout_device(self, token: str) -> None:
-    await self.db.run(revoke_device_token_request(access_token=token))
+    await self.db.run(revoke_device_token_request(RevokeDeviceTokenParams(access_token=token)))
 
   async def get_session(
     self,
@@ -175,9 +186,7 @@ class SessionModule(BaseModule):
     try:
       await self.db.run(
         update_session_request(
-          access_token=token,
-          ip_address=ip_address,
-          user_agent=user_agent,
+          UpdateSessionParams(access_token=token, ip_address=ip_address, user_agent=user_agent),
         ),
       )
     except Exception as e:

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from azure.storage.blob.aio import BlobServiceClient
 from azure.storage.blob import ContentSettings
 from fastapi import FastAPI
-from server.registry.system.config import get_config_request
+from server.registry.system.config import ConfigKeyParams, get_config_request
 from server.registry.account.cache import (
   count_rows_request,
   list_public_request,
@@ -63,7 +63,7 @@ class StorageModule(BaseModule):
       logging.error("[StorageModule] Failed to load AZURE_BLOB_CONNECTION_STRING: %s", e)
 
     try:
-      res = await self.db.run(get_config_request(key="StorageCacheTime"))
+      res = await self.db.run(get_config_request(ConfigKeyParams(key="StorageCacheTime")))
       value = res.rows[0]["value"] if res.rows else "15m"
       try:
         self.reindex_interval = self._parse_duration(value)
@@ -101,7 +101,7 @@ class StorageModule(BaseModule):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
+    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -377,7 +377,7 @@ class StorageModule(BaseModule):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
+    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -438,7 +438,7 @@ class StorageModule(BaseModule):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
+    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -480,7 +480,7 @@ class StorageModule(BaseModule):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
+    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -531,7 +531,7 @@ class StorageModule(BaseModule):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
+    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -571,7 +571,7 @@ class StorageModule(BaseModule):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
+    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -818,7 +818,7 @@ class StorageModule(BaseModule):
     if not self.connection_string or not self.db:
       logging.error("[StorageModule] Missing connection string or database module")
       return
-    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
+    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
@@ -894,7 +894,7 @@ class StorageModule(BaseModule):
         "user_folder_count": 0,
         "db_rows": db_rows,
       }
-    res = await self.db.run(get_config_request(key="AzureBlobContainerName"))
+    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
     container_name = res.rows[0]["value"] if res.rows else None
     if not container_name:
       return {

--- a/server/modules/system_config_module.py
+++ b/server/modules/system_config_module.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 import logging
 from fastapi import FastAPI
 from server.registry.system.config import (
+  ConfigKeyParams,
+  UpsertConfigParams,
   delete_config_request,
   get_configs_request,
   upsert_config_request,
@@ -57,7 +59,7 @@ class SystemConfigModule(BaseModule):
       value,
     )
     await self.db.run(
-      upsert_config_request(key=key, value=value),
+      upsert_config_request(UpsertConfigParams(key=key, value=value)),
     )
     logging.debug(
       "[system_config_upsert_config_v1] upserted config %s",
@@ -73,7 +75,7 @@ class SystemConfigModule(BaseModule):
       key,
     )
     await self.db.run(
-      delete_config_request(key),
+      delete_config_request(ConfigKeyParams(key=key)),
     )
     logging.debug(
       "[system_config_delete_config_v1] deleted config %s",

--- a/server/registry/account/__init__.py
+++ b/server/registry/account/__init__.py
@@ -23,10 +23,7 @@ __all__ = [
 def register(router: "RegistryRouter") -> None:
   domain = router.domain("account")
   content.register(domain)
-  accounts.register(
-    domain.subdomain("accounts"),
-    legacy_op_segment="account",
-  )
+  accounts.register(domain.subdomain("accounts"))
   actions.register(domain.subdomain("actions"))
   enablements.register(domain.subdomain("enablements"))
   providers.register(domain.subdomain("providers"))

--- a/server/registry/account/accounts/MIGRATION.md
+++ b/server/registry/account/accounts/MIGRATION.md
@@ -1,0 +1,13 @@
+# Migration: Remove ``db:account:account`` aliases
+
+Historically the account security helpers exposed duplicate operation names
+(``db:account:account:*``) to provide a temporary compatibility layer while the
+registry naming scheme was being aligned with the ``db:<domain>:<subdomain>``
+pattern.  That shim has been removed—every consumer must now invoke the plural
+``accounts`` subdomain explicitly:
+
+* ``db:account:accounts:get_security_profile:1``
+* ``db:account:accounts:exists:1``
+
+Update any hard-coded references or request builders that still target the old
+``db:account:account`` prefix before upgrading to this release.

--- a/server/registry/account/accounts/__init__.py
+++ b/server/registry/account/accounts/__init__.py
@@ -45,32 +45,6 @@ def account_exists_request(user_guid: str) -> DBRequest:
   )
 
 
-def register(
-  router: "SubdomainRouter",
-  *,
-  legacy_op_segment: str | None = None,
-) -> None:
+def register(router: "SubdomainRouter") -> None:
   router.add_function("get_security_profile", version=1)
   router.add_function("account_exists", version=1)
-
-  if legacy_op_segment:
-    # Temporary compatibility alias while dependents migrate off singular ops.
-    from server.registry import SubdomainRouter as _SubdomainRouter
-
-    legacy_router = _SubdomainRouter(
-      router._registry,
-      router._domain,
-      router._module_components,
-      (legacy_op_segment,),
-      provider=router._provider,
-    )
-    legacy_router.add_function(
-      "get_security_profile",
-      version=1,
-      implementation="get_security_profile",
-    )
-    legacy_router.add_function(
-      "account_exists",
-      version=1,
-      implementation="account_exists",
-    )

--- a/server/registry/account/profile/__init__.py
+++ b/server/registry/account/profile/__init__.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from server.registry.types import DBRequest
+from .model import (
+  GuidParams,
+  SetDisplayParams,
+  SetOptInParams,
+  SetProfileImageParams,
+  SetRolesParams,
+  UpdateIfUneditedParams,
+)
 
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
@@ -17,55 +25,43 @@ __all__ = [
   "set_roles_request",
   "update_if_unedited_request",
   "register",
+  "GuidParams",
+  "SetDisplayParams",
+  "SetOptInParams",
+  "SetProfileImageParams",
+  "SetRolesParams",
+  "UpdateIfUneditedParams",
 ]
 
 
-def _request(name: str, params: dict[str, Any]) -> DBRequest:
+def _request(name: str, params: dict[str, object]) -> DBRequest:
   return DBRequest(op=f"db:account:profile:{name}:1", params=params)
 
 
-def get_profile_request(*, guid: str) -> DBRequest:
-  return _request("get_profile", {"guid": guid})
+def get_profile_request(params: GuidParams) -> DBRequest:
+  return _request("get_profile", params.model_dump())
 
 
-def set_display_request(*, guid: str, display_name: str) -> DBRequest:
-  return _request("set_display", {"guid": guid, "display_name": display_name})
+def set_display_request(params: SetDisplayParams) -> DBRequest:
+  return _request("set_display", params.model_dump())
 
 
-def set_optin_request(*, guid: str, display_email: bool) -> DBRequest:
-  return _request("set_optin", {"guid": guid, "display_email": display_email})
+def set_optin_request(params: SetOptInParams) -> DBRequest:
+  payload = params.model_dump()
+  payload["display_email"] = 1 if params.display_email else 0
+  return _request("set_optin", payload)
 
 
-def set_profile_image_request(
-  *,
-  guid: str,
-  provider: str,
-  image_b64: str | None,
-) -> DBRequest:
-  params: dict[str, Any] = {
-    "guid": guid,
-    "provider": provider,
-    "image_b64": image_b64,
-  }
-  return _request("set_profile_image", params)
+def set_profile_image_request(params: SetProfileImageParams) -> DBRequest:
+  return _request("set_profile_image", params.model_dump())
 
 
-def set_roles_request(*, guid: str, roles: int) -> DBRequest:
-  return _request("set_roles", {"guid": guid, "roles": roles})
+def set_roles_request(params: SetRolesParams) -> DBRequest:
+  return _request("set_roles", params.model_dump())
 
 
-def update_if_unedited_request(
-  *,
-  guid: str,
-  display_name: str | None = None,
-  email: str | None = None,
-) -> DBRequest:
-  params: dict[str, Any] = {"guid": guid}
-  if display_name is not None:
-    params["display_name"] = display_name
-  if email is not None:
-    params["email"] = email
-  return _request("update_if_unedited", params)
+def update_if_unedited_request(params: UpdateIfUneditedParams) -> DBRequest:
+  return _request("update_if_unedited", params.model_dump(exclude_none=True))
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/account/profile/model.py
+++ b/server/registry/account/profile/model.py
@@ -1,0 +1,80 @@
+"""Typed payload helpers for account profile registry operations."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+__all__ = [
+  "GuidParams",
+  "ProfileRecord",
+  "SetDisplayParams",
+  "SetOptInParams",
+  "SetProfileImageParams",
+  "SetRolesParams",
+  "UpdateIfUneditedParams",
+]
+
+
+def _normalize_uuid(value: Any) -> str:
+  return str(value)
+
+
+class GuidParams(BaseModel):
+  """Base payload carrying a profile guid."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str
+
+  @field_validator("guid")
+  @classmethod
+  def _normalize_guid(cls, value: Any) -> str:
+    return _normalize_uuid(value)
+
+
+class SetDisplayParams(GuidParams):
+  """Parameters for updating a user's display name."""
+
+  display_name: str
+
+
+class SetOptInParams(GuidParams):
+  """Parameters controlling opt-in email visibility."""
+
+  display_email: bool
+
+
+class SetProfileImageParams(GuidParams):
+  """Payload used to set or clear the user's profile image."""
+
+  provider: str
+  image_b64: str | None
+
+
+class SetRolesParams(GuidParams):
+  """Parameters used to update the user's role mask."""
+
+  roles: int
+
+
+class UpdateIfUneditedParams(GuidParams):
+  """Parameters for updating profile fields if untouched by the user."""
+
+  display_name: str | None = None
+  email: str | None = None
+
+
+class ProfileRecord(TypedDict, total=False):
+  """Projection returned by profile queries."""
+
+  guid: str
+  display_name: str | None
+  email: str | None
+  credits: int | None
+  profile_image: str | None
+  default_provider: str | None
+  roles: int | None
+  element_created_on: str | None
+  element_modified_on: str | None

--- a/server/registry/account/providers/__init__.py
+++ b/server/registry/account/providers/__init__.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from server.registry.types import DBRequest
+from .model import (
+  CreateFromProviderParams,
+  GetUserByEmailParams,
+  LinkProviderParams,
+  ProviderIdentifierParams,
+  SetProviderParams,
+  SoftDeleteAccountParams,
+  UnlinkLastProviderParams,
+  UnlinkProviderParams,
+)
 
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
@@ -20,123 +30,79 @@ __all__ = [
   "soft_delete_account_request",
   "unlink_provider_request",
   "unlink_last_provider_request",
+  "CreateFromProviderParams",
+  "GetUserByEmailParams",
+  "LinkProviderParams",
+  "ProviderIdentifierParams",
+  "SetProviderParams",
+  "SoftDeleteAccountParams",
+  "UnlinkLastProviderParams",
+  "UnlinkProviderParams",
 ]
 
 
-def _request(op: str, params: dict[str, Any]) -> DBRequest:
+def _request(op: str, params: dict[str, object]) -> DBRequest:
   return DBRequest(op=op, params=params)
 
 
-def create_from_provider_request(
-  *,
-  provider: str,
-  provider_identifier: str,
-  provider_email: str,
-  provider_displayname: str,
-  provider_profile_image: str | None = None,
-) -> DBRequest:
-  return _request(
-    "db:account:providers:create_from_provider:1",
-    {
-      "provider": provider,
-      "provider_identifier": provider_identifier,
-      "provider_email": provider_email,
-      "provider_displayname": provider_displayname,
-      "provider_profile_image": provider_profile_image or "",
-    },
-  )
+def create_from_provider_request(params: CreateFromProviderParams) -> DBRequest:
+  payload = params.model_dump()
+  if payload.get("provider_profile_image") is None:
+    payload["provider_profile_image"] = ""
+  return _request("db:account:providers:create_from_provider:1", payload)
 
 
-def get_by_provider_identifier_request(
-  *,
-  provider: str,
-  provider_identifier: str,
-) -> DBRequest:
+def get_by_provider_identifier_request(params: ProviderIdentifierParams) -> DBRequest:
   return _request(
     "db:account:providers:get_by_provider_identifier:1",
-    {
-      "provider": provider,
-      "provider_identifier": provider_identifier,
-    },
+    params.model_dump(),
   )
 
 
-def get_any_by_provider_identifier_request(
-  *,
-  provider: str,
-  provider_identifier: str,
-) -> DBRequest:
+def get_any_by_provider_identifier_request(params: ProviderIdentifierParams) -> DBRequest:
   return _request(
     "db:account:providers:get_any_by_provider_identifier:1",
-    {
-      "provider": provider,
-      "provider_identifier": provider_identifier,
-    },
+    params.model_dump(),
   )
 
 
-def get_user_by_email_request(*, email: str) -> DBRequest:
+def get_user_by_email_request(params: GetUserByEmailParams) -> DBRequest:
   return _request(
     "db:account:providers:get_user_by_email:1",
-    {"email": email},
+    params.model_dump(),
   )
 
 
-def link_provider_request(
-  *,
-  guid: str,
-  provider: str,
-  provider_identifier: str,
-) -> DBRequest:
+def link_provider_request(params: LinkProviderParams) -> DBRequest:
   return _request(
     "db:account:providers:link_provider:1",
-    {
-      "guid": guid,
-      "provider": provider,
-      "provider_identifier": provider_identifier,
-    },
+    params.model_dump(),
   )
 
 
-def set_provider_request(*, guid: str, provider: str) -> DBRequest:
+def set_provider_request(params: SetProviderParams) -> DBRequest:
   return _request(
     "db:account:providers:set_provider:1",
-    {
-      "guid": guid,
-      "provider": provider,
-    },
+    params.model_dump(),
   )
 
 
-def soft_delete_account_request(*, guid: str) -> DBRequest:
+def soft_delete_account_request(params: SoftDeleteAccountParams) -> DBRequest:
   return _request(
     "db:account:providers:soft_delete_account:1",
-    {"guid": guid},
+    params.model_dump(),
   )
 
 
-def unlink_provider_request(
-  *,
-  guid: str,
-  provider: str,
-  new_provider_recid: int | None = None,
-) -> DBRequest:
-  params: dict[str, Any] = {
-    "guid": guid,
-    "provider": provider,
-  }
-  if new_provider_recid is not None:
-    params["new_provider_recid"] = new_provider_recid
-  return _request("db:account:providers:unlink_provider:1", params)
+def unlink_provider_request(params: UnlinkProviderParams) -> DBRequest:
+  payload = params.model_dump(exclude_none=True)
+  return _request("db:account:providers:unlink_provider:1", payload)
 
 
-def unlink_last_provider_request(*, guid: str, provider: str) -> DBRequest:
+def unlink_last_provider_request(params: UnlinkLastProviderParams) -> DBRequest:
   return _request(
     "db:account:providers:unlink_last_provider:1",
-    {
-      "guid": guid,
-      "provider": provider,
-    },
+    params.model_dump(),
   )
 
 

--- a/server/registry/account/providers/model.py
+++ b/server/registry/account/providers/model.py
@@ -1,0 +1,126 @@
+"""Typed payload and response models for account provider registry ops."""
+
+from __future__ import annotations
+
+from typing import Any, NotRequired, TypedDict
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+__all__ = [
+  "CreateFromProviderParams",
+  "GetUserByEmailParams",
+  "LinkProviderParams",
+  "ProviderAccountRecord",
+  "ProviderIdentifierRecord",
+  "ProviderIdentifierParams",
+  "ProviderUnlinkSummary",
+  "SetProviderParams",
+  "SoftDeleteAccountParams",
+  "UnlinkLastProviderParams",
+  "UnlinkProviderParams",
+]
+
+
+def _normalize_uuid(value: Any) -> str:
+  return str(value)
+
+
+class ProviderIdentifierParams(BaseModel):
+  """Payload identifying an account linkage by provider identifier."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  provider: str
+  provider_identifier: str
+
+  @field_validator("provider_identifier")
+  @classmethod
+  def _normalize_identifier(cls, value: Any) -> str:
+    return _normalize_uuid(value)
+
+
+class CreateFromProviderParams(ProviderIdentifierParams):
+  """Parameters required to create a user from a provider profile."""
+
+  provider_email: str
+  provider_displayname: str
+  provider_profile_image: str | None = None
+
+
+class GetUserByEmailParams(BaseModel):
+  """Lookup payload targeting a user by e-mail."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  email: str
+
+
+class _GuidParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str
+
+  @field_validator("guid")
+  @classmethod
+  def _normalize_guid(cls, value: Any) -> str:
+    return _normalize_uuid(value)
+
+
+class LinkProviderParams(_GuidParams):
+  """Associate an existing account with a provider identifier."""
+
+  provider: str
+  provider_identifier: str
+
+  @field_validator("provider_identifier")
+  @classmethod
+  def _normalize_identifier(cls, value: Any) -> str:
+    return _normalize_uuid(value)
+
+
+class SetProviderParams(_GuidParams):
+  """Parameters for setting an account's default provider."""
+
+  provider: str
+
+
+class SoftDeleteAccountParams(_GuidParams):
+  """Parameters for soft-deleting an account."""
+
+
+class UnlinkProviderParams(_GuidParams):
+  """Parameters for unlinking a provider from an account."""
+
+  provider: str
+  new_provider_recid: int | None = None
+
+
+class UnlinkLastProviderParams(_GuidParams):
+  """Parameters for unlinking the final provider from an account."""
+
+  provider: str
+
+
+class ProviderAccountRecord(TypedDict, total=False):
+  """Projection returned when hydrating a provider-backed account."""
+
+  guid: str
+  display_name: str
+  email: str | None
+  credits: int | None
+  provider_name: str | None
+  provider_display: str | None
+  profile_image: str | None
+
+
+class ProviderIdentifierRecord(TypedDict, total=False):
+  """Minimal record returned by identifier lookups."""
+
+  guid: str
+  element_soft_deleted_at: str | None
+
+
+class ProviderUnlinkSummary(TypedDict):
+  """Summary payload returned after unlinking a provider."""
+
+  providers_remaining: NotRequired[int]

--- a/server/registry/account/session/__init__.py
+++ b/server/registry/account/session/__init__.py
@@ -2,10 +2,20 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from server.registry.types import DBRequest
+from .model import (
+  CreateSessionParams,
+  GuidParams,
+  ListSessionSnapshotsParams,
+  RevokeAllDeviceTokensParams,
+  RevokeDeviceTokenParams,
+  RevokeProviderTokensParams,
+  SetRotkeyParams,
+  UpdateDeviceTokenParams,
+  UpdateSessionParams,
+)
 
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
@@ -22,107 +32,61 @@ __all__ = [
   "list_session_snapshots_request",
   "update_device_token_request",
   "update_session_request",
+  "CreateSessionParams",
+  "GuidParams",
+  "ListSessionSnapshotsParams",
+  "RevokeAllDeviceTokensParams",
+  "RevokeDeviceTokenParams",
+  "RevokeProviderTokensParams",
+  "SetRotkeyParams",
+  "UpdateDeviceTokenParams",
+  "UpdateSessionParams",
 ]
 
 
-def _request(name: str, params: dict[str, Any]) -> DBRequest:
+def _request(name: str, params: dict[str, object]) -> DBRequest:
   return DBRequest(op=f"db:account:session:{name}:1", params=params)
 
 
-def list_session_snapshots_request(*, guid: str) -> DBRequest:
-  return _request("list_snapshots", {"guid": guid})
+def list_session_snapshots_request(params: ListSessionSnapshotsParams) -> DBRequest:
+  return _request("list_snapshots", params.model_dump())
 
 
-def get_security_snapshot_request(*, guid: str) -> DBRequest:
-  return _request("get_security_snapshot", {"guid": guid})
+def get_security_snapshot_request(params: GuidParams) -> DBRequest:
+  return _request("get_security_snapshot", params.model_dump())
 
 
-def create_session_request(
-  *,
-  access_token: str,
-  expires,
-  fingerprint: str,
-  user_guid: str,
-  provider: str,
-  user_agent: str | None = None,
-  ip_address: str | None = None,
-) -> DBRequest:
-  params: dict[str, Any] = {
-    "access_token": access_token,
-    "expires": expires,
-    "fingerprint": fingerprint,
-    "user_guid": user_guid,
-    "provider": provider,
-  }
-  if user_agent is not None:
-    params["user_agent"] = user_agent
-  if ip_address is not None:
-    params["ip_address"] = ip_address
-  return _request("create_session", params)
+def create_session_request(params: CreateSessionParams) -> DBRequest:
+  payload = params.model_dump(exclude_none=True)
+  return _request("create_session", payload)
 
 
-def update_session_request(
-  *,
-  access_token: str,
-  user_agent: str | None,
-  ip_address: str | None,
-) -> DBRequest:
-  params: dict[str, Any] = {
-    "access_token": access_token,
-    "user_agent": user_agent,
-    "ip_address": ip_address,
-  }
-  return _request("update_session", params)
+def update_session_request(params: UpdateSessionParams) -> DBRequest:
+  return _request("update_session", params.model_dump())
 
 
-def update_device_token_request(*, device_guid: str, access_token: str) -> DBRequest:
-  return _request(
-    "update_device_token",
-    {
-      "device_guid": device_guid,
-      "access_token": access_token,
-    },
-  )
+def update_device_token_request(params: UpdateDeviceTokenParams) -> DBRequest:
+  return _request("update_device_token", params.model_dump())
 
 
-def revoke_device_token_request(*, access_token: str) -> DBRequest:
-  return _request("revoke_device_token", {"access_token": access_token})
+def revoke_device_token_request(params: RevokeDeviceTokenParams) -> DBRequest:
+  return _request("revoke_device_token", params.model_dump())
 
 
-def revoke_all_device_tokens_request(*, guid: str) -> DBRequest:
-  return _request("revoke_all_device_tokens", {"guid": guid})
+def revoke_all_device_tokens_request(params: RevokeAllDeviceTokensParams) -> DBRequest:
+  return _request("revoke_all_device_tokens", params.model_dump())
 
 
-def revoke_provider_tokens_request(*, guid: str, provider: str) -> DBRequest:
-  return _request(
-    "revoke_provider_tokens",
-    {
-      "guid": guid,
-      "provider": provider,
-    },
-  )
+def revoke_provider_tokens_request(params: RevokeProviderTokensParams) -> DBRequest:
+  return _request("revoke_provider_tokens", params.model_dump())
 
 
-def get_rotkey_request(*, guid: str) -> DBRequest:
-  return _request("get_rotkey", {"guid": guid})
+def get_rotkey_request(params: GuidParams) -> DBRequest:
+  return _request("get_rotkey", params.model_dump())
 
 
-def set_rotkey_request(
-  *,
-  guid: str,
-  rotkey: str,
-  iat: datetime,
-  exp: datetime,
-) -> DBRequest:
-  return _request(
-    "set_rotkey",
-    {
-      "guid": guid,
-      "rotkey": rotkey,
-      "iat": iat,
-      "exp": exp,
-    },
-  )
+def set_rotkey_request(params: SetRotkeyParams) -> DBRequest:
+  return _request("set_rotkey", params.model_dump())
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/account/session/model.py
+++ b/server/registry/account/session/model.py
@@ -1,0 +1,187 @@
+"""Typed payload and response helpers for session registry operations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, NotRequired, TypedDict
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+__all__ = [
+  "CreateSessionParams",
+  "GuidParams",
+  "ListSessionSnapshotsParams",
+  "RevokeAllDeviceTokensParams",
+  "RevokeDeviceTokenParams",
+  "RevokeProviderTokensParams",
+  "RotkeyRecord",
+  "SecuritySnapshotRecord",
+  "SessionCreationResult",
+  "SessionSnapshotRecord",
+  "SetRotkeyParams",
+  "UpdateDeviceTokenParams",
+  "UpdateSessionParams",
+]
+
+
+def _normalize_uuid(value: Any) -> str:
+  return str(value)
+
+
+class GuidParams(BaseModel):
+  """Generic payload carrying a user guid."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str
+
+  @field_validator("guid")
+  @classmethod
+  def _normalize_guid(cls, value: Any) -> str:
+    return _normalize_uuid(value)
+
+
+class ListSessionSnapshotsParams(GuidParams):
+  """Parameters used for listing session snapshot rows."""
+
+
+class CreateSessionParams(BaseModel):
+  """Payload required to create or refresh a device session."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  access_token: str
+  expires: datetime
+  fingerprint: str
+  user_guid: str
+  provider: str
+  user_agent: str | None = None
+  ip_address: str | None = None
+
+  @field_validator("user_guid")
+  @classmethod
+  def _normalize_user_guid(cls, value: Any) -> str:
+    return _normalize_uuid(value)
+
+
+class UpdateSessionParams(BaseModel):
+  """Metadata attached to an existing device session."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  access_token: str
+  user_agent: str | None
+  ip_address: str | None
+
+
+class UpdateDeviceTokenParams(BaseModel):
+  """Payload targeting a device token by guid."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  device_guid: str
+  access_token: str
+
+  @field_validator("device_guid")
+  @classmethod
+  def _normalize_guid(cls, value: Any) -> str:
+    return _normalize_uuid(value)
+
+
+class RevokeDeviceTokenParams(BaseModel):
+  """Payload targeting an access token for revocation."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  access_token: str
+
+
+class RevokeProviderTokensParams(GuidParams):
+  """Payload revoking tokens associated with a provider."""
+
+  provider: str
+
+
+class SetRotkeyParams(GuidParams):
+  """Rotation key payload for a user."""
+
+  rotkey: str
+  iat: datetime
+  exp: datetime
+
+
+class SessionCreationResult(TypedDict, total=False):
+  """Result payload returned after creating a session."""
+
+  session_guid: str
+  device_guid: str
+
+
+class RotkeyRecord(TypedDict, total=False):
+  """Rotkey metadata returned from storage."""
+
+  user_guid: str
+  rotkey: str
+  rotkey_iat: str
+  rotkey_exp: str
+  provider_name: str | None
+  provider_display: str | None
+  session_guid: str | None
+  session_created_on: str | None
+  session_modified_on: str | None
+  device_guid: str | None
+  device_token: str | None
+  device_token_iat: str | None
+  device_token_exp: str | None
+  revoked_at: str | None
+  device_fingerprint: str | None
+  user_agent: str | None
+  ip_last_seen: str | None
+
+
+class SessionSnapshotRecord(TypedDict, total=False):
+  """Historical session snapshot entry."""
+
+  user_guid: str
+  user_roles: int | None
+  user_created_on: str | None
+  user_modified_on: str | None
+  element_rotkey: str | None
+  element_rotkey_iat: str | None
+  element_rotkey_exp: str | None
+  session_guid: str | None
+  session_created_on: str | None
+  session_modified_on: str | None
+  device_guid: str | None
+  device_created_on: str | None
+  device_modified_on: str | None
+  element_token: str | None
+  element_token_iat: str | None
+  element_token_exp: str | None
+  element_revoked_at: str | None
+  element_device_fingerprint: str | None
+  element_user_agent: str | None
+  element_ip_last_seen: str | None
+
+
+class SecuritySnapshotRecord(TypedDict, total=False):
+  """Condensed security snapshot entry."""
+
+  user_guid: str
+  element_rotkey: str | None
+  element_rotkey_iat: str | None
+  element_rotkey_exp: str | None
+  session_guid: str | None
+  device_guid: str | None
+  element_token: str | None
+  element_token_iat: str | None
+  element_token_exp: str | None
+  element_revoked_at: str | None
+  element_device_fingerprint: str | None
+  element_user_agent: str | None
+  element_ip_last_seen: str | None
+
+
+class RevokeAllDeviceTokensParams(GuidParams):
+  """Payload revoking every token for a user."""
+

--- a/server/registry/system/config/__init__.py
+++ b/server/registry/system/config/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from server.registry.types import DBRequest
+from .model import ConfigKeyParams, UpsertConfigParams
 
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
@@ -15,26 +16,28 @@ __all__ = [
   "get_configs_request",
   "register",
   "upsert_config_request",
+  "ConfigKeyParams",
+  "UpsertConfigParams",
 ]
 
 
-def get_config_request(key: str) -> DBRequest:
-  return DBRequest(op="db:system:config:get_config:1", params={"key": key})
+def get_config_request(params: ConfigKeyParams) -> DBRequest:
+  return DBRequest(op="db:system:config:get_config:1", params=params.model_dump())
 
 
 def get_configs_request() -> DBRequest:
   return DBRequest(op="db:system:config:get_configs:1", params={})
 
 
-def upsert_config_request(key: str, value: str) -> DBRequest:
-  return DBRequest(op="db:system:config:upsert_config:1", params={
-    "key": key,
-    "value": value,
-  })
+def upsert_config_request(params: UpsertConfigParams) -> DBRequest:
+  return DBRequest(
+    op="db:system:config:upsert_config:1",
+    params=params.model_dump(),
+  )
 
 
-def delete_config_request(key: str) -> DBRequest:
-  return DBRequest(op="db:system:config:delete_config:1", params={"key": key})
+def delete_config_request(params: ConfigKeyParams) -> DBRequest:
+  return DBRequest(op="db:system:config:delete_config:1", params=params.model_dump())
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/system/config/model.py
+++ b/server/registry/system/config/model.py
@@ -1,0 +1,34 @@
+"""Typed payload and response helpers for system config registry ops."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "ConfigKeyParams",
+  "ConfigRecord",
+  "UpsertConfigParams",
+]
+
+
+class ConfigKeyParams(BaseModel):
+  """Payload targeting a single configuration entry."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  key: str
+
+
+class UpsertConfigParams(ConfigKeyParams):
+  """Parameters for inserting or updating a configuration value."""
+
+  value: str
+
+
+class ConfigRecord(TypedDict, total=False):
+  """Record representation returned by configuration queries."""
+
+  key: str
+  value: str | None

--- a/server/registry/system/roles/__init__.py
+++ b/server/registry/system/roles/__init__.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from server.registry.types import DBRequest
+from .model import (
+  DeleteRoleParams,
+  ModifyRoleMemberParams,
+  RoleScopeParams,
+  UpsertRoleParams,
+)
 
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
@@ -18,6 +24,10 @@ __all__ = [
   "register",
   "remove_role_member_request",
   "upsert_role_request",
+  "DeleteRoleParams",
+  "ModifyRoleMemberParams",
+  "RoleScopeParams",
+  "UpsertRoleParams",
 ]
 
 
@@ -25,38 +35,46 @@ def list_roles_request() -> DBRequest:
   return DBRequest(op="db:system:roles:list:1", params={})
 
 
-def get_role_members_request(role: str) -> DBRequest:
-  return DBRequest(op="db:system:roles:get_role_members:1", params={"role": role})
+def get_role_members_request(params: RoleScopeParams) -> DBRequest:
+  return DBRequest(
+    op="db:system:roles:get_role_members:1",
+    params=params.model_dump(),
+  )
 
 
-def get_role_non_members_request(role: str) -> DBRequest:
-  return DBRequest(op="db:system:roles:get_role_non_members:1", params={"role": role})
+def get_role_non_members_request(params: RoleScopeParams) -> DBRequest:
+  return DBRequest(
+    op="db:system:roles:get_role_non_members:1",
+    params=params.model_dump(),
+  )
 
 
-def add_role_member_request(role: str, user_guid: str) -> DBRequest:
-  return DBRequest(op="db:system:roles:add_role_member:1", params={
-    "role": role,
-    "user_guid": user_guid,
-  })
+def add_role_member_request(params: ModifyRoleMemberParams) -> DBRequest:
+  return DBRequest(
+    op="db:system:roles:add_role_member:1",
+    params=params.model_dump(),
+  )
 
 
-def remove_role_member_request(role: str, user_guid: str) -> DBRequest:
-  return DBRequest(op="db:system:roles:remove_role_member:1", params={
-    "role": role,
-    "user_guid": user_guid,
-  })
+def remove_role_member_request(params: ModifyRoleMemberParams) -> DBRequest:
+  return DBRequest(
+    op="db:system:roles:remove_role_member:1",
+    params=params.model_dump(),
+  )
 
 
-def upsert_role_request(name: str, mask: int, display: str | None) -> DBRequest:
-  return DBRequest(op="db:system:roles:upsert_role:1", params={
-    "name": name,
-    "mask": mask,
-    "display": display,
-  })
+def upsert_role_request(params: UpsertRoleParams) -> DBRequest:
+  return DBRequest(
+    op="db:system:roles:upsert_role:1",
+    params=params.model_dump(),
+  )
 
 
-def delete_role_request(name: str) -> DBRequest:
-  return DBRequest(op="db:system:roles:delete_role:1", params={"name": name})
+def delete_role_request(params: DeleteRoleParams) -> DBRequest:
+  return DBRequest(
+    op="db:system:roles:delete_role:1",
+    params=params.model_dump(),
+  )
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/system/roles/model.py
+++ b/server/registry/system/roles/model.py
@@ -1,0 +1,73 @@
+"""Typed payload and response helpers for system role registry operations."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+__all__ = [
+  "DeleteRoleParams",
+  "ModifyRoleMemberParams",
+  "RoleMemberRecord",
+  "RoleRecord",
+  "RoleScopeParams",
+  "UpsertRoleParams",
+]
+
+
+def _normalize_uuid(value: Any) -> str:
+  return str(UUID(str(value)))
+
+
+class RoleScopeParams(BaseModel):
+  """Payload that scopes operations to a single role."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  role: str
+
+
+class ModifyRoleMemberParams(RoleScopeParams):
+  """Parameters describing a role membership change."""
+
+  user_guid: str
+
+  @field_validator("user_guid")
+  @classmethod
+  def _normalize_guid(cls, value: Any) -> str:
+    return _normalize_uuid(value)
+
+
+class UpsertRoleParams(BaseModel):
+  """Parameters for inserting or updating a role definition."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  name: str
+  mask: int
+  display: str | None = None
+
+
+class DeleteRoleParams(BaseModel):
+  """Payload describing a role deletion."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  name: str
+
+
+class RoleRecord(TypedDict, total=False):
+  """Role metadata returned when listing roles."""
+
+  name: str
+  mask: int
+  display: str | None
+
+
+class RoleMemberRecord(TypedDict, total=False):
+  """Projection of a role membership row."""
+
+  guid: str
+  display_name: str | None

--- a/server/registry/system/vars/__init__.py
+++ b/server/registry/system/vars/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from server.registry.types import DBRequest
+from .model import PublicVarRecord
 
 if TYPE_CHECKING:
   from server.registry import SubdomainRouter
@@ -14,6 +15,7 @@ __all__ = [
   "get_repo_request",
   "get_version_request",
   "register",
+  "PublicVarRecord",
 ]
 
 

--- a/server/registry/system/vars/model.py
+++ b/server/registry/system/vars/model.py
@@ -1,0 +1,15 @@
+"""Response payload helpers for public system vars."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+__all__ = ["PublicVarRecord"]
+
+
+class PublicVarRecord(TypedDict, total=False):
+  """Representation of a public system variable."""
+
+  version: str | None
+  hostname: str | None
+  repo: str | None

--- a/server/routers/discord_events.py
+++ b/server/routers/discord_events.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from discord.ext import commands
-from server.registry.system.config import get_config_request
+from server.registry.system.config import ConfigKeyParams, get_config_request
 
 if TYPE_CHECKING:  # pragma: no cover - runtime import cycle guard
   from server.modules.discord_bot_module import DiscordBotModule
@@ -25,9 +25,9 @@ def _register_on_ready_handler(bot_module: "DiscordBotModule", bot: commands.Bot
   async def on_ready():
     channel = bot.get_channel(bot_module.syschan)
     if channel:
-      res = await bot_module.db.run(get_config_request(key="Version"))
+      res = await bot_module.db.run(get_config_request(ConfigKeyParams(key="Version")))
       version = res.rows[0]["value"] if res.rows else None
-      name_res = await bot_module.db.run(get_config_request(key="BotName"))
+      name_res = await bot_module.db.run(get_config_request(ConfigKeyParams(key="BotName")))
       bot_name = name_res.rows[0]["value"] if name_res.rows else None
       msg = f"{(bot_name or 'TheOracleGPT-Dev')} Online. Version: {version or 'unknown'}"
       if await bot_module._try_send_channel(channel.id, msg):

--- a/tests/test_registry_contracts.py
+++ b/tests/test_registry_contracts.py
@@ -1,0 +1,28 @@
+"""Sanity checks for registry metadata and operation naming conventions."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_registered_ops_align_with_module_paths():
+  registry = importlib.import_module("server.registry")
+  providers = registry._registry_router._registry._providers
+  assert providers, "registry should have providers registered"
+
+  for provider, ops in providers.items():
+    assert ops, f"provider {provider} must register operations"
+    for op, spec in ops.items():
+      domain, path, version = registry.parse_db_op(op)
+      assert version > 0, f"{op} must use a positive version number"
+      module_parts = spec.module.split(".")
+      try:
+        reg_index = module_parts.index("registry")
+      except ValueError:  # pragma: no cover - defensive guard
+        raise AssertionError(f"handler module missing registry segment: {spec.module}")
+      package_parts = module_parts[reg_index + 1 : -1]
+      assert package_parts, f"{op} must live under server.registry.*"
+      assert domain == package_parts[0], f"{op} domain mismatch"
+      expected_path = tuple(package_parts[1:])
+      actual_path = tuple(path[:-1])
+      assert actual_path == expected_path, f"{op} subdomain path mismatch"


### PR DESCRIPTION
## Summary
- add Pydantic/TypedDict payload models for account providers, session, profile, and system config/roles/vars registries
- update request builders and service modules to consume the new models, removing legacy db:account:account alias
- add a registry contract self-test that verifies every registered operation parses and maps to its module path

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f83ee03cb883259b56ef9bcf2d0923