### PR TITLE
Consolidate public vars RPC operations

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -105,14 +105,9 @@ User focused calls used by the React application.
 
 ### `vars`
 
-| Operation                              | Description                                            |
-| -------------------------------------- | ------------------------------------------------------ |
-| `urn:public:vars:get_version:1`        | Read the configured application version.               |
-| `urn:public:vars:get_hostname:1`       | Read the configured hostname.                          |
-| `urn:public:vars:get_repo:1`           | Read the GitHub repository URL.                        |
-| `urn:public:vars:get_ffmpeg_version:1` | Return the installed FFmpeg version.                   |
-| `urn:public:vars:get_odbc_version:1`   | Return the installed Linux MSSQL ODBC driver versions. |
-| `urn:public:vars:get_versions:1`       | Return app and component versions; component versions require `ROLE_SERVICE_ADMIN`. |
+| Operation                              | Description |
+| -------------------------------------- | ----------- |
+| `urn:public:vars:get_versions:1`       | Return public metadata (version, hostname, repo) and, when authorized with `ROLE_SERVICE_ADMIN`, include FFmpeg and ODBC component versions. |
 
 ### `users`
 

--- a/rpc/public/vars/__init__.py
+++ b/rpc/public/vars/__init__.py
@@ -1,18 +1,7 @@
-from .services import (
-  public_vars_get_ffmpeg_version_v1,
-  public_vars_get_hostname_v1,
-  public_vars_get_repo_v1,
-  public_vars_get_version_v1,
-  public_vars_get_odbc_version_v1,
-  public_vars_get_versions_v1,
-)
+from .services import public_vars_get_versions_v1
+
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
-  ("get_version", "1"): public_vars_get_version_v1,
-  ("get_hostname", "1"): public_vars_get_hostname_v1,
-  ("get_repo", "1"): public_vars_get_repo_v1,
-  ("get_ffmpeg_version", "1"): public_vars_get_ffmpeg_version_v1,
-  ("get_odbc_version", "1"): public_vars_get_odbc_version_v1,
   ("get_versions", "1"): public_vars_get_versions_v1,
 }
 

--- a/rpc/public/vars/models.py
+++ b/rpc/public/vars/models.py
@@ -1,26 +1,6 @@
 from pydantic import BaseModel
 
 
-class PublicVarsVersion1(BaseModel):
-  version: str
-
-
-class PublicVarsHostname1(BaseModel):
-  hostname: str
-
-
-class PublicVarsRepo1(BaseModel):
-  repo: str
-
-
-class PublicVarsFfmpegVersion1(BaseModel):
-  ffmpeg_version: str
-
-
-class PublicVarsOdbcVersion1(BaseModel):
-  odbc_version: str
-
-
 class PublicVarsVersions1(BaseModel):
   hostname: str
   version: str

--- a/rpc/public/vars/services.py
+++ b/rpc/public/vars/services.py
@@ -1,94 +1,18 @@
-from fastapi import HTTPException, Request
+from fastapi import Request
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from typing import TYPE_CHECKING
+
+from .models import PublicVarsVersions1
+
 if TYPE_CHECKING:
   from server.modules.public_vars_module import PublicVarsModule
-from .models import (
-  PublicVarsFfmpegVersion1,
-  PublicVarsHostname1,
-  PublicVarsRepo1,
-  PublicVarsVersion1,
-  PublicVarsOdbcVersion1,
-  PublicVarsVersions1,
-)
 
-
-async def public_vars_get_version_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
-  vars_mod: PublicVarsModule = request.app.state.public_vars
-  version = await vars_mod.get_version()
-  payload = PublicVarsVersion1(version=version)
-  return RPCResponse(
-    op=rpc_request.op,
-    payload=payload.model_dump(),
-    version=rpc_request.version,
-  )
-
-async def public_vars_get_hostname_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
-  vars_mod: PublicVarsModule = request.app.state.public_vars
-  hostname = await vars_mod.get_hostname()
-  payload = PublicVarsHostname1(hostname=hostname)
-  return RPCResponse(
-    op=rpc_request.op,
-    payload=payload.model_dump(),
-    version=rpc_request.version,
-  )
-
-async def public_vars_get_repo_v1(request: Request):
-  rpc_request, _, _ = await unbox_request(request)
-  vars_mod: PublicVarsModule = request.app.state.public_vars
-  repo = await vars_mod.get_repo()
-  payload = PublicVarsRepo1(repo=repo)
-  return RPCResponse(
-    op=rpc_request.op,
-    payload=payload.model_dump(),
-    version=rpc_request.version,
-  )
-
-async def public_vars_get_ffmpeg_version_v1(request: Request):
-  rpc_request, auth_ctx, _ = await unbox_request(request)
-  vars_mod: PublicVarsModule = request.app.state.public_vars
-  required_mask = 0
-  if vars_mod.auth:
-    required_mask = vars_mod.auth.roles.get("ROLE_SERVICE_ADMIN", 0)
-  if not (auth_ctx.role_mask & required_mask):
-    raise HTTPException(status_code=403, detail="Forbidden")
-  try:
-    version_line = await vars_mod.get_ffmpeg_version()
-  except Exception as e:
-    raise HTTPException(status_code=500, detail=str(e))
-  payload = PublicVarsFfmpegVersion1(ffmpeg_version=version_line)
-  return RPCResponse(
-    op=rpc_request.op,
-    payload=payload.model_dump(),
-    version=rpc_request.version,
-  )
-
-async def public_vars_get_odbc_version_v1(request: Request):
-  rpc_request, auth_ctx, _ = await unbox_request(request)
-  vars_mod: PublicVarsModule = request.app.state.public_vars
-  required_mask = 0
-  if vars_mod.auth:
-    required_mask = vars_mod.auth.roles.get("ROLE_SERVICE_ADMIN", 0)
-  if not (auth_ctx.role_mask & required_mask):
-    raise HTTPException(status_code=403, detail="Forbidden")
-  try:
-    version_line = await vars_mod.get_odbc_version()
-  except Exception as e:
-    raise HTTPException(status_code=500, detail=str(e))
-  payload = PublicVarsOdbcVersion1(odbc_version=version_line)
-  return RPCResponse(
-    op=rpc_request.op,
-    payload=payload.model_dump(),
-    version=rpc_request.version,
-  )
 
 async def public_vars_get_versions_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   vars_mod: PublicVarsModule = request.app.state.public_vars
