### PR TITLE
Refine DB request handling

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -91,16 +91,10 @@ class DbModule(BaseModule):
       cfg.update(overrides)
     return cfg
 
-  async def run(
-    self,
-    request: DBRequest | str,
-    args: Dict[str, Any] | None = None,
-  ) -> DBResponse:
+  async def run(self, request: DBRequest) -> DBResponse:
     assert self._provider, "db_module not initialized"
-    if isinstance(request, str):
-      request = DBRequest(op=request, payload=args or {})
-    elif args is not None:
-      raise TypeError("args cannot be provided when passing a DBRequest instance")
+    if not isinstance(request, DBRequest):
+      raise TypeError("DbModule.run requires a DBRequest instance")
     op = request.op
     out = await self._provider.run(request)
     if isinstance(out, DBResponse):

--- a/server/modules/providers/__init__.py
+++ b/server/modules/providers/__init__.py
@@ -50,14 +50,9 @@ class AuthProviderBase(LifecycleProvider):
 
 
 class DbProviderBase(LifecycleProvider):
-  async def run(
-    self,
-    request: DBRequest | str,
-    args: Dict[str, Any] | None = None,
-  ) -> DBResponse:
-    if isinstance(request, str):
-      payload = args or {}
-      return await self._run(DBRequest(op=request, payload=payload))
+  async def run(self, request: DBRequest) -> DBResponse:
+    if not isinstance(request, DBRequest):
+      raise TypeError("DbProviderBase.run requires a DBRequest instance")
     return await self._run(request)
 
   async def execute(self, op: str, args: Dict[str, Any]) -> DBResponse:

--- a/tests/test_db_assistant_conversations.py
+++ b/tests/test_db_assistant_conversations.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from server.modules.providers import DBResponse
+from server.modules.providers import DBRequest, DBResponse
 from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.registry.providers.mssql as registry_mssql
 
@@ -23,10 +23,14 @@ def test_assistant_conversations_list_by_time(monkeypatch):
 
   monkeypatch.setattr(registry_mssql, 'fetch_json', fake_fetch_json)
 
-  res = asyncio.run(provider.run(
-    'db:system:conversations:list_by_time:1',
-    {'personas_recid': personas_recid, 'start': start, 'end': end},
-  ))
+  res = asyncio.run(
+    provider.run(
+      DBRequest(
+        op='db:system:conversations:list_by_time:1',
+        payload={'personas_recid': personas_recid, 'start': start, 'end': end},
+      )
+    )
+  )
   assert isinstance(res, DBResponse)
   assert res.rows == [{"recid": 1}]
 
@@ -53,7 +57,11 @@ def test_assistant_conversations_insert(monkeypatch):
 
   monkeypatch.setattr(registry_mssql, 'fetch_json', fake_fetch_json)
 
-  res = asyncio.run(provider.run('db:system:conversations:insert:1', args))
+  res = asyncio.run(
+    provider.run(
+      DBRequest(op='db:system:conversations:insert:1', payload=args)
+    )
+  )
   assert res.rows == [{'recid': 9}]
 
 
@@ -79,7 +87,11 @@ def test_assistant_conversations_find_recent(monkeypatch):
 
   monkeypatch.setattr(registry_mssql, 'fetch_json', fake_fetch_json)
 
-  res = asyncio.run(provider.run('db:system:conversations:find_recent:1', args))
+  res = asyncio.run(
+    provider.run(
+      DBRequest(op='db:system:conversations:find_recent:1', payload=args)
+    )
+  )
   assert res.rows == [{'recid': 5}]
 
 
@@ -95,7 +107,11 @@ def test_assistant_conversations_update_output(monkeypatch):
 
   monkeypatch.setattr(registry_mssql, 'exec_query', fake_exec)
 
-  res = asyncio.run(provider.run('db:system:conversations:update_output:1', args))
+  res = asyncio.run(
+    provider.run(
+      DBRequest(op='db:system:conversations:update_output:1', payload=args)
+    )
+  )
   assert res.rowcount == 1
 
 
@@ -114,7 +130,11 @@ def test_assistant_conversations_list_recent(monkeypatch):
 
   monkeypatch.setattr(registry_mssql, 'fetch_json', fake_fetch_json)
 
-  res = asyncio.run(provider.run('db:system:conversations:list_recent:1', {}))
+  res = asyncio.run(
+    provider.run(
+      DBRequest(op='db:system:conversations:list_recent:1', payload={})
+    )
+  )
   assert isinstance(res, DBResponse)
   assert res.rows == [{"recid": 2}]
 

