### PR TITLE
Add postponed annotations to public RPC services

### DIFF
--- a/rpc/public/gallery/services.py
+++ b/rpc/public/gallery/services.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 from fastapi import Request
 from rpc.helpers import unbox_request

--- a/rpc/public/links/services.py
+++ b/rpc/public/links/services.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from fastapi import Request
 from rpc.helpers import unbox_request
 from server.models import RPCResponse

--- a/rpc/public/users/services.py
+++ b/rpc/public/users/services.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from fastapi import HTTPException, Request
 from rpc.helpers import unbox_request
 from server.models import RPCResponse

--- a/rpc/public/vars/services.py
+++ b/rpc/public/vars/services.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from fastapi import Request
 from rpc.helpers import unbox_request
 from server.models import RPCResponse

--- a/tests/test_public_users_service.py
+++ b/tests/test_public_users_service.py
@@ -22,8 +22,12 @@ class RPCResponse(BaseModel):
   payload: dict
   version: int = 1
 
+class AuthContext(BaseModel):
+  role_mask: int = 0
+
 models_pkg.RPCRequest = RPCRequest
 models_pkg.RPCResponse = RPCResponse
+models_pkg.AuthContext = AuthContext
 server_pkg.models = models_pkg
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)


### PR DESCRIPTION
## Summary
- add `from __future__ import annotations` to public RPC service modules to defer annotation evaluation
- align the public gallery service with the same postponed-annotation import for consistency
- extend the public users service test stub with `AuthContext` so helper imports continue to work

## Testing
- pytest tests/test_public_links_service.py
- pytest tests/test_public_users_service.py
- pytest tests/test_public_vars_service.py

------
https://chatgpt.com/codex/tasks/task_e_69033f7952dc8325ad7eced1748371a0