### PR TITLE
Add service routes module and refactor RPC handlers

### DIFF
--- a/rpc/service/routes/services.py
+++ b/rpc/service/routes/services.py
@@ -3,13 +3,7 @@ import logging
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.db_module import DbModule
-from server.modules.auth_module import AuthModule
-from server.registry.system.routes import (
-  delete_route_request,
-  get_routes_request,
-  upsert_route_request,
-)
+from server.modules.service_routes_module import ServiceRoutesModule
 from .models import (
   ServiceRoutesRouteItem1,
   ServiceRoutesList1,
@@ -24,26 +18,9 @@ async def service_routes_get_routes_v1(request: Request):
     auth_ctx.user_guid,
     auth_ctx.roles,
   )
-  db: DbModule = request.app.state.db
-  auth: AuthModule = request.app.state.auth
-  res = await db.run(get_routes_request())
-  routes = []
-  for row in res.rows:
-    mask = int(row.get("element_roles", 0))
-    roles = auth.mask_to_names(mask)
-    item = ServiceRoutesRouteItem1(
-      path=row.get("element_path", ""),
-      name=row.get("element_name", ""),
-      icon=row.get("element_icon"),
-      sequence=int(row.get("element_sequence", 0)),
-      required_roles=roles,
-    )
-    routes.append(item)
-  payload = ServiceRoutesList1(routes=routes)
-  logging.debug(
-    "[service_routes_get_routes_v1] returning %d routes",
-    len(routes),
-  )
+  module: ServiceRoutesModule = request.app.state.service_routes
+  await module.on_ready()
+  payload = await module.get_routes(auth_ctx.user_guid, auth_ctx.roles)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -60,22 +37,9 @@ async def service_routes_upsert_route_v1(request: Request):
     rpc_request.payload,
   )
   payload = ServiceRoutesRouteItem1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  auth: AuthModule = request.app.state.auth
-  mask = auth.names_to_mask(payload.required_roles)
-  await db.run(
-    upsert_route_request(
-      path=payload.path,
-      name=payload.name,
-      icon=payload.icon,
-      sequence=payload.sequence,
-      roles=mask,
-    )
-  )
-  logging.debug(
-    "[service_routes_upsert_route_v1] upserted route %s",
-    payload.path,
-  )
+  module: ServiceRoutesModule = request.app.state.service_routes
+  await module.on_ready()
+  await module.upsert_route(auth_ctx.user_guid, auth_ctx.roles, payload)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -92,12 +56,9 @@ async def service_routes_delete_route_v1(request: Request):
     rpc_request.payload,
   )
   payload = ServiceRoutesDeleteRoute1(**(rpc_request.payload or {}))
-  db: DbModule = request.app.state.db
-  await db.run(delete_route_request(payload.path))
-  logging.debug(
-    "[service_routes_delete_route_v1] deleted route %s",
-    payload.path,
-  )
+  module: ServiceRoutesModule = request.app.state.service_routes
+  await module.on_ready()
+  await module.delete_route(auth_ctx.user_guid, auth_ctx.roles, payload.path)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),

--- a/server/modules/service_routes_module.py
+++ b/server/modules/service_routes_module.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import logging
+from fastapi import FastAPI
+
+from rpc.service.routes.models import (
+  ServiceRoutesDeleteRoute1,
+  ServiceRoutesList1,
+  ServiceRoutesRouteItem1,
+)
+from server.registry.system.routes import (
+  delete_route_request,
+  get_routes_request,
+  upsert_route_request,
+)
+
+from . import BaseModule
+from .auth_module import AuthModule
+from .db_module import DbModule
+
+
+class ServiceRoutesModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+    self.auth: AuthModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.auth = self.app.state.auth
+    await self.auth.on_ready()
+    self.mark_ready()
+
+  async def shutdown(self):
+    self.db = None
+    self.auth = None
+
+  async def get_routes(
+    self,
+    user_guid: str,
+    roles: list[str],
+  ) -> ServiceRoutesList1:
+    logging.debug(
+      "[service_routes_get_routes_v1] user=%s roles=%s",
+      user_guid,
+      roles,
+    )
+    if not self.db or not self.auth:
+      raise RuntimeError("ServiceRoutesModule not ready")
+    res = await self.db.run(get_routes_request())
+    routes: list[ServiceRoutesRouteItem1] = []
+    for row in res.rows:
+      mask = int(row.get("element_roles", 0))
+      required_roles = self.auth.mask_to_names(mask)
+      route = ServiceRoutesRouteItem1(
+        path=row.get("element_path", ""),
+        name=row.get("element_name", ""),
+        icon=row.get("element_icon"),
+        sequence=int(row.get("element_sequence", 0)),
+        required_roles=required_roles,
+      )
+      routes.append(route)
+    logging.debug(
+      "[service_routes_get_routes_v1] returning %d routes",
+      len(routes),
+    )
+    return ServiceRoutesList1(routes=routes)
+
+  async def upsert_route(
+    self,
+    user_guid: str,
+    roles: list[str],
+    route: ServiceRoutesRouteItem1,
+  ) -> ServiceRoutesRouteItem1:
+    logging.debug(
+      "[service_routes_upsert_route_v1] user=%s roles=%s payload=%s",
+      user_guid,
+      roles,
+      route.model_dump(),
+    )
+    if not self.db or not self.auth:
+      raise RuntimeError("ServiceRoutesModule not ready")
+    mask = self.auth.names_to_mask(route.required_roles)
+    await self.db.run(
+      upsert_route_request(
+        path=route.path,
+        name=route.name,
+        icon=route.icon,
+        sequence=route.sequence,
+        roles=mask,
+      )
+    )
+    logging.debug(
+      "[service_routes_upsert_route_v1] upserted route %s",
+      route.path,
+    )
+    return route
+
+  async def delete_route(
+    self,
+    user_guid: str,
+    roles: list[str],
+    path: str,
+  ) -> ServiceRoutesDeleteRoute1:
+    logging.debug(
+      "[service_routes_delete_route_v1] user=%s roles=%s payload={'path': %s}",
+      user_guid,
+      roles,
+      path,
+    )
+    if not self.db:
+      raise RuntimeError("ServiceRoutesModule not ready")
+    await self.db.run(delete_route_request(path))
+    logging.debug(
+      "[service_routes_delete_route_v1] deleted route %s",
+      path,
+    )
+    return ServiceRoutesDeleteRoute1(path=path)

