### PR TITLE
Refactor storage module to use provider abstraction

### DIFF
--- a/server/modules/providers/storage/__init__.py
+++ b/server/modules/providers/storage/__init__.py
@@ -1,0 +1,229 @@
+"""Storage provider interfaces and shared data models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Sequence
+
+from .. import LifecycleProvider
+
+__all__ = [
+  "StorageProvider",
+  "StorageBlobItem",
+  "StorageReindexRequest",
+  "StorageReindexResponse",
+  "StorageUploadFile",
+  "StorageUploadRequest",
+  "StorageUploadResult",
+  "StorageUploadResponse",
+  "StorageDeleteRequest",
+  "StorageDeleteResponse",
+  "StorageDeleteFolderRequest",
+  "StorageDeletedEntry",
+  "StorageDeleteFolderResponse",
+  "StorageCreateFolderRequest",
+  "StorageCreateFolderResult",
+  "StorageMoveRequest",
+  "StorageBlobProperties",
+  "StorageMoveResult",
+  "StorageRenameRequest",
+  "StorageRenameOperation",
+  "StorageRenameResponse",
+  "StorageStatsRequest",
+  "StorageStats",
+]
+
+
+@dataclass(slots=True)
+class StorageBlobItem:
+  """Representation of a blob returned from storage."""
+
+  name: str
+  metadata: dict[str, Any]
+  content_type: str | None
+  created_on: datetime | None
+  modified_on: datetime | None
+  url: str
+  size: int | None
+  is_directory: bool
+
+
+@dataclass(slots=True)
+class StorageReindexRequest:
+  container_name: str
+  prefix: str | None = None
+
+
+@dataclass(slots=True)
+class StorageReindexResponse:
+  container_url: str
+  blobs: list[StorageBlobItem]
+
+
+@dataclass(slots=True)
+class StorageUploadFile:
+  blob_name: str
+  relative_path: str
+  data: bytes
+  content_type: str | None
+
+
+@dataclass(slots=True)
+class StorageUploadRequest:
+  container_name: str
+  files: Sequence[StorageUploadFile]
+
+
+@dataclass(slots=True)
+class StorageUploadResult:
+  relative_path: str
+  url: str
+  content_type: str | None
+  created_on: datetime
+  modified_on: datetime
+
+
+@dataclass(slots=True)
+class StorageUploadResponse:
+  results: list[StorageUploadResult]
+  errors: dict[str, str]
+
+
+@dataclass(slots=True)
+class StorageDeleteRequest:
+  container_name: str
+  blob_names: Sequence[str]
+  relative_paths: Sequence[str]
+
+
+@dataclass(slots=True)
+class StorageDeleteResponse:
+  deleted: list[str]
+  errors: dict[str, str]
+
+
+@dataclass(slots=True)
+class StorageDeletedEntry:
+  relative_path: str
+
+
+@dataclass(slots=True)
+class StorageDeleteFolderRequest:
+  container_name: str
+  user_guid: str
+  prefix: str
+
+
+@dataclass(slots=True)
+class StorageDeleteFolderResponse:
+  deleted_entries: list[StorageDeletedEntry]
+  errors: dict[str, str]
+
+
+@dataclass(slots=True)
+class StorageCreateFolderRequest:
+  container_name: str
+  blob_name: str
+  init_blob_name: str
+
+
+@dataclass(slots=True)
+class StorageCreateFolderResult:
+  relative_path: str
+
+
+@dataclass(slots=True)
+class StorageMoveRequest:
+  container_name: str
+  src_blob: str
+  dst_blob: str
+  src_relative: str
+  dst_relative: str
+
+
+@dataclass(slots=True)
+class StorageBlobProperties:
+  content_type: str | None
+  created_on: datetime | None
+  modified_on: datetime | None
+
+
+@dataclass(slots=True)
+class StorageMoveResult:
+  src_relative: str
+  dst_relative: str
+  url: str | None
+  properties: StorageBlobProperties
+
+
+@dataclass(slots=True)
+class StorageRenameRequest:
+  container_name: str
+  user_guid: str
+  old_relative: str
+  new_relative: str
+  is_folder: bool
+
+
+@dataclass(slots=True)
+class StorageRenameOperation:
+  old_relative: str
+  new_relative: str
+  url: str | None
+  properties: StorageBlobProperties | None
+  source_missing: bool
+
+
+@dataclass(slots=True)
+class StorageRenameResponse:
+  container_url: str
+  operations: list[StorageRenameOperation]
+  errors: list[str]
+
+
+@dataclass(slots=True)
+class StorageStatsRequest:
+  container_name: str
+
+
+@dataclass(slots=True)
+class StorageStats:
+  file_count: int
+  total_bytes: int
+  folder_paths: list[tuple[str, str]]
+  user_ids: list[str]
+
+
+class StorageProvider(LifecycleProvider):
+  """Base class for storage providers."""
+
+  async def startup(self) -> None:  # pragma: no cover - interface default
+    return None
+
+  async def shutdown(self) -> None:  # pragma: no cover - interface default
+    return None
+
+  async def reindex(self, request: StorageReindexRequest) -> StorageReindexResponse:
+    raise NotImplementedError
+
+  async def upload_files(self, request: StorageUploadRequest) -> StorageUploadResponse:
+    raise NotImplementedError
+
+  async def delete_files(self, request: StorageDeleteRequest) -> StorageDeleteResponse:
+    raise NotImplementedError
+
+  async def delete_folder(self, request: StorageDeleteFolderRequest) -> StorageDeleteFolderResponse:
+    raise NotImplementedError
+
+  async def create_folder(self, request: StorageCreateFolderRequest) -> StorageCreateFolderResult:
+    raise NotImplementedError
+
+  async def move_file(self, request: StorageMoveRequest) -> StorageMoveResult | None:
+    raise NotImplementedError
+
+  async def rename_file(self, request: StorageRenameRequest) -> StorageRenameResponse:
+    raise NotImplementedError
+
+  async def get_storage_stats(self, request: StorageStatsRequest) -> StorageStats:
+    raise NotImplementedError

--- a/server/modules/providers/storage/azure_blob_provider.py
+++ b/server/modules/providers/storage/azure_blob_provider.py
@@ -1,0 +1,408 @@
+"""Azure Blob Storage provider implementation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+from typing import Any
+from uuid import UUID
+
+from azure.storage.blob.aio import BlobServiceClient
+from azure.storage.blob import ContentSettings
+
+from . import (
+  StorageBlobItem,
+  StorageBlobProperties,
+  StorageCreateFolderRequest,
+  StorageCreateFolderResult,
+  StorageDeleteFolderRequest,
+  StorageDeleteFolderResponse,
+  StorageDeleteRequest,
+  StorageDeleteResponse,
+  StorageDeletedEntry,
+  StorageMoveRequest,
+  StorageMoveResult,
+  StorageProvider,
+  StorageReindexRequest,
+  StorageReindexResponse,
+  StorageRenameOperation,
+  StorageRenameRequest,
+  StorageRenameResponse,
+  StorageStats,
+  StorageStatsRequest,
+  StorageUploadFile,
+  StorageUploadRequest,
+  StorageUploadResponse,
+  StorageUploadResult,
+)
+
+
+class AzureBlobStorageProvider(StorageProvider):
+  """Provider encapsulating Azure Blob interactions."""
+
+  def __init__(self, *, connection_string: str):
+    super().__init__()
+    self.connection_string = connection_string
+
+  async def startup(self) -> None:
+    if not self.connection_string:
+      logging.error("[AzureBlobStorageProvider] Missing connection string")
+
+  async def shutdown(self) -> None:
+    return None
+
+  async def _open_container(self, container_name: str):
+    if not self.connection_string:
+      raise ValueError("Azure connection string is not configured")
+    if not container_name:
+      raise ValueError("Azure container name is required")
+    service = BlobServiceClient.from_connection_string(self.connection_string)
+    container = service.get_container_client(container_name)
+    return service, container
+
+  def _extract_properties(self, blob: Any, *, container_url: str) -> StorageBlobItem:
+    metadata = getattr(blob, "metadata", {}) or {}
+    content_type = None
+    if hasattr(blob, "content_settings") and blob.content_settings:
+      content_type = getattr(blob.content_settings, "content_type", None)
+    if not content_type:
+      content_type = getattr(blob, "content_type", None)
+    created_on = getattr(blob, "creation_time", None) or getattr(blob, "created_on", None)
+    modified_on = getattr(blob, "last_modified", None)
+    size = getattr(blob, "size", None)
+    if size is None:
+      props = getattr(blob, "properties", None)
+      if props is not None:
+        size = getattr(props, "content_length", None)
+    name = getattr(blob, "name", "")
+    return StorageBlobItem(
+      name=name,
+      metadata=dict(metadata),
+      content_type=content_type,
+      created_on=created_on,
+      modified_on=modified_on,
+      url=f"{container_url}/{name}" if name else "",
+      size=size,
+      is_directory=metadata.get("hdi_isfolder") == "true",
+    )
+
+  async def reindex(self, request: StorageReindexRequest) -> StorageReindexResponse:
+    service, container = await self._open_container(request.container_name)
+    container_url = container.url
+    blobs: list[StorageBlobItem] = []
+    try:
+      iterator = (
+        container.list_blobs(name_starts_with=request.prefix)
+        if request.prefix
+        else container.list_blobs()
+      )
+      async for blob in iterator:
+        item = self._extract_properties(blob, container_url=container_url)
+        if not item.name:
+          continue
+        blobs.append(item)
+    finally:
+      await container.close()
+      await service.close()
+    return StorageReindexResponse(container_url=container_url, blobs=blobs)
+
+  async def upload_files(self, request: StorageUploadRequest) -> StorageUploadResponse:
+    service, container = await self._open_container(request.container_name)
+    container_url = container.url
+    results: list[StorageUploadResult] = []
+    errors: dict[str, str] = {}
+    try:
+      now = datetime.now(timezone.utc)
+      for file in request.files:
+        try:
+          await container.upload_blob(
+            file.blob_name,
+            file.data,
+            overwrite=True,
+            content_settings=ContentSettings(content_type=file.content_type) if file.content_type else None,
+          )
+        except Exception as exc:  # pragma: no cover - network failure
+          logging.error("[AzureBlobStorageProvider] Failed to upload %s: %s", file.blob_name, exc)
+          errors[file.relative_path] = str(exc)
+          continue
+        results.append(
+          StorageUploadResult(
+            relative_path=file.relative_path,
+            url=f"{container_url}/{file.blob_name}",
+            content_type=file.content_type,
+            created_on=now,
+            modified_on=now,
+          )
+        )
+    finally:
+      await container.close()
+      await service.close()
+    return StorageUploadResponse(results=results, errors=errors)
+
+  async def delete_files(self, request: StorageDeleteRequest) -> StorageDeleteResponse:
+    service, container = await self._open_container(request.container_name)
+    deleted: list[str] = []
+    errors: dict[str, str] = {}
+    try:
+      for blob_name, rel in zip(request.blob_names, request.relative_paths):
+        blob = container.get_blob_client(blob_name)
+        try:
+          await blob.delete_blob()
+          deleted.append(rel)
+        except Exception as exc:  # pragma: no cover - network failure
+          logging.error("[AzureBlobStorageProvider] Failed to delete %s: %s", blob_name, exc)
+          errors[rel] = str(exc)
+    finally:
+      await container.close()
+      await service.close()
+    return StorageDeleteResponse(deleted=deleted, errors=errors)
+
+  async def delete_folder(self, request: StorageDeleteFolderRequest) -> StorageDeleteFolderResponse:
+    service, container = await self._open_container(request.container_name)
+    deleted_entries: list[StorageDeletedEntry] = []
+    errors: dict[str, str] = {}
+    try:
+      async for blob in container.list_blobs(name_starts_with=request.prefix):
+        name = getattr(blob, "name", None)
+        if not name or not name.startswith(f"{request.user_guid}/"):
+          continue
+        try:
+          await container.delete_blob(name)
+          relative = name[len(f"{request.user_guid}/"):]
+          deleted_entries.append(StorageDeletedEntry(relative_path=relative))
+        except Exception as exc:  # pragma: no cover - network failure
+          logging.error("[AzureBlobStorageProvider] Failed to delete %s: %s", name, exc)
+          errors[name] = str(exc)
+    finally:
+      await container.close()
+      await service.close()
+    return StorageDeleteFolderResponse(deleted_entries=deleted_entries, errors=errors)
+
+  async def create_folder(self, request: StorageCreateFolderRequest) -> StorageCreateFolderResult:
+    service, container = await self._open_container(request.container_name)
+    try:
+      await container.upload_blob(
+        request.blob_name,
+        b"",
+        metadata={"hdi_isfolder": "true"},
+        overwrite=True,
+      )
+      await container.upload_blob(
+        request.init_blob_name,
+        b"",
+        overwrite=True,
+      )
+      rel = request.blob_name.split("/", 1)[-1]
+      return StorageCreateFolderResult(relative_path=rel)
+    finally:
+      await container.close()
+      await service.close()
+
+  async def move_file(self, request: StorageMoveRequest) -> StorageMoveResult | None:
+    service, container = await self._open_container(request.container_name)
+    try:
+      src_blob = container.get_blob_client(request.src_blob)
+      dst_blob = container.get_blob_client(request.dst_blob)
+      props = await src_blob.get_blob_properties()
+      await dst_blob.start_copy_from_url(src_blob.url)
+      await src_blob.delete_blob()
+      ct = None
+      if getattr(props, "content_settings", None):
+        ct = getattr(props.content_settings, "content_type", None)
+      created_on = getattr(props, "creation_time", None) or getattr(props, "created_on", None)
+      modified_on = getattr(props, "last_modified", None)
+      properties = StorageBlobProperties(
+        content_type=ct or "application/octet-stream",
+        created_on=created_on,
+        modified_on=modified_on,
+      )
+      return StorageMoveResult(
+        src_relative=request.src_relative,
+        dst_relative=request.dst_relative,
+        url=dst_blob.url,
+        properties=properties,
+      )
+    except Exception as exc:  # pragma: no cover - network failure
+      logging.error(
+        "[AzureBlobStorageProvider] Failed to move blob %s -> %s: %s",
+        request.src_blob,
+        request.dst_blob,
+        exc,
+      )
+      return None
+    finally:
+      await container.close()
+      await service.close()
+
+  async def rename_file(self, request: StorageRenameRequest) -> StorageRenameResponse:
+    service, container = await self._open_container(request.container_name)
+    container_url = container.url
+    operations: list[StorageRenameOperation] = []
+    errors: list[str] = []
+
+    def _full_name(relative: str) -> str:
+      if relative.startswith(f"{request.user_guid}/"):
+        return relative
+      return f"{request.user_guid}/{relative.lstrip('/')}"  # type: ignore[no-any-return]
+
+    async def rename_single(old_rel: str, new_rel: str) -> None:
+      src_name = _full_name(old_rel)
+      dst_name = _full_name(new_rel)
+      src_blob = container.get_blob_client(src_name)
+      dst_blob = container.get_blob_client(dst_name)
+      try:
+        src_exists = await src_blob.exists()
+      except Exception as exc:  # pragma: no cover - network failure
+        logging.error("[AzureBlobStorageProvider] Failed to check blob %s: %s", src_name, exc)
+        errors.append(f"exists:{src_name}:{exc}")
+        return
+      if not src_exists:
+        operations.append(
+          StorageRenameOperation(
+            old_relative=old_rel,
+            new_relative=new_rel,
+            url=None,
+            properties=None,
+            source_missing=True,
+          )
+        )
+        return
+      try:
+        if await dst_blob.exists():
+          msg = f"Destination blob already exists for rename {old_rel} -> {new_rel}"
+          logging.error("[AzureBlobStorageProvider] %s", msg)
+          errors.append(f"exists:{dst_name}")
+          return
+      except Exception as exc:  # pragma: no cover - network failure
+        logging.error("[AzureBlobStorageProvider] Failed to check destination blob %s: %s", dst_name, exc)
+        errors.append(f"dst-check:{dst_name}:{exc}")
+        return
+      try:
+        props = await src_blob.get_blob_properties()
+        await dst_blob.start_copy_from_url(src_blob.url)
+        await src_blob.delete_blob()
+        ct = None
+        if getattr(props, "content_settings", None):
+          ct = getattr(props.content_settings, "content_type", None)
+        created_on = getattr(props, "creation_time", None) or getattr(props, "created_on", None)
+        modified_on = getattr(props, "last_modified", None)
+        properties = StorageBlobProperties(
+          content_type=ct or "application/octet-stream",
+          created_on=created_on,
+          modified_on=modified_on,
+        )
+        operations.append(
+          StorageRenameOperation(
+            old_relative=old_rel,
+            new_relative=new_rel,
+            url=dst_blob.url,
+            properties=properties,
+            source_missing=False,
+          )
+        )
+      except Exception as exc:  # pragma: no cover - network failure
+        logging.error(
+          "[AzureBlobStorageProvider] Failed to rename blob %s to %s: %s",
+          old_rel,
+          new_rel,
+          exc,
+        )
+        errors.append(f"rename:{old_rel}:{new_rel}:{exc}")
+
+    async def rename_folder(old_rel: str, new_rel: str) -> None:
+      if new_rel.startswith(f"{old_rel}/"):
+        msg = f"Cannot rename folder {old_rel} into its own child {new_rel}"
+        logging.error("[AzureBlobStorageProvider] %s", msg)
+        errors.append(f"cycle:{old_rel}->{new_rel}")
+        return
+      src_prefix = _full_name(old_rel)
+      dst_prefix = _full_name(new_rel)
+      dst_placeholder = container.get_blob_client(dst_prefix)
+      try:
+        if await dst_placeholder.exists():
+          msg = f"Target folder {new_rel} already exists"
+          logging.error("[AzureBlobStorageProvider] %s", msg)
+          errors.append(f"exists:{dst_prefix}")
+          return
+      except Exception as exc:  # pragma: no cover - network failure
+        logging.error("[AzureBlobStorageProvider] Failed to check destination folder %s: %s", dst_prefix, exc)
+        errors.append(f"dst-check:{dst_prefix}:{exc}")
+        return
+      try:
+        async for _ in container.list_blobs(name_starts_with=f"{dst_prefix}/"):
+          msg = f"Target folder {new_rel} already contains blobs"
+          logging.error("[AzureBlobStorageProvider] %s", msg)
+          errors.append(f"nonempty:{dst_prefix}")
+          return
+      except Exception as exc:  # pragma: no cover - network failure
+        logging.error("[AzureBlobStorageProvider] Failed to inspect destination folder %s: %s", dst_prefix, exc)
+        errors.append(f"inspect:{dst_prefix}:{exc}")
+        return
+      await rename_single(old_rel, new_rel)
+      try:
+        async for blob in container.list_blobs(name_starts_with=f"{src_prefix}/"):
+          rel_name = blob.name[len(f"{request.user_guid}/"):]
+          if not rel_name:
+            continue
+          suffix = rel_name[len(old_rel):]
+          await rename_single(rel_name, f"{new_rel}{suffix}")
+      except Exception as exc:  # pragma: no cover - network failure
+        logging.error("[AzureBlobStorageProvider] Failed to list blobs for folder %s: %s", old_rel, exc)
+        errors.append(f"list:{src_prefix}:{exc}")
+
+    try:
+      if request.is_folder:
+        await rename_folder(request.old_relative, request.new_relative)
+      else:
+        await rename_single(request.old_relative, request.new_relative)
+    finally:
+      await container.close()
+      await service.close()
+    return StorageRenameResponse(
+      container_url=container_url,
+      operations=operations,
+      errors=errors,
+    )
+
+  async def get_storage_stats(self, request: StorageStatsRequest) -> StorageStats:
+    service, container = await self._open_container(request.container_name)
+    file_count = 0
+    total_bytes = 0
+    folders: set[tuple[str, str]] = set()
+    users: set[str] = set()
+    try:
+      async for blob in container.list_blobs():
+        name = getattr(blob, "name", "")
+        if not name:
+          continue
+        parts = name.split("/")
+        if len(parts) < 2:
+          continue
+        guid = parts[0]
+        try:
+          UUID(guid)
+        except Exception:
+          continue
+        users.add(guid)
+        parent = ""
+        for folder_name in parts[1:-1]:
+          parent = f"{parent}/{folder_name}" if parent else folder_name
+          folders.add((guid, parent))
+        if parts[-1] == ".init":
+          continue
+        file_count += 1
+        size = getattr(blob, "size", None)
+        if size is None:
+          props = getattr(blob, "properties", None)
+          if props is not None:
+            size = getattr(props, "content_length", 0)
+        total_bytes += size or 0
+    finally:
+      await container.close()
+      await service.close()
+    return StorageStats(
+      file_count=file_count,
+      total_bytes=total_bytes,
+      folder_paths=sorted(folders),
+      user_ids=sorted(users),
+    )

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -4,8 +4,6 @@ import asyncio, logging, re, base64
 from typing import Any
 from datetime import datetime, timezone
 from uuid import UUID
