### PR TITLE
Require DBRequest payload argument

### DIFF
--- a/server/registry/account/accounts/__init__.py
+++ b/server/registry/account/accounts/__init__.py
@@ -35,13 +35,13 @@ def get_security_profile_request(
     params["provider_identifier"] = provider_identifier
   if discord_id is not None:
     params["discord_id"] = discord_id
-  return DBRequest(op="db:account:accounts:get_security_profile:1", params=params)
+  return DBRequest(op="db:account:accounts:get_security_profile:1", payload=params)
 
 
 def account_exists_request(user_guid: str) -> DBRequest:
   return DBRequest(
     op="db:account:accounts:exists:1",
-    params={"user_guid": user_guid},
+    payload={"user_guid": user_guid},
   )
 
 

--- a/server/registry/account/actions/__init__.py
+++ b/server/registry/account/actions/__init__.py
@@ -45,7 +45,7 @@ def list_user_actions_request(
     params["action_recid"] = action_recid
   if limit is not None:
     params["limit"] = limit
-  return DBRequest(op=_op("list_by_user"), params=params)
+  return DBRequest(op=_op("list_by_user"), payload=params)
 
 
 def log_user_action_request(
@@ -65,7 +65,7 @@ def log_user_action_request(
     params["element_url"] = element_url
   if element_notes is not None:
     params["element_notes"] = element_notes
-  return DBRequest(op=_op("log"), params=params)
+  return DBRequest(op=_op("log"), payload=params)
 
 
 def update_user_action_request(
@@ -79,7 +79,7 @@ def update_user_action_request(
     params["element_url"] = element_url
   if element_notes is not None:
     params["element_notes"] = element_notes
-  return DBRequest(op=_op("update"), params=params)
+  return DBRequest(op=_op("update"), payload=params)
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/account/cache/__init__.py
+++ b/server/registry/account/cache/__init__.py
@@ -66,18 +66,18 @@ def list_cache_request(params: ListCacheParams) -> DBRequest:
   from server.registry.types import DBRequest
   return DBRequest(
     op="db:account:cache:list:1",
-    params=params.model_dump(),
+    payload=params.model_dump(),
   )
 
 
 def list_public_request():
   from server.registry.types import DBRequest
-  return DBRequest(op="db:account:cache:list_public:1", params={})
+  return DBRequest(op="db:account:cache:list_public:1", payload={})
 
 
 def list_reported_request():
   from server.registry.types import DBRequest
-  return DBRequest(op="db:account:cache:list_reported:1", params={})
+  return DBRequest(op="db:account:cache:list_reported:1", payload={})
 
 
 def replace_user_cache_request(params: ReplaceUserCacheParams) -> DBRequest:
@@ -85,7 +85,7 @@ def replace_user_cache_request(params: ReplaceUserCacheParams) -> DBRequest:
   normalized_items = [item.model_dump() for item in params.items]
   payload = params.model_dump()
   payload["items"] = normalized_items
-  return DBRequest(op="db:account:cache:replace_user:1", params=payload)
+  return DBRequest(op="db:account:cache:replace_user:1", payload=payload)
 
 
 def upsert_cache_item_request(item: UpsertCacheItemParams | Dict[str, Any]):
@@ -94,36 +94,36 @@ def upsert_cache_item_request(item: UpsertCacheItemParams | Dict[str, Any]):
     normalized = item.model_dump()
   else:
     normalized = _normalize_cache_item_payload(item)
-  return DBRequest(op="db:account:cache:upsert:1", params=normalized)
+  return DBRequest(op="db:account:cache:upsert:1", payload=normalized)
 
 
 def delete_cache_item_request(params: CacheItemKey) -> DBRequest:
   from server.registry.types import DBRequest
-  return DBRequest(op="db:account:cache:delete:1", params=params.model_dump())
+  return DBRequest(op="db:account:cache:delete:1", payload=params.model_dump())
 
 
 def delete_cache_folder_request(params: DeleteCacheFolderParams) -> DBRequest:
   from server.registry.types import DBRequest
-  return DBRequest(op="db:account:cache:delete_folder:1", params=params.model_dump())
+  return DBRequest(op="db:account:cache:delete_folder:1", payload=params.model_dump())
 
 
 def set_public_request(params: SetPublicParams) -> DBRequest:
   from server.registry.types import DBRequest
   payload = params.model_dump(exclude_none=True)
   payload["public"] = 1 if params.public else 0
-  return DBRequest(op="db:account:cache:set_public:1", params=payload)
+  return DBRequest(op="db:account:cache:set_public:1", payload=payload)
 
 
 def set_reported_request(params: SetReportedParams) -> DBRequest:
   from server.registry.types import DBRequest
   payload = params.model_dump()
   payload["reported"] = 1 if params.reported else 0
-  return DBRequest(op="db:account:cache:set_reported:1", params=payload)
+  return DBRequest(op="db:account:cache:set_reported:1", payload=payload)
 
 
 def count_rows_request():
   from server.registry.types import DBRequest
-  return DBRequest(op="db:account:cache:count_rows:1", params={})
+  return DBRequest(op="db:account:cache:count_rows:1", payload={})
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/account/enablements/__init__.py
+++ b/server/registry/account/enablements/__init__.py
@@ -31,7 +31,7 @@ def _op(name: str) -> str:
 
 def get_user_enablements_request(*, users_guid: str) -> DBRequest:
   params: dict[str, Any] = {"users_guid": users_guid}
-  return DBRequest(op=_op("get_by_user"), params=params)
+  return DBRequest(op=_op("get_by_user"), payload=params)
 
 
 def upsert_user_enablements_request(
@@ -43,7 +43,7 @@ def upsert_user_enablements_request(
     "users_guid": users_guid,
     "element_enablements": element_enablements,
   }
-  return DBRequest(op=_op("upsert"), params=params)
+  return DBRequest(op=_op("upsert"), payload=params)
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/account/files/__init__.py
+++ b/server/registry/account/files/__init__.py
@@ -18,7 +18,7 @@ __all__ = [
 def set_gallery_request(user_guid: str, name: str, gallery: bool) -> DBRequest:
   return DBRequest(
     op="db:account:files:set_gallery:1",
-    params={
+    payload={
       "user_guid": user_guid,
       "name": name,
       "gallery": bool(gallery),

--- a/server/registry/account/oauth/__init__.py
+++ b/server/registry/account/oauth/__init__.py
@@ -18,7 +18,7 @@ __all__ = [
 
 
 def _relink_request(name: str, params: dict[str, Any]) -> DBRequest:
-  return DBRequest(op=f"db:account:oauth:{name}:1", params=params)
+  return DBRequest(op=f"db:account:oauth:{name}:1", payload=params)
 
 
 def _common_params(

--- a/server/registry/account/profile/__init__.py
+++ b/server/registry/account/profile/__init__.py
@@ -38,7 +38,7 @@ __all__ = [
 
 
 def _request(name: str, params: dict[str, object]) -> DBRequest:
-  return DBRequest(op=f"db:account:profile:{name}:1", params=params)
+  return DBRequest(op=f"db:account:profile:{name}:1", payload=params)
 
 
 def get_profile_request(params: GuidParams) -> DBRequest:

--- a/server/registry/account/providers/__init__.py
+++ b/server/registry/account/providers/__init__.py
@@ -42,7 +42,7 @@ __all__ = [
 
 
 def _request(op: str, params: dict[str, object]) -> DBRequest:
-  return DBRequest(op=op, params=params)
+  return DBRequest(op=op, payload=params)
 
 
 def create_from_provider_request(params: CreateFromProviderParams) -> DBRequest:

--- a/server/registry/account/public/__init__.py
+++ b/server/registry/account/public/__init__.py
@@ -18,7 +18,7 @@ __all__ = [
 
 
 def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
-  return DBRequest(op=op, params=params or {})
+  return DBRequest(op=op, payload=params or {})
 
 
 def list_public_request() -> DBRequest:

--- a/server/registry/account/session/__init__.py
+++ b/server/registry/account/session/__init__.py
@@ -45,7 +45,7 @@ __all__ = [
 
 
 def _request(name: str, params: dict[str, object]) -> DBRequest:
-  return DBRequest(op=f"db:account:session:{name}:1", params=params)
+  return DBRequest(op=f"db:account:session:{name}:1", payload=params)
 
 
 def list_session_snapshots_request(params: ListSessionSnapshotsParams) -> DBRequest:

--- a/server/registry/finance/credits/__init__.py
+++ b/server/registry/finance/credits/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
 def _request(name: str, params: SetCreditsParams) -> DBRequest:
   return DBRequest(
     op=f"db:finance:credits:{name}:1",
-    params=params.model_dump(),
+    payload=params.model_dump(),
   )
 
 

--- a/server/registry/models.py
+++ b/server/registry/models.py
@@ -1,7 +1,7 @@
 """Database registry models.
 
 These mirror the RPC request/response shapes.  Requests carry an ``op``
-name and an arbitrary ``payload`` dictionary.  Responses standardize
+name and a required ``payload`` dictionary.  Responses standardize
 ``op``/``payload`` and expose ``rows``/``rowcount`` aliases for existing
 callers.
 """
@@ -22,23 +22,13 @@ class DBRequest:
     self,
     *,
     op: str,
-    payload: Mapping[str, Any] | None = None,
-    params: Mapping[str, Any] | None = None,
+    payload: Mapping[str, Any],
   ) -> None:
     if not op:
       raise ValueError("op is required for DBRequest")
-    source = payload if payload is not None else params
-    if source is None:
-      source = {}
     self.op = op
     # normalize to a mutable dict for convenience
-    self.payload: Dict[str, Any] = dict(source)
-
-  @property
-  def params(self) -> Dict[str, Any]:
-    """Alias retained for backwards compatibility."""
-
-    return self.payload
+    self.payload: Dict[str, Any] = dict(payload)
 
   def copy(self) -> "DBRequest":
     return DBRequest(op=self.op, payload=dict(self.payload))

--- a/server/registry/system/config/__init__.py
+++ b/server/registry/system/config/__init__.py
@@ -22,22 +22,22 @@ __all__ = [
 
 
 def get_config_request(params: ConfigKeyParams) -> DBRequest:
-  return DBRequest(op="db:system:config:get_config:1", params=params.model_dump())
+  return DBRequest(op="db:system:config:get_config:1", payload=params.model_dump())
 
 
 def get_configs_request() -> DBRequest:
-  return DBRequest(op="db:system:config:get_configs:1", params={})
+  return DBRequest(op="db:system:config:get_configs:1", payload={})
 
 
 def upsert_config_request(params: UpsertConfigParams) -> DBRequest:
   return DBRequest(
     op="db:system:config:upsert_config:1",
-    params=params.model_dump(),
+    payload=params.model_dump(),
   )
 
 
 def delete_config_request(params: ConfigKeyParams) -> DBRequest:
-  return DBRequest(op="db:system:config:delete_config:1", params=params.model_dump())
+  return DBRequest(op="db:system:config:delete_config:1", payload=params.model_dump())
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/system/conversations/__init__.py
+++ b/server/registry/system/conversations/__init__.py
@@ -57,7 +57,7 @@ def insert_conversation_request(
 ) -> DBRequest:
   return DBRequest(
     op=_op("insert"),
-    params={
+    payload={
       "personas_recid": personas_recid,
       "models_recid": models_recid,
       "guild_id": _normalize_identifier(guild_id),
@@ -80,7 +80,7 @@ def find_recent_request(
   input_data: str,
   window_seconds: int | None = None,
 ) -> DBRequest:
-  params = {
+  payload = {
     "personas_recid": personas_recid,
     "models_recid": models_recid,
     "guild_id": _normalize_identifier(guild_id),
@@ -89,8 +89,8 @@ def find_recent_request(
     "input_data": input_data,
   }
   if window_seconds is not None:
-    params["window_seconds"] = window_seconds
-  return DBRequest(op=_op("find_recent"), params=params)
+    payload["window_seconds"] = window_seconds
+  return DBRequest(op=_op("find_recent"), payload=payload)
 
 
 def update_output_request(
@@ -101,7 +101,7 @@ def update_output_request(
 ) -> DBRequest:
   return DBRequest(
     op=_op("update_output"),
-    params={
+    payload={
       "recid": recid,
       "output_data": output_data,
       "tokens": tokens,
@@ -112,7 +112,7 @@ def update_output_request(
 def list_by_time_request(*, personas_recid: int, start: str, end: str) -> DBRequest:
   return DBRequest(
     op=_op("list_by_time"),
-    params={
+    payload={
       "personas_recid": personas_recid,
       "start": start,
       "end": end,
@@ -121,7 +121,7 @@ def list_by_time_request(*, personas_recid: int, start: str, end: str) -> DBRequ
 
 
 def list_recent_request() -> DBRequest:
-  return DBRequest(op=_op("list_recent"), params={})
+  return DBRequest(op=_op("list_recent"), payload={})
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/system/guilds/__init__.py
+++ b/server/registry/system/guilds/__init__.py
@@ -28,7 +28,7 @@ def _normalise_identifier(value: str | int | None) -> str | None:
 
 
 def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
-  return DBRequest(op=op, params=params or {})
+  return DBRequest(op=op, payload=params or {})
 
 
 def upsert_guild_request(

--- a/server/registry/system/links/__init__.py
+++ b/server/registry/system/links/__init__.py
@@ -27,7 +27,7 @@ __all__ = [
 
 def _request(op: str, params: NavbarRoutesParams | None = None) -> DBRequest:
   payload = params.model_dump(exclude_none=True) if params else {}
-  return DBRequest(op=op, params=payload)
+  return DBRequest(op=op, payload=payload)
 
 
 def get_home_links_request() -> DBRequest:

--- a/server/registry/system/models/__init__.py
+++ b/server/registry/system/models/__init__.py
@@ -30,11 +30,11 @@ def _op(name: str) -> str:
 
 
 def list_models_request() -> DBRequest:
-  return DBRequest(op=_op("list"), params={})
+  return DBRequest(op=_op("list"), payload={})
 
 
 def get_model_by_name_request(name: str) -> DBRequest:
-  return DBRequest(op=_op("get_by_name"), params={"name": name})
+  return DBRequest(op=_op("get_by_name"), payload={"name": name})
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/system/personas/__init__.py
+++ b/server/registry/system/personas/__init__.py
@@ -36,11 +36,11 @@ def _op(name: str) -> str:
 
 
 def get_persona_by_name_request(name: str) -> DBRequest:
-  return DBRequest(op=_op("get_by_name"), params={"name": name})
+  return DBRequest(op=_op("get_by_name"), payload={"name": name})
 
 
 def list_personas_request() -> DBRequest:
-  return DBRequest(op=_op("list"), params={})
+  return DBRequest(op=_op("list"), payload={})
 
 
 def upsert_persona_request(
@@ -53,7 +53,7 @@ def upsert_persona_request(
 ) -> DBRequest:
   return DBRequest(
     op=_op("upsert"),
-    params={
+    payload={
       "recid": recid,
       "name": name,
       "prompt": prompt,
@@ -66,7 +66,7 @@ def upsert_persona_request(
 def delete_persona_request(*, recid: int | None = None, name: str | None = None) -> DBRequest:
   return DBRequest(
     op=_op("delete"),
-    params={
+    payload={
       "recid": recid,
       "name": name,
     },

--- a/server/registry/system/public_users/__init__.py
+++ b/server/registry/system/public_users/__init__.py
@@ -28,7 +28,7 @@ __all__ = [
 
 
 def _request(op: str, params: dict[str, Any]) -> DBRequest:
-  return DBRequest(op=op, params=params)
+  return DBRequest(op=op, payload=params)
 
 
 def get_profile_request(*, guid: str) -> DBRequest:

--- a/server/registry/system/roles/__init__.py
+++ b/server/registry/system/roles/__init__.py
@@ -32,48 +32,48 @@ __all__ = [
 
 
 def list_roles_request() -> DBRequest:
-  return DBRequest(op="db:system:roles:list:1", params={})
+  return DBRequest(op="db:system:roles:list:1", payload={})
 
 
 def get_role_members_request(params: RoleScopeParams) -> DBRequest:
   return DBRequest(
     op="db:system:roles:get_role_members:1",
-    params=params.model_dump(),
+    payload=params.model_dump(),
   )
 
 
 def get_role_non_members_request(params: RoleScopeParams) -> DBRequest:
   return DBRequest(
     op="db:system:roles:get_role_non_members:1",
-    params=params.model_dump(),
+    payload=params.model_dump(),
   )
 
 
 def add_role_member_request(params: ModifyRoleMemberParams) -> DBRequest:
   return DBRequest(
     op="db:system:roles:add_role_member:1",
-    params=params.model_dump(),
+    payload=params.model_dump(),
   )
 
 
 def remove_role_member_request(params: ModifyRoleMemberParams) -> DBRequest:
   return DBRequest(
     op="db:system:roles:remove_role_member:1",
-    params=params.model_dump(),
+    payload=params.model_dump(),
   )
 
 
 def upsert_role_request(params: UpsertRoleParams) -> DBRequest:
   return DBRequest(
     op="db:system:roles:upsert_role:1",
-    params=params.model_dump(),
+    payload=params.model_dump(),
   )
 
 
 def delete_role_request(params: DeleteRoleParams) -> DBRequest:
   return DBRequest(
     op="db:system:roles:delete_role:1",
-    params=params.model_dump(),
+    payload=params.model_dump(),
   )
 
 

--- a/server/registry/system/routes/__init__.py
+++ b/server/registry/system/routes/__init__.py
@@ -18,7 +18,7 @@ __all__ = [
 
 
 def get_routes_request() -> DBRequest:
-  return DBRequest(op="db:system:routes:get_routes:1", params={})
+  return DBRequest(op="db:system:routes:get_routes:1", payload={})
 
 
 def upsert_route_request(
@@ -29,7 +29,7 @@ def upsert_route_request(
   sequence: int,
   roles: int,
 ) -> DBRequest:
-  return DBRequest(op="db:system:routes:upsert_route:1", params={
+  return DBRequest(op="db:system:routes:upsert_route:1", payload={
     "path": path,
     "name": name,
     "icon": icon,
@@ -39,7 +39,7 @@ def upsert_route_request(
 
 
 def delete_route_request(path: str) -> DBRequest:
-  return DBRequest(op="db:system:routes:delete_route:1", params={"path": path})
+  return DBRequest(op="db:system:routes:delete_route:1", payload={"path": path})
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/system/service_pages/__init__.py
+++ b/server/registry/system/service_pages/__init__.py
@@ -44,15 +44,15 @@ def _op(name: str) -> str:
 
 
 def list_service_pages_request(*, include_inactive: bool = True) -> DBRequest:
-  params: ListServicePagesParams = {}
+  payload: ListServicePagesParams = {}
   if not include_inactive:
-    params["element_is_active"] = True
-  return DBRequest(op=_op("list"), params=params)
+    payload["element_is_active"] = True
+  return DBRequest(op=_op("list"), payload=payload)
 
 
 def get_service_page_request(*, recid: int) -> DBRequest:
-  params: GetServicePageParams = {"recid": recid}
-  return DBRequest(op=_op("get"), params=params)
+  payload: GetServicePageParams = {"recid": recid}
+  return DBRequest(op=_op("get"), payload=payload)
 
 
 def get_service_page_by_route_request(
@@ -60,10 +60,10 @@ def get_service_page_by_route_request(
   route_name: str,
   active_only: bool = True,
 ) -> DBRequest:
-  params: GetServicePageByRouteParams = {"element_route_name": route_name}
+  payload: GetServicePageByRouteParams = {"element_route_name": route_name}
   if active_only:
-    params["element_is_active"] = True
-  return DBRequest(op=_op("get_by_route"), params=params)
+    payload["element_is_active"] = True
+  return DBRequest(op=_op("get_by_route"), payload=payload)
 
 
 def create_service_page_request(
@@ -76,7 +76,7 @@ def create_service_page_request(
   version: int | None = None,
   is_active: bool | None = None,
 ) -> DBRequest:
-  params: CreateServicePageParams = {
+  payload: CreateServicePageParams = {
     "recid": recid,
     "element_route_name": route_name,
     "element_pageblob": page_blob,
@@ -84,10 +84,10 @@ def create_service_page_request(
     "element_modified_by": modified_by,
   }
   if version is not None:
-    params["element_version"] = version
+    payload["element_version"] = version
   if is_active is not None:
-    params["element_is_active"] = is_active
-  return DBRequest(op=_op("create"), params=params)
+    payload["element_is_active"] = is_active
+  return DBRequest(op=_op("create"), payload=payload)
 
 
 def update_service_page_request(
@@ -99,24 +99,24 @@ def update_service_page_request(
   version: int | None = None,
   is_active: bool | None = None,
 ) -> DBRequest:
-  params: UpdateServicePageParams = {
+  payload: UpdateServicePageParams = {
     "recid": recid,
     "element_modified_by": modified_by,
   }
   if route_name is not None:
-    params["element_route_name"] = route_name
+    payload["element_route_name"] = route_name
   if page_blob is not None:
-    params["element_pageblob"] = page_blob
+    payload["element_pageblob"] = page_blob
   if version is not None:
-    params["element_version"] = version
+    payload["element_version"] = version
   if is_active is not None:
-    params["element_is_active"] = is_active
-  return DBRequest(op=_op("update"), params=params)
+    payload["element_is_active"] = is_active
+  return DBRequest(op=_op("update"), payload=payload)
 
 
 def delete_service_page_request(*, recid: int) -> DBRequest:
-  params: DeleteServicePageParams = {"recid": recid}
-  return DBRequest(op=_op("delete"), params=params)
+  payload: DeleteServicePageParams = {"recid": recid}
+  return DBRequest(op=_op("delete"), payload=payload)
 
 
 def register(router: "SubdomainRouter") -> None:

--- a/server/registry/system/vars/__init__.py
+++ b/server/registry/system/vars/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
 
 
 def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:
-  return DBRequest(op=op, params=params or {})
+  return DBRequest(op=op, payload=params or {})
 
 
 def get_version_request() -> DBRequest:

--- a/tests/test_users_profile_services.py
+++ b/tests/test_users_profile_services.py
@@ -59,10 +59,9 @@ registry_types_pkg = types.ModuleType("server.registry.types")
 registry_types_pkg.__path__ = [str(root_path / "server/registry")]
 
 class DBRequest:
-  def __init__(self, *, op, payload=None, params=None):
-    source = payload if payload is not None else params or {}
+  def __init__(self, *, op, payload):
     self.op = op
-    self.payload = dict(source)
+    self.payload = dict(payload)
 
 class DBResponse:
   def __init__(self, *, op="", payload=None, rows=None, rowcount=None):


### PR DESCRIPTION
## Summary
- require a payload mapping when constructing `DBRequest` and drop the legacy params alias
- update registry helpers across account, finance, and system packages to pass payload dictionaries
- align the users profile service test stub with the new constructor

## Testing
- pytest tests/test_users_profile_services.py tests/test_account_role_services.py tests/test_system_roles_services.py tests/test_service_roles_services.py


------
https://chatgpt.com/codex/tasks/task_e_68fd374591b08325ac5325a3d4eb2934