--- a/tests/test_service_routes_services.py
+++ b/tests/test_service_routes_services.py
@@ -17,52 +17,16 @@ rpc_service_routes_pkg = types.ModuleType('rpc.service.routes')
 rpc_service_routes_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / 'rpc/service/routes')]
 sys.modules.setdefault('rpc.service.routes', rpc_service_routes_pkg)
 
+from rpc.service.routes.models import (
+  ServiceRoutesDeleteRoute1,
+  ServiceRoutesList1,
+  ServiceRoutesRouteItem1,
+)
+
 # Stub server modules
 server_pkg = types.ModuleType('server')
 modules_pkg = types.ModuleType('server.modules')
-db_module_pkg = types.ModuleType('server.modules.db_module')
-auth_module_pkg = types.ModuleType('server.modules.auth_module')
 models_pkg = types.ModuleType('server.models')
-
-
-class DbModule:
-  pass
-
-
-db_module_pkg.DbModule = DbModule
-modules_pkg.db_module = db_module_pkg
-
-
-class RoleCache:
-  def __init__(self):
-    self.roles = {'ROLE_SERVICE_ADMIN': 1}
-
-  def mask_to_names(self, mask):
-    return [name for name, bit in self.roles.items() if mask & bit]
-
-  def names_to_mask(self, names):
-    mask = 0
-    for n in names:
-      mask |= self.roles.get(n, 0)
-    return mask
-
-class AuthModule:
-  def __init__(self):
-    self.role_cache = RoleCache()
-
-  @property
-  def roles(self):
-    return self.role_cache.roles
-
-  def mask_to_names(self, mask):
-    return self.role_cache.mask_to_names(mask)
-
-  def names_to_mask(self, names):
-    return self.role_cache.names_to_mask(names)
-
-
-auth_module_pkg.AuthModule = AuthModule
-modules_pkg.auth_module = auth_module_pkg
 
 
 class RPCResponse:
@@ -90,55 +54,55 @@ models_pkg.AuthContext = AuthContext
 server_pkg.modules = modules_pkg
 server_pkg.models = models_pkg
 
+service_routes_module_pkg = types.ModuleType('server.modules.service_routes_module')
+
+
+class StubServiceRoutesModule:
+  def __init__(self):
+    self.calls = []
+
+  async def on_ready(self):
+    self.calls.append(('on_ready', None))
+
+  async def get_routes(self, user_guid, roles):
+    self.calls.append(('get_routes', user_guid, tuple(roles)))
+    route = ServiceRoutesRouteItem1(
+      path='/a',
+      name='A',
+      icon='home',
+      sequence=1,
+      required_roles=['ROLE_SERVICE_ADMIN'],
+    )
+    return ServiceRoutesList1(routes=[route])
+
+  async def upsert_route(self, user_guid, roles, route):
+    self.calls.append(('upsert_route', user_guid, tuple(roles), route))
+    return route
+
+  async def delete_route(self, user_guid, roles, path):
+    self.calls.append(('delete_route', user_guid, tuple(roles), path))
+    return ServiceRoutesDeleteRoute1(path=path)
+
+
+service_routes_module_pkg.ServiceRoutesModule = StubServiceRoutesModule
+modules_pkg.service_routes_module = service_routes_module_pkg
+
+
 registry_pkg = types.ModuleType('server.registry')
 registry_pkg.__path__ = []
 
 registry_system_pkg = types.ModuleType('server.registry.system')
 registry_system_pkg.__path__ = []
 