-from azure.storage.blob.aio import BlobServiceClient
-from azure.storage.blob import ContentSettings
 from fastapi import FastAPI
 from server.registry.system.config import ConfigKeyParams, get_config_request
 from server.registry.account.cache import (
@@ -19,6 +17,19 @@ from . import BaseModule
 from .env_module import EnvModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
+from .providers.storage import (
+  StorageBlobProperties,
+  StorageCreateFolderRequest,
+  StorageDeleteFolderRequest,
+  StorageDeleteRequest,
+  StorageMoveRequest,
+  StorageRenameRequest,
+  StorageReindexRequest,
+  StorageUploadFile,
+  StorageUploadRequest,
+  StorageStatsRequest,
+)
+from .providers.storage.azure_blob_provider import AzureBlobStorageProvider
 
 
 class StorageModule(BaseModule):
@@ -37,6 +48,7 @@ class StorageModule(BaseModule):
     self._reindex_task: asyncio.Task | None = None
     self.reindex_interval = 15 * 60
     self.discord: DiscordBotModule | None = None
+    self.provider: AzureBlobStorageProvider | None = None
 
   @staticmethod
   def _parse_duration(value: str) -> int:
@@ -59,8 +71,13 @@ class StorageModule(BaseModule):
       self.connection_string = self.env.get("AZURE_BLOB_CONNECTION_STRING")
       if not self.connection_string:
         logging.error("[StorageModule] AZURE_BLOB_CONNECTION_STRING missing")
+        self.provider = None
+      else:
+        self.provider = AzureBlobStorageProvider(connection_string=self.connection_string)
+        await self.provider.startup()
     except Exception as e:
       logging.error("[StorageModule] Failed to load AZURE_BLOB_CONNECTION_STRING: %s", e)
+      self.provider = None
 
     try:
       res = await self.db.run(get_config_request(ConfigKeyParams(key="StorageCacheTime")))
@@ -83,6 +100,12 @@ class StorageModule(BaseModule):
       except asyncio.CancelledError:
         pass
       self._reindex_task = None
+    if self.provider:
+      try:
+        await self.provider.shutdown()
+      except Exception as exc:
+        logging.error("[StorageModule] Provider shutdown failed: %s", exc)
+      self.provider = None
 
   async def _reindex_loop(self):
     while True:
@@ -92,196 +115,207 @@ class StorageModule(BaseModule):
       except Exception as e:
         logging.error("[StorageModule] Reindex failed: %s", e)
 
+  def _require_provider(self) -> AzureBlobStorageProvider | None:
+    if not self.provider:
+      logging.error("[StorageModule] Storage provider is not configured")
+      return None
+    return self.provider
+
+  async def _get_container_name(self) -> str | None:
+    if not self.db:
+      logging.error("[StorageModule] Database module unavailable")
+      return None
+    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
+    container_name = res.rows[0]["value"] if res.rows else None
+    if not container_name:
+      logging.error("[StorageModule] AzureBlobContainerName missing")
+    return container_name
+
   async def reindex(self, user_guid: str | None = None):
     """Perform a scan of storage and update database cache."""
     logging.info(
       "[StorageModule] Reindexing storage%s",
       f" for {user_guid}" if user_guid else " for all users",
     )
-    if not self.connection_string or not self.db:
-      logging.error("[StorageModule] Missing connection string or database module")
+    if not self.db:
+      logging.error("[StorageModule] Missing database module")
       return
-    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
-    container_name = res.rows[0]["value"] if res.rows else None
+    provider = self._require_provider()
+    if not provider:
+      return
+    container_name = await self._get_container_name()
     if not container_name:
-      logging.error("[StorageModule] AzureBlobContainerName missing")
       return
     valid_users: set[str] = set()
     missing_users: set[str] = set()
-    if user_guid:
+
+    async def ensure_user(guid: str) -> bool:
+      if guid in valid_users:
+        return True
+      if guid in missing_users:
+        return False
       try:
-        if not await self.db.user_exists(user_guid):
-          logging.warning("[StorageModule] Skipping reindex for unknown user %s", user_guid)
-          return
-        valid_users.add(user_guid)
-      except Exception as e:
-        logging.error("[StorageModule] Failed to validate user %s: %s", user_guid, e)
+        exists = await self.db.user_exists(guid)
+      except Exception as exc:
+        logging.error("[StorageModule] Failed to validate user %s: %s", guid, exc)
+        missing_users.add(guid)
+        return False
+      if not exists:
+        logging.warning("[StorageModule] Skipping blob for unknown user %s", guid)
+        missing_users.add(guid)
+        return False
+      valid_users.add(guid)
+      return True
+
+    if user_guid:
+      if not await ensure_user(user_guid):
         return
-    bsc = BlobServiceClient.from_connection_string(self.connection_string)
-    container = bsc.get_container_client(container_name)
+
+    prefix = f"{user_guid}/" if user_guid else None
+    response = await provider.reindex(
+      StorageReindexRequest(container_name=container_name, prefix=prefix)
+    )
     files_seen: dict[str, set[tuple[str, str]]] = {}
     folder_seen: dict[str, set[tuple[str, str]]] = {}
     public_map: dict[str, dict[tuple[str, str], int]] = {}
     files_indexed = 0
     folders_indexed = 0
-    prefix = f"{user_guid}/" if user_guid else None
-    try:
-      iterator = container.list_blobs(name_starts_with=prefix) if prefix else container.list_blobs()
-      async for blob in iterator:
-        name = getattr(blob, "name", None)
-        if not name:
-          continue
-        parts = name.split("/")
-        if len(parts) < 2:
-          continue
-        guid = parts[0]
-        try:
-          UUID(guid)
-        except Exception:
-          continue
-        if user_guid and guid != user_guid:
-          continue
-        if guid in missing_users:
-          continue
-        if guid not in valid_users:
-          try:
-            exists = await self.db.user_exists(guid)
-          except Exception as e:
-            logging.error("[StorageModule] Failed to validate user %s: %s", guid, e)
-            missing_users.add(guid)
-            continue
-          if not exists:
-            logging.warning("[StorageModule] Skipping blob for unknown user %s", guid)
-            missing_users.add(guid)
-            continue
-          valid_users.add(guid)
-        filename = parts[-1]
-        path = "/".join(parts[1:-1])
-        if guid not in public_map:
-          rows = await self.db.list_storage_cache(guid)
-          public_map[guid] = {
-            (r.get("path") or "", r.get("filename")): r.get("public", 0)
-            for r in rows
-            if r.get("content_type") != "path/folder"
-          }
-        # index folders along the path (up to 4 levels)
-        parent = ""
-        fset = folder_seen.setdefault(guid, set())
-        for folder_name in parts[1:-1][:4]:
-          key = (parent, folder_name)
-          if key not in fset:
-            logging.debug(
-              "[StorageModule] indexing folder %s/%s", parent or ".", folder_name
-            )
-            res = await self.db.upsert_storage_cache({
-              "user_guid": guid,
-              "path": parent,
-              "filename": folder_name,
-              "content_type": "path/folder",
-              "public": 0,
-              "created_on": None,
-              "modified_on": None,
-              "url": None,
-              "reported": 0,
-              "moderation_recid": None,
-            })
-            if res.rowcount == 0:
-              logging.error(
-                "[StorageModule] Failed to upsert folder %s/%s",
-                parent or ".",
-                folder_name,
-              )
-            fset.add(key)
-            folders_indexed += 1
-          parent = f"{parent}/{folder_name}" if parent else folder_name
-        # handle explicit folder markers (Azure Storage Explorer etc.)
-        meta = getattr(blob, "metadata", {}) or {}
-        if meta.get("hdi_isfolder") == "true":
-          key = (path, filename)
-          if key not in fset:
-            logging.debug(
-              "[StorageModule] indexing folder %s/%s", path or ".", filename
-            )
-            res = await self.db.upsert_storage_cache({
-              "user_guid": guid,
-              "path": path,
-              "filename": filename,
-              "content_type": "path/folder",
-              "public": 0,
-              "created_on": None,
-              "modified_on": None,
-              "url": None,
-              "reported": 0,
-              "moderation_recid": None,
-            })
-            if res.rowcount == 0:
-              logging.error(
-                "[StorageModule] Failed to upsert folder %s/%s",
-                path or ".",
-                filename,
-              )
-            fset.add(key)
-            folders_indexed += 1
-          continue
-        if not filename or filename == ".init":
-          continue
-        ct = None
-        if hasattr(blob, "content_settings") and blob.content_settings:
-          ct = getattr(blob.content_settings, "content_type", None)
-        if not ct:
-          ct = getattr(blob, "content_type", None)
-        created_on = getattr(blob, "creation_time", None) or getattr(blob, "created_on", None)
-        modified_on = getattr(blob, "last_modified", None)
-        url = f"{container.url}/{name}"
-        logging.debug(
-          "[StorageModule] indexing file %s/%s", path or ".", filename
-        )
-        public_val = public_map.get(guid, {}).get((path, filename), 0)
-        res = await self.db.upsert_storage_cache({
-          "user_guid": guid,
-          "path": path,
-          "filename": filename,
-          "content_type": ct or "application/octet-stream",
-          "public": public_val,
-          "created_on": created_on,
-          "modified_on": modified_on,
-          "url": url,
-          "reported": 0,
-          "moderation_recid": None,
-        })
-        if res.rowcount == 0:
-          logging.error(
-            "[StorageModule] Failed to upsert file %s/%s",
-            path or ".",
-            filename,
+
+    for blob in response.blobs:
+      name = blob.name
+      if not name:
+        continue
+      parts = name.split("/")
+      if len(parts) < 2:
+        continue
+      guid = parts[0]
+      try:
+        UUID(guid)
+      except Exception:
+        continue
+      if user_guid and guid != user_guid:
+        continue
+      if not await ensure_user(guid):
+        continue
+      filename = parts[-1]
+      path = "/".join(parts[1:-1])
+      if guid not in public_map:
+        rows = await self.db.list_storage_cache(guid)
+        public_map[guid] = {
+          (r.get("path") or "", r.get("filename")): r.get("public", 0)
+          for r in rows
+          if r.get("content_type") != "path/folder"
+        }
+      parent = ""
+      fset = folder_seen.setdefault(guid, set())
+      for folder_name in parts[1:-1][:4]:
+        key = (parent, folder_name)
+        if key not in fset:
+          logging.debug(
+            "[StorageModule] indexing folder %s/%s", parent or ".", folder_name
           )
-        files_seen.setdefault(guid, set()).add((path, filename))
-        public_map.setdefault(guid, {})[(path, filename)] = public_val
-        files_indexed += 1
-      if user_guid:
-        existing = public_map.get(user_guid, {})
-        for key in list(existing.keys()):
-          if key not in files_seen.get(user_guid, set()):
-            await self.db.delete_storage_cache(user_guid, key[0], key[1])
-      else:
-        for guid, items_seen in files_seen.items():
-          existing = public_map.get(guid, {})
-          for key in list(existing.keys()):
-            if key not in items_seen:
-              await self.db.delete_storage_cache(guid, key[0], key[1])
-    finally:
+          res = await self.db.upsert_storage_cache({
+            "user_guid": guid,
+            "path": parent,
+            "filename": folder_name,
+            "content_type": "path/folder",
+            "public": 0,
+            "created_on": None,
+            "modified_on": None,
+            "url": None,
+            "reported": 0,
+            "moderation_recid": None,
+          })
+          if res.rowcount == 0:
+            logging.error(
+              "[StorageModule] Failed to upsert folder %s/%s",
+              parent or ".",
+              folder_name,
+            )
+          fset.add(key)
+          folders_indexed += 1
+        parent = f"{parent}/{folder_name}" if parent else folder_name
+      if blob.is_directory:
+        key = (path, filename)
+        if key not in fset:
+          logging.debug(
+            "[StorageModule] indexing folder %s/%s", path or ".", filename
+          )
+          res = await self.db.upsert_storage_cache({
+            "user_guid": guid,
+            "path": path,
+            "filename": filename,
+            "content_type": "path/folder",
+            "public": 0,
+            "created_on": None,
+            "modified_on": None,
+            "url": None,
+            "reported": 0,
+            "moderation_recid": None,
+          })
+          if res.rowcount == 0:
+            logging.error(
+              "[StorageModule] Failed to upsert folder %s/%s",
+              path or ".",
+              filename,
+            )
+          fset.add(key)
+          folders_indexed += 1
+        continue
+      if not filename or filename == ".init":
+        continue
+      ct = blob.content_type or "application/octet-stream"
+      created_on = blob.created_on
+      modified_on = blob.modified_on
+      url = blob.url or f"{response.container_url}/{name}"
       logging.debug(
-        "[StorageModule] Reindex found %d files and %d folders%s",
-        files_indexed,
-        folders_indexed,
-        f" for {user_guid}" if user_guid else "",
+        "[StorageModule] indexing file %s/%s", path or ".", filename
       )
-      await container.close()
-      await bsc.close()
-      logging.info(
-        "[StorageModule] Reindex complete%s",
-        f" for {user_guid}" if user_guid else "",
-      )
+      public_val = public_map.get(guid, {}).get((path, filename), 0)
+      res = await self.db.upsert_storage_cache({
+        "user_guid": guid,
+        "path": path,
+        "filename": filename,
+        "content_type": ct,
+        "public": public_val,
+        "created_on": created_on,
+        "modified_on": modified_on,
+        "url": url,
+        "reported": 0,
+        "moderation_recid": None,
+      })
+      if res.rowcount == 0:
+        logging.error(
+          "[StorageModule] Failed to upsert file %s/%s",
+          path or ".",
+          filename,
+        )
+      files_seen.setdefault(guid, set()).add((path, filename))
+      public_map.setdefault(guid, {})[(path, filename)] = public_val
+      files_indexed += 1
+
+    if user_guid:
+      existing = public_map.get(user_guid, {})
+      for key in list(existing.keys()):
+        if key not in files_seen.get(user_guid, set()):
+          await self.db.delete_storage_cache(user_guid, key[0], key[1])
+    else:
+      for guid, items_seen in files_seen.items():
+        existing = public_map.get(guid, {})
+        for key in list(existing.keys()):
+          if key not in items_seen:
+            await self.db.delete_storage_cache(guid, key[0], key[1])
+
+    logging.debug(
+      "[StorageModule] Reindex found %d files and %d folders%s",
+      files_indexed,
+      folders_indexed,
+      f" for {user_guid}" if user_guid else "",
+    )
+    logging.info(
+      "[StorageModule] Reindex complete%s",
+      f" for {user_guid}" if user_guid else "",
+    )
 
   async def upsert_file_record(self, user_guid: str, path: str, filename: str, file_type: str, **kwargs):
     """Upsert a file record into the ``users_storage_cache`` table."""
@@ -374,98 +408,112 @@ class StorageModule(BaseModule):
     return res.rows
 
   async def upload_files(self, user_guid: str, files):
-    if not self.connection_string or not self.db:
-      logging.error("[StorageModule] Missing connection string or database module")
+    if not self.db:
+      logging.error("[StorageModule] Missing database module")
       return
-    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
-    container_name = res.rows[0]["value"] if res.rows else None
+    provider = self._require_provider()
+    if not provider:
+      return
+    container_name = await self._get_container_name()
     if not container_name:
-      logging.error("[StorageModule] AzureBlobContainerName missing")
       return
-    bsc = BlobServiceClient.from_connection_string(self.connection_string)
-    container = bsc.get_container_client(container_name)
-    try:
-      for f in files:
-        name = getattr(f, "name", None)
-        if not name and isinstance(f, dict):
-          name = f.get("name")
-        content_b64 = getattr(f, "content_b64", None)
-        if not content_b64 and isinstance(f, dict):
-          content_b64 = f.get("content_b64")
-        if not name or not content_b64:
-          continue
-        blob_name = f"{user_guid}/{name.lstrip('/')}"
+    payload: list[StorageUploadFile] = []
+    for f in files:
+      name = getattr(f, "name", None)
+      if not name and isinstance(f, dict):
+        name = f.get("name")
+      content_b64 = getattr(f, "content_b64", None)
+      if not content_b64 and isinstance(f, dict):
+        content_b64 = f.get("content_b64")
+      if not name or not content_b64:
+        continue
+      ct = getattr(f, "content_type", None)
+      if ct is None and isinstance(f, dict):
+        ct = f.get("content_type")
+      try:
         data = base64.b64decode(content_b64)
-        ct = getattr(f, "content_type", None)
-        if ct is None and isinstance(f, dict):
-          ct = f.get("content_type")
-        try:
-          await container.upload_blob(
-            blob_name,
-            data,
-            overwrite=True,
-            content_settings=ContentSettings(content_type=ct) if ct else None,
+      except Exception as exc:
+        logging.error("[StorageModule] Failed to decode upload for %s: %s", name, exc)
+        continue
+      normalized = name.lstrip("/")
+      payload.append(
+        StorageUploadFile(
+          blob_name=f"{user_guid}/{normalized}",
+          relative_path=normalized,
+          data=data,
+          content_type=ct,
+        )
+      )
+    if not payload:
+      return
+    response = await provider.upload_files(
+      StorageUploadRequest(container_name=container_name, files=payload)
+    )
+    for rel, err in response.errors.items():
+      logging.error("[StorageModule] Failed to upload %s: %s", rel, err)
+    for result in response.results:
+      name = result.relative_path.lstrip("/")
+      path = "/".join(name.split("/")[:-1])
+      filename = name.split("/")[-1]
+      try:
+        res = await self.db.upsert_storage_cache({
+          "user_guid": user_guid,
+          "path": path,
+          "filename": filename,
+          "content_type": result.content_type or "application/octet-stream",
+          "public": 0,
+          "created_on": result.created_on,
+          "modified_on": result.modified_on,
+          "url": result.url,
+          "reported": 0,
+          "moderation_recid": None,
+        })
+        if res.rowcount == 0:
+          logging.error(
+            "[StorageModule] Failed to upsert file %s/%s",
+            path or ".",
+            filename,
           )
-        except Exception as e:
-          logging.error("[StorageModule] Failed to upload %s: %s", blob_name, e)
-          continue
-        now = datetime.now(timezone.utc)
-        path = "/".join(name.split("/")[:-1])
-        filename = name.split("/")[-1]
-        url = f"{container.url}/{blob_name}"
-        try:
-          res = await self.db.upsert_storage_cache({
-            "user_guid": user_guid,
-            "path": path,
-            "filename": filename,
-            "content_type": ct or "application/octet-stream",
-            "public": 0,
-            "created_on": now,
-            "modified_on": now,
-            "url": url,
-            "reported": 0,
-            "moderation_recid": None,
-          })
-          if res.rowcount == 0:
-            logging.error("[StorageModule] Failed to upsert file %s/%s", path or '.', filename)
-        except Exception as e:
-          logging.error("[StorageModule] Failed to update cache for %s/%s: %s", path or '.', filename, e)
-    finally:
-      await container.close()
-      await bsc.close()
+      except Exception as exc:
+        logging.error(
+          "[StorageModule] Failed to update cache for %s/%s: %s",
+          path or ".",
+          filename,
+          exc,
+        )
 
   async def delete_files(self, user_guid: str, names: list[str]):
-    if not self.connection_string or not self.db:
-      logging.error("[StorageModule] Missing connection string or database module")
+    if not self.db:
+      logging.error("[StorageModule] Missing database module")
       return
-    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
-    container_name = res.rows[0]["value"] if res.rows else None
+    provider = self._require_provider()
+    if not provider:
+      return
+    container_name = await self._get_container_name()
     if not container_name:
-      logging.error("[StorageModule] AzureBlobContainerName missing")
       return
-    bsc = BlobServiceClient.from_connection_string(self.connection_string)
-    container = bsc.get_container_client(container_name)
-    try:
-      for name in names:
-        blob_name = f"{user_guid}/{name.lstrip('/')}"
-        path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
-        blob = container.get_blob_client(blob_name)
-        try:
-          await blob.delete_blob()
-        except Exception as e:
-          logging.error("[StorageModule] Failed to delete %s: %s", blob_name, e)
-        try:
-          await self.db.delete_storage_cache(user_guid, path, filename)
-        except Exception as e:
-          logging.error(
-            "[StorageModule] Failed to delete cache for %s/%s: %s",
-            path or '.',
-            filename,
-            e,
-          )
-    finally:
-      await container.close()
-      await bsc.close()
+    normalized = [name.lstrip("/") for name in names]
+    blob_names = [f"{user_guid}/{name}" for name in normalized]
+    response = await provider.delete_files(
+      StorageDeleteRequest(
+        container_name=container_name,
+        blob_names=blob_names,
+        relative_paths=normalized,
+      )
+    )
+    for rel, err in response.errors.items():
+      logging.error("[StorageModule] Failed to delete %s: %s", rel, err)
+    for rel in response.deleted:
+      path, filename = rel.rsplit("/", 1) if "/" in rel else ("", rel)
+      try:
+        await self.db.delete_storage_cache(user_guid, path, filename)
+      except Exception as exc:
+        logging.error(
+          "[StorageModule] Failed to delete cache for %s/%s: %s",
+          path or ".",
+          filename,
+          exc,
+        )
 
   async def set_gallery(self, user_guid: str, name: str, gallery: bool):
     assert self.db
@@ -477,149 +525,167 @@ class StorageModule(BaseModule):
     await self.db.run(set_reported_request(user_guid, path=path, filename=filename, reported=True))
 
   async def create_folder(self, user_guid: str, path: str):
-    if not self.connection_string or not self.db:
-      logging.error("[StorageModule] Missing connection string or database module")
+    if not self.db:
+      logging.error("[StorageModule] Missing database module")
       return
-    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
-    container_name = res.rows[0]["value"] if res.rows else None
+    provider = self._require_provider()
+    if not provider:
+      return
+    container_name = await self._get_container_name()
     if not container_name:
-      logging.error("[StorageModule] AzureBlobContainerName missing")
       return
-    bsc = BlobServiceClient.from_connection_string(self.connection_string)
-    container = bsc.get_container_client(container_name)
     folder_path = path.lstrip("/")
     blob_name = f"{user_guid}/{folder_path}"
     init_name = f"{blob_name}/.init"
-    parent, folder_name = folder_path.rsplit("/", 1) if "/" in folder_path else ("", folder_path)
     try:
-      await container.upload_blob(
-        blob_name,
-        b"",
-        metadata={"hdi_isfolder": "true"},
-        overwrite=True,
-      )
-      await container.upload_blob(
-        init_name,
-        b"",
-        overwrite=True,
-      )
-      try:
-        await self.db.upsert_storage_cache({
-          "user_guid": user_guid,
-          "path": parent,
-          "filename": folder_name,
-          "content_type": "path/folder",
-          "public": 0,
-          "created_on": None,
-          "modified_on": None,
-          "url": None,
-          "reported": 0,
-          "moderation_recid": None,
-        })
-      except Exception as e:
-        logging.error(
-          "[StorageModule] Failed to update cache for %s/%s: %s",
-          parent or ".",
-          folder_name,
-          e,
+      result = await provider.create_folder(
+        StorageCreateFolderRequest(
+          container_name=container_name,
+          blob_name=blob_name,
+          init_blob_name=init_name,
         )
-    finally:
-      await container.close()
-      await bsc.close()
+      )
+    except Exception as exc:
+      logging.error("[StorageModule] Failed to create folder %s: %s", path, exc)
+      return
+    relative = result.relative_path
+    parent, folder_name = relative.rsplit("/", 1) if "/" in relative else ("", relative)
+    try:
+      await self.db.upsert_storage_cache({
+        "user_guid": user_guid,
+        "path": parent,
+        "filename": folder_name,
+        "content_type": "path/folder",
+        "public": 0,
+        "created_on": None,
+        "modified_on": None,
+        "url": None,
+        "reported": 0,
+        "moderation_recid": None,
+      })
+    except Exception as exc:
+      logging.error(
+        "[StorageModule] Failed to update cache for %s/%s: %s",
+        parent or ".",
+        folder_name,
+        exc,
+      )
 
   async def delete_folder(self, user_guid: str, path: str):
-    if not self.connection_string or not self.db:
-      logging.error("[StorageModule] Missing connection string or database module")
+    if not self.db:
+      logging.error("[StorageModule] Missing database module")
       return
-    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
-    container_name = res.rows[0]["value"] if res.rows else None
+    provider = self._require_provider()
+    if not provider:
+      return
+    container_name = await self._get_container_name()
     if not container_name:
-      logging.error("[StorageModule] AzureBlobContainerName missing")
       return
-    bsc = BlobServiceClient.from_connection_string(self.connection_string)
-    container = bsc.get_container_client(container_name)
-    prefix = f"{user_guid}/{path.lstrip('/')}"
+    normalized = path.lstrip("/")
+    prefix = f"{user_guid}/{normalized}" if normalized else user_guid
+    response = await provider.delete_folder(
+      StorageDeleteFolderRequest(
+        container_name=container_name,
+        user_guid=user_guid,
+        prefix=prefix,
+      )
+    )
+    for rel, err in response.errors.items():
+      logging.error("[StorageModule] Failed to delete folder entry %s: %s", rel, err)
+    for entry in response.deleted_entries:
+      rel = entry.relative_path
+      if not rel:
+        continue
+      file_path, filename = rel.rsplit("/", 1) if "/" in rel else ("", rel)
+      try:
+        await self.db.delete_storage_cache(user_guid, file_path, filename)
+      except Exception as exc:
+        logging.error(
+          "[StorageModule] Failed to delete cache for %s/%s: %s",
+          file_path or ".",
+          filename,
+          exc,
+        )
     try:
-      async for blob in container.list_blobs(name_starts_with=prefix):
-        try:
-          await container.delete_blob(blob.name)
-        except Exception as e:
-          logging.error("[StorageModule] Failed to delete %s: %s", blob.name, e)
-        parts = blob.name.split("/")
-        if len(parts) < 2:
-          continue
-        file_path = "/".join(parts[1:-1])
-        filename = parts[-1]
-        try:
-          await self.db.delete_storage_cache(user_guid, file_path, filename)
-        except Exception as e:
-          logging.error(
-            "[StorageModule] Failed to delete cache for %s/%s: %s",
-            file_path or '.',
-            filename,
-            e,
-          )
-      await self.db.delete_storage_cache_folder(user_guid, path.lstrip('/'))
-    finally:
-      await container.close()
-      await bsc.close()
+      await self.db.delete_storage_cache_folder(user_guid, normalized)
+    except Exception as exc:
+      logging.error(
+        "[StorageModule] Failed to delete folder cache for %s/%s: %s",
+        user_guid,
+        normalized,
+        exc,
+      )
 
   async def create_user_folder(self, user_guid: str, path: str):
     await self.create_folder(user_guid, path)
 
   async def move_file(self, user_guid: str, src: str, dst: str):
-    if not self.connection_string or not self.db:
-      logging.error("[StorageModule] Missing connection string or database module")
+    if not self.db:
+      logging.error("[StorageModule] Missing database module")
       return
-    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
-    container_name = res.rows[0]["value"] if res.rows else None
+    provider = self._require_provider()
+    if not provider:
+      return
+    container_name = await self._get_container_name()
     if not container_name:
-      logging.error("[StorageModule] AzureBlobContainerName missing")
       return
-    bsc = BlobServiceClient.from_connection_string(self.connection_string)
-    container = bsc.get_container_client(container_name)
-    src_blob_name = f"{user_guid}/{src.lstrip('/')}"
-    dst_blob_name = f"{user_guid}/{dst.lstrip('/')}"
-    src_path, src_filename = src.rsplit('/', 1) if '/' in src else ('', src)
-    dst_path, dst_filename = dst.rsplit('/', 1) if '/' in dst else ('', dst)
-    src_blob = container.get_blob_client(src_blob_name)
-    dst_blob = container.get_blob_client(dst_blob_name)
+    normalized_src = src.lstrip("/")
+    normalized_dst = dst.lstrip("/")
+    result = await provider.move_file(
+      StorageMoveRequest(
+        container_name=container_name,
+        src_blob=f"{user_guid}/{normalized_src}",
+        dst_blob=f"{user_guid}/{normalized_dst}",
+        src_relative=normalized_src,
+        dst_relative=normalized_dst,
+      )
+    )
+    if not result:
+      return
+    src_path, src_filename = normalized_src.rsplit("/", 1) if "/" in normalized_src else ("", normalized_src)
+    dst_path, dst_filename = normalized_dst.rsplit("/", 1) if "/" in normalized_dst else ("", normalized_dst)
     try:
-      props = await src_blob.get_blob_properties()
-      await dst_blob.start_copy_from_url(src_blob.url)
-      await src_blob.delete_blob()
       await self.db.delete_storage_cache(user_guid, src_path, src_filename)
-      ct = None
-      if getattr(props, "content_settings", None):
-        ct = getattr(props.content_settings, "content_type", None)
-      created_on = getattr(props, "creation_time", None) or getattr(props, "created_on", None)
-      modified_on = getattr(props, "last_modified", None)
+    except Exception as exc:
+      logging.error(
+        "[StorageModule] Failed to delete cache for %s/%s: %s",
+        src_path or ".",
+        src_filename,
+        exc,
+      )
+    props = result.properties
+    try:
       await self.db.upsert_storage_cache({
         "user_guid": user_guid,
         "path": dst_path,
         "filename": dst_filename,
-        "content_type": ct or "application/octet-stream",
+        "content_type": props.content_type or "application/octet-stream",
         "public": 0,
-        "created_on": created_on,
-        "modified_on": modified_on,
-        "url": dst_blob.url,
+        "created_on": props.created_on,
+        "modified_on": props.modified_on,
+        "url": result.url,
         "reported": 0,
         "moderation_recid": None,
       })
-    except Exception as e:
-      logging.error("[StorageModule] Failed to move %s to %s: %s", src, dst, e)
-    finally:
-      await container.close()
-      await bsc.close()
+    except Exception as exc:
+      logging.error(
+        "[StorageModule] Failed to update cache for %s/%s: %s",
+        dst_path or ".",
+        dst_filename,
+        exc,
+      )
+
+  async def get_file_link(self, user_guid: str, name: str) -> str:
+    raise NotImplementedError
 
   async def _update_cache_entry(
     self,
-    container: Any,
     user_guid: str,
     old_rel: str,
     new_rel: str,
     cache_entry: dict[str, Any] | None,
-    props: Any,
+    properties: StorageBlobProperties | None,
+    container_url: str | None,
     dest_url: str | None,
   ):
     if not self.db:
@@ -628,34 +694,29 @@ class StorageModule(BaseModule):
     new_path, new_filename = new_rel.rsplit("/", 1) if "/" in new_rel else ("", new_rel)
     try:
       await self.db.delete_storage_cache(user_guid, old_path, old_filename)
-    except Exception as e:
+    except Exception as exc:
       logging.error(
         "[StorageModule] Failed to delete cache for %s/%s: %s",
-        old_path or '.',
+        old_path or ".",
         old_filename,
-        e,
+        exc,
       )
     if cache_entry is None:
       return
     ct = cache_entry.get("content_type") or "application/octet-stream"
-    if props is not None and getattr(props, "content_settings", None):
-      ct = getattr(props.content_settings, "content_type", None) or ct
+    if properties and properties.content_type:
+      ct = properties.content_type or ct
     created_on = cache_entry.get("created_on")
     modified_on = cache_entry.get("modified_on")
-    if props is not None:
-      created_on = (
-        getattr(props, "creation_time", None)
-        or getattr(props, "created_on", None)
-        or created_on
-      )
-      modified_on = getattr(props, "last_modified", None) or modified_on
-    url = dest_url
-    if url is None:
-      existing = cache_entry.get("url")
-      if existing:
-        base = getattr(container, "url", "").rstrip("/")
-        rel = f"{user_guid}/{new_rel}".lstrip("/")
-        url = f"{base}/{rel}" if base else existing
+    if properties:
+      created_on = properties.created_on or created_on
+      modified_on = properties.modified_on or modified_on
+    url = dest_url or cache_entry.get("url")
+    if not url and container_url:
+      rel = f"{user_guid}/{new_rel}".lstrip("/")
+      base = container_url.rstrip("/")
+      if base and rel:
+        url = f"{base}/{rel}"
     try:
       await self.db.upsert_storage_cache({
         "user_guid": user_guid,
@@ -669,159 +730,23 @@ class StorageModule(BaseModule):
         "reported": cache_entry.get("reported", 0),
         "moderation_recid": cache_entry.get("moderation_recid"),
       })
-    except Exception as e:
+    except Exception as exc:
       logging.error(
         "[StorageModule] Failed to update cache for %s/%s: %s",
-        new_path or '.',
+        new_path or ".",
         new_filename,
-        e,
+        exc,
       )
-
-  async def _rename_single_blob(
-    self,
-    container: Any,
-    user_guid: str,
-    old_rel: str,
-    new_rel: str,
-    cache_entry: dict[str, Any] | None,
-    processed: set[str],
-  ):
-    if old_rel == new_rel:
-      return
-    src_name = f"{user_guid}/{old_rel}"
-    dst_name = f"{user_guid}/{new_rel}"
-    src_blob = container.get_blob_client(src_name)
-    dst_blob = container.get_blob_client(dst_name)
-    try:
-      src_exists = await src_blob.exists()
-    except Exception as e:
-      logging.error("[StorageModule] Failed to check blob %s: %s", src_name, e)
-      src_exists = False
-    if not src_exists:
-      if cache_entry is not None:
-        await self._update_cache_entry(container, user_guid, old_rel, new_rel, cache_entry, None, None)
-        processed.add(old_rel)
-      return
-    try:
-      if await dst_blob.exists():
-        logging.error(
-          "[StorageModule] Destination blob already exists for rename %s -> %s",
-          old_rel,
-          new_rel,
-        )
-        return
-    except Exception as e:
-      logging.error("[StorageModule] Failed to check destination blob %s: %s", dst_name, e)
-      return
-    try:
-      props = await src_blob.get_blob_properties()
-      await dst_blob.start_copy_from_url(src_blob.url)
-      await src_blob.delete_blob()
-      await self._update_cache_entry(
-        container,
-        user_guid,
-        old_rel,
-        new_rel,
-        cache_entry,
-        props,
-        dst_blob.url,
-      )
-      if cache_entry is not None:
-        processed.add(old_rel)
-    except Exception as e:
-      logging.error(
-        "[StorageModule] Failed to rename blob %s to %s: %s",
-        old_rel,
-        new_rel,
-        e,
-      )
-
-  async def _rename_folder_contents(
-    self,
-    container: Any,
-    user_guid: str,
-    old_rel: str,
-    new_rel: str,
-    cache_map: dict[str, dict[str, Any]],
-    processed: set[str],
-  ):
-    if new_rel.startswith(f"{old_rel}/"):
-      logging.error(
-        "[StorageModule] Cannot rename folder %s into its own child %s",
-        old_rel,
-        new_rel,
-      )
-      return
-    dst_prefix = f"{user_guid}/{new_rel}"
-    dst_placeholder = container.get_blob_client(dst_prefix)
-    try:
-      if await dst_placeholder.exists():
-        logging.error("[StorageModule] Target folder %s already exists", new_rel)
-        return
-    except Exception as e:
-      logging.error("[StorageModule] Failed to check destination folder %s: %s", dst_prefix, e)
-      return
-    try:
-      async for _ in container.list_blobs(name_starts_with=f"{dst_prefix}/"):
-        logging.error("[StorageModule] Target folder %s already contains blobs", new_rel)
-        return
-    except Exception as e:
-      logging.error("[StorageModule] Failed to inspect destination folder %s: %s", dst_prefix, e)
-      return
-    await self._rename_single_blob(
-      container,
-      user_guid,
-      old_rel,
-      new_rel,
-      cache_map.get(old_rel),
-      processed,
-    )
-    src_prefix = f"{user_guid}/{old_rel}"
-    try:
-      async for blob in container.list_blobs(name_starts_with=f"{src_prefix}/"):
-        rel_name = blob.name[len(f"{user_guid}/"):]
-        if not rel_name:
-          continue
-        suffix = rel_name[len(old_rel):]
-        new_rel_name = f"{new_rel}{suffix}"
-        await self._rename_single_blob(
-          container,
-          user_guid,
-          rel_name,
-          new_rel_name,
-          cache_map.get(rel_name),
-          processed,
-        )
-    except Exception as e:
-      logging.error("[StorageModule] Failed to list blobs for folder %s: %s", old_rel, e)
-    prefix = f"{old_rel}/"
-    for full, entry in cache_map.items():
-      if full == old_rel or full.startswith(prefix):
-        if full in processed:
-          continue
-        new_full = f"{new_rel}{full[len(old_rel):]}"
-        await self._update_cache_entry(
-          container,
-          user_guid,
-          full,
-          new_full,
-          entry,
-          None,
-          None,
-        )
-        processed.add(full)
-
-  async def get_file_link(self, user_guid: str, name: str) -> str:
-    raise NotImplementedError
 
   async def rename_file(self, user_guid: str, old_name: str, new_name: str):
-    if not self.connection_string or not self.db:
-      logging.error("[StorageModule] Missing connection string or database module")
+    if not self.db:
+      logging.error("[StorageModule] Missing database module")
       return
-    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
-    container_name = res.rows[0]["value"] if res.rows else None
+    provider = self._require_provider()
+    if not provider:
+      return
+    container_name = await self._get_container_name()
     if not container_name:
-      logging.error("[StorageModule] AzureBlobContainerName missing")
       return
     old_rel = (old_name or "").strip("/")
     new_rel = (new_name or "").strip("/")
@@ -830,8 +755,6 @@ class StorageModule(BaseModule):
       return
     if old_rel == new_rel:
       return
-    bsc = BlobServiceClient.from_connection_string(self.connection_string)
-    container = bsc.get_container_client(container_name)
     cache_rows = await self.db.list_storage_cache(user_guid)
     cache_map: dict[str, dict[str, Any]] = {}
     for row in cache_rows:
@@ -839,42 +762,60 @@ class StorageModule(BaseModule):
       filename = row.get("filename") or ""
       full = f"{path}/{filename}" if path else filename
       cache_map[full] = row
-    processed: set[str] = set()
+    entry = cache_map.get(old_rel)
+    is_folder = bool(entry and entry.get("content_type") == "path/folder")
+    if not is_folder:
+      prefix = f"{old_rel}/"
+      for key in cache_map.keys():
+        if key.startswith(prefix):
+          is_folder = True
+          break
     try:
-      entry = cache_map.get(old_rel)
-      is_folder = bool(entry and entry.get("content_type") == "path/folder")
-      if not is_folder:
-        src_prefix = f"{user_guid}/{old_rel}"
-        try:
-          async for _ in container.list_blobs(name_starts_with=f"{src_prefix}/"):
-            is_folder = True
-            break
-        except Exception as e:
-          logging.error("[StorageModule] Failed to inspect folder %s: %s", old_rel, e)
-        if not is_folder:
-          try:
-            props = await container.get_blob_client(src_prefix).get_blob_properties()
-            metadata = getattr(props, "metadata", {}) or {}
-            if metadata.get("hdi_isfolder") == "true":
-              is_folder = True
-          except Exception:
-            pass
-      if is_folder:
-        await self._rename_folder_contents(container, user_guid, old_rel, new_rel, cache_map, processed)
-      else:
-        await self._rename_single_blob(
-          container,
-          user_guid,
-          old_rel,
-          new_rel,
-          entry,
-          processed,
+      response = await provider.rename_file(
+        StorageRenameRequest(
+          container_name=container_name,
+          user_guid=user_guid,
+          old_relative=old_rel,
+          new_relative=new_rel,
+          is_folder=is_folder,
         )
-    except Exception as e:
-      logging.error("[StorageModule] Failed to rename %s to %s: %s", old_name, new_name, e)
-    finally:
-      await container.close()
-      await bsc.close()
+      )
+    except Exception as exc:
+      logging.error("[StorageModule] Failed to rename %s to %s: %s", old_name, new_name, exc)
+      return
+    for err in response.errors:
+      logging.error("[StorageModule] Provider rename error: %s", err)
+    processed: set[str] = set()
+    for op in response.operations:
+      cache_entry = cache_map.get(op.old_relative)
+      await self._update_cache_entry(
+        user_guid,
+        op.old_relative,
+        op.new_relative,
+        cache_entry,
+        op.properties if not op.source_missing else None,
+        response.container_url or None,
+        op.url,
+      )
+      if cache_entry is not None:
+        processed.add(op.old_relative)
+    if is_folder:
+      prefix = f"{old_rel}/"
+      for full, cache_entry in cache_map.items():
+        if full == old_rel or full.startswith(prefix):
+          if full in processed:
+            continue
+          new_full = f"{new_rel}{full[len(old_rel):]}" if full != old_rel else new_rel
+          await self._update_cache_entry(
+            user_guid,
+            full,
+            new_full,
+            cache_entry,
+            None,
+            response.container_url or None,
+            None,
+          )
+          processed.add(full)
 
   async def get_file_metadata(self, user_guid: str, name: str):
     raise NotImplementedError
@@ -886,7 +827,8 @@ class StorageModule(BaseModule):
     assert self.db
     db_res = await self.db.run(count_rows_request())
     db_rows = db_res.rows[0]["count"] if db_res.rows else 0
-    if not self.connection_string:
+    provider = self._require_provider()
+    if not provider:
       return {
         "file_count": 0,
         "total_bytes": 0,
@@ -894,8 +836,7 @@ class StorageModule(BaseModule):
         "user_folder_count": 0,
         "db_rows": db_rows,
       }
-    res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
-    container_name = res.rows[0]["value"] if res.rows else None
+    container_name = await self._get_container_name()
     if not container_name:
       return {
         "file_count": 0,
@@ -904,44 +845,23 @@ class StorageModule(BaseModule):
         "user_folder_count": 0,
         "db_rows": db_rows,
       }
-    bsc = BlobServiceClient.from_connection_string(self.connection_string)
-    container = bsc.get_container_client(container_name)
-    file_count = 0
-    total_bytes = 0
-    folders: set[tuple[str, str]] = set()
-    users: set[str] = set()
     try:
-      async for blob in container.list_blobs():
-        name = getattr(blob, "name", "")
-        if not name:
-          continue
-        parts = name.split("/")
-        if len(parts) < 2:
-          continue
-        guid = parts[0]
-        try:
-          UUID(guid)
-        except Exception:
-          continue
-        users.add(guid)
-        parent = ""
-        for folder_name in parts[1:-1]:
-          parent = f"{parent}/{folder_name}" if parent else folder_name
-          folders.add((guid, parent))
-        if parts[-1] == ".init":
-          continue
-        file_count += 1
-        size = getattr(blob, "size", None)
-        if size is None:
-          size = getattr(getattr(blob, "properties", None), "content_length", 0)
-        total_bytes += size or 0
-    finally:
-      await container.close()
-      await bsc.close()
+      stats = await provider.get_storage_stats(
+        StorageStatsRequest(container_name=container_name)
+      )
+    except Exception as exc:
+      logging.error("[StorageModule] Failed to fetch storage stats: %s", exc)
+      return {
+        "file_count": 0,
+        "total_bytes": 0,
+        "folder_count": 0,
+        "user_folder_count": 0,
+        "db_rows": db_rows,
+      }
     return {
-      "file_count": file_count,
-      "total_bytes": total_bytes,
-      "folder_count": len(folders),
-      "user_folder_count": len(users),
+      "file_count": stats.file_count,
+      "total_bytes": stats.total_bytes,
+      "folder_count": len(stats.folder_paths),
+      "user_folder_count": len(stats.user_ids),
       "db_rows": db_rows,
     }

--- a/server/registry/account/profile/__init__.py
+++ b/server/registry/account/profile/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from server.registry.types import DBRequest
 from .model import (
   GuidParams,
+  ProfileRecord,
   SetDisplayParams,
   SetOptInParams,
   SetProfileImageParams,
@@ -27,6 +28,7 @@ __all__ = [
   "update_if_unedited_request",
   "register",
   "GuidParams",
+  "ProfileRecord",
   "SetDisplayParams",
   "SetOptInParams",
   "SetProfileImageParams",

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -8,6 +8,19 @@ from server.modules import BaseModule
 from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.registry.providers.mssql as registry_mssql
 from server.modules.providers import DBResult
+from server.modules.providers.storage import (
+  StorageBlobItem,
+  StorageBlobProperties,
+  StorageCreateFolderResult,
+  StorageDeleteResponse,
+  StorageMoveResult,
+  StorageRenameOperation,
+  StorageRenameResponse,
+  StorageReindexResponse,
+  StorageStats,
+  StorageUploadResult,
+  StorageUploadResponse,
+)
 
 
 class DummyEnv(BaseModule):
@@ -196,46 +209,45 @@ def test_reindex_indexes_files_and_folders(monkeypatch):
   mod.db = app.state.db
   mod.connection_string = "UseDevelopmentStorage=true"
 
-  from types import SimpleNamespace
+  class FakeProvider:
+    async def reindex(self, request):
+      return StorageReindexResponse(
+        container_url="http://blob",
+        blobs=[
+          StorageBlobItem(
+            name="123e4567-e89b-12d3-a456-426614174000/docs/.init",
+            metadata={},
+            content_type="text/plain",
+            created_on=None,
+            modified_on=None,
+            url="http://blob/123e4567-e89b-12d3-a456-426614174000/docs/.init",
+            size=None,
+            is_directory=False,
+          ),
+          StorageBlobItem(
+            name="123e4567-e89b-12d3-a456-426614174000/docs/file.txt",
+            metadata={},
+            content_type="text/plain",
+            created_on=None,
+            modified_on=None,
+            url="http://blob/123e4567-e89b-12d3-a456-426614174000/docs/file.txt",
+            size=None,
+            is_directory=False,
+          ),
+          StorageBlobItem(
+            name="123e4567-e89b-12d3-a456-426614174000/empty_test",
+            metadata={"hdi_isfolder": "true"},
+            content_type="text/plain",
+            created_on=None,
+            modified_on=None,
+            url="http://blob/123e4567-e89b-12d3-a456-426614174000/empty_test",
+            size=None,
+            is_directory=True,
+          ),
+        ],
+      )
 
-  class FakeBlob:
-    def __init__(self, name, metadata=None):
-      self.name = name
-      self.content_settings = SimpleNamespace(content_type = "text/plain")
-      self.creation_time = None
-      self.last_modified = None
-      self.metadata = metadata
-
-  class FakeContainer:
-    def __init__(self, blobs):
-      self.blobs = blobs
-      self.url = "http://blob"
-    def list_blobs(self, name_starts_with=None):
-      async def gen():
-        for b in self.blobs:
-          if not name_starts_with or b.name.startswith(name_starts_with):
-            yield b
-      return gen()
-    async def close(self):
-      pass
-
-  fake_container = FakeContainer([
-    FakeBlob("123e4567-e89b-12d3-a456-426614174000/docs/.init"),
-    FakeBlob("123e4567-e89b-12d3-a456-426614174000/docs/file.txt"),
-    FakeBlob("123e4567-e89b-12d3-a456-426614174000/empty_test", {"hdi_isfolder": "true"}),
-  ])
-
-  class FakeBSC:
-    def get_container_client(self, name):
-      return fake_container
-    async def close(self):
-      pass
-
-  monkeypatch.setattr(
-    storage_module,
-    "BlobServiceClient",
-    SimpleNamespace(from_connection_string=lambda conn: FakeBSC()),
-  )
+  mod.provider = FakeProvider()
 
   asyncio.run(mod.reindex())
   assert any(u["filename"] == "docs" for u in app.state.db.upserts)
@@ -298,44 +310,35 @@ def test_reindex_skips_unknown_users(monkeypatch):
   mod.db = app.state.db
   mod.connection_string = "UseDevelopmentStorage=true"
 
-  from types import SimpleNamespace
+  class FakeProvider:
+    async def reindex(self, request):
+      return StorageReindexResponse(
+        container_url="http://blob",
+        blobs=[
+          StorageBlobItem(
+            name=f"{orphan_guid}/docs/file.txt",
+            metadata={},
+            content_type="text/plain",
+            created_on=None,
+            modified_on=None,
+            url=f"http://blob/{orphan_guid}/docs/file.txt",
+            size=None,
+            is_directory=False,
+          ),
+          StorageBlobItem(
+            name=f"{known_guid}/docs/file.txt",
+            metadata={},
+            content_type="text/plain",
+            created_on=None,
+            modified_on=None,
+            url=f"http://blob/{known_guid}/docs/file.txt",
+            size=None,
+            is_directory=False,
+          ),
+        ],
+      )
 
-  class FakeBlob:
-    def __init__(self, name):
-      self.name = name
-      self.content_settings = SimpleNamespace(content_type = "text/plain")
-      self.creation_time = None
-      self.last_modified = None
-      self.metadata = {}
-
-  class FakeContainer:
-    def __init__(self, blobs):
-      self.blobs = blobs
-      self.url = "http://blob"
-    def list_blobs(self, name_starts_with=None):
-      async def gen():
-        for b in self.blobs:
-          yield b
-      return gen()
-    async def close(self):
-      pass
-
-  fake_container = FakeContainer([
-    FakeBlob(f"{orphan_guid}/docs/file.txt"),
-    FakeBlob(f"{known_guid}/docs/file.txt"),
-  ])
-
-  class FakeBSC:
-    def get_container_client(self, name):
-      return fake_container
-    async def close(self):
-      pass
-
-  monkeypatch.setattr(
-    storage_module,
-    "BlobServiceClient",
-    SimpleNamespace(from_connection_string=lambda conn: FakeBSC()),
-  )
+  mod.provider = FakeProvider()
 
   asyncio.run(mod.reindex())
   assert app.state.db.upserts
@@ -380,57 +383,36 @@ def test_move_file_copies_and_updates_cache(monkeypatch):
   mod.db = db
   mod.connection_string = "UseDevelopmentStorage=true"
 
-  from types import SimpleNamespace
+  class FakeProvider:
+    def __init__(self):
+      self.requests = []
 
-  class FakeBlob:
-    def __init__(self, name):
-      self.name = name
-      self.url = f"http://blob/{name}"
-      self.copied = None
-      self.deleted = False
-      self.content_settings = SimpleNamespace(content_type="text/plain")
-      self.creation_time = "now"
-      self.last_modified = "later"
-    async def get_blob_properties(self):
-      return self
-    async def start_copy_from_url(self, url):
-      self.copied = url
-    async def delete_blob(self):
-      self.deleted = True
+    async def move_file(self, request):
+      self.requests.append(request)
+      return StorageMoveResult(
+        src_relative=request.src_relative,
+        dst_relative=request.dst_relative,
+        url=f"http://blob/{request.dst_blob}",
+        properties=StorageBlobProperties(
+          content_type="text/plain",
+          created_on="now",
+          modified_on="later",
+        ),
+      )
 
-  blobs = {
-    "u1/a.txt": FakeBlob("u1/a.txt"),
-    "u1/docs/b.txt": FakeBlob("u1/docs/b.txt"),
-  }
-
-  class FakeContainer:
-    def get_blob_client(self, name):
-      return blobs[name]
-    async def close(self):
-      pass
-
-  fake_container = FakeContainer()
-
-  class FakeBSC:
-    def get_container_client(self, name):
-      return fake_container
-    async def close(self):
-      pass
-
-  monkeypatch.setattr(
-    storage_module,
-    "BlobServiceClient",
-    SimpleNamespace(from_connection_string=lambda conn: FakeBSC()),
-  )
+  provider = FakeProvider()
+  mod.provider = provider
 
   asyncio.run(mod.move_file("u1", "a.txt", "docs/b.txt"))
-  assert blobs["u1/docs/b.txt"].copied == blobs["u1/a.txt"].url
-  assert blobs["u1/a.txt"].deleted
+  assert provider.requests
+  request = provider.requests[0]
+  assert request.src_blob == "u1/a.txt"
+  assert request.dst_blob == "u1/docs/b.txt"
   assert db.deleted == ("u1", "", "a.txt")
   assert db.upserted["path"] == "docs" and db.upserted["filename"] == "b.txt"
 
 
-def test_rename_file_preserves_public_flag(monkeypatch):
+def test_rename_file_preserves_public_flag():
   class DummyDb(BaseModule):
     def __init__(self, app: FastAPI):
       super().__init__(app)
@@ -483,88 +465,40 @@ def test_rename_file_preserves_public_flag(monkeypatch):
   mod = StorageModule(app)
   mod.db = db
   mod.connection_string = "UseDevelopmentStorage=true"
-
-  from types import SimpleNamespace
-
-  class FakeBlob:
-    def __init__(self, name):
-      self.name = name
-      self.url = f"http://blob/{name}"
-      self.exists_flag = True
-      self.copied = None
-      self.deleted = False
-      self.content_settings = SimpleNamespace(content_type="text/plain")
-      self.creation_time = "now"
-      self.last_modified = "later"
-      self.metadata = {}
-
-    async def exists(self):
-      return self.exists_flag
-
-    async def get_blob_properties(self):
-      return self
-
-    async def start_copy_from_url(self, url):
-      self.exists_flag = True
-      self.copied = url
-
-    async def delete_blob(self):
-      self.deleted = True
-      self.exists_flag = False
-
-  class FakeContainer:
+  class FakeProvider:
     def __init__(self):
-      self.url = "http://blob/container"
-      self.blobs: dict[str, FakeBlob] = {
-        "u1/a.txt": FakeBlob("u1/a.txt"),
-        "u1/b.txt": FakeBlob("u1/b.txt"),
-      }
-      self.blobs["u1/b.txt"].exists_flag = False
+      self.requests = []
 
-    def get_blob_client(self, name):
-      blob = self.blobs.get(name)
-      if blob is None:
-        blob = FakeBlob(name)
-        blob.exists_flag = False
-        self.blobs[name] = blob
-      return blob
+    async def rename_file(self, request):
+      self.requests.append(request)
+      return StorageRenameResponse(
+        container_url="http://blob/container",
+        operations=[
+          StorageRenameOperation(
+            old_relative="a.txt",
+            new_relative="b.txt",
+            url="http://blob/container/u1/b.txt",
+            properties=StorageBlobProperties(
+              content_type="text/plain",
+              created_on="now",
+              modified_on="later",
+            ),
+            source_missing=False,
+          ),
+        ],
+        errors=[],
+      )
 
-    def list_blobs(self, name_starts_with=None):
-      async def gen():
-        for name, blob in list(self.blobs.items()):
-          if not blob.exists_flag:
-            continue
-          if name_starts_with and not name.startswith(name_starts_with):
-            continue
-          yield SimpleNamespace(name=name)
-      return gen()
-
-    async def close(self):
-      pass
-
-  fake_container = FakeContainer()
-
-  class FakeBSC:
-    def get_container_client(self, name):
-      return fake_container
-
-    async def close(self):
-      pass
-
-  monkeypatch.setattr(
-    storage_module,
-    "BlobServiceClient",
-    SimpleNamespace(from_connection_string=lambda conn: FakeBSC()),
-  )
+  provider = FakeProvider()
+  mod.provider = provider
 
   asyncio.run(mod.rename_file("u1", "a.txt", "b.txt"))
-  assert fake_container.blobs["u1/b.txt"].copied == fake_container.blobs["u1/a.txt"].url
-  assert fake_container.blobs["u1/a.txt"].deleted
+  assert provider.requests and not provider.requests[0].is_folder
   assert ("u1", "", "a.txt") in db.deleted
   assert any(item["filename"] == "b.txt" and item["public"] == 1 for item in db.upserted)
 
 
-def test_rename_folder_updates_nested_entries(monkeypatch):
+def test_rename_folder_updates_nested_entries():
   class DummyDb(BaseModule):
     def __init__(self, app: FastAPI):
       super().__init__(app)
@@ -612,89 +546,60 @@ def test_rename_folder_updates_nested_entries(monkeypatch):
   mod = StorageModule(app)
   mod.db = db
   mod.connection_string = "UseDevelopmentStorage=true"
-
-  from types import SimpleNamespace
-
-  class FakeBlob:
-    def __init__(self, name, *, exists=True, metadata=None):
-      self.name = name
-      self.url = f"http://blob/{name}"
-      self.exists_flag = exists
-      self.copied = None
-      self.deleted = False
-      self.content_settings = SimpleNamespace(content_type="text/plain")
-      self.creation_time = "now"
-      self.last_modified = "later"
-      self.metadata = metadata or {}
-
-    async def exists(self):
-      return self.exists_flag
-
-    async def get_blob_properties(self):
-      return self
-
-    async def start_copy_from_url(self, url):
-      self.exists_flag = True
-      self.copied = url
-
-    async def delete_blob(self):
-      self.deleted = True
-      self.exists_flag = False
-
-  class FakeContainer:
+  class FakeProvider:
     def __init__(self):
-      self.url = "http://blob/container"
-      self.blobs: dict[str, FakeBlob] = {
-        "u1/docs": FakeBlob("u1/docs", metadata={"hdi_isfolder": "true"}),
-        "u1/docs/.init": FakeBlob("u1/docs/.init"),
-        "u1/docs/a.txt": FakeBlob("u1/docs/a.txt"),
-        "u1/docs/sub": FakeBlob("u1/docs/sub", metadata={"hdi_isfolder": "true"}),
-        "u1/docs/sub/.init": FakeBlob("u1/docs/sub/.init"),
-        "u1/docs/sub/b.txt": FakeBlob("u1/docs/sub/b.txt"),
-        "u1/renamed": FakeBlob("u1/renamed", exists=False, metadata={"hdi_isfolder": "true"}),
-        "u1/renamed/a.txt": FakeBlob("u1/renamed/a.txt", exists=False),
-        "u1/renamed/sub": FakeBlob("u1/renamed/sub", exists=False, metadata={"hdi_isfolder": "true"}),
-        "u1/renamed/sub/b.txt": FakeBlob("u1/renamed/sub/b.txt", exists=False),
-      }
+      self.requests = []
 
-    def get_blob_client(self, name):
-      blob = self.blobs.get(name)
-      if blob is None:
-        blob = FakeBlob(name, exists=False)
-        self.blobs[name] = blob
-      return blob
+    async def rename_file(self, request):
+      self.requests.append(request)
+      return StorageRenameResponse(
+        container_url="http://blob/container",
+        operations=[
+          StorageRenameOperation(
+            old_relative="docs",
+            new_relative="renamed",
+            url=None,
+            properties=None,
+            source_missing=False,
+          ),
+          StorageRenameOperation(
+            old_relative="docs/a.txt",
+            new_relative="renamed/a.txt",
+            url="http://blob/container/u1/renamed/a.txt",
+            properties=StorageBlobProperties(
+              content_type="text/plain",
+              created_on="now",
+              modified_on="later",
+            ),
+            source_missing=False,
+          ),
+          StorageRenameOperation(
+            old_relative="docs/sub",
+            new_relative="renamed/sub",
+            url=None,
+            properties=None,
+            source_missing=False,
+          ),
+          StorageRenameOperation(
+            old_relative="docs/sub/b.txt",
+            new_relative="renamed/sub/b.txt",
+            url="http://blob/container/u1/renamed/sub/b.txt",
+            properties=StorageBlobProperties(
+              content_type="text/plain",
+              created_on="now",
+              modified_on="later",
+            ),
+            source_missing=False,
+          ),
+        ],
+        errors=[],
+      )
 
-    def list_blobs(self, name_starts_with=None):
-      async def gen():
-        for name, blob in list(self.blobs.items()):
-          if not blob.exists_flag:
-            continue
-          if name_starts_with and not name.startswith(name_starts_with):
-            continue
-          yield SimpleNamespace(name=name)
-      return gen()
-
-    async def close(self):
-      pass
-
-  fake_container = FakeContainer()
-
-  class FakeBSC:
-    def get_container_client(self, name):
-      return fake_container
-
-    async def close(self):
-      pass
-
-  monkeypatch.setattr(
-    storage_module,
-    "BlobServiceClient",
-    SimpleNamespace(from_connection_string=lambda conn: FakeBSC()),
-  )
+  provider = FakeProvider()
+  mod.provider = provider
 
   asyncio.run(mod.rename_file("u1", "docs", "renamed"))
-  assert fake_container.blobs["u1/renamed/a.txt"].copied == fake_container.blobs["u1/docs/a.txt"].url
-  assert fake_container.blobs["u1/docs/a.txt"].deleted
+  assert provider.requests and provider.requests[0].is_folder
   assert any(item["filename"] == "renamed" for item in db.upserted)
   paths = {(item["path"], item["filename"]) for item in db.upserted}
   assert ("", "renamed") in paths
@@ -702,7 +607,7 @@ def test_rename_folder_updates_nested_entries(monkeypatch):
   assert ("renamed", "sub") in paths
   assert ("renamed/sub", "b.txt") in paths
 
-def test_get_storage_stats_counts_all_folders(monkeypatch):
+def test_get_storage_stats_counts_all_folders():
   class DummyDb:
     async def run(self, op, args=None):
       if not isinstance(op, str):
@@ -723,42 +628,19 @@ def test_get_storage_stats_counts_all_folders(monkeypatch):
   mod = StorageModule(app)
   mod.db = DummyDb()
   mod.connection_string = "UseDevelopmentStorage=true"
+  class FakeProvider:
+    async def get_storage_stats(self, request):
+      return StorageStats(
+        file_count=2,
+        total_bytes=3,
+        folder_paths=[
+          ("123e4567-e89b-12d3-a456-426614174000", "docs"),
+          ("123e4567-e89b-12d3-a456-426614174000", "docs/sub"),
+        ],
+        user_ids=["123e4567-e89b-12d3-a456-426614174000"],
+      )
 
-  from types import SimpleNamespace
-
-  class FakeBlob:
-    def __init__(self, name, size):
-      self.name = name
-      self.size = size
-
-  class FakeContainer:
-    def __init__(self, blobs):
-      self.blobs = blobs
-      self.url = "http://blob"
-    def list_blobs(self):
-      async def gen():
-        for b in self.blobs:
-          yield b
-      return gen()
-    async def close(self):
-      pass
-
-  fake_container = FakeContainer([
-    FakeBlob("123e4567-e89b-12d3-a456-426614174000/docs/file1.txt", 1),
-    FakeBlob("123e4567-e89b-12d3-a456-426614174000/docs/sub/file2.txt", 2),
-  ])
-
-  class FakeBSC:
-    def get_container_client(self, name):
-      return fake_container
-    async def close(self):
-      pass
-
-  monkeypatch.setattr(
-    storage_module,
-    "BlobServiceClient",
-    SimpleNamespace(from_connection_string=lambda conn: FakeBSC()),
-  )
+  mod.provider = FakeProvider()
 
   stats = asyncio.run(mod.get_storage_stats())
   assert stats == {
@@ -770,7 +652,7 @@ def test_get_storage_stats_counts_all_folders(monkeypatch):
   }
 
 
-def test_upload_files_sets_created_on(monkeypatch):
+def test_upload_files_sets_created_on():
   app = FastAPI()
   mod = StorageModule(app)
   mod.connection_string = "UseDevelopmentStorage=true"
@@ -799,33 +681,28 @@ def test_upload_files_sets_created_on(monkeypatch):
 
   mod.db = DummyDb()
 
-  class FakeContainer:
+  class FakeProvider:
     def __init__(self):
-      self.uploads = []
-      self.url = "http://blob"
+      self.requests = []
 
-    async def upload_blob(self, name, data, overwrite, content_settings=None):
-      self.uploads.append((name, data, getattr(content_settings, "content_type", None)))
+    async def upload_files(self, request):
+      self.requests.append(request)
+      now = datetime.now(timezone.utc)
+      return StorageUploadResponse(
+        results=[
+          StorageUploadResult(
+            relative_path="docs/a.txt",
+            url="http://blob/u1/docs/a.txt",
+            content_type="text/plain",
+            created_on=now,
+            modified_on=now,
+          )
+        ],
+        errors={},
+      )
 
-    async def close(self):
-      pass
-
-  fake_container = FakeContainer()
-
-  class FakeBSC:
-    def get_container_client(self, name):
-      return fake_container
-
-    async def close(self):
-      pass
-
-  from types import SimpleNamespace
-
-  monkeypatch.setattr(
-    storage_module,
-    "BlobServiceClient",
-    SimpleNamespace(from_connection_string=lambda conn: FakeBSC()),
-  )
+  provider = FakeProvider()
+  mod.provider = provider
 
   files = [{
     "name": "docs/a.txt",
@@ -834,14 +711,12 @@ def test_upload_files_sets_created_on(monkeypatch):
   }]
 
   asyncio.run(mod.upload_files("u1", files))
-
-  assert fake_container.uploads[0][0] == "u1/docs/a.txt"
   created_on = mod.db.upserts[0]["created_on"]
   assert isinstance(created_on, datetime)
   assert created_on.tzinfo == timezone.utc
 
 
-def test_create_folder_creates_marker_and_cache(monkeypatch):
+def test_create_folder_creates_marker_and_cache():
   class DummyDb(BaseModule):
     def __init__(self, app: FastAPI):
       super().__init__(app)
@@ -888,40 +763,25 @@ def test_create_folder_creates_marker_and_cache(monkeypatch):
   mod.env = app.state.env
   mod.db = app.state.db
   mod.connection_string = "UseDevelopmentStorage=true"
-
-  class FakeContainer:
+  class FakeProvider:
     def __init__(self):
-      self.uploads = []
-    async def upload_blob(self, name, data, **kwargs):
-      self.uploads.append((name, kwargs.get("metadata")))
-    async def close(self):
-      pass
+      self.requests = []
 
-  class FakeBSC:
-    def __init__(self):
-      self.container = FakeContainer()
-    def get_container_client(self, name):
-      return self.container
-    async def close(self):
-      pass
+    async def create_folder(self, request):
+      self.requests.append(request)
+      return StorageCreateFolderResult(relative_path="docs/new")
 
-  from types import SimpleNamespace
-  bsc = FakeBSC()
-  monkeypatch.setattr(
-    storage_module,
-    "BlobServiceClient",
-    SimpleNamespace(from_connection_string=lambda conn: bsc),
-  )
+  provider = FakeProvider()
+  mod.provider = provider
 
   asyncio.run(mod.create_folder("u1", "/docs/new"))
-  assert ("u1/docs/new", {"hdi_isfolder": "true"}) in bsc.container.uploads
-  assert ("u1/docs/new/.init", None) in bsc.container.uploads
+  assert provider.requests
   assert app.state.db.upserts[0]["filename"] == "new"
   assert app.state.db.upserts[0]["path"] == "docs"
   assert app.state.db.upserts[0]["content_type"] == "path/folder"
 
 
-def test_get_storage_stats_counts_user_folders(monkeypatch):
+def test_get_storage_stats_counts_user_folders():
   class DummyDb:
     async def run(self, op, args=None):
       if not isinstance(op, str):
@@ -942,45 +802,25 @@ def test_get_storage_stats_counts_user_folders(monkeypatch):
   mod = StorageModule(app)
   mod.db = DummyDb()
   mod.connection_string = "UseDevelopmentStorage=true"
+  class FakeProvider:
+    async def get_storage_stats(self, request):
+      return StorageStats(
+        file_count=3,
+        total_bytes=3,
+        folder_paths=[
+          ("22222222-2222-2222-2222-222222222222", "docs"),
+          ("33333333-3333-3333-3333-333333333333", "docs"),
+          ("33333333-3333-3333-3333-333333333333", "docs/sub"),
+        ],
+        user_ids=[
+          "11111111-1111-1111-1111-111111111111",
+          "22222222-2222-2222-2222-222222222222",
+          "33333333-3333-3333-3333-333333333333",
+          "44444444-4444-4444-4444-444444444444",
+        ],
+      )
 
-  class FakeBlob:
-    def __init__(self, name, size=0):
-      self.name = name
-      self.size = size
-
-  blobs = [
-    FakeBlob("11111111-1111-1111-1111-111111111111/file.txt", 1),
-    FakeBlob("22222222-2222-2222-2222-222222222222/docs/a.txt", 1),
-    FakeBlob("33333333-3333-3333-3333-333333333333/docs/sub/b.txt", 1),
-    FakeBlob("44444444-4444-4444-4444-444444444444/.init", 0),
-    FakeBlob("notguid/skip.txt", 1),
-  ]
-
-  class FakeContainer:
-    def __init__(self):
-      self.url = "http://blob"
-    def list_blobs(self):
-      async def gen():
-        for b in blobs:
-          yield b
-      return gen()
-    async def close(self):
-      pass
-
-  class FakeBSC:
-    def __init__(self):
-      self.container = FakeContainer()
-    def get_container_client(self, name):
-      return self.container
-    async def close(self):
-      pass
-
-  from types import SimpleNamespace
-  monkeypatch.setattr(
-    storage_module,
-    "BlobServiceClient",
-    SimpleNamespace(from_connection_string=lambda conn: FakeBSC()),
-  )
+  mod.provider = FakeProvider()
 
   stats = asyncio.run(mod.get_storage_stats())
   assert stats == {


### PR DESCRIPTION
## Summary
- add storage provider interfaces and Azure Blob implementation
- refactor `StorageModule` to delegate blob operations to the provider and reuse shared helpers
- adjust tests and registry exports to work with the provider-backed design

## Testing
- pytest tests/test_storage_module.py

------
https://chatgpt.com/codex/tasks/task_e_68fcf70306b88325b1ddc8895b20371b