--- a/tests/test_db_provider_contract.py
+++ b/tests/test_db_provider_contract.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from server.modules.providers.database.mssql_provider import MssqlProvider
 import server.modules.providers.database.mssql_provider as mssql_provider
-from server.modules.providers import DBResponse
+from server.modules.providers import DBRequest, DBResponse
 from server.registry.account.files import mssql as users_files_mssql
 
 
@@ -21,7 +21,9 @@ def test_run_returns_dbresult_from_async_handler(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
 
-  res = asyncio.run(provider.run("db:account:test:json_one:1", {}))
+  res = asyncio.run(
+    provider.run(DBRequest(op="db:account:test:json_one:1", payload={}))
+  )
   assert isinstance(res, DBResponse)
   assert res.rows == [{"v": 1}]
   assert res.rowcount == 1
@@ -41,7 +43,9 @@ def test_run_returns_dbresult_from_sync_handler(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
 
-  res = asyncio.run(provider.run("db:account:test:row_one:1", {}))
+  res = asyncio.run(
+    provider.run(DBRequest(op="db:account:test:row_one:1", payload={}))
+  )
   assert isinstance(res, DBResponse)
   assert res.rows == [{"v": 1}]
   assert res.rowcount == 1
@@ -62,7 +66,12 @@ def test_run_row_many(monkeypatch):
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
 
   res = asyncio.run(
-    provider.run("db:system:public_users:get_published_files:1", {"guid": guid})
+    provider.run(
+      DBRequest(
+        op="db:system:public_users:get_published_files:1",
+        payload={"guid": guid},
+      )
+    )
   )
   assert isinstance(res, DBResponse)
   assert res.rows == [{"path": "a"}, {"path": "b"}]
@@ -83,7 +92,9 @@ def test_run_normalizes_dict_response(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
 
-  res = asyncio.run(provider.run("db:account:test:json_many:1", {}))
+  res = asyncio.run(
+    provider.run(DBRequest(op="db:account:test:json_many:1", payload={}))
+  )
   assert isinstance(res, DBResponse)
   assert res.rows == [{"v": 1}, {"v": 2}]
   assert res.rowcount == 2
@@ -103,7 +114,9 @@ def test_run_returns_empty_response_for_none(monkeypatch):
 
   monkeypatch.setattr(mssql_provider, "get_handler", fake_get_handler)
 
-  res = asyncio.run(provider.run("db:account:test:exec:1", {}))
+  res = asyncio.run(
+    provider.run(DBRequest(op="db:account:test:exec:1", payload={}))
+  )
   assert isinstance(res, DBResponse)
   assert res.rows == []
   assert res.rowcount == 0
@@ -122,7 +135,12 @@ def test_storage_files_set_gallery(monkeypatch):
   monkeypatch.setattr(users_files_mssql, "run_exec", fake_run_exec)
 
   res = asyncio.run(
-    provider.run("db:account:files:set_gallery:1", {"user_guid": guid, "name": "file.txt", "gallery": True})
+    provider.run(
+      DBRequest(
+        op="db:account:files:set_gallery:1",
+        payload={"user_guid": guid, "name": "file.txt", "gallery": True},
+      )
+    )
   )
   assert isinstance(res, DBResponse)
   assert res.rowcount == 1

--- a/tests/test_openai_module.py
+++ b/tests/test_openai_module.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi import FastAPI
 
 from server.modules.openai_module import OpenaiModule, SummaryQueue
-from server.modules.providers import DBResponse
+from server.modules.providers import DBRequest, DBResponse
 
 
 def test_fetch_chat_message_order_and_return():
@@ -98,12 +98,10 @@ def test_fetch_chat_logs_conversation():
     def __init__(self):
       self.calls = []
 
-    async def run(self, op, args=None):
-      if not isinstance(op, str):
-        args = op.payload
-        op = op.op
-      elif args is None:
-        args = {}
+    async def run(self, request: DBRequest):
+      assert isinstance(request, DBRequest)
+      op = request.op
+      args = request.payload
       self.calls.append((op, args))
       if op == "db:system:personas:get_by_name:1":
         return DBResponse(
@@ -172,14 +170,10 @@ def test_log_conversation_end_warns_when_no_rows_updated(caplog):
   module = OpenaiModule(app)
 
   class DummyDB:
-    async def run(self, op, args=None):
-      if not isinstance(op, str):
-        args = op.payload
-        op = op.op
-      elif args is None:
-        args = {}
-      assert op == "db:system:conversations:update_output:1"
-      assert args == {"recid": 99, "output_data": "done", "tokens": 3}
+    async def run(self, request: DBRequest):
+      assert isinstance(request, DBRequest)
+      assert request.op == "db:system:conversations:update_output:1"
+      assert request.payload == {"recid": 99, "output_data": "done", "tokens": 3}
       return DBResponse(rowcount=0)
 
   module.db = DummyDB()
@@ -195,14 +189,10 @@ def test_get_recent_persona_conversation_history_returns_ordered_messages():
   module = OpenaiModule(app)
 
   class DummyDB:
-    async def run(self, op, args=None):
-      if not isinstance(op, str):
-        args = op.payload
-        op = op.op
-      elif args is None:
-        args = {}
-      assert op == "db:system:conversations:list_by_time:1"
-      assert args["personas_recid"] == 7
+    async def run(self, request: DBRequest):
+      assert isinstance(request, DBRequest)
+      assert request.op == "db:system:conversations:list_by_time:1"
+      assert request.payload["personas_recid"] == 7
       return DBResponse(
         rows=[
           {
@@ -258,12 +248,10 @@ def test_fetch_chat_reuses_existing_conversation():
       self.calls: list[tuple[str, dict]] = []
       self.insert_count = 0
 
-    async def run(self, op, args=None):
-      if not isinstance(op, str):
-        args = op.payload
-        op = op.op
-      elif args is None:
-        args = {}
+    async def run(self, request: DBRequest):
+      assert isinstance(request, DBRequest)
+      op = request.op
+      args = request.payload
       self.calls.append((op, args))
       if op == "db:system:personas:get_by_name:1":
         return DBResponse(
@@ -339,12 +327,10 @@ def test_persona_response_calls_openai():
     def __init__(self):
       self.calls = []
 
-    async def run(self, op, args=None):
-      if not isinstance(op, str):
-        args = op.payload
-        op = op.op
-      elif args is None:
-        args = {}
+    async def run(self, request: DBRequest):
+      assert isinstance(request, DBRequest)
+      op = request.op
+      args = request.payload
       self.calls.append((op, args))
       if op == "db:system:personas:get_by_name:1":
         return DBResponse(
@@ -412,13 +398,9 @@ def test_persona_response_missing_persona():
   module = OpenaiModule(app)
 
   class DummyDB:
-    async def run(self, op, args=None):
-      if not isinstance(op, str):
-        args = op.payload
-        op = op.op
-      elif args is None:
-        args = {}
-      if op == "db:system:personas:get_by_name:1":
+    async def run(self, request: DBRequest):
+      assert isinstance(request, DBRequest)
+      if request.op == "db:system:personas:get_by_name:1":
         return DBResponse(rows=[], rowcount=0)
       return DBResponse()
 
@@ -434,13 +416,9 @@ def test_persona_response_stub_without_client():
   module = OpenaiModule(app)
 
   class DummyDB:
-    async def run(self, op, args=None):
-      if not isinstance(op, str):
-        args = op.payload
-        op = op.op
-      elif args is None:
-        args = {}
-      if op == "db:system:personas:get_by_name:1":
+    async def run(self, request: DBRequest):
+      assert isinstance(request, DBRequest)
+      if request.op == "db:system:personas:get_by_name:1":
         return DBResponse(
           rows=[{
             "recid": 1,

--- a/tests/test_registry_provider_isolation.py
+++ b/tests/test_registry_provider_isolation.py
@@ -102,7 +102,9 @@ def test_db_module_uses_provider_specific_configuration(monkeypatch):
     assert provider.config["dsn"] == "mock://dsn"
     assert provider.config["blob"] == "blob"
 
-    response = await db_module.run("db:test:echo:1", {"foo": "bar"})
+    response = await db_module.run(
+      DBRequest(op="db:test:echo:1", payload={"foo": "bar"})
+    )
     assert response.op == "db:test:echo:1"
     assert response.payload == {"payload": {"foo": "bar"}}
     assert provider.requests and provider.requests[-1].payload == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- require `DbProviderBase.run` and `DbModule.run` to receive fully constructed `DBRequest` objects
- update database-related tests to construct `DBRequest` instances explicitly
- adjust dummy database helpers to assert on `DBRequest` payloads

## Testing
- pytest tests/test_db_provider_contract.py tests/test_db_assistant_conversations.py tests/test_registry_provider_isolation.py tests/test_openai_module.py

------
https://chatgpt.com/codex/tasks/task_e_68fd39716d7083258351dac7289d7191