### PR TITLE
Refactor OAuth logins through module

### DIFF
--- a/rpc/auth/discord/services.py
+++ b/rpc/auth/discord/services.py
@@ -1,4 +1,4 @@
-import logging, uuid
+import logging
 
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -7,20 +7,8 @@ from pydantic import ValidationError
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.env_module import EnvModule
-from server.modules.auth_module import AuthModule
-from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
-from server.registry.system.config import ConfigKeyParams, get_config_request
-from server.registry.types import DBRequest
 from .models import AuthDiscordOauthLogin1, AuthDiscordOauthLoginPayload1
-
-
-def normalize_provider_identifier(pid: str) -> str:
-  try:
-    return str(uuid.UUID(pid))
-  except ValueError:
-    return str(uuid.uuid5(uuid.NAMESPACE_URL, pid))
 
 
 async def auth_discord_oauth_login_v1(request: Request):
@@ -40,88 +28,23 @@ async def auth_discord_oauth_login_v1(request: Request):
     f"[auth_discord_oauth_login_v1] code={code[:40] if code else None}"
   )
 
-  env: EnvModule = request.app.state.env
-  auth: AuthModule = request.app.state.auth
-  db: DbModule = request.app.state.db
   oauth: OauthModule = request.app.state.oauth
 
-  discord_provider = getattr(auth, "providers", {}).get("discord")
-  if not discord_provider or not getattr(discord_provider, "audience", None):
-    raise HTTPException(status_code=500, detail="Discord OAuth client_id not configured")
-  client_id = getattr(discord_provider, "audience")
-
-  client_secret = env.get("DISCORD_AUTH_SECRET")
-  if not client_secret:
-    raise HTTPException(status_code=500, detail="DISCORD_AUTH_SECRET not configured")
-
-  res_redirect = await db.run(get_config_request(ConfigKeyParams(key="Hostname")))
-  if not res_redirect.rows:
-    raise HTTPException(status_code=500, detail="Discord OAuth redirect URI not configured")
-  redirect_uri = res_redirect.rows[0]["value"]
-  logging.debug("[auth_discord_oauth_login_v1] DiscordClientId=%s", client_id)
-  logging.debug("[auth_discord_oauth_login_v1] redirect_uri=%s", redirect_uri)
-
-  id_token, access_token = await oauth.exchange_code_for_tokens(
-    code,
-    client_id,
-    client_secret,
-    redirect_uri,
-    provider=provider,
-  )
-
-  provider_uid, profile, payload = await auth.handle_auth_login(
-    "discord", id_token, access_token
-  )
-  provider_uid = normalize_provider_identifier(provider_uid)
-  logging.debug(
-    f"[auth_discord_oauth_login_v1] provider_uid={provider_uid[:40] if provider_uid else None}"
-  )
-
-  user = await oauth.resolve_user(
-    provider,
-    provider_uid,
-    profile,
-    payload,
-    confirm=confirm,
-    reauth_token=reauth_token,
-  )
-
-  user_guid = user["guid"]
-  new_img = profile.get("profilePicture")
-  if new_img and new_img != user.get("profile_image"):
-    await db.run(
-      DBRequest(
-        op="db:account:profile:set_profile_image:1",
-        payload={
-          "guid": user_guid,
-          "image_b64": new_img,
-          "provider": provider,
-        },
-      ),
-    )
-    user["profile_image"] = new_img
-  if user.get("provider_name") == "discord":
-    res_prof = await db.run(
-      DBRequest(
-        op="db:account:profile:update_if_unedited:1",
-        payload={
-          "guid": user_guid,
-          "email": profile["email"],
-          "display_name": profile["username"],
-        },
-      ),
-    )
-    if res_prof.rows:
-      updated = res_prof.rows[0]
-      if updated.get("display_name"):
-        user["display_name"] = updated["display_name"]
-      if updated.get("email"):
-        user["email"] = updated["email"]
   user_agent = request.headers.get("user-agent")
   ip_address = request.client.host if request.client else None
