### PR TITLE
Handle missing Azure SQL connection string in test runner

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -32,11 +32,15 @@ async def update_build_version() -> None:
   from dotenv import load_dotenv
   load_dotenv()
 
+  dsn = os.environ.get("AZURE_SQL_CONNECTION_STRING")
+  if not dsn:
+    print('AZURE_SQL_CONNECTION_STRING not set, skipping build version update')
+    return
+
   pool = None
   try:
-    dsn = os.environ["AZURE_SQL_CONNECTION_STRING"]
-    pool = await aioodbc.create_pool(dsn=dsn, autocommit=True)
-  except Exception as e:
+    pool = await asyncio.wait_for(aioodbc.create_pool(dsn=dsn, autocommit=True), timeout=10)
+  except (asyncio.TimeoutError, Exception) as e:
     print(f'Unable to connect to database: {e}')
     return
 


### PR DESCRIPTION
## Summary
- skip the build version update when the Azure SQL connection string is not provided
- add a timeout around the Azure SQL connection attempt so failing connections return promptly

## Testing
- python -c "import asyncio, sys; sys.path.insert(0, '/workspace/elideus-group/scripts'); import run_tests; asyncio.run(run_tests.update_build_version())"


------
https://chatgpt.com/codex/tasks/task_e_68fea9e386ec8325ba3567dcf51e36cc