### PR TITLE
Refactor persona logging to route through modules

### DIFF
--- a/rpc/auth/providers/services.py
+++ b/rpc/auth/providers/services.py
@@ -3,8 +3,7 @@ from pydantic import ValidationError
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.db_module import DbModule
-from server.registry.account.providers import unlink_last_provider_request
+from server.modules.oauth_module import OauthModule
 
 from .models import AuthProvidersUnlinkLastProvider1
 
@@ -15,8 +14,9 @@ async def auth_providers_unlink_last_provider_v1(request: Request):
     payload = AuthProvidersUnlinkLastProvider1(**(rpc_request.payload or {}))
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
-  db: DbModule = request.app.state.db
-  await db.run(
-    unlink_last_provider_request(guid=payload.guid, provider=payload.provider),
-  )
+  oauth_module: OauthModule | None = getattr(request.app.state, "oauth", None)
+  if not oauth_module:
+    raise HTTPException(status_code=503, detail="oauth module unavailable")
+  await oauth_module.on_ready()
+  await oauth_module.unlink_last_provider_record(payload.guid, payload.provider)
   return RPCResponse(op=rpc_request.op, payload={"ok": True}, version=rpc_request.version)

--- a/rpc/discord/chat/services.py
+++ b/rpc/discord/chat/services.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List
 
 from fastapi import HTTPException, Request
@@ -8,11 +7,6 @@ from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.discord_chat_module import DiscordChatModule
 from server.modules.openai_module import OpenaiModule
-from server.registry.system.conversations import (
-  insert_conversation_request,
-  list_by_time_request,
-  update_output_request,
-)
 
 from .models import (
   DiscordChatPersonaRequest1,
@@ -282,12 +276,11 @@ async def discord_chat_get_conversation_history_v1(request: Request):
       version=rpc_request.version,
     )
 
-  db_module = getattr(request.app.state, "db", None)
   openai_module: OpenaiModule | None = getattr(request.app.state, "openai", None)
-  if not db_module or not openai_module:
+  if not openai_module:
     logging.warning(
-      "[discord_chat_get_conversation_history_v1] required modules unavailable",
-      extra={"has_db": bool(db_module), "has_openai": bool(openai_module)},
+      "[discord_chat_get_conversation_history_v1] OpenAI module unavailable",
+      extra={"has_openai": False},
     )
     return RPCResponse(
       op=rpc_request.op,
@@ -299,10 +292,16 @@ async def discord_chat_get_conversation_history_v1(request: Request):
       version=rpc_request.version,
     )
 
-  await db_module.on_ready()
   await openai_module.on_ready()
 
-  persona_details = await openai_module.get_persona_definition(persona)
+  try:
+    persona_details = await openai_module.get_persona_definition(persona)
+  except Exception:
+    logging.exception(
+      "[discord_chat_get_conversation_history_v1] failed to load persona",
+      extra={"persona": persona},
+    )
+    persona_details = None
   personas_recid = persona_details.get("recid") if persona_details else None
   if personas_recid is None:
     return RPCResponse(
@@ -315,18 +314,17 @@ async def discord_chat_get_conversation_history_v1(request: Request):
       version=rpc_request.version,
     )
 
-  now = datetime.now(timezone.utc)
-  start = now - timedelta(days=30)
   try:
