### PR TITLE
Use helper request builder in DbModule.user_exists

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -188,7 +188,7 @@ class DbModule(BaseModule):
     await self.run(replace_user_cache_request(params))
 
   async def user_exists(self, user_guid: str) -> bool:
-    res = await self.run(account_exists_request(user_guid))
+    res = await self.run(account_exists_request(user_guid=user_guid))
     return bool(res.rows)
 
   async def upsert_storage_cache(self, item: Dict[str, Any]) -> DBResponse:


### PR DESCRIPTION
## Summary
- ensure `DbModule.user_exists` calls the shared `account_exists_request` helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69017c65b5e8832587b2843793cdc482