-  data = await vars_mod.get_versions(auth_ctx.role_mask)
+  data = await vars_mod.get_versions(getattr(auth_ctx, "role_mask", 0))
   payload = PublicVarsVersions1(**data)
   return RPCResponse(
     op=rpc_request.op,

--- a/tests/test_public_vars_service.py
+++ b/tests/test_public_vars_service.py
@@ -32,70 +32,19 @@ server_pkg.models = models_pkg
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)
 
-from rpc.public.vars.services import (
-  public_vars_get_hostname_v1,
-  public_vars_get_version_v1,
-  public_vars_get_versions_v1,
-)
-
-
-class DummyVarsHostnameModule:
-  async def get_hostname(self):
-    return "example.com"
-
-
-class DummyVarsVersionModule:
-  async def get_version(self):
-    return "1.2.3"
-
+from rpc.public.vars.services import public_vars_get_versions_v1
 
 class DummyVarsVersionsModule:
+  def __init__(self):
+    self.masks: list[int] = []
+
   async def get_versions(self, role_mask):
+    self.masks.append(role_mask)
     res = {"hostname": "example.com", "version": "1.2.3", "repo": "https://repo"}
     if role_mask:
       res["ffmpeg_version"] = "ffmpeg 1"
       res["odbc_version"] = "odbc 1"
     return res
-
-
-app = FastAPI()
-app.state.public_vars = DummyVarsHostnameModule()
-
-
-@app.post("/rpc")
-async def rpc_endpoint(request: Request):
-  return await public_vars_get_hostname_v1(request)
-
-
-client = TestClient(app)
-
-
-def test_get_hostname_service():
-  resp = client.post("/rpc", json={"op": "urn:public:vars:get_hostname:1"})
-  assert resp.status_code == 200
-  data = resp.json()
-  assert data["op"] == "urn:public:vars:get_hostname:1"
-  assert data["payload"] == {"hostname": "example.com"}
-
-
-app_version = FastAPI()
-app_version.state.public_vars = DummyVarsVersionModule()
-
-
-@app_version.post("/rpc")
-async def rpc_endpoint_version(request: Request):
-  return await public_vars_get_version_v1(request)
-
-
-client_version = TestClient(app_version)
-
-
-def test_get_version_service():
-  resp = client_version.post("/rpc", json={"op": "urn:public:vars:get_version:1"})
-  assert resp.status_code == 200
-  data = resp.json()
-  assert data["op"] == "urn:public:vars:get_version:1"
-  assert data["payload"] == {"version": "1.2.3"}
 
 
 app_versions = FastAPI()
@@ -104,8 +53,6 @@ app_versions.state.public_vars = DummyVarsVersionsModule()
 
 @app_versions.post("/rpc")
 async def rpc_endpoint_versions(request: Request):
-  request.state.rpc_request = RPCRequest(op="urn:public:vars:get_versions:1")
-  request.state.auth_ctx = AuthContext(role_mask=0)
   return await public_vars_get_versions_v1(request)
 
 
@@ -113,11 +60,12 @@ client_versions = TestClient(app_versions)
 
 
 def test_get_versions_public():
-  resp = client_versions.post("/rpc", json={})
+  resp = client_versions.post("/rpc", json={"op": "urn:public:vars:get_versions:1"})
   assert resp.status_code == 200
   data = resp.json()
   assert data["op"] == "urn:public:vars:get_versions:1"
   assert data["payload"] == {"hostname": "example.com", "version": "1.2.3", "repo": "https://repo"}
+  assert app_versions.state.public_vars.masks == [0]
 
 
 app_versions_admin = FastAPI()
@@ -146,4 +94,5 @@ def test_get_versions_admin():
     "ffmpeg_version": "ffmpeg 1",
     "odbc_version": "odbc 1",
   }
+  assert app_versions_admin.state.public_vars.masks == [1]
 


### PR DESCRIPTION
## Summary
- remove the legacy public vars RPC handlers and route clients through `public_vars_get_versions_v1`
- streamline models, dispatchers, and documentation to reflect the consolidated metadata endpoint
- refresh the service tests to validate both public and admin responses from the combined call

## Testing
- python -m pytest tests/test_public_vars_service.py

------
https://chatgpt.com/codex/tasks/task_e_68fd3c94d6108325ab6bade045558af2