-registry_system_routes_pkg = types.ModuleType('server.registry.system.routes')
-
-
-def _make_request(op, payload=None):
-  if payload is None:
-    payload = {}
-  return SimpleNamespace(op=op, payload=payload)
-
-
-def get_routes_request():
-  return _make_request('db:system:routes:get_routes:1')
-
-
-def upsert_route_request(*, path, name, icon, sequence, roles):
-  return _make_request('db:system:routes:upsert_route:1', {
-    'path': path,
-    'name': name,
-    'icon': icon,
-    'sequence': sequence,
-    'roles': roles,
-  })
-
-
-def delete_route_request(path):
-  return _make_request('db:system:routes:delete_route:1', {'path': path})
-
-
-registry_system_routes_pkg.get_routes_request = get_routes_request
-registry_system_routes_pkg.upsert_route_request = upsert_route_request
-registry_system_routes_pkg.delete_route_request = delete_route_request
-
 sys.modules.setdefault('server.registry', registry_pkg)
 sys.modules.setdefault('server.registry.system', registry_system_pkg)
-sys.modules.setdefault('server.registry.system.routes', registry_system_routes_pkg)
 
 server_pkg.registry = registry_pkg
 registry_pkg.system = registry_system_pkg
-registry_system_pkg.routes = registry_system_routes_pkg
 
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.modules', modules_pkg)
-sys.modules.setdefault('server.modules.db_module', db_module_pkg)
-sys.modules.setdefault('server.modules.auth_module', auth_module_pkg)
+sys.modules.setdefault('server.modules.service_routes_module', service_routes_module_pkg)
 sys.modules.setdefault('server.models', models_pkg)
 
 import importlib.util
@@ -168,37 +132,9 @@ async def fake_unbox(request: Request):
 svc.unbox_request = fake_unbox
 
 
-class DummyDb:
-  def __init__(self):
-    self.calls = []
-
-  async def run(self, op, args=None):
-    if not isinstance(op, str):
-      args = op.payload
-      op = op.op
-    elif args is None:
-      args = {}
-    self.calls.append((op, args))
-    if op == 'db:system:routes:get_routes:1':
-      rows = [{
-        'element_path': '/a',
-        'element_name': 'A',
-        'element_icon': 'home',
-        'element_sequence': 1,
-        'element_roles': 1,
-      }]
-      return SimpleNamespace(rows=rows, rowcount=1)
-    if op in ('db:system:routes:upsert_route:1', 'db:system:routes:delete_route:1'):
-      return SimpleNamespace(rows=[], rowcount=1)
-    raise AssertionError(f'unexpected op {op}')
-
-
-db = DummyDb()
-auth = AuthModule()
-
 app = FastAPI()
-app.state.db = db
-app.state.auth = auth
+module = StubServiceRoutesModule()
+app.state.service_routes = module
 
 
 @app.post('/rpc')
@@ -230,7 +166,7 @@ def test_get_routes_service():
       'required_roles': ['ROLE_SERVICE_ADMIN'],
     }]
   }
-  assert ('db:system:routes:get_routes:1', {}) in db.calls
+  assert ('get_routes', 'u1', ('ROLE_SERVICE_ADMIN',)) in module.calls
 
 
 def test_upsert_and_delete_route_service():
@@ -245,11 +181,5 @@ def test_upsert_and_delete_route_service():
   assert resp.status_code == 200
   resp = client.post('/rpc', json={'op': 'urn:service:routes:delete_route:1', 'payload': {'path': '/a'}})
   assert resp.status_code == 200
-  assert ('db:system:routes:upsert_route:1', {
-    'path': '/a',
-    'name': 'A',
-    'icon': 'home',
-    'sequence': 1,
-    'roles': 1,
-  }) in db.calls
-  assert ('db:system:routes:delete_route:1', {'path': '/a'}) in db.calls
+  assert any(call[0] == 'upsert_route' and call[3].path == '/a' for call in module.calls)
+  assert ('delete_route', 'u1', ('ROLE_SERVICE_ADMIN',), '/a') in module.calls


### PR DESCRIPTION
## Summary
- add a ServiceRoutesModule that wraps database calls and role mask translation for service route operations
- refactor the service routes RPC handlers to resolve the module from app state and delegate work to it
- update service routes service tests to exercise the new module-driven flow

## Testing
- pytest tests/test_service_routes_services.py

------
https://chatgpt.com/codex/tasks/task_e_68f98a21cd388325815707263688964a