### PR TITLE
Refactor MSSQL provider helpers

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -107,8 +107,9 @@ class DbModule(BaseModule):
     except KeyError:
       handler_info = None
 
+    provider = self._provider
     if not handler_info or handler_info.legacy:
-      return await self._provider.run(request)
+      return await provider.run(request)
 
     registry_logger.info(
       "Registry handler resolved",
@@ -116,22 +117,33 @@ class DbModule(BaseModule):
     )
 
     handler = handler_info.load()
-    domain, path, version = parse_db_op(op)
-    provider_module = self._provider.__module__
-    provider_class = self._provider.__class__.__name__
+    provider_module = provider.__module__
+    provider_class = provider.__class__.__name__
     provider_logger = logging.getLogger(provider_module)
-    provider_logger.debug(
-      "%s dispatching op=%s domain=%s path=%s v=%d",
-      f"[{provider_class}]",
-      op,
-      domain,
-      "/".join(path),
-      version,
-    )
+    log_dispatch = getattr(provider, "log_dispatch", None)
+    if callable(log_dispatch):
+      log_dispatch(op)
+    else:
+      domain, path, version = parse_db_op(op)
+      provider_logger.debug(
+        "%s dispatching op=%s domain=%s path=%s v=%d",
+        f"[{provider_class}]",
+        op,
+        domain,
+        "/".join(path),
+        version,
+      )
 
     result = handler(request.payload)
-    if inspect.isawaitable(result):
+    await_handler_result = getattr(provider, "await_handler_result", None)
+    if callable(await_handler_result):
+      result = await await_handler_result(result)
+    elif inspect.isawaitable(result):
       result = await result
+
+    normalize_response = getattr(provider, "normalize_response", None)
+    if callable(normalize_response):
+      return normalize_response(op, result)
     return self._normalize_response(op, result)
 
   def _normalize_response(self, op: str, result: Any) -> DBResponse:

--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -1,6 +1,6 @@
 # providers/database/mssql_provider/__init__.py
 import logging
-from typing import Any
+from typing import Any, Callable, Mapping
 
 from ... import DbProviderBase
 from server.registry import get_handler as resolve_handler, parse_db_op
@@ -22,25 +22,41 @@ class MssqlProvider(DbProviderBase):
     await close_pool()
 
   async def _run(self, request: DBRequest) -> DBResponse:
-    domain, path, version = parse_db_op(request.op)
+    self.log_dispatch(request.op)
+    handler = self.resolve_handler(request.op)
+    result = await self.call_handler(handler, request.payload)
+    return self.normalize_response(request.op, result)
+
+  def resolve_handler(self, op: str) -> Callable[[Mapping[str, Any]], Any]:
+    return get_handler(op)
+
+  def describe_operation(self, op: str) -> tuple[str, tuple[str, ...], int]:
+    return parse_db_op(op)
+
+  def log_dispatch(self, op: str) -> None:
+    domain, path, version = self.describe_operation(op)
     logger.debug(
-      "[MssqlProvider] dispatching op=%s domain=%s path=%s v=%d",
-      request.op,
+      "[%s] dispatching op=%s domain=%s path=%s v=%d",
+      self.__class__.__name__,
+      op,
       domain,
       "/".join(path),
       version,
     )
-    handler = get_handler(request.op)
-    spec = handler(request.payload)
-    result = await self._execute_spec(spec)
-    return self._normalize_response(request.op, result)
 
-  async def _execute_spec(self, spec: Any) -> Any:
-    if hasattr(spec, "__await__"):
-      return await spec
-    return spec
+  async def call_handler(
+    self,
+    handler: Callable[[Mapping[str, Any]], Any],
+    payload: Mapping[str, Any],
+  ) -> Any:
+    return await self.await_handler_result(handler(payload))
 
-  def _normalize_response(self, op: str, result: Any) -> DBResponse:
+  async def await_handler_result(self, result: Any) -> Any:
+    if hasattr(result, "__await__"):
+      return await result
+    return result
+
+  def normalize_response(self, op: str, result: Any) -> DBResponse:
     if isinstance(result, DBResponse):
       if not result.op:
         result.attach_op(op)


### PR DESCRIPTION
## Summary
- expose helper methods on the MSSQL provider for handler resolution, logging, awaiting, and response normalization
- update the database module to use provider helpers when dispatching registry-backed handlers while keeping legacy behavior intact

## Testing
- pytest tests/test_provider_queries.py *(fails: ModuleNotFoundError: No module named 'server.registry.system.vars')*

------
https://chatgpt.com/codex/tasks/task_e_6902c84fc8288325b3a5318a99fccda2