### PR TITLE
Handle missing registry handlers during storage user validation

### DIFF
--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -28,7 +28,7 @@ from server.modules.registry.helpers import (
   upsert_cache_item_request,
 )
 from server.helpers.logging import update_logging_level
-from server.registry import get_handler_info, parse_db_op
+from server.registry import get_handler_info, parse_db_op, try_get_handler_info
 
 
 class DbModule(BaseModule):
@@ -261,8 +261,34 @@ class DbModule(BaseModule):
     await self.run(replace_user_cache_request(params))
 
   async def user_exists(self, user_guid: str) -> bool:
-    res = await self.run(account_exists_request(user_guid=user_guid))
+    request = account_exists_request(user_guid=user_guid)
+    provider_name = self.provider or "mssql"
+    handler_info = try_get_handler_info(request.op, provider=provider_name)
+    if not handler_info:
+      logging.getLogger("server.registry").warning(
+        "Registry handler missing for user lookup",
+        extra={"db_op": request.op, "db_provider": provider_name},
+      )
+      return await self._fallback_user_exists(user_guid=user_guid)
+    res = await self.run(request)
     return bool(res.rows)
+
+  async def _fallback_user_exists(self, *, user_guid: str) -> bool:
+    provider_name = self.provider or "mssql"
+    if provider_name != "mssql":
+      logging.getLogger("server.registry").error(
+        "No registry handler for %s and no fallback available", provider_name
+      )
+      return False
+    try:
+      from server.registry.account.accounts.mssql import account_exists_v1
+    except ModuleNotFoundError:
+      logging.getLogger("server.registry").error(
+        "MSSQL account exists handler unavailable"
+      )
+      return False
+    response = await account_exists_v1({"user_guid": user_guid})
+    return bool(response.rows)
 
   async def upsert_storage_cache(self, item: Dict[str, Any]) -> DBResponse:
     params = UpsertCacheItemParams.model_validate(item)

--- a/server/registry/__init__.py
+++ b/server/registry/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
   "RegistryRouter",
   "get_handler",
   "get_handler_info",
+  "try_get_handler_info",
   "parse_db_op",
 ]
 
@@ -49,6 +50,12 @@ class HandlerInfo:
 class _HandlerRegistry:
   def __init__(self) -> None:
     self._providers: Dict[str, Dict[str, _HandlerSpec]] = {}
+
+  def try_get_spec(self, op: str, *, provider: str) -> _HandlerSpec | None:
+    provider_map = self._providers.get(provider)
+    if not provider_map:
+      return None
+    return provider_map.get(op)
 
   def register(
     self,
@@ -171,4 +178,15 @@ def get_handler_info(
       "Registry handler resolved",
       extra={"db_op": op, "db_provider": provider},
     )
+  return HandlerInfo(_spec=spec)
+
+
+def try_get_handler_info(
+  op: str,
+  *,
+  provider: str = "mssql",
+) -> HandlerInfo | None:
+  spec = _registry_router._registry.try_get_spec(op, provider=provider)
+  if spec is None:
+    return None
   return HandlerInfo(_spec=spec)

--- a/tests/test_db_module_run.py
+++ b/tests/test_db_module_run.py
@@ -160,6 +160,36 @@ def test_user_exists_dispatches_exists_handler(monkeypatch):
   assert request.payload == {"user_guid": "guid-123"}
 
 
+def test_user_exists_falls_back_when_registry_missing(monkeypatch):
+  app = FastAPI()
+  db = DbModule(app)
+
+  async def fake_exists(args):
+    assert args == {"user_guid": "guid-123"}
+    return DBResponse(rows=[{"exists_flag": 1}], rowcount=1)
+
+  def fake_try_get_handler_info(op, *, provider):
+    assert op == "db:account:accounts:exists:1"
+    assert provider == db.provider
+    return None
+
+  async def fake_run(_request):
+    raise AssertionError("DbModule.run should not be called when fallback is used")
+
+  monkeypatch.setattr("server.modules.db_module.try_get_handler_info", fake_try_get_handler_info)
+  monkeypatch.setattr(
+    "server.registry.account.accounts.mssql.account_exists_v1",
+    fake_exists,
+  )
+  monkeypatch.setattr(db, "run", fake_run)
+
+  async def run_scenario():
+    result = await db.user_exists("guid-123")
+    assert result is True
+
+  asyncio.run(run_scenario())
+
+
 def test_run_uses_registry_account_exists_handler(monkeypatch):
   app = FastAPI()
   db = DbModule(app)


### PR DESCRIPTION
## Summary
- add a registry helper to probe for handlers without emitting error logs
- update `DbModule.user_exists` to fall back to the MSSQL handler when a registry binding is absent
- cover the new fallback path with a unit test

## Testing
- pytest tests/test_db_module_run.py -vv


------
https://chatgpt.com/codex/tasks/task_e_69051711a9ac8325a8f39dbf97ea4f7a