### PR TITLE
Log DB registry fallback misses and test warning emission

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -108,7 +108,30 @@ class DbModule(BaseModule):
       handler_info = None
 
     provider = self._provider
-    if not handler_info or handler_info.legacy:
+    fallback_reason = None
+    if not handler_info:
+      fallback_reason = "missing_handler"
+    elif handler_info.legacy:
+      fallback_reason = "legacy_handler"
+
+    if fallback_reason:
+      registry_logger.warning(
+        "Registry handler fallback triggered",
+        extra={
+          "db_op": op,
+          "db_provider": provider_name,
+          "db_fallback_reason": fallback_reason,
+        },
+      )
+      metrics_logger = logging.getLogger("metrics.registry")
+      metrics_logger.info(
+        "db_registry_fallback",
+        extra={
+          "db_op": op,
+          "db_provider": provider_name,
+          "db_fallback_reason": fallback_reason,
+        },
+      )
       return await provider.run(request)
 
     registry_logger.info(

--- a/tests/test_db_module_run.py
+++ b/tests/test_db_module_run.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 from fastapi import FastAPI
 
@@ -97,7 +98,7 @@ def test_run_dispatches_registry_handler(monkeypatch):
   asyncio.run(run_scenario())
 
 
-def test_run_falls_back_to_provider_for_legacy_handlers(monkeypatch):
+def test_run_falls_back_to_provider_for_legacy_handlers(monkeypatch, caplog):
   app = FastAPI()
   db = DbModule(app)
   provider = _LegacyProvider()
@@ -120,7 +121,17 @@ def test_run_falls_back_to_provider_for_legacy_handlers(monkeypatch):
     assert response.rows == [{"result": "legacy"}]
     assert response.rowcount == 1
 
-  asyncio.run(run_scenario())
+  with caplog.at_level(logging.WARNING, logger="server.registry"):
+    asyncio.run(run_scenario())
+
+  fallback_logs = [
+    record
+    for record in caplog.records
+    if record.name == "server.registry" and record.levelno == logging.WARNING
+  ]
+  assert any("Registry handler fallback triggered" in record.message for record in fallback_logs)
+  assert any(record.db_op == request.op for record in fallback_logs)
+  assert any(record.db_provider == db.provider for record in fallback_logs)
 
 
 def test_user_exists_dispatches_exists_handler(monkeypatch):


### PR DESCRIPTION
## Summary
- add warning and metric logging when registry handler lookup falls back to the provider
- log a metrics-friendly event for registry fallback handling
- extend the DB module tests to assert the warning is emitted during fallback scenarios

## Testing
- pytest tests/test_db_module_run.py

------
https://chatgpt.com/codex/tasks/task_e_6902d9bfd2248325a715e39f5a4e222b