-    history_res = await db_module.run(
-      list_by_time_request(
-        personas_recid=personas_recid,
-        start=start.isoformat(),
-        end=now.isoformat(),
-      )
+    conversation_history = await openai_module.get_recent_persona_conversation_history(
+      personas_recid=personas_recid,
+      lookback_days=30,
+      limit=5,
     )
   except Exception:
-    logging.exception("[discord_chat_get_conversation_history_v1] db query failed")
+    logging.exception(
+      "[discord_chat_get_conversation_history_v1] failed to load history",
+      extra={"persona": persona, "personas_recid": personas_recid},
+    )
     return RPCResponse(
       op=rpc_request.op,
       payload={
@@ -336,32 +334,6 @@ async def discord_chat_get_conversation_history_v1(request: Request):
       },
       version=rpc_request.version,
     )
-
-  rows = list(history_res.rows or [])
-
-  def _parse_timestamp(value: Any) -> datetime:
-    if not value:
-      return datetime.min.replace(tzinfo=timezone.utc)
-    if isinstance(value, datetime):
-      return value.astimezone(timezone.utc)
-    if isinstance(value, str):
-      candidate = value.replace("Z", "+00:00")
-      try:
-        return datetime.fromisoformat(candidate)
-      except ValueError:
-        pass
-    return datetime.min.replace(tzinfo=timezone.utc)
-
-  rows.sort(key=lambda row: _parse_timestamp(row.get("element_created_on")))
-  recent_rows = rows[-5:]
-  conversation_history: List[Dict[str, str]] = []
-  for row in recent_rows:
-    user_input = (row.get("element_input") or "").strip()
-    if user_input:
-      conversation_history.append({"role": "user", "content": user_input})
-    assistant_output = (row.get("element_output") or "").strip()
-    if assistant_output:
-      conversation_history.append({"role": "assistant", "content": assistant_output})
 
   return RPCResponse(
     op=rpc_request.op,
@@ -482,12 +454,11 @@ async def discord_chat_insert_conversation_input_v1(request: Request):
       version=rpc_request.version,
     )
 
-  db_module = getattr(request.app.state, "db", None)
   openai_module: OpenaiModule | None = getattr(request.app.state, "openai", None)
-  if not db_module or not openai_module:
+  if not openai_module:
     logging.warning(
-      "[discord_chat_insert_conversation_input_v1] required modules unavailable",
-      extra={"has_db": bool(db_module), "has_openai": bool(openai_module)},
+      "[discord_chat_insert_conversation_input_v1] OpenAI module unavailable",
+      extra={"has_openai": False},
     )
     return RPCResponse(
       op=rpc_request.op,
@@ -499,7 +470,6 @@ async def discord_chat_insert_conversation_input_v1(request: Request):
       version=rpc_request.version,
     )
 
-  await db_module.on_ready()
   await openai_module.on_ready()
 
   persona_details = payload.get("persona_details") or await openai_module.get_persona_definition(persona)
@@ -536,17 +506,14 @@ async def discord_chat_insert_conversation_input_v1(request: Request):
   user_id = payload.get("user_id")
 
   try:
-    insert_res = await db_module.run(
-      insert_conversation_request(
-        personas_recid=personas_recid,
-        models_recid=models_recid,
-        guild_id=guild_id,
-        channel_id=channel_id,
-        user_id=user_id,
-        input_data=message,
-        output_data="",
-        tokens=None,
-      )
+    recid = await openai_module.log_persona_conversation_input(
+      personas_recid,
+      models_recid,
+      guild_id,
+      channel_id,
+      user_id,
+      message,
+      None,
     )
   except Exception:
     logging.exception("[discord_chat_insert_conversation_input_v1] insert failed", extra={"persona": persona})
@@ -559,10 +526,6 @@ async def discord_chat_insert_conversation_input_v1(request: Request):
       },
       version=rpc_request.version,
     )
-
-  recid = None
-  if insert_res.rows:
-    recid = insert_res.rows[0].get("recid")
 
   return RPCResponse(
     op=rpc_request.op,
@@ -593,7 +556,6 @@ async def discord_chat_generate_persona_response_v1(request: Request):
     )
 
   openai_module: OpenaiModule | None = getattr(request.app.state, "openai", None)
