### PR TITLE
Fix account exists handler registration

### DIFF
--- a/server/registry/account/accounts/__init__.py
+++ b/server/registry/account/accounts/__init__.py
@@ -47,4 +47,4 @@ def account_exists_request(user_guid: str) -> DBRequest:
 
 def register(router: "SubdomainRouter") -> None:
   router.add_function("get_security_profile", version=1)
-  router.add_function("account_exists", version=1)
+  router.add_function("exists", implementation="account_exists", version=1)

--- a/tests/test_db_module_run.py
+++ b/tests/test_db_module_run.py
@@ -121,3 +121,27 @@ def test_run_falls_back_to_provider_for_legacy_handlers(monkeypatch):
     assert response.rowcount == 1
 
   asyncio.run(run_scenario())
+
+
+def test_user_exists_dispatches_exists_handler(monkeypatch):
+  app = FastAPI()
+  db = DbModule(app)
+
+  requests = []
+
+  async def fake_run(request):
+    requests.append(request)
+    return DBResponse(op=request.op, rows=[{"result": True}], rowcount=1)
+
+  monkeypatch.setattr(db, "run", fake_run)
+
+  async def run_scenario():
+    result = await db.user_exists("guid-123")
+    assert result is True
+
+  asyncio.run(run_scenario())
+
+  assert requests, "DbModule.user_exists should dispatch a DB request"
+  request = requests[0]
+  assert request.op == "db:account:accounts:exists:1"
+  assert request.payload == {"user_guid": "guid-123"}


### PR DESCRIPTION
## Summary
- register the account exists handler under `db:account:accounts:exists:1`
- add a regression test covering `DbModule.user_exists`

## Testing
- pytest tests/test_db_module_run.py

------
https://chatgpt.com/codex/tasks/task_e_6902d1f1bab48325b150a4e6ff6ab223