### PR TITLE
Add profile module and refactor profile services

### DIFF
--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -2,8 +2,7 @@ from fastapi import HTTPException, Request
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.db_module import DbModule
-from server.registry.types import DBRequest
+from server.modules.profile_module import ProfileModule
 from .models import (
   UsersProfileProfile1,
   UsersProfileSetDisplay1,
@@ -27,26 +26,20 @@ async def users_profile_get_profile_v1(request: Request):
   if user_guid is None:
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
-  db: DbModule = request.app.state.db
-  res = await db.run(
-    DBRequest(
-      op="db:account:profile:get_profile:1",
-      payload={"guid": user_guid},
-    ),
-  )
-  if not res.rows:
+  profile: ProfileModule = request.app.state.profile
+  record = await profile.get_profile(user_guid)
+  if not record:
     raise HTTPException(status_code=404, detail="Profile not found")
-  row = res.rows[0]
-  row["guid"] = str(row.get("guid", ""))
-  auth_providers = row.get("auth_providers")
+  record["guid"] = str(record.get("guid", ""))
+  auth_providers = record.get("auth_providers")
   if auth_providers is None:
-    row["auth_providers"] = []
+    record["auth_providers"] = []
   elif not isinstance(auth_providers, list):
     raise HTTPException(status_code=500, detail="Invalid auth provider payload")
-  profile = UsersProfileProfile1(**row)
+  profile_payload = UsersProfileProfile1(**record)
   return RPCResponse(
     op=rpc_request.op,
-    payload=profile.model_dump(),
+    payload=profile_payload.model_dump(),
     version=rpc_request.version,
   )
 
@@ -57,16 +50,8 @@ async def users_profile_set_display_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   payload = UsersProfileSetDisplay1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  await db.run(
-    DBRequest(
-      op="db:account:profile:set_display:1",
-      payload={
-        "guid": user_guid,
-        "display_name": payload.display_name,
-      },
-    ),
-  )
+  profile: ProfileModule = request.app.state.profile
+  await profile.set_display(user_guid, payload.display_name)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -80,16 +65,8 @@ async def users_profile_set_optin_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   payload = UsersProfileSetOptin1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  await db.run(
-    DBRequest(
-      op="db:account:profile:set_optin:1",
-      payload={
-        "guid": user_guid,
-        "display_email": payload.display_email,
-      },
-    ),
-  )
+  profile: ProfileModule = request.app.state.profile
+  await profile.set_optin(user_guid, payload.display_email)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -102,14 +79,8 @@ async def users_profile_get_roles_v1(request: Request):
   if user_guid is None:
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
-  db: DbModule = request.app.state.db
-  res = await db.run(
-    DBRequest(
-      op="db:account:profile:get_roles:1",
-      payload={"guid": user_guid},
-    ),
-  )
-  roles = int(res.rows[0].get("element_roles", 0)) if res.rows else 0
+  profile: ProfileModule = request.app.state.profile
+  roles = await profile.get_roles(user_guid)
   payload = UsersProfileRoles1(roles=roles)
   return RPCResponse(
     op=rpc_request.op,
@@ -124,16 +95,11 @@ async def users_profile_set_profile_image_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   payload = UsersProfileSetProfileImage1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  await db.run(
-    DBRequest(
-      op="db:account:profile:set_profile_image:1",
-      payload={
-        "guid": user_guid,
-        "image_b64": payload.image_b64,
-        "provider": payload.provider,
-      },
-    ),
+  profile: ProfileModule = request.app.state.profile
+  await profile.set_profile_image(
+    user_guid,
+    payload.provider,
+    payload.image_b64,
   )
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/profile_module.py
+++ b/server/modules/profile_module.py
@@ -1,0 +1,65 @@
+"""Profile module wrapping account profile registry helpers."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from . import BaseModule
+from .db_module import DbModule
+from server.registry.account.profile import (
+  GuidParams,
+  ProfileRecord,
+  SetDisplayParams,
+  SetOptInParams,
+  SetProfileImageParams,
+  get_profile_request,
+  get_roles_request,
+  set_display_request,
+  set_optin_request,
+  set_profile_image_request,
+)
+
+
+class ProfileModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    self.db = None
+
+  async def get_profile(self, guid: str) -> ProfileRecord | None:
+    assert self.db
+    params = GuidParams(guid=guid)
+    res = await self.db.run(get_profile_request(params))
+    return res.rows[0] if res.rows else None
+
+  async def set_display(self, guid: str, display_name: str) -> None:
+    assert self.db
+    params = SetDisplayParams(guid=guid, display_name=display_name)
+    await self.db.run(set_display_request(params))
+
+  async def set_optin(self, guid: str, display_email: bool) -> None:
+    assert self.db
+    params = SetOptInParams(guid=guid, display_email=display_email)
+    await self.db.run(set_optin_request(params))
+
+  async def get_roles(self, guid: str) -> int:
+    assert self.db
+    params = GuidParams(guid=guid)
+    res = await self.db.run(get_roles_request(params))
+    if not res.rows:
+      return 0
+    row = res.rows[0]
+    value = row.get("element_roles") if isinstance(row, dict) else None
+    return int(value or 0)
+
+  async def set_profile_image(self, guid: str, provider: str, image_b64: str | None) -> None:
+    assert self.db
+    params = SetProfileImageParams(guid=guid, provider=provider, image_b64=image_b64)
+    await self.db.run(set_profile_image_request(params))

--- a/server/registry/account/profile/__init__.py
+++ b/server/registry/account/profile/__init__.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 __all__ = [
   "get_profile_request",
+  "get_roles_request",
   "set_display_request",
   "set_optin_request",
   "set_profile_image_request",
@@ -40,6 +41,10 @@ def _request(name: str, params: dict[str, object]) -> DBRequest:
 
 def get_profile_request(params: GuidParams) -> DBRequest:
   return _request("get_profile", params.model_dump())
+
+
+def get_roles_request(params: GuidParams) -> DBRequest:
+  return _request("get_roles", params.model_dump())
 
 
 def set_display_request(params: SetDisplayParams) -> DBRequest:
@@ -66,6 +71,7 @@ def update_if_unedited_request(params: UpdateIfUneditedParams) -> DBRequest:
 
 def register(router: "SubdomainRouter") -> None:
   router.add_function("get_profile", version=1)
+  router.add_function("get_roles", version=1)
   router.add_function("set_display", version=1)
   router.add_function("set_optin", version=1)
   router.add_function("set_profile_image", version=1)

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -34,6 +34,10 @@ db_module_pkg = types.ModuleType("server.modules.db_module")
 class DbModule: ...
 db_module_pkg.DbModule = DbModule
 modules_pkg.db_module = db_module_pkg
+profile_module_pkg = types.ModuleType("server.modules.profile_module")
+class ProfileModule: ...
+profile_module_pkg.ProfileModule = ProfileModule
+modules_pkg.profile_module = profile_module_pkg
 server_pkg.modules = modules_pkg
 models_pkg = types.ModuleType("server.models")
 class AuthContext:
@@ -46,6 +50,7 @@ server_pkg.models = models_pkg
 sys.modules.setdefault("server", server_pkg)
 sys.modules.setdefault("server.modules", modules_pkg)
 sys.modules.setdefault("server.modules.db_module", db_module_pkg)
+sys.modules.setdefault("server.modules.profile_module", profile_module_pkg)
 sys.modules.setdefault("server.models", models_pkg)
 
 registry_pkg = types.ModuleType("server.registry")
@@ -117,15 +122,10 @@ users_profile_get_profile_v1 = svc_mod.users_profile_get_profile_v1
 users_profile_get_roles_v1 = svc_mod.users_profile_get_roles_v1
 users_profile_set_profile_image_v1 = svc_mod.users_profile_set_profile_image_v1
 
-class DBRes:
-  def __init__(self, rows=None, rowcount=0):
-    self.rows = rows or []
-    self.rowcount = rowcount
-
 _DEFAULT_PROVIDERS = object()
 
 
-class DummyDb:
+class DummyProfileModule:
   def __init__(self, roles=0, auth_providers=_DEFAULT_PROVIDERS):
     self.calls = []
     self.roles = roles
@@ -135,35 +135,40 @@ class DummyDb:
         {"name": "google", "display": "Google"},
       ]
     self.auth_providers = auth_providers
-  async def run(self, op, args=None):
-    if not isinstance(op, str):
-      args = op.payload
-      op = op.op
-    elif args is None:
-      args = {}
-    self.calls.append((op, args))
-    if op == "db:account:profile:get_profile:1":
-      return DBRes([
-        {
-          "guid": args.get("guid"),
-          "display_name": "Test User",
-          "email": "user@example.com",
-          "display_email": True,
-          "credits": 10,
-          "profile_image": None,
-          "default_provider": "microsoft",
-          "auth_providers": self.auth_providers,
-        }
-      ], 1)
-    if op == "db:account:profile:get_roles:1":
-      return DBRes([{"element_roles": self.roles}], 1)
-    if op == "db:account:profile:set_profile_image:1":
-      return DBRes([], 1)
-    return DBRes()
+
+  async def get_profile(self, guid: str):
+    self.calls.append(("get_profile", {"guid": guid}))
+    return {
+      "guid": guid,
+      "display_name": "Test User",
+      "email": "user@example.com",
+      "display_email": True,
+      "credits": 10,
+      "profile_image": None,
+      "default_provider": "microsoft",
+      "auth_providers": self.auth_providers,
+    }
+
+  async def set_display(self, guid: str, display_name: str):
+    self.calls.append(("set_display", {"guid": guid, "display_name": display_name}))
+
+  async def set_optin(self, guid: str, display_email: bool):
+    self.calls.append(("set_optin", {"guid": guid, "display_email": display_email}))
+
+  async def get_roles(self, guid: str) -> int:
+    self.calls.append(("get_roles", {"guid": guid}))
+    return int(self.roles)
+
+  async def set_profile_image(self, guid: str, provider: str, image_b64: str | None):
+    self.calls.append((
+      "set_profile_image",
+      {"guid": guid, "provider": provider, "image_b64": image_b64},
+    ))
+
 
 class DummyState:
-  def __init__(self, db):
-    self.db = db
+  def __init__(self, profile):
+    self.profile = profile
 
 class DummyApp:
   def __init__(self, state):
@@ -179,12 +184,12 @@ def test_get_roles_service_returns_mask():
     rpc = RPCRequest(op="urn:users:profile:get_roles:1", payload=None, version=1)
     return rpc, SimpleNamespace(user_guid="u1"), None
   svc_mod.unbox_request = fake_get
-  db = DummyDb(roles=5)
-  req = DummyRequest(DummyState(db))
+  profile = DummyProfileModule(roles=5)
+  req = DummyRequest(DummyState(profile))
   resp = asyncio.run(users_profile_get_roles_v1(req))
   assert isinstance(resp, RPCResponse)
   assert resp.payload["roles"] == 5
-  assert ("db:account:profile:get_roles:1", {"guid": "u1"}) in db.calls
+  assert ("get_roles", {"guid": "u1"}) in profile.calls
 
 
 def test_get_profile_returns_structured_auth_providers():
@@ -192,8 +197,8 @@ def test_get_profile_returns_structured_auth_providers():
     rpc = RPCRequest(op="urn:users:profile:get_profile:1", payload=None, version=1)
     return rpc, SimpleNamespace(user_guid="user-guid"), None
   svc_mod.unbox_request = fake_get
-  db = DummyDb()
-  req = DummyRequest(DummyState(db))
+  profile = DummyProfileModule()
+  req = DummyRequest(DummyState(profile))
   resp = asyncio.run(users_profile_get_profile_v1(req))
   assert isinstance(resp, RPCResponse)
   assert resp.payload["guid"] == "user-guid"
@@ -201,7 +206,7 @@ def test_get_profile_returns_structured_auth_providers():
   assert isinstance(providers, list)
   assert providers[0]["name"] == "microsoft"
   assert providers[1]["display"] == "Google"
-  assert ("db:account:profile:get_profile:1", {"guid": "user-guid"}) in db.calls
+  assert ("get_profile", {"guid": "user-guid"}) in profile.calls
 
 
 def test_get_profile_defaults_auth_providers_to_empty_list():
@@ -209,8 +214,8 @@ def test_get_profile_defaults_auth_providers_to_empty_list():
     rpc = RPCRequest(op="urn:users:profile:get_profile:1", payload=None, version=1)
     return rpc, SimpleNamespace(user_guid="user-guid"), None
   svc_mod.unbox_request = fake_get
-  db = DummyDb(auth_providers=None)
-  req = DummyRequest(DummyState(db))
+  profile = DummyProfileModule(auth_providers=None)
+  req = DummyRequest(DummyState(profile))
   resp = asyncio.run(users_profile_get_profile_v1(req))
   assert isinstance(resp, RPCResponse)
   assert resp.payload["auth_providers"] == []
@@ -221,8 +226,8 @@ def test_get_profile_raises_on_invalid_auth_providers_shape():
     rpc = RPCRequest(op="urn:users:profile:get_profile:1", payload=None, version=1)
     return rpc, SimpleNamespace(user_guid="user-guid"), None
   svc_mod.unbox_request = fake_get
-  db = DummyDb(auth_providers="not-json")
-  req = DummyRequest(DummyState(db))
+  profile = DummyProfileModule(auth_providers="not-json")
+  req = DummyRequest(DummyState(profile))
   with pytest.raises(HTTPException) as exc:
     asyncio.run(users_profile_get_profile_v1(req))
   assert exc.value.status_code == 500
@@ -232,10 +237,13 @@ def test_set_profile_image_calls_db():
     rpc = RPCRequest(op="urn:users:profile:set_profile_image:1", payload={"image_b64": "abc", "provider": "microsoft"}, version=1)
     return rpc, SimpleNamespace(user_guid="u1"), None
   svc_mod.unbox_request = fake_img
-  db = DummyDb()
-  req = DummyRequest(DummyState(db))
+  profile = DummyProfileModule()
+  req = DummyRequest(DummyState(profile))
   resp = asyncio.run(users_profile_set_profile_image_v1(req))
-  assert ("db:account:profile:set_profile_image:1", {"guid": "u1", "image_b64": "abc", "provider": "microsoft"}) in db.calls
+  assert (
+    "set_profile_image",
+    {"guid": "u1", "image_b64": "abc", "provider": "microsoft"},
+  ) in profile.calls
   assert resp.payload["image_b64"] == "abc"
 
 
@@ -244,8 +252,8 @@ def test_missing_user_guid_raises():
     rpc = RPCRequest(op="urn:users:profile:get_roles:1", payload=None, version=1)
     return rpc, SimpleNamespace(user_guid=None), None
   svc_mod.unbox_request = fake_get
-  db = DummyDb()
-  req = DummyRequest(DummyState(db))
+  profile = DummyProfileModule()
+  req = DummyRequest(DummyState(profile))
   with pytest.raises(HTTPException) as exc:
     asyncio.run(users_profile_get_roles_v1(req))
   assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary
- add a profile module that wraps account profile registry helpers and exposes typed async methods
- register the missing get_roles request in the account profile registry
- refactor the users profile services and tests to call the profile module instead of DbModule

## Testing
- pytest tests/test_users_profile_services.py

------
https://chatgpt.com/codex/tasks/task_e_68f95dd8ec548325ba1790c68a91bb0b