-  db_module = getattr(request.app.state, "db", None)
   if not openai_module:
     logging.warning("[discord_chat_generate_persona_response_v1] OpenAI module unavailable")
     return RPCResponse(
@@ -696,21 +658,26 @@ async def discord_chat_generate_persona_response_v1(request: Request):
     total_tokens = usage.get("total_tokens")
 
   conversation_reference = payload.get("conversation_reference")
-  if db_module and conversation_reference is not None:
-    await db_module.on_ready()
+  if conversation_reference is not None:
     try:
-      await db_module.run(
-        update_output_request(
-          recid=conversation_reference,
-          output_data=content or "",
-          tokens=total_tokens,
-        )
-      )
-    except Exception:
-      logging.exception(
-        "[discord_chat_generate_persona_response_v1] failed to update conversation output",
+      conversation_id = int(conversation_reference)
+    except (TypeError, ValueError):
+      logging.warning(
+        "[discord_chat_generate_persona_response_v1] invalid conversation reference",
         extra={"conversation_reference": conversation_reference},
       )
+    else:
+      try:
+        await openai_module.finalize_persona_conversation(
+          conversation_id,
+          content or "",
+          total_tokens,
+        )
+      except Exception:
+        logging.exception(
+          "[discord_chat_generate_persona_response_v1] failed to update conversation output",
+          extra={"conversation_reference": conversation_reference},
+        )
 
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -282,6 +282,14 @@ class OauthModule(BaseModule):
       )
     return {"provider": provider}
 
+  async def unlink_last_provider_record(self, guid: str, provider: str) -> None:
+    assert self.db
+    await self.db.run(
+      unlink_last_provider_request(
+        UnlinkLastProviderParams(guid=guid, provider=provider)
+      )
+    )
+
   async def get_user_by_provider_identifier(
     self, provider: str, provider_identifier: str
   ):

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Dict, List
 from fastapi import FastAPI
 from openai import AsyncOpenAI
@@ -12,6 +13,7 @@ from server.registry.system.config import ConfigKeyParams, get_config_request
 from server.registry.system.conversations import (
   find_recent_request,
   insert_conversation_request,
+  list_by_time_request,
   update_output_request,
 )
 from server.registry.system.models import list_models_request
@@ -194,7 +196,7 @@ class OpenaiModule(BaseModule):
     assert self.db
     await self.db.run(delete_persona_request(recid=recid, name=name))
 
-  async def _log_conversation_start(
+  async def log_persona_conversation_input(
     self,
     personas_recid: int | None,
     models_recid: int | None,
@@ -239,7 +241,7 @@ class OpenaiModule(BaseModule):
       logging.exception("[OpenaiModule] insert conversation failed")
     return None
 
-  async def _log_conversation_end(
+  async def finalize_persona_conversation(
     self,
     recid: int,
     output_data: str,
@@ -258,6 +260,61 @@ class OpenaiModule(BaseModule):
         )
     except Exception:
       logging.exception("[OpenaiModule] update conversation failed")
+
+  async def get_recent_persona_conversation_history(
+    self,
+    personas_recid: int,
+    *,
+    lookback_days: int = 30,
+    limit: int = 5,
+  ) -> List[Dict[str, str]]:
+    if not self.db:
+      return []
+    if personas_recid is None:
+      return []
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=max(lookback_days, 0))
+    try:
+      res = await self.db.run(
+        list_by_time_request(
+          personas_recid=personas_recid,
+          start=start.isoformat(),
+          end=end.isoformat(),
+        )
+      )
+    except Exception:
+      logging.exception("[OpenaiModule] failed to load persona conversation history")
+      raise
+
+    rows = list(res.rows or [])
+
+    def _parse_timestamp(value: Any) -> datetime:
+      if not value:
+        return datetime.min.replace(tzinfo=timezone.utc)
+      if isinstance(value, datetime):
+        return value.astimezone(timezone.utc)
+      if isinstance(value, str):
+        candidate = value.replace("Z", "+00:00")
+        try:
+          return datetime.fromisoformat(candidate)
+        except ValueError:
+          pass
+      return datetime.min.replace(tzinfo=timezone.utc)
+
+    rows.sort(key=lambda row: _parse_timestamp(row.get("element_created_on")))
+    if limit and limit > 0:
+      rows = rows[-limit:]
+
+    conversation_history: List[Dict[str, str]] = []
+    for row in rows:
+      user_input = (row.get("element_input") or "").strip()
+      if user_input:
+        conversation_history.append({"role": "user", "content": user_input})
+      assistant_output = (row.get("element_output") or "").strip()
+      if assistant_output:
+        conversation_history.append({"role": "assistant", "content": assistant_output})
+
+    return conversation_history
 
   async def generate_chat(
     self,
@@ -315,7 +372,7 @@ class OpenaiModule(BaseModule):
       resolved_tokens = 64
 
     if persona and personas_recid is not None and models_recid is not None:
-      conv_id = await self._log_conversation_start(
+      conv_id = await self.log_persona_conversation_input(
         personas_recid,
         models_recid,
         guild_id,
@@ -361,7 +418,7 @@ class OpenaiModule(BaseModule):
         "total_tokens": total_tokens,
       }
     if conv_id:
-      await self._log_conversation_end(conv_id, content, total_tokens)
+      await self.finalize_persona_conversation(conv_id, content, total_tokens)
     return result
 
   async def persona_response(

--- a/tests/test_auth_providers_services.py
+++ b/tests/test_auth_providers_services.py
@@ -1,0 +1,97 @@
+import asyncio
+import importlib.util
+import pathlib
+import sys
+import types
+from types import SimpleNamespace
+
+
+def _dummy_request(oauth_module):
+  return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(oauth=oauth_module)))
+
+
+def _load_module(name: str, path: pathlib.Path):
+  spec = importlib.util.spec_from_file_location(name, path)
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+class StubOauthModule:
+  def __init__(self):
+    self.calls = []
+    self.ready = False
+
+  async def on_ready(self):
+    self.ready = True
+
+  async def unlink_last_provider_record(self, guid: str, provider: str):
+    self.calls.append((guid, provider))
+
+
+def test_auth_providers_unlink_last_provider_uses_module(monkeypatch):
+  root_path = pathlib.Path(__file__).resolve().parent.parent
+
+  rpc_pkg = types.ModuleType("rpc")
+  rpc_pkg.__path__ = [str(root_path / "rpc")]
+  rpc_pkg.HANDLERS = {}
+  monkeypatch.setitem(sys.modules, "rpc", rpc_pkg)
+
+  server_pkg = types.ModuleType("server")
+  server_pkg.__path__ = [str(root_path / "server")]
+  monkeypatch.setitem(sys.modules, "server", server_pkg)
+
+  models_mod = _load_module("server.models", root_path / "server/models.py")
+  RPCRequest = models_mod.RPCRequest
+  monkeypatch.setitem(sys.modules, "server.models", models_mod)
+  server_pkg.models = models_mod
+
+  helpers_mod = _load_module("rpc.helpers", root_path / "rpc/helpers.py")
+  monkeypatch.setitem(sys.modules, "rpc.helpers", helpers_mod)
+
+  modules_mod = _load_module("server.modules", root_path / "server/modules/__init__.py")
+  monkeypatch.setitem(sys.modules, "server.modules", modules_mod)
+  server_pkg.modules = modules_mod
+
+  oauth_stub = types.ModuleType("server.modules.oauth_module")
+  class OauthModule:  # pragma: no cover
+    pass
+  oauth_stub.OauthModule = OauthModule
+  monkeypatch.setitem(sys.modules, "server.modules.oauth_module", oauth_stub)
+
+  auth_models_mod = _load_module(
+    "rpc.auth.providers.models",
+    root_path / "rpc/auth/providers/models.py",
+  )
+  monkeypatch.setitem(sys.modules, "rpc.auth.providers.models", auth_models_mod)
+
+  services_mod = _load_module(
+    "rpc.auth.providers.services",
+    root_path / "rpc/auth/providers/services.py",
+  )
+
+  module = StubOauthModule()
+  request = _dummy_request(module)
+
+  async def fake_unbox(_request):
+    return (
+      RPCRequest(
+        op="urn:auth:providers:unlink_last_provider:1",
+        payload={"guid": "user-guid", "provider": "google"},
+        version=1,
+      ),
+      None,
+      None,
+    )
+
+  original_unbox = services_mod.unbox_request
+  monkeypatch.setattr(services_mod, "unbox_request", fake_unbox)
+
+  try:
+    resp = asyncio.run(services_mod.auth_providers_unlink_last_provider_v1(request))
+  finally:
+    services_mod.unbox_request = original_unbox
+
+  assert module.ready is True
+  assert module.calls == [("user-guid", "google")]
+  assert resp.payload == {"ok": True}

--- a/tests/test_discord_chat_services.py
+++ b/tests/test_discord_chat_services.py
@@ -95,9 +95,41 @@ class StubModule:
     }
 
 class StubOpenAIModule:
-  def __init__(self, response=None):
+  def __init__(
+    self,
+    response=None,
+    *,
+    persona_details=None,
+    history=None,
+    conversation_id=777,
+    generate_response=None,
+  ):
     self.calls = []
+    self.log_calls = []
+    self.finalize_calls = []
+    self.history_calls = []
+    self.generate_calls = []
     self._response = response
+    self._conversation_id = conversation_id
+    self._persona_details = persona_details or {
+      'stark': {
+        'recid': 1,
+        'models_recid': 2,
+        'prompt': 'be stark',
+        'tokens': 128,
+        'model': 'gpt-4o-mini',
+        'name': 'Stark',
+      }
+    }
+    self._history = history or [
+      {'role': 'user', 'content': 'Hi'},
+      {'role': 'assistant', 'content': 'Hello there'},
+    ]
+    self._generate_response = generate_response or {
+      'content': 'generated reply',
+      'model': 'gpt-4o-mini',
+      'usage': {'total_tokens': 50},
+    }
 
   async def on_ready(self):
     pass
@@ -112,6 +144,62 @@ class StubOpenAIModule:
         'role': 'role',
       }
     return dict(self._response)
+
+  async def get_persona_definition(self, persona):
+    key = persona.strip().lower()
+    return self._persona_details.get(key)
+
+  async def log_persona_conversation_input(
+    self,
+    personas_recid,
+    models_recid,
+    guild_id,
+    channel_id,
+    user_id,
+    input_data,
+    tokens,
+  ):
+    self.log_calls.append(
+      {
+        'personas_recid': personas_recid,
+        'models_recid': models_recid,
+        'guild_id': guild_id,
+        'channel_id': channel_id,
+        'user_id': user_id,
+        'input_data': input_data,
+        'tokens': tokens,
+      }
+    )
+    return self._conversation_id
+
+  async def finalize_persona_conversation(self, recid, output_data, tokens):
+    self.finalize_calls.append(
+      {
+        'recid': recid,
+        'output_data': output_data,
+        'tokens': tokens,
+      }
+    )
+
+  async def get_recent_persona_conversation_history(
+    self,
+    *,
+    personas_recid,
+    lookback_days,
+    limit,
+  ):
+    self.history_calls.append(
+      {
+        'personas_recid': personas_recid,
+        'lookback_days': lookback_days,
+        'limit': limit,
+      }
+    )
+    return list(self._history)
+
+  async def generate_chat(self, **kwargs):
+    self.generate_calls.append(kwargs)
+    return dict(self._generate_response)
 
 
 def test_summarize_channel_handler():
@@ -250,5 +338,172 @@ def test_persona_response_handler_uses_openai_results():
     'role': 'be stark',
   }
   assert data['payload'] == expected
+
+  chat_services.unbox_request = original
+
+
+def test_get_conversation_history_handler_uses_openai_module():
+  app = FastAPI()
+  module = StubOpenAIModule(
+    persona_details={
+      'helper': {
+        'recid': 5,
+        'models_recid': 9,
+        'model': 'gpt-4o-mini',
+        'tokens': 64,
+        'name': 'Helper',
+      }
+    },
+    history=[
+      {'role': 'user', 'content': 'Hello'},
+      {'role': 'assistant', 'content': 'Hi there'},
+    ],
+  )
+  app.state.openai = module
+
+  async def fake_unbox(request):
+    return (
+      RPCRequest(
+        op='urn:discord:chat:get_conversation_history:1',
+        payload={'persona': 'Helper'},
+      ),
+      AuthContext(),
+      [],
+    )
+
+  original = chat_services.unbox_request
+  chat_services.unbox_request = fake_unbox
+
+  @app.post('/rpc')
+  async def rpc_endpoint(request: Request):
+    return await chat_services.discord_chat_get_conversation_history_v1(request)
+
+  client = TestClient(app)
+  resp = client.post('/rpc', json={'op': 'urn:discord:chat:get_conversation_history:1'})
+  assert resp.status_code == 200
+  data = resp.json()['payload']
+  assert data['success'] is True
+  assert data['conversation_history'] == module._history
+  assert data['personas_recid'] == 5
+  assert data['models_recid'] == 9
+  assert module.history_calls == [
+    {'personas_recid': 5, 'lookback_days': 30, 'limit': 5}
+  ]
+
+  chat_services.unbox_request = original
+
+
+def test_insert_conversation_input_handler_logs_via_module():
+  app = FastAPI()
+  module = StubOpenAIModule(
+    persona_details={
+      'helper': {
+        'recid': 7,
+        'models_recid': 11,
+        'model': 'gpt-4o-mini',
+        'tokens': 256,
+        'name': 'Helper',
+      }
+    },
+    conversation_id=4321,
+  )
+  app.state.openai = module
+
+  async def fake_unbox(request):
+    return (
+      RPCRequest(
+        op='urn:discord:chat:insert_conversation_input:1',
+        payload={
+          'persona': 'helper',
+          'message': 'Tell me something',
+          'guild_id': 1,
+          'channel_id': 2,
+          'user_id': 3,
+        },
+      ),
+      AuthContext(),
+      [],
+    )
+
+  original = chat_services.unbox_request
+  chat_services.unbox_request = fake_unbox
+
+  @app.post('/rpc')
+  async def rpc_endpoint(request: Request):
+    return await chat_services.discord_chat_insert_conversation_input_v1(request)
+
+  client = TestClient(app)
+  resp = client.post('/rpc', json={'op': 'urn:discord:chat:insert_conversation_input:1'})
+  assert resp.status_code == 200
+  data = resp.json()['payload']
+  assert data['success'] is True
+  assert data['conversation_reference'] == 4321
+  assert module.log_calls == [
+    {
+      'personas_recid': 7,
+      'models_recid': 11,
+      'guild_id': 1,
+      'channel_id': 2,
+      'user_id': 3,
+      'input_data': 'Tell me something',
+      'tokens': None,
+    }
+  ]
+
+  chat_services.unbox_request = original
+
+
+def test_generate_persona_response_handler_finalizes_conversation():
+  app = FastAPI()
+  module = StubOpenAIModule(
+    persona_details={
+      'helper': {
+        'recid': 12,
+        'models_recid': 14,
+        'model': 'gpt-4o-mini',
+        'tokens': 256,
+        'name': 'Helper',
+        'prompt': 'Assist helpfully',
+      }
+    },
+    generate_response={
+      'content': 'Final reply',
+      'model': 'gpt-4.1',
+      'usage': {'total_tokens': 33},
+    },
+  )
+  app.state.openai = module
+
+  async def fake_unbox(request):
+    return (
+      RPCRequest(
+        op='urn:discord:chat:generate_persona_response:1',
+        payload={
+          'persona': 'helper',
+          'message': 'What is up?',
+          'conversation_reference': 9001,
+        },
+      ),
+      AuthContext(),
+      [],
+    )
+
+  original = chat_services.unbox_request
+  chat_services.unbox_request = fake_unbox
+
+  @app.post('/rpc')
+  async def rpc_endpoint(request: Request):
+    return await chat_services.discord_chat_generate_persona_response_v1(request)
+
+  client = TestClient(app)
+  resp = client.post('/rpc', json={'op': 'urn:discord:chat:generate_persona_response:1'})
+  assert resp.status_code == 200
+  payload = resp.json()['payload']
+  assert payload['success'] is True
+  assert payload['conversation_reference'] == 9001
+  assert module.finalize_calls == [
+    {'recid': 9001, 'output_data': 'Final reply', 'tokens': 33}
+  ]
+  assert module.generate_calls
 
   chat_services.unbox_request = original

--- a/tests/test_openai_module.py
+++ b/tests/test_openai_module.py
@@ -185,9 +185,56 @@ def test_log_conversation_end_warns_when_no_rows_updated(caplog):
   module.db = DummyDB()
 
   with caplog.at_level(logging.WARNING):
-    asyncio.run(module._log_conversation_end(99, "done", 3))
+    asyncio.run(module.finalize_persona_conversation(99, "done", 3))
 
   assert "conversation update affected 0 rows (recid=99)" in caplog.text
+
+
+def test_get_recent_persona_conversation_history_returns_ordered_messages():
+  app = FastAPI()
+  module = OpenaiModule(app)
+
+  class DummyDB:
+    async def run(self, op, args=None):
+      if not isinstance(op, str):
+        args = op.payload
+        op = op.op
+      elif args is None:
+        args = {}
+      assert op == "db:system:conversations:list_by_time:1"
+      assert args["personas_recid"] == 7
+      return DBResult(
+        rows=[
+          {
+            "element_created_on": "2024-05-01T12:00:00Z",
+            "element_input": "Hi",
+            "element_output": "Hello",
+          },
+          {
+            "element_created_on": "2024-05-02T15:00:00+00:00",
+            "element_input": "How are you?",
+            "element_output": "I'm good",
+          },
+        ],
+        rowcount=2,
+      )
+
+  module.db = DummyDB()
+
+  history = asyncio.run(
+    module.get_recent_persona_conversation_history(
+      personas_recid=7,
+      lookback_days=7,
+      limit=5,
+    )
+  )
+
+  assert history == [
+    {"role": "user", "content": "Hi"},
+    {"role": "assistant", "content": "Hello"},
+    {"role": "user", "content": "How are you?"},
+    {"role": "assistant", "content": "I'm good"},
+  ]
 
 
 def test_fetch_chat_reuses_existing_conversation():


### PR DESCRIPTION
## Summary
- expose conversation logging helpers and a recent history accessor from the OpenAI module
- update Discord chat RPC handlers to call the module helpers instead of constructing registry requests directly
- add an OAuth unlink helper and tests to confirm the auth provider RPC handler delegates through the module boundary

## Testing
- `pytest tests/test_openai_module.py tests/test_discord_chat_services.py tests/test_auth_providers_services.py` *(fails: ImportError: cannot import name 'ProfileRecord' from 'server.registry.account.profile')*

------
https://chatgpt.com/codex/tasks/task_e_68faed96a9c88325a2f0dcbac5747f94