### PR TITLE
Replace DBResult alias with DBResponse

### DIFF
--- a/server/modules/providers/__init__.py
+++ b/server/modules/providers/__init__.py
@@ -11,7 +11,7 @@ from fastapi import HTTPException, status
 from jose import jwt
 import logging
 
-from server.registry.types import DBRequest, DBResponse, DBResult
+from server.registry.types import DBRequest, DBResponse
 
 __all__ = [
   "AuthProvider",
@@ -21,7 +21,6 @@ __all__ = [
   "DbProviderBase",
   "DBRequest",
   "DBResponse",
-  "DBResult",
 ]
 
 class BaseProvider(ABC):

--- a/server/modules/providers/database/mssql_provider/db_helpers.py
+++ b/server/modules/providers/database/mssql_provider/db_helpers.py
@@ -1,12 +1,12 @@
 import json, logging
 from typing import Any, Iterable, AsyncIterator
 from . import logic
-from ... import DBResult
+from ... import DBResponse
 
 def _rowdict(cols: Iterable[str], row: Iterable[Any]):
   return dict(zip(cols, row))
 
-async def fetch_rows(query: str, params: tuple[Any, ...] = (), *, one: bool = False, stream: bool = False) -> DBResult | AsyncIterator[dict]:
+async def fetch_rows(query: str, params: tuple[Any, ...] = (), *, one: bool = False, stream: bool = False) -> DBResponse | AsyncIterator[dict]:
   assert logic._pool, "MSSQL pool not initialized"
   async def _ensure_result_set(cur) -> bool:
     if cur.description is not None:
@@ -37,21 +37,21 @@ async def fetch_rows(query: str, params: tuple[Any, ...] = (), *, one: bool = Fa
       async with conn.cursor() as cur:
         await cur.execute(query, params)
         if not await _ensure_result_set(cur):
-          return DBResult()
+          return DBResponse()
         cols = [c[0] for c in cur.description]
         if one:
           row = await cur.fetchone()
           if not row:
-            return DBResult()
-          return DBResult(rows=[_rowdict(cols, row)], rowcount=1)
+            return DBResponse()
+          return DBResponse(rows=[_rowdict(cols, row)], rowcount=1)
         rows_raw = await cur.fetchall()
         rows = [_rowdict(cols, r) for r in rows_raw]
-        return DBResult(rows=rows, rowcount=len(rows))
+        return DBResponse(rows=rows, rowcount=len(rows))
   except Exception as e:
     logging.debug(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
-    return DBResult()
+    return DBResponse()
 
-async def fetch_json(query: str, params: tuple[Any, ...] = (), *, many: bool = False) -> DBResult:
+async def fetch_json(query: str, params: tuple[Any, ...] = (), *, many: bool = False) -> DBResponse:
   assert logic._pool, "MSSQL pool not initialized"
   try:
     async with logic._pool.acquire() as conn:
@@ -64,22 +64,22 @@ async def fetch_json(query: str, params: tuple[Any, ...] = (), *, many: bool = F
             break
           parts.append(row[0])
         if not parts:
-          return DBResult()
+          return DBResponse()
         data = json.loads("".join(parts))
         if many and isinstance(data, list):
-          return DBResult(rows=data, rowcount=len(data))
-        return DBResult(rows=[data], rowcount=1)
+          return DBResponse(rows=data, rowcount=len(data))
+        return DBResponse(rows=[data], rowcount=1)
   except Exception as e:
     logging.error(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")
     raise
 
-async def exec_query(query: str, params: tuple[Any, ...] = ()) -> DBResult:
+async def exec_query(query: str, params: tuple[Any, ...] = ()) -> DBResponse:
   assert logic._pool, "MSSQL pool not initialized"
   try:
     async with logic._pool.acquire() as conn:
       async with conn.cursor() as cur:
         await cur.execute(query, params)
-        return DBResult(rowcount=cur.rowcount or 0)
+        return DBResponse(rowcount=cur.rowcount or 0)
   except Exception as e:
     logging.error(f"Exec failed:\n{query}\nArgs: {params}\nError: {e}")
     raise

--- a/server/registry/models.py
+++ b/server/registry/models.py
@@ -1,8 +1,7 @@
 """Database registry models.
 
-These mirror the RPC request/response shapes while retaining backward
-compatibility with the existing ``DBResult`` helpers.  Requests carry an
-``op`` name and an arbitrary ``payload`` dictionary.  Responses standardize
+These mirror the RPC request/response shapes.  Requests carry an ``op``
+name and an arbitrary ``payload`` dictionary.  Responses standardize
 ``op``/``payload`` and expose ``rows``/``rowcount`` aliases for existing
 callers.
 """
@@ -11,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterator, Mapping, Sequence
 
-__all__ = ["DBRequest", "DBResponse", "DBResult"]
+__all__ = ["DBRequest", "DBResponse"]
 
 
 class DBRequest:
@@ -103,7 +102,3 @@ class DBResponse:
   # Backwards compatibility for helper usage expecting dict unpacking
   def __iter__(self) -> Iterator[tuple[str, Any]]:  # type: ignore[override]
     yield from {"rows": self.rows, "rowcount": self.rowcount}.items()
-
-
-# Historical name kept for downstream imports/tests.
-DBResult = DBResponse

--- a/server/registry/types.py
+++ b/server/registry/types.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from .models import DBRequest, DBResponse, DBResult
+from .models import DBRequest, DBResponse
 
-__all__ = ["DBRequest", "DBResponse", "DBResult"]
+__all__ = ["DBRequest", "DBResponse"]

--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from server.modules.providers import DBResult
+from server.modules.providers import DBResponse
 from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.registry.providers.mssql as registry_mssql
 
@@ -19,7 +19,7 @@ def test_assistant_conversations_list_by_time(monkeypatch):
     assert "FOR JSON PATH" in sql
     assert "INCLUDE_NULL_VALUES" in sql
     assert params == (personas_recid, start, end)
-    return DBResult(rows=[{"recid": 1}], rowcount=1)
+    return DBResponse(rows=[{"recid": 1}], rowcount=1)
 
   monkeypatch.setattr(registry_mssql, 'fetch_json', fake_fetch_json)
 
@@ -27,7 +27,7 @@ def test_assistant_conversations_list_by_time(monkeypatch):
     'db:system:conversations:list_by_time:1',
     {'personas_recid': personas_recid, 'start': start, 'end': end},
   ))
-  assert isinstance(res, DBResult)
+  assert isinstance(res, DBResponse)
   assert res.rows == [{"recid": 1}]
 
 
@@ -49,7 +49,7 @@ def test_assistant_conversations_insert(monkeypatch):
     assert "INSERT INTO assistant_conversations" in sql
     assert "FOR JSON PATH" in sql
     assert params == (1, 2, '1', '2', '3', 'hi', '', 5)
-    return DBResult(rows=[{'recid': 9}], rowcount=1)
+    return DBResponse(rows=[{'recid': 9}], rowcount=1)
 
   monkeypatch.setattr(registry_mssql, 'fetch_json', fake_fetch_json)
 
@@ -75,7 +75,7 @@ def test_assistant_conversations_find_recent(monkeypatch):
     assert "DATEADD" in sql
     assert "FOR JSON PATH" in sql
     assert params == (1, 2, 'hi', '1', '1', '2', '2', '3', '3', 120)
-    return DBResult(rows=[{'recid': 5}], rowcount=1)
+    return DBResponse(rows=[{'recid': 5}], rowcount=1)
 
   monkeypatch.setattr(registry_mssql, 'fetch_json', fake_fetch_json)
 
@@ -91,7 +91,7 @@ def test_assistant_conversations_update_output(monkeypatch):
     assert "element_modified_on" not in sql
     assert "element_tokens" in sql
     assert params == ('out', 12, 9)
-    return DBResult(rowcount=1)
+    return DBResponse(rowcount=1)
 
   monkeypatch.setattr(registry_mssql, 'exec_query', fake_exec)
 
@@ -110,11 +110,11 @@ def test_assistant_conversations_list_recent(monkeypatch):
     assert "FOR JSON PATH" in sql
     assert "INCLUDE_NULL_VALUES" in sql
     assert params == ()
-    return DBResult(rows=[{"recid": 2}], rowcount=1)
+    return DBResponse(rows=[{"recid": 2}], rowcount=1)
 
   monkeypatch.setattr(registry_mssql, 'fetch_json', fake_fetch_json)
 
   res = asyncio.run(provider.run('db:system:conversations:list_recent:1', {}))
-  assert isinstance(res, DBResult)
+  assert isinstance(res, DBResponse)
   assert res.rows == [{"recid": 2}]
 

--- a/tests/test_db_module_api_ids.py
+++ b/tests/test_db_module_api_ids.py
@@ -2,7 +2,7 @@ import asyncio
 from fastapi import FastAPI
 
 from server.modules.db_module import DbModule
-from server.modules.providers import DBResult
+from server.modules.providers import DBResponse
 from server.registry.models import DBRequest
 
 
@@ -14,7 +14,7 @@ def test_get_google_client_id():
     assert isinstance(request, DBRequest)
     assert request.op == "db:system:config:get_config:1"
     assert request.payload == {"key": "GoogleClientId"}
-    return DBResult(rows=[{"value": "gid"}], rowcount=1)
+    return DBResponse(rows=[{"value": "gid"}], rowcount=1)
 
   db.run = fake_run
   assert asyncio.run(db.get_google_client_id()) == "gid"
@@ -41,7 +41,7 @@ def test_get_discord_client_id():
     assert isinstance(request, DBRequest)
     assert request.op == "db:system:config:get_config:1"
     assert request.payload == {"key": "DiscordClientId"}
-    return DBResult(rows=[{"value": "dcid"}], rowcount=1)
+    return DBResponse(rows=[{"value": "dcid"}], rowcount=1)
 
   db.run = fake_run
   assert asyncio.run(db.get_discord_client_id()) == "dcid"
@@ -55,7 +55,7 @@ def test_get_ms_api_id():
     assert isinstance(request, DBRequest)
     assert request.op == "db:system:config:get_config:1"
     assert request.payload == {"key": "MsApiId"}
-    return DBResult(rows=[{"value": "mid"}], rowcount=1)
+    return DBResponse(rows=[{"value": "mid"}], rowcount=1)
 
   db.run = fake_run
   assert asyncio.run(db.get_ms_api_id()) == "mid"
@@ -69,7 +69,7 @@ def test_get_auth_providers():
     assert isinstance(request, DBRequest)
     assert request.op == "db:system:config:get_config:1"
     assert request.payload == {"key": "AuthProviders"}
-    return DBResult(rows=[{"value": "microsoft,google,discord"}], rowcount=1)
+    return DBResponse(rows=[{"value": "microsoft,google,discord"}], rowcount=1)
 
   db.run = fake_run
   assert asyncio.run(db.get_auth_providers()) == ["microsoft", "google", "discord"]
@@ -83,7 +83,7 @@ def test_get_jwks_cache_time():
     assert isinstance(request, DBRequest)
     assert request.op == "db:system:config:get_config:1"
     assert request.payload == {"key": "JwksCacheTime"}
-    return DBResult(rows=[{"value": "45"}], rowcount=1)
+    return DBResponse(rows=[{"value": "45"}], rowcount=1)
 
   db.run = fake_run
   assert asyncio.run(db.get_jwks_cache_time()) == 45

--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.modules.providers.database.mssql_provider as mssql_provider
-from server.modules.providers import DBResult
+from server.modules.providers import DBResponse
 from server.registry.account.files import mssql as users_files_mssql
 
 
@@ -15,14 +15,14 @@ def test_run_returns_dbresult_from_async_handler(monkeypatch):
 
     async def handler(args):
       assert args == {}
-      return DBResult(rows=[{"v": 1}], rowcount=1)
+      return DBResponse(rows=[{"v": 1}], rowcount=1)
 
     return handler
 
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
 
   res = asyncio.run(provider.run("db:account:test:json_one:1", {}))
-  assert isinstance(res, DBResult)
+  assert isinstance(res, DBResponse)
   assert res.rows == [{"v": 1}]
   assert res.rowcount == 1
 
@@ -35,14 +35,14 @@ def test_run_returns_dbresult_from_sync_handler(monkeypatch):
 
     def handler(args):
       assert args == {}
-      return DBResult(rows=[{"v": 1}], rowcount=1)
+      return DBResponse(rows=[{"v": 1}], rowcount=1)
 
     return handler
 
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
 
   res = asyncio.run(provider.run("db:account:test:row_one:1", {}))
-  assert isinstance(res, DBResult)
+  assert isinstance(res, DBResponse)
   assert res.rows == [{"v": 1}]
   assert res.rowcount == 1
 
@@ -53,7 +53,7 @@ def test_run_row_many(monkeypatch):
 
   async def fake_handler(payload):
     assert payload == {"guid": guid}
-    return DBResult(rows=[{"path": "a"}, {"path": "b"}], rowcount=2)
+    return DBResponse(rows=[{"path": "a"}, {"path": "b"}], rowcount=2)
 
   def fake_get_handler(op):
     assert op == "db:system:public_users:get_published_files:1"
@@ -64,7 +64,7 @@ def test_run_row_many(monkeypatch):
   res = asyncio.run(
     provider.run("db:system:public_users:get_published_files:1", {"guid": guid})
   )
-  assert isinstance(res, DBResult)
+  assert isinstance(res, DBResponse)
   assert res.rows == [{"path": "a"}, {"path": "b"}]
   assert res.rowcount == 2
 
@@ -84,7 +84,7 @@ def test_run_normalizes_dict_response(monkeypatch):
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
 
   res = asyncio.run(provider.run("db:account:test:json_many:1", {}))
-  assert isinstance(res, DBResult)
+  assert isinstance(res, DBResponse)
   assert res.rows == [{"v": 1}, {"v": 2}]
   assert res.rowcount == 2
 
@@ -104,7 +104,7 @@ def test_run_returns_empty_response_for_none(monkeypatch):
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
 
   res = asyncio.run(provider.run("db:account:test:exec:1", {}))
-  assert isinstance(res, DBResult)
+  assert isinstance(res, DBResponse)
   assert res.rows == []
   assert res.rowcount == 0
 
@@ -117,12 +117,12 @@ def test_storage_files_set_gallery(monkeypatch):
   async def fake_run_exec(sql, params):
     assert "UPDATE users_storage_cache" in sql
     assert params == (1, expected_guid, "", "file.txt")
-    return DBResult(rowcount=1)
+    return DBResponse(rowcount=1)
 
   monkeypatch.setattr(users_files_mssql, "run_exec", fake_run_exec)
 
   res = asyncio.run(
     provider.run("db:account:files:set_gallery:1", {"user_guid": guid, "name": "file.txt", "gallery": True})
   )
-  assert isinstance(res, DBResult)
+  assert isinstance(res, DBResponse)
   assert res.rowcount == 1

--- a/tests/test_openai_module.py
+++ b/tests/test_openai_module.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi import FastAPI
 
 from server.modules.openai_module import OpenaiModule, SummaryQueue
-from server.modules.providers import DBResult
+from server.modules.providers import DBResponse
 
 
 def test_fetch_chat_message_order_and_return():
@@ -106,7 +106,7 @@ def test_fetch_chat_logs_conversation():
         args = {}
       self.calls.append((op, args))
       if op == "db:system:personas:get_by_name:1":
-        return DBResult(
+        return DBResponse(
           rows=[
             {
               "recid": 1,
@@ -124,7 +124,7 @@ def test_fetch_chat_logs_conversation():
         assert args["channel_id"] == "2"
         assert args["user_id"] == "3"
         assert args["input_data"] == "hello"
-        return DBResult(rows=[], rowcount=0)
+        return DBResponse(rows=[], rowcount=0)
       if op == "db:system:conversations:insert:1":
         assert args["personas_recid"] == 1
         assert args["models_recid"] == 2
@@ -133,11 +133,11 @@ def test_fetch_chat_logs_conversation():
         assert args["user_id"] == "3"
         assert args["input_data"] == "hello"
         assert args["tokens"] == 7
-        return DBResult(rows=[{"recid": 99}], rowcount=1)
+        return DBResponse(rows=[{"recid": 99}], rowcount=1)
       if op == "db:system:conversations:update_output:1":
         assert args == {"recid": 99, "output_data": "hi", "tokens": 42}
-        return DBResult(rowcount=1)
-      return DBResult()
+        return DBResponse(rowcount=1)
+      return DBResponse()
 
   module.db = DummyDB()
 
@@ -180,7 +180,7 @@ def test_log_conversation_end_warns_when_no_rows_updated(caplog):
         args = {}
       assert op == "db:system:conversations:update_output:1"
       assert args == {"recid": 99, "output_data": "done", "tokens": 3}
-      return DBResult(rowcount=0)
+      return DBResponse(rowcount=0)
 
   module.db = DummyDB()
 
@@ -203,7 +203,7 @@ def test_get_recent_persona_conversation_history_returns_ordered_messages():
         args = {}
       assert op == "db:system:conversations:list_by_time:1"
       assert args["personas_recid"] == 7
-      return DBResult(
+      return DBResponse(
         rows=[
           {
             "element_created_on": "2024-05-01T12:00:00Z",
@@ -266,7 +266,7 @@ def test_fetch_chat_reuses_existing_conversation():
         args = {}
       self.calls.append((op, args))
       if op == "db:system:personas:get_by_name:1":
-        return DBResult(
+        return DBResponse(
           rows=[
             {
               "recid": 7,
@@ -279,14 +279,14 @@ def test_fetch_chat_reuses_existing_conversation():
         )
       if op == "db:system:conversations:find_recent:1":
         if self.insert_count:
-          return DBResult(rows=[{"recid": 555}], rowcount=1)
-        return DBResult(rows=[], rowcount=0)
+          return DBResponse(rows=[{"recid": 555}], rowcount=1)
+        return DBResponse(rows=[], rowcount=0)
       if op == "db:system:conversations:insert:1":
         self.insert_count += 1
-        return DBResult(rows=[{"recid": 555}], rowcount=1)
+        return DBResponse(rows=[{"recid": 555}], rowcount=1)
       if op == "db:system:conversations:update_output:1":
-        return DBResult(rowcount=1)
-      return DBResult()
+        return DBResponse(rowcount=1)
+      return DBResponse()
 
   module.db = DummyDB()
 
@@ -347,7 +347,7 @@ def test_persona_response_calls_openai():
         args = {}
       self.calls.append((op, args))
       if op == "db:system:personas:get_by_name:1":
-        return DBResult(
+        return DBResponse(
           rows=[{
             "recid": 1,
             "name": "Stark",
@@ -360,7 +360,7 @@ def test_persona_response_calls_openai():
         )
       if op == "db:system:conversations:find_recent:1":
         assert args["input_data"] == "Tell me"
-        return DBResult(rows=[], rowcount=0)
+        return DBResponse(rows=[], rowcount=0)
       if op == "db:system:conversations:insert:1":
         assert args["personas_recid"] == 1
         assert args["models_recid"] == 2
@@ -369,11 +369,11 @@ def test_persona_response_calls_openai():
         assert args["user_id"] == "3"
         assert args["input_data"] == "Tell me"
         assert args["tokens"] is None
-        return DBResult(rows=[{"recid": 77}], rowcount=1)
+        return DBResponse(rows=[{"recid": 77}], rowcount=1)
       if op == "db:system:conversations:update_output:1":
         assert args == {"recid": 77, "output_data": "Response", "tokens": 11}
-        return DBResult(rowcount=1)
-      return DBResult()
+        return DBResponse(rowcount=1)
+      return DBResponse()
 
   module.db = DummyDB()
 
@@ -419,8 +419,8 @@ def test_persona_response_missing_persona():
       elif args is None:
         args = {}
       if op == "db:system:personas:get_by_name:1":
-        return DBResult(rows=[], rowcount=0)
-      return DBResult()
+        return DBResponse(rows=[], rowcount=0)
+      return DBResponse()
 
   module.db = DummyDB()
   module.client = SimpleNamespace(chat=SimpleNamespace(completions=None))
@@ -441,7 +441,7 @@ def test_persona_response_stub_without_client():
       elif args is None:
         args = {}
       if op == "db:system:personas:get_by_name:1":
-        return DBResult(
+        return DBResponse(
           rows=[{
             "recid": 1,
             "name": "stark",
@@ -452,7 +452,7 @@ def test_persona_response_stub_without_client():
           }],
           rowcount=1,
         )
-      return DBResult()
+      return DBResponse()
 
   module.db = DummyDB()
   module.client = None

--- a/tests/test_storage_module.py
+++ b/tests/test_storage_module.py
@@ -7,7 +7,7 @@ import server.modules.storage_module as storage_module
 from server.modules import BaseModule
 from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.registry.providers.mssql as registry_mssql
-from server.modules.providers import DBResult
+from server.modules.providers import DBResponse
 from server.modules.providers.storage import (
   StorageBlobItem,
   StorageBlobProperties,
@@ -95,7 +95,7 @@ def test_list_public_files(monkeypatch):
 
   async def fake_fetch_json(sql, params, *, many=False):
     assert many
-    return DBResult(rows=[
+    return DBResponse(rows=[
       {"user_guid": "u1", "display_name": "U1", "path": "", "name": "a.txt", "url": "u/a.txt", "content_type": "text/plain"},
       {"user_guid": "u2", "display_name": "U2", "path": "", "name": "b.txt", "url": "u/b.txt", "content_type": "text/plain"},
     ], rowcount=2)


### PR DESCRIPTION
## Summary
- remove the legacy `DBResult` export from the registry models/types
- adjust provider helpers to construct `DBResponse` objects directly
- update database-related tests to depend on `DBResponse`

## Testing
- pytest *(fails: OAuth client configuration missing in auth test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68fd206e10688325b071eff9c6be6132