### PR TITLE
Refactor system config module interfaces

### DIFF
--- a/rpc/system/config/services.py
+++ b/rpc/system/config/services.py
@@ -7,12 +7,19 @@ if TYPE_CHECKING:
 from .models import (
   SystemConfigConfigItem1,
   SystemConfigDeleteConfig1,
+  SystemConfigList1,
 )
 
 async def system_config_get_configs_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   config_mod: SystemConfigModule = request.app.state.system_config
-  payload = await config_mod.get_configs(auth_ctx.user_guid, auth_ctx.roles)
+  module_payload = await config_mod.get_configs(auth_ctx.user_guid, auth_ctx.roles)
+  payload = SystemConfigList1(
+    items=[
+      SystemConfigConfigItem1(key=item.key, value=item.value)
+      for item in module_payload.items
+    ],
+  )
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),
@@ -23,11 +30,15 @@ async def system_config_upsert_config_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   input_payload = SystemConfigConfigItem1(**(rpc_request.payload or {}))
   config_mod: SystemConfigModule = request.app.state.system_config
-  payload = await config_mod.upsert_config(
+  module_payload = await config_mod.upsert_config(
     auth_ctx.user_guid,
     auth_ctx.roles,
     input_payload.key,
     input_payload.value,
+  )
+  payload = SystemConfigConfigItem1(
+    key=module_payload.key,
+    value=module_payload.value,
   )
   return RPCResponse(
     op=rpc_request.op,
@@ -39,11 +50,12 @@ async def system_config_delete_config_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   input_payload = SystemConfigDeleteConfig1(**(rpc_request.payload or {}))
   config_mod: SystemConfigModule = request.app.state.system_config
-  payload = await config_mod.delete_config(
+  module_payload = await config_mod.delete_config(
     auth_ctx.user_guid,
     auth_ctx.roles,
     input_payload.key,
   )
+  payload = SystemConfigDeleteConfig1(key=module_payload.key)
   return RPCResponse(
     op=rpc_request.op,
     payload=payload.model_dump(),

--- a/server/modules/models/__init__.py
+++ b/server/modules/models/__init__.py
@@ -1,0 +1,11 @@
+from .system_config import (
+  SystemConfigDeleteResult,
+  SystemConfigItem,
+  SystemConfigList,
+)
+
+__all__ = [
+  'SystemConfigDeleteResult',
+  'SystemConfigItem',
+  'SystemConfigList',
+]

--- a/server/modules/models/system_config.py
+++ b/server/modules/models/system_config.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class SystemConfigItem:
+  key: str
+  value: str
+
+
+@dataclass(slots=True)
+class SystemConfigList:
+  items: list[SystemConfigItem]
+
+
+@dataclass(slots=True)
+class SystemConfigDeleteResult:
+  key: str

--- a/server/modules/system_config_module.py
+++ b/server/modules/system_config_module.py
@@ -11,10 +11,10 @@ from server.registry.system.config import (
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
-from rpc.system.config.models import (
-  SystemConfigConfigItem1,
-  SystemConfigDeleteConfig1,
-  SystemConfigList1,
+from .models import (
+  SystemConfigDeleteResult,
+  SystemConfigItem,
+  SystemConfigList,
 )
 
 class SystemConfigModule(BaseModule):
@@ -34,11 +34,11 @@ class SystemConfigModule(BaseModule):
   async def shutdown(self):
     self.db = None
 
-  async def get_configs(self, user_guid: str, roles: list[str]) -> SystemConfigList1:
+  async def get_configs(self, user_guid: str, roles: list[str]) -> SystemConfigList:
     logging.debug("[system_config_get_configs_v1] user=%s roles=%s", user_guid, roles)
     res = await self.db.run(get_configs_request())
     items = [
-      SystemConfigConfigItem1(
+      SystemConfigItem(
         key=row.get("element_key", ""),
         value=row.get("element_value", ""),
       )
@@ -48,9 +48,9 @@ class SystemConfigModule(BaseModule):
       "[system_config_get_configs_v1] returning %d items",
       len(items),
     )
-    return SystemConfigList1(items=items)
+    return SystemConfigList(items=items)
 
-  async def upsert_config(self, user_guid: str, roles: list[str], key: str, value: str) -> SystemConfigConfigItem1:
+  async def upsert_config(self, user_guid: str, roles: list[str], key: str, value: str) -> SystemConfigItem:
     logging.debug(
       "[system_config_upsert_config_v1] user=%s roles=%s payload={'key': %s, 'value': %s}",
       user_guid,
@@ -65,9 +65,9 @@ class SystemConfigModule(BaseModule):
       "[system_config_upsert_config_v1] upserted config %s",
       key,
     )
-    return SystemConfigConfigItem1(key=key, value=value)
+    return SystemConfigItem(key=key, value=value)
 
-  async def delete_config(self, user_guid: str, roles: list[str], key: str) -> SystemConfigDeleteConfig1:
+  async def delete_config(self, user_guid: str, roles: list[str], key: str) -> SystemConfigDeleteResult:
     logging.debug(
       "[system_config_delete_config_v1] user=%s roles=%s payload={'key': %s}",
       user_guid,
@@ -81,4 +81,4 @@ class SystemConfigModule(BaseModule):
       "[system_config_delete_config_v1] deleted config %s",
       key,
     )
-    return SystemConfigDeleteConfig1(key=key)
+    return SystemConfigDeleteResult(key=key)

--- a/tests/test_system_config_module.py
+++ b/tests/test_system_config_module.py
@@ -98,8 +98,11 @@ def test_get_configs_module():
   assert ('db:system:config:get_configs:1', {}) in db.calls
 
 def test_upsert_and_delete_module():
-  asyncio.run(module.upsert_config('u1', [], 'LoggingLevel', '2'))
-  asyncio.run(module.delete_config('u1', [], 'LoggingLevel'))
+  item = asyncio.run(module.upsert_config('u1', [], 'LoggingLevel', '2'))
+  delete_result = asyncio.run(module.delete_config('u1', [], 'LoggingLevel'))
+  assert item.key == 'LoggingLevel'
+  assert item.value == '2'
+  assert delete_result.key == 'LoggingLevel'
   assert (
     'db:system:config:upsert_config:1',
     {'key': 'LoggingLevel', 'value': '2'}

--- a/tests/test_system_config_services.py
+++ b/tests/test_system_config_services.py
@@ -1,4 +1,5 @@
 import types, sys, pathlib
+from dataclasses import dataclass
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.requests import Request
@@ -22,20 +23,52 @@ sys.modules.setdefault('rpc.system.config', rpc_system_config_pkg)
 server_pkg = types.ModuleType('server')
 models_pkg = types.ModuleType('server.models')
 
+modules_pkg = types.ModuleType('server.modules')
+modules_models_pkg = types.ModuleType('server.modules.models')
+
+@dataclass
+class SystemConfigItem:
+  key: str
+  value: str
+
+
+@dataclass
+class SystemConfigList:
+  items: list[SystemConfigItem]
+
+
+@dataclass
+class SystemConfigDeleteResult:
+  key: str
+
 class RPCResponse(BaseModel):
   op: str
   payload: dict
   version: int = 1
+
+
+class RPCRequest(BaseModel):
+  op: str
+  payload: dict | None = None
+  version: int = 1
+
 
 class AuthContext(BaseModel):
   user_guid: str = ''
   roles: list[str] = []
 
 models_pkg.RPCResponse = RPCResponse
+models_pkg.RPCRequest = RPCRequest
 models_pkg.AuthContext = AuthContext
 server_pkg.models = models_pkg
+modules_pkg.models = modules_models_pkg
+modules_models_pkg.SystemConfigItem = SystemConfigItem
+modules_models_pkg.SystemConfigList = SystemConfigList
+modules_models_pkg.SystemConfigDeleteResult = SystemConfigDeleteResult
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)
+sys.modules.setdefault('server.modules', modules_pkg)
+sys.modules.setdefault('server.modules.models', modules_models_pkg)
 
 import importlib.util
 
@@ -66,17 +99,17 @@ class DummySystemConfigModule:
     self.calls = []
   async def get_configs(self, user_guid, roles):
     self.calls.append(('get_configs', user_guid, roles))
-    from rpc.system.config.models import SystemConfigConfigItem1, SystemConfigList1
-    item = SystemConfigConfigItem1(key='LoggingLevel', value='4')
-    return SystemConfigList1(items=[item])
+    from server.modules.models import SystemConfigItem, SystemConfigList
+    item = SystemConfigItem(key='LoggingLevel', value='4')
+    return SystemConfigList(items=[item])
   async def upsert_config(self, user_guid, roles, key, value):
     self.calls.append(('upsert_config', key, value))
-    from rpc.system.config.models import SystemConfigConfigItem1
-    return SystemConfigConfigItem1(key=key, value=value)
+    from server.modules.models import SystemConfigItem
+    return SystemConfigItem(key=key, value=value)
   async def delete_config(self, user_guid, roles, key):
     self.calls.append(('delete_config', key))
-    from rpc.system.config.models import SystemConfigDeleteConfig1
-    return SystemConfigDeleteConfig1(key=key)
+    from server.modules.models import SystemConfigDeleteResult
+    return SystemConfigDeleteResult(key=key)
 
 app = FastAPI()
 mod = DummySystemConfigModule()


### PR DESCRIPTION
## Summary
- introduce internal dataclasses for system config entities used by the server layer
- refactor the system config module to return internal types and let the RPC service translate them to RPC models
- update module/service tests to validate the new interfaces

## Testing
- pytest tests/test_system_config_module.py tests/test_system_config_services.py

------
https://chatgpt.com/codex/tasks/task_e_68fae9720b0c8325b25b8706c098c4de