-  session_token, session_exp, rotation_token, rot_exp = await oauth.create_session(
-    user_guid, provider, fingerprint, user_agent, ip_address
+  result = await oauth.login_provider(
+    provider,
+    code=code,
+    fingerprint=fingerprint,
+    confirm=confirm,
+    reauth_token=reauth_token,
+    user_agent=user_agent,
+    ip_address=ip_address,
   )
+  user = result["user"]
+  session_token = result["session_token"]
+  rotation_token = result["rotation_token"]
+  rot_exp = result["rotation_exp"]
 
   payload = AuthDiscordOauthLogin1(
     sessionToken=session_token,

--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -1,27 +1,14 @@
-import logging, uuid
+import logging
 
 from fastapi import HTTPException, Request
 from pydantic import ValidationError
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.env_module import EnvModule
-from server.modules.auth_module import AuthModule
-from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
-from server.registry.system.config import ConfigKeyParams, get_config_request
-from server.registry.types import DBRequest
 from .models import AuthGoogleOauthLogin1, AuthGoogleOauthLoginPayload1
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
-
-
-def normalize_provider_identifier(pid: str) -> str:
-  try:
-    return str(uuid.UUID(pid))
-  except ValueError:
-    return str(uuid.uuid5(uuid.NAMESPACE_URL, pid))
-
 
 async def auth_google_oauth_login_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
@@ -39,96 +26,24 @@ async def auth_google_oauth_login_v1(request: Request):
     f"[auth_google_oauth_login_v1] code={code[:40] if code else None}"
   )
 
-  env: EnvModule = request.app.state.env
-  auth: AuthModule = request.app.state.auth
-  db: DbModule = request.app.state.db
   oauth: OauthModule = request.app.state.oauth
 
-  # Get provider metadata
-  google_provider = getattr(auth, "providers", {}).get("google")
-
-  # Require Google client_id from provider config
-  if not google_provider or not google_provider.audience:
-      raise HTTPException(status_code=500, detail="Google OAuth client_id not configured")
-  client_id = google_provider.audience
-
-  # Acquire client_secret from environment
-  client_secret = env.get("GOOGLE_AUTH_SECRET")
-  if not client_secret:
-    raise HTTPException(status_code=500, detail="GOOGLE_AUTH_SECRET not configured")
-
-  # Require redirect_uri from system config
-  res_redirect = await db.run(get_config_request(ConfigKeyParams(key="Hostname")))
-  if not res_redirect.rows:
-      raise HTTPException(status_code=500, detail="Google OAuth redirect URI not configured")
-  redirect_uri = res_redirect.rows[0]["value"]
-  logging.debug("[auth_google_oauth_login_v1] GoogleClientId=%s", client_id)
-  logging.debug("[auth_google_oauth_login_v1] redirect_uri=%s", redirect_uri)
-
-  id_token, access_token = await oauth.exchange_code_for_tokens(
-    code,
-    client_id,
-    client_secret,
-    redirect_uri,
-    provider,
-  )
-  if not id_token:
-    raise HTTPException(status_code=400, detail="Missing id_token")
-
-  provider_uid, profile, payload = await auth.handle_auth_login(
-    provider, id_token, access_token
-  )
-  provider_uid = normalize_provider_identifier(provider_uid)
-  logging.debug(
-    f"[auth_google_oauth_login_v1] provider_uid={provider_uid[:40] if provider_uid else None}"
-  )
-
-  user = await oauth.resolve_user(
-    provider,
-    provider_uid,
-    profile,
-    payload,
-    confirm=confirm,
-    reauth_token=reauth_token,
-  )
-
-  user_guid = user["guid"]
-  new_img = profile.get("profilePicture")
-  if new_img and new_img != user.get("profile_image"):
-    await db.run(
-      DBRequest(
-        op="db:account:profile:set_profile_image:1",
-        payload={
-          "guid": user_guid,
-          "image_b64": new_img,
-          "provider": provider,
-        },
-      ),
-    )
-    user["profile_image"] = new_img
-  if user.get("provider_name") == "google":
-    res_prof = await db.run(
-      DBRequest(
-        op="db:account:profile:update_if_unedited:1",
-        payload={
-          "guid": user_guid,
-          "email": profile["email"],
-          "display_name": profile["username"],
-        },
-      ),
-    )
-    if res_prof.rows:
-      updated = res_prof.rows[0]
-      if updated.get("display_name"):
-        user["display_name"] = updated["display_name"]
-      if updated.get("email"):
-        user["email"] = updated["email"]
   fingerprint = req_payload.fingerprint
   user_agent = request.headers.get("user-agent")
   ip_address = request.client.host if request.client else None
-  session_token, session_exp, rotation_token, rot_exp = await oauth.create_session(
-    user_guid, provider, fingerprint, user_agent, ip_address
+  result = await oauth.login_provider(
+    provider,
+    code=code,
+    fingerprint=fingerprint,
+    confirm=confirm,
+    reauth_token=reauth_token,
+    user_agent=user_agent,
+    ip_address=ip_address,
   )
+  user = result["user"]
+  session_token = result["session_token"]
+  rotation_token = result["rotation_token"]
+  rot_exp = result["rotation_exp"]
 
   payload = AuthGoogleOauthLogin1(
     sessionToken=session_token,

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -1,30 +1,13 @@
-import base64, logging, uuid
+import logging
 
-from fastapi import HTTPException, Request
+from fastapi import Request
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.auth_module import AuthModule
-from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
-from server.registry.types import DBRequest
 from .models import AuthMicrosoftOauthLogin1
-
-
-def normalize_provider_identifier(pid: str) -> str:
-  try:
-    return str(uuid.UUID(pid))
-  except ValueError:
-    try:
-      pad = pid + "=" * (-len(pid) % 4)
-      raw = base64.urlsafe_b64decode(pad)
-      if len(raw) >= 16:
-        return str(uuid.UUID(bytes=raw[-16:]))
-    except Exception:
-      pass
-    return str(uuid.uuid5(uuid.NAMESPACE_URL, pid))
 
 
 async def auth_microsoft_oauth_login_v1(request: Request):
@@ -34,6 +17,9 @@ async def auth_microsoft_oauth_login_v1(request: Request):
   provider = req_payload.get("provider", "microsoft")
   id_token = req_payload.get("idToken") or req_payload.get("id_token")
   access_token = req_payload.get("accessToken") or req_payload.get("access_token")
+  confirm = req_payload.get("confirm")
+  reauth_token = req_payload.get("reauthToken") or req_payload.get("reAuthToken")
+  fingerprint = req_payload.get("fingerprint")
   logging.debug(f"[auth_microsoft_oauth_login_v1] provider={provider}")
   logging.debug(
     f"[auth_microsoft_oauth_login_v1] id_token={id_token[:40] if id_token else None}"
@@ -41,69 +27,25 @@ async def auth_microsoft_oauth_login_v1(request: Request):
   logging.debug(
     f"[auth_microsoft_oauth_login_v1] access_token={access_token[:40] if access_token else None}"
   )
-  if not id_token or not access_token:
-    raise HTTPException(status_code=400, detail="Missing credentials")
 
-  auth: AuthModule = request.app.state.auth
-  db: DbModule = request.app.state.db
   oauth: OauthModule = request.app.state.oauth
 
-  provider_uid, profile, payload = await auth.handle_auth_login(
-    provider, id_token, access_token
-  )
-  provider_uid = normalize_provider_identifier(provider_uid)
-  logging.debug(
-    f"[auth_microsoft_oauth_login_v1] provider_uid={provider_uid[:40] if provider_uid else None}"
-  )
-
-  user = await oauth.resolve_user(
-    provider,
-    provider_uid,
-    profile,
-    payload,
-    confirm=req_payload.get("confirm"),
-    reauth_token=req_payload.get("reauthToken") or req_payload.get("reAuthToken"),
-  )
-
-  user_guid = user["guid"]
-  new_img = profile.get("profilePicture")
-  if new_img != user.get("profile_image"):
-    await db.run(
-      DBRequest(
-        op="db:account:profile:set_profile_image:1",
-        payload={
-          "guid": user_guid,
-          "image_b64": new_img,
-          "provider": provider,
-        },
-      ),
-    )
-    user["profile_image"] = new_img
-  if user.get("provider_name") == "microsoft":
-    res_prof = await db.run(
-      DBRequest(
-        op="db:account:profile:update_if_unedited:1",
-        payload={
-          "guid": user_guid,
-          "email": profile["email"],
-          "display_name": profile["username"],
-        },
-      ),
-    )
-    if res_prof.rows:
-      updated = res_prof.rows[0]
-      if updated.get("display_name"):
-        user["display_name"] = updated["display_name"]
-      if updated.get("email"):
-        user["email"] = updated["email"]
-  fingerprint = req_payload.get("fingerprint")
-  if not fingerprint:
-    raise HTTPException(status_code=400, detail="Missing fingerprint")
   user_agent = request.headers.get("user-agent")
   ip_address = request.client.host if request.client else None
-  session_token, session_exp, rotation_token, rot_exp = await oauth.create_session(
-    user_guid, provider, fingerprint, user_agent, ip_address
+  result = await oauth.login_provider(
+    provider,
+    id_token=id_token,
+    access_token=access_token,
+    fingerprint=fingerprint,
+    confirm=confirm,
+    reauth_token=reauth_token,
+    user_agent=user_agent,
+    ip_address=ip_address,
   )
+  user = result["user"]
+  session_token = result["session_token"]
+  rotation_token = result["rotation_token"]
+  rot_exp = result["rotation_exp"]
 
   payload = AuthMicrosoftOauthLogin1(
     sessionToken=session_token,

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -578,3 +578,77 @@ class OauthModule(BaseModule):
 
     return user
 
+  async def login_provider(
+    self,
+    provider: str,
+    *,
+    fingerprint: str | None,
+    code: str | None = None,
+    id_token: str | None = None,
+    access_token: str | None = None,
+    confirm: bool | None = None,
+    reauth_token: str | None = None,
+    user_agent: str | None = None,
+    ip_address: str | None = None,
+  ):
+    provider = provider.lower()
+    if not fingerprint:
+      raise HTTPException(status_code=400, detail="Missing fingerprint")
+    id_token, access_token = await self._prepare_tokens(
+      provider, code, id_token, access_token
+    )
+    provider_uid, profile, payload = await self.auth.handle_auth_login(
+      provider, id_token, access_token
+    )
+    provider_uid = self.normalize_provider_identifier(provider_uid)
+    user = await self.resolve_user(
+      provider,
+      provider_uid,
+      profile,
+      payload,
+      confirm=confirm,
+      reauth_token=reauth_token,
+    )
+    user_guid = user["guid"]
+    new_img = profile.get("profilePicture")
+    if new_img and new_img != user.get("profile_image"):
+      await self.db.run(
+        DBRequest(
+          op="db:account:profile:set_profile_image:1",
+          payload={
+            "guid": user_guid,
+            "image_b64": new_img,
+            "provider": provider,
+          },
+        )
+      )
+      user["profile_image"] = new_img
+    if user.get("provider_name") == provider:
+      res_prof = await self.db.run(
+        DBRequest(
+          op="db:account:profile:update_if_unedited:1",
+          payload={
+            "guid": user_guid,
+            "email": profile["email"],
+            "display_name": profile["username"],
+          },
+        ),
+      )
+      if res_prof.rows:
+        updated = res_prof.rows[0]
+        if updated.get("display_name"):
+          user["display_name"] = updated["display_name"]
+        if updated.get("email"):
+          user["email"] = updated["email"]
+    session_token, session_exp, rotation_token, rot_exp = await self.create_session(
+      user_guid, provider, fingerprint, user_agent, ip_address
+    )
+    return {
+      "session_token": session_token,
+      "session_exp": session_exp,
+      "rotation_token": rotation_token,
+      "rotation_exp": rot_exp,
+      "user": user,
+      "profile": profile,
+    }
+


### PR DESCRIPTION
## Summary
- add a consolidated `login_provider` flow to the OAuth module to exchange tokens, update profiles, and create sessions
- update Google, Discord, and Microsoft RPC services to call the module flow instead of duplicating database and configuration logic

## Testing
- python -m compileall server/modules/oauth_module.py rpc/auth/google/services.py rpc/auth/discord/services.py rpc/auth/microsoft/services.py

------
https://chatgpt.com/codex/tasks/task_e_68f98eb463c0832597a0081e24d933ad