### PR TITLE
Refactor registry handler discovery

### DIFF
--- a/server/registry/__init__.py
+++ b/server/registry/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from importlib import import_module
-from typing import Any, Callable, Dict, Mapping
+from typing import Any, Callable, Mapping
 
 from .models import DBRequest
 
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
   "HandlerInfo",
-  "RegistryRouter",
   "get_handler",
   "get_handler_info",
   "try_get_handler_info",
@@ -22,65 +21,17 @@ __all__ = [
 
 
 @dataclass(slots=True)
-class _HandlerSpec:
+class HandlerInfo:
   module: str
   attribute: str
   legacy: bool = False
-  cached: Callable[[Mapping[str, Any]], Any] | None = None
+  _cached: Callable[[Mapping[str, Any]], Any] | None = None
 
   def load(self) -> Callable[[Mapping[str, Any]], Any]:
-    if self.cached is None:
+    if self._cached is None:
       module = import_module(self.module)
-      self.cached = getattr(module, self.attribute)
-    return self.cached
-
-
-@dataclass(slots=True)
-class HandlerInfo:
-  _spec: _HandlerSpec
-
-  @property
-  def legacy(self) -> bool:
-    return self._spec.legacy
-
-  def load(self) -> Callable[[Mapping[str, Any]], Any]:
-    return self._spec.load()
-
-
-class _HandlerRegistry:
-  def __init__(self) -> None:
-    self._providers: Dict[str, Dict[str, _HandlerSpec]] = {}
-
-  def try_get_spec(self, op: str, *, provider: str) -> _HandlerSpec | None:
-    provider_map = self._providers.get(provider)
-    if not provider_map:
-      return None
-    return provider_map.get(op)
-
-  def register(
-    self,
-    provider: str,
-    op: str,
-    *,
-    module: str,
-    attribute: str,
-    legacy: bool = False,
-  ) -> None:
-    provider_map = self._providers.setdefault(provider, {})
-    if op in provider_map:
-      raise ValueError(f"Duplicate handler registration for {op}")
-    provider_map[op] = _HandlerSpec(module=module, attribute=attribute, legacy=legacy)
-
-  def get_spec(self, op: str, *, provider: str) -> _HandlerSpec:
-    try:
-      return self._providers[provider][op]
-    except KeyError as exc:
-      raise KeyError(
-        f"No handler registered for operation '{op}' with provider '{provider}'"
-      ) from exc
- 
-  def get(self, op: str, *, provider: str) -> Callable[[Mapping[str, Any]], Any]:
-    return self.get_spec(op, provider=provider).load()
+      self._cached = getattr(module, self.attribute)
+    return self._cached
 
 
 def parse_db_op(op: str) -> tuple[str, tuple[str, ...], int]:
@@ -94,76 +45,41 @@ def parse_db_op(op: str) -> tuple[str, tuple[str, ...], int]:
     raise ValueError(f"Invalid DB operation version: {op}") from exc
   domain, *path = segments
   return domain, tuple(path), version
-
-
-class RegistryRouter:
-  def __init__(self, *, provider: str = "mssql") -> None:
-    self._registry = _HandlerRegistry()
-    self._provider = provider
-
-  @property
-  def provider(self) -> str:
-    return self._provider
-
-  def register_function(
-    self,
-    *,
-    domain: str,
-    path: tuple[str, ...] = (),
-    name: str,
-    version: int = 1,
-    implementation: str | None = None,
-    provider: str | None = None,
-    legacy: bool = False,
-    op_path: tuple[str, ...] | None = None,
-  ) -> None:
-    func = implementation or name
-    effective_op_path = op_path if op_path is not None else path
-    op_segments = ("db", domain, *effective_op_path, name, str(version))
-    op = ":".join(segment for segment in op_segments if segment)
-    module_components = (domain, *path)
-    module = ".".join((__name__, *module_components, self._provider))
-    attribute = f"{func}_v{version}"
-    self._registry.register(
-      provider or self._provider,
-      op,
-      module=module,
-      attribute=attribute,
-      legacy=legacy,
-    )
-
-  def get_handler(self, op: str) -> Callable[[Mapping[str, Any]], Any]:
-    return self._registry.get(op, provider=self._provider)
-
-
-_registry_router = RegistryRouter()
-
-from . import account, finance, system  # noqa: E402
-
-finance.register(_registry_router)
-account.register(_registry_router)
-system.register(_registry_router)
-
-
-def _lookup_handler_spec(op: str, *, provider: str) -> _HandlerSpec:
+def _build_handler_info(
+  op: str,
+  *,
+  provider: str,
+  log_errors: bool = True,
+) -> HandlerInfo:
+  domain, path, version = parse_db_op(op)
+  if not path:
+    raise ValueError(f"Invalid database operation path: {op}")
+  *subpath, operation = path
+  module = ".".join(("server", "registry", domain, *subpath, provider))
+  attribute = f"{operation}_v{version}"
+  info = HandlerInfo(module=module, attribute=attribute)
   try:
-    return _registry_router._registry.get_spec(op, provider=provider)
-  except KeyError:
-    logger.error(
-      "Registry handler resolution failed",
-      extra={"db_op": op, "db_provider": provider},
-      exc_info=False,
-    )
-    raise
+    info.load()
+  except (ModuleNotFoundError, AttributeError) as exc:
+    if log_errors:
+      logger.error(
+        "Registry handler resolution failed",
+        extra={"db_op": op, "db_provider": provider},
+        exc_info=False,
+      )
+    raise KeyError(
+      f"No handler registered for operation '{op}' with provider '{provider}'"
+    ) from exc
+  return info
 
 
 def get_handler(op: str, *, provider: str = "mssql") -> Callable[[Mapping[str, Any]], Any]:
-  spec = _lookup_handler_spec(op, provider=provider)
+  info = _build_handler_info(op, provider=provider)
   logger.info(
     "Registry handler resolved",
     extra={"db_op": op, "db_provider": provider},
   )
-  return spec.load()
+  return info.load()
 
 
 def get_handler_info(
@@ -172,13 +88,13 @@ def get_handler_info(
   provider: str = "mssql",
   log_resolution: bool = True,
 ) -> HandlerInfo:
-  spec = _lookup_handler_spec(op, provider=provider)
+  info = _build_handler_info(op, provider=provider)
   if log_resolution:
     logger.info(
       "Registry handler resolved",
       extra={"db_op": op, "db_provider": provider},
     )
-  return HandlerInfo(_spec=spec)
+  return info
 
 
 def try_get_handler_info(
@@ -186,7 +102,7 @@ def try_get_handler_info(
   *,
   provider: str = "mssql",
 ) -> HandlerInfo | None:
-  spec = _registry_router._registry.try_get_spec(op, provider=provider)
-  if spec is None:
+  try:
+    return _build_handler_info(op, provider=provider, log_errors=False)
+  except KeyError:
     return None
-  return HandlerInfo(_spec=spec)

--- a/server/registry/account/__init__.py
+++ b/server/registry/account/__init__.py
@@ -1,13 +1,8 @@
-"""Account domain registry bindings."""
+"""Account domain registry helpers."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from . import actions, accounts, content, enablements, oauth, providers, session
-
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
 
 __all__ = [
   "actions",
@@ -15,16 +10,5 @@ __all__ = [
   "content",
   "enablements",
   "providers",
-  "register",
   "session",
 ]
-
-
-def register(router: "RegistryRouter") -> None:
-  content.register(router, domain="account")
-  accounts.register(router, domain="account", path=("accounts",))
-  actions.register(router, domain="account", path=("actions",))
-  enablements.register(router, domain="account", path=("enablements",))
-  providers.register(router, domain="account", path=("providers",))
-  oauth.register(router, domain="account", path=("oauth",))
-  session.register(router, domain="account", path=("session",))

--- a/server/registry/account/accounts/__init__.py
+++ b/server/registry/account/accounts/__init__.py
@@ -2,18 +2,13 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 from server.registry.types import DBRequest
-
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
 
 __all__ = [
   "account_exists_request",
   "get_security_profile_request",
-  "register",
 ]
 
 
@@ -44,14 +39,3 @@ def account_exists_request(user_guid: str) -> DBRequest:
     op="db:account:accounts:exists:1",
     payload={"user_guid": user_guid},
   )
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="get_security_profile", version=1)
-  register_op(name="exists", implementation="account_exists", version=1)

--- a/server/registry/account/accounts/mssql.py
+++ b/server/registry/account/accounts/mssql.py
@@ -10,6 +10,7 @@ from server.registry.types import DBResponse
 
 __all__ = [
   "account_exists_v1",
+  "exists_v1",
   "get_security_profile_v1",
 ]
 
@@ -135,3 +136,7 @@ async def account_exists_v1(args: dict[str, Any]) -> DBResponse:
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
   return await run_json_one(sql, (guid,))
+
+
+async def exists_v1(args: dict[str, Any]) -> DBResponse:
+  return await account_exists_v1(args)

--- a/server/registry/account/actions/__init__.py
+++ b/server/registry/account/actions/__init__.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
 
 from .model import (
@@ -14,13 +11,9 @@ from .model import (
   UserActionLogRecord,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "list_user_actions_request",
   "log_user_action_request",
-  "register",
   "update_user_action_request",
   "ListUserActionsParams",
   "LogUserActionParams",
@@ -81,15 +74,3 @@ def update_user_action_request(
   if element_notes is not None:
     params["element_notes"] = element_notes
   return DBRequest(op=_op("update"), payload=params)
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="list_by_user", version=1)
-  register_op(name="log", version=1)
-  register_op(name="update", version=1)

--- a/server/registry/account/cache/__init__.py
+++ b/server/registry/account/cache/__init__.py
@@ -7,8 +7,7 @@ services and providers while providing eager validation for shared payloads.
 
 from __future__ import annotations
 
-from functools import partial
-from typing import Any, Dict, Mapping, TYPE_CHECKING
+from typing import Any, Dict, Mapping
 
 from .model import (
   CacheItemKey,
@@ -22,11 +21,7 @@ from .model import (
   normalize_content_cache_item,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
-  "register",
   "delete_cache_folder_request",
   "delete_cache_item_request",
   "set_public_request",
@@ -125,22 +120,3 @@ def set_reported_request(params: SetReportedParams) -> DBRequest:
 def count_rows_request():
   from server.registry.types import DBRequest
   return DBRequest(op="db:account:cache:count_rows:1", payload={})
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="list", version=1)
-  register_op(name="list_public", version=1)
-  register_op(name="list_reported", version=1)
-  register_op(name="replace_user", version=1)
-  register_op(name="upsert", version=1)
-  register_op(name="delete", version=1)
-  register_op(name="delete_folder", version=1)
-  register_op(name="set_public", version=1)
-  register_op(name="set_reported", version=1)
-  register_op(name="count_rows", version=1)

--- a/server/registry/account/content/__init__.py
+++ b/server/registry/account/content/__init__.py
@@ -1,25 +1,12 @@
-"""Content registry bindings for the account domain."""
+"""Content registry helpers for the account domain."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from server.registry.account import cache, files, profile, public
-
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
 
 __all__ = [
   "cache",
   "files",
   "profile",
   "public",
-  "register",
 ]
-
-
-def register(router: "RegistryRouter", *, domain: str) -> None:
-  cache.register(router, domain=domain, path=("cache",))
-  files.register(router, domain=domain, path=("files",))
-  public.register(router, domain=domain, path=("public",))
-  profile.register(router, domain=domain, path=("profile",))

--- a/server/registry/account/enablements/__init__.py
+++ b/server/registry/account/enablements/__init__.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 from server.registry.types import DBRequest
 
@@ -12,12 +11,8 @@ from .model import (
   UserEnablementsRecord,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "get_user_enablements_request",
-  "register",
   "upsert_user_enablements_request",
   "UpsertUserEnablementsParams",
   "UserEnablementsRecord",
@@ -45,14 +40,3 @@ def upsert_user_enablements_request(
     "element_enablements": element_enablements,
   }
   return DBRequest(op=_op("upsert"), payload=params)
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="get_by_user", version=1)
-  register_op(name="upsert", version=1)

--- a/server/registry/account/files/__init__.py
+++ b/server/registry/account/files/__init__.py
@@ -1,18 +1,11 @@
-"""Account files registry bindings."""
+"""Account files registry helpers."""
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
-
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
 
 __all__ = [
   "set_gallery_request",
-  "register",
 ]
 
 
@@ -25,13 +18,3 @@ def set_gallery_request(user_guid: str, name: str, gallery: bool) -> DBRequest:
       "gallery": bool(gallery),
     },
   )
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="set_gallery", version=1)

--- a/server/registry/account/oauth/__init__.py
+++ b/server/registry/account/oauth/__init__.py
@@ -2,19 +2,14 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 from server.registry.types import DBRequest
-
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
 
 __all__ = [
   "relink_discord_request",
   "relink_google_request",
   "relink_microsoft_request",
-  "register",
 ]
 
 
@@ -108,15 +103,3 @@ def relink_microsoft_request(
       reauth_token=reauth_token,
     ),
   )
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="relink_discord", version=1)
-  register_op(name="relink_google", version=1)
-  register_op(name="relink_microsoft", version=1)

--- a/server/registry/account/profile/__init__.py
+++ b/server/registry/account/profile/__init__.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
 from .model import (
   GuidParams,
@@ -16,9 +13,6 @@ from .model import (
   UpdateIfUneditedParams,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "get_profile_request",
   "get_roles_request",
@@ -27,7 +21,6 @@ __all__ = [
   "set_profile_image_request",
   "set_roles_request",
   "update_if_unedited_request",
-  "register",
   "GuidParams",
   "ProfileRecord",
   "SetDisplayParams",
@@ -70,19 +63,3 @@ def set_roles_request(params: SetRolesParams) -> DBRequest:
 
 def update_if_unedited_request(params: UpdateIfUneditedParams) -> DBRequest:
   return _request("update_if_unedited", params.model_dump(exclude_none=True))
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="get_profile", version=1)
-  register_op(name="get_roles", version=1)
-  register_op(name="set_display", version=1)
-  register_op(name="set_optin", version=1)
-  register_op(name="set_profile_image", version=1)
-  register_op(name="set_roles", version=1)
-  register_op(name="update_if_unedited", version=1)

--- a/server/registry/account/providers/__init__.py
+++ b/server/registry/account/providers/__init__.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
 from .model import (
   CreateFromProviderParams,
@@ -17,16 +14,12 @@ from .model import (
   UnlinkProviderParams,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "create_from_provider_request",
   "get_any_by_provider_identifier_request",
   "get_by_provider_identifier_request",
   "get_user_by_email_request",
   "link_provider_request",
-  "register",
   "set_provider_request",
   "soft_delete_account_request",
   "unlink_provider_request",
@@ -105,21 +98,3 @@ def unlink_last_provider_request(params: UnlinkLastProviderParams) -> DBRequest:
     "db:account:providers:unlink_last_provider:1",
     params.model_dump(),
   )
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="create_from_provider", version=1)
-  register_op(name="get_any_by_provider_identifier", version=1)
-  register_op(name="get_by_provider_identifier", version=1)
-  register_op(name="get_user_by_email", version=1)
-  register_op(name="link_provider", version=1)
-  register_op(name="set_provider", version=1)
-  register_op(name="soft_delete_account", version=1)
-  register_op(name="unlink_provider", version=1)
-  register_op(name="unlink_last_provider", version=1)

--- a/server/registry/account/public/__init__.py
+++ b/server/registry/account/public/__init__.py
@@ -2,19 +2,14 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from server.registry.types import DBRequest
-
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
 
 __all__ = [
   "get_public_files_request",
   "list_public_request",
   "list_reported_request",
-  "register",
 ]
 
 
@@ -32,15 +27,3 @@ def list_reported_request() -> DBRequest:
 
 def get_public_files_request() -> DBRequest:
   return _request("db:account:public:get_public_files:1")
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="list_public", version=1)
-  register_op(name="list_reported", version=1)
-  register_op(name="get_public_files", version=1, implementation="list_public")

--- a/server/registry/account/public/mssql.py
+++ b/server/registry/account/public/mssql.py
@@ -8,6 +8,7 @@ from server.registry.providers.mssql import run_json_many
 from server.registry.types import DBResponse
 
 __all__ = [
+  "get_public_files_v1",
   "list_public_v1",
   "list_reported_v1",
 ]
@@ -45,3 +46,7 @@ async def list_reported_v1(_: Dict[str, Any]) -> DBResponse:
     FOR JSON PATH;
   """
   return await run_json_many(sql)
+
+
+async def get_public_files_v1(args: Dict[str, Any]) -> DBResponse:
+  return await list_public_v1(args)

--- a/server/registry/account/session/__init__.py
+++ b/server/registry/account/session/__init__.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
 from .model import (
   CreateSessionParams,
@@ -18,13 +15,9 @@ from .model import (
   UpdateSessionParams,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "create_session_request",
   "get_rotkey_request",
-  "register",
   "revoke_all_device_tokens_request",
   "revoke_device_token_request",
   "revoke_provider_tokens_request",
@@ -88,22 +81,3 @@ def get_rotkey_request(params: GuidParams) -> DBRequest:
 
 def set_rotkey_request(params: SetRotkeyParams) -> DBRequest:
   return _request("set_rotkey", params.model_dump())
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="create_session", version=1)
-  register_op(name="update_session", version=1)
-  register_op(name="update_device_token", version=1)
-  register_op(name="revoke_device_token", version=1)
-  register_op(name="revoke_all_device_tokens", version=1)
-  register_op(name="revoke_provider_tokens", version=1)
-  register_op(name="get_rotkey", version=1)
-  register_op(name="set_rotkey", version=1)
-  register_op(name="list_snapshots", version=1)
-  register_op(name="get_security_snapshot", version=1)

--- a/server/registry/finance/__init__.py
+++ b/server/registry/finance/__init__.py
@@ -1,19 +1,9 @@
-"""Finance domain registry bindings."""
+"""Finance domain registry helpers."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from . import credits
-
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
 
 __all__ = [
   "credits",
-  "register",
 ]
-
-
-def register(router: "RegistryRouter") -> None:
-  credits.register(router, domain="finance", path=("credits",))

--- a/server/registry/finance/credits/__init__.py
+++ b/server/registry/finance/credits/__init__.py
@@ -6,19 +6,12 @@ service and provider implementations agree on the credit update contract.
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
 
 from .model import SetCreditsParams
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "SetCreditsParams",
-  "register",
   "set_credits_request",
 ]
 
@@ -34,13 +27,3 @@ def set_credits_request(params: SetCreditsParams) -> DBRequest:
   """Build a ``set`` registry request using validated parameters."""
 
   return _request("set", params)
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="set", version=1, implementation="set_credits")

--- a/server/registry/finance/credits/mssql.py
+++ b/server/registry/finance/credits/mssql.py
@@ -9,6 +9,7 @@ from server.registry.types import DBResponse
 
 __all__ = [
   "set_credits_v1",
+  "set_v1",
 ]
 
 
@@ -24,3 +25,7 @@ async def set_credits_v1(args: dict[str, Any]) -> DBResponse:
   sql = _build_update_sql()
   params = (args["credits"], args["guid"])
   return await run_exec(sql, params)
+
+
+async def set_v1(args: dict[str, Any]) -> DBResponse:
+  return await set_credits_v1(args)

--- a/server/registry/system/__init__.py
+++ b/server/registry/system/__init__.py
@@ -1,8 +1,6 @@
-"""System domain registry bindings."""
+"""System domain registry helpers."""
 
 from __future__ import annotations
-
-from typing import TYPE_CHECKING
 
 from . import (
   config,
@@ -18,9 +16,6 @@ from . import (
   service_pages,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "config",
   "conversations",
@@ -30,22 +25,7 @@ __all__ = [
   "personas",
   "public_users",
   "public_vars",
-  "register",
   "roles",
   "routes",
   "service_pages",
 ]
-
-
-def register(router: "RegistryRouter") -> None:
-  config.register(router, domain="system", path=("config",))
-  conversations.register(router, domain="system", path=("conversations",))
-  guilds.register(router, domain="system", path=("guilds",))
-  links.register(router, domain="system", path=("links",))
-  models.register(router, domain="system", path=("models",))
-  personas.register(router, domain="system", path=("personas",))
-  roles.register(router, domain="system", path=("roles",))
-  routes.register(router, domain="system", path=("routes",))
-  public_users.register(router, domain="system", path=("public_users",))
-  service_pages.register(router, domain="system", path=("service_pages",))
-  public_vars.register(router, domain="system", path=("public_vars",))

--- a/server/registry/system/config/__init__.py
+++ b/server/registry/system/config/__init__.py
@@ -2,20 +2,13 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
 from .model import ConfigKeyParams, UpsertConfigParams
-
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
 
 __all__ = [
   "delete_config_request",
   "get_config_request",
   "get_configs_request",
-  "register",
   "upsert_config_request",
   "ConfigKeyParams",
   "UpsertConfigParams",
@@ -39,16 +32,3 @@ def upsert_config_request(params: UpsertConfigParams) -> DBRequest:
 
 def delete_config_request(params: ConfigKeyParams) -> DBRequest:
   return DBRequest(op="db:system:config:delete_config:1", payload=params.model_dump())
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="get_config", version=1)
-  register_op(name="get_configs", version=1)
-  register_op(name="upsert_config", version=1)
-  register_op(name="delete_config", version=1)

--- a/server/registry/system/conversations/__init__.py
+++ b/server/registry/system/conversations/__init__.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from server.registry.types import DBRequest
 
@@ -15,15 +14,11 @@ from .model import (
   UpdateConversationOutputParams,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "find_recent_request",
   "insert_conversation_request",
   "list_by_time_request",
   "list_recent_request",
-  "register",
   "update_output_request",
   "ConversationRecord",
   "FindRecentConversationParams",
@@ -123,17 +118,3 @@ def list_by_time_request(*, personas_recid: int, start: str, end: str) -> DBRequ
 
 def list_recent_request() -> DBRequest:
   return DBRequest(op=_op("list_recent"), payload={})
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="find_recent", version=1)
-  register_op(name="insert", version=1, implementation="insert_conversation")
-  register_op(name="list_by_time", version=1)
-  register_op(name="list_recent", version=1)
-  register_op(name="update_output", version=1)

--- a/server/registry/system/conversations/mssql.py
+++ b/server/registry/system/conversations/mssql.py
@@ -10,6 +10,7 @@ from server.registry.types import DBResponse
 __all__ = [
   "find_recent_v1",
   "insert_conversation_v1",
+  "insert_v1",
   "list_by_time_v1",
   "list_recent_v1",
   "update_output_v1",
@@ -52,6 +53,10 @@ async def insert_conversation_v1(args: dict[str, Any]) -> DBResponse:
       tokens,
     ),
   )
+
+
+async def insert_v1(args: dict[str, Any]) -> DBResponse:
+  return await insert_conversation_v1(args)
 
 
 async def find_recent_v1(args: dict[str, Any]) -> DBResponse:

--- a/server/registry/system/guilds/__init__.py
+++ b/server/registry/system/guilds/__init__.py
@@ -3,18 +3,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from server.registry.types import DBRequest
-
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
 
 __all__ = [
   "get_guild_request",
   "list_guilds_request",
-  "register",
   "upsert_guild_request",
 ]
 
@@ -73,15 +68,3 @@ def list_guilds_request(*, include_inactive: bool = True) -> DBRequest:
   if not include_inactive:
     params["include_inactive"] = False
   return _request(f"{_DEF_PROVIDER_KEY}:list_guilds:1", params)
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="upsert_guild", version=1)
-  register_op(name="get_guild", version=1)
-  register_op(name="list_guilds", version=1)

--- a/server/registry/system/links/__init__.py
+++ b/server/registry/system/links/__init__.py
@@ -1,4 +1,4 @@
-"""Public links registry bindings.
+"""Public links registry helpers.
 
 Helpers in this module exchange validated Pydantic models so registries,
 providers, and services share consistent payload shapes for public link data.
@@ -6,15 +6,9 @@ providers, and services share consistent payload shapes for public link data.
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
 
 from .model import HomeLink, NavbarRoute, NavbarRoutesParams
-
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
 
 __all__ = [
   "HomeLink",
@@ -22,7 +16,6 @@ __all__ = [
   "NavbarRoutesParams",
   "get_home_links_request",
   "get_navbar_routes_request",
-  "register",
 ]
 
 
@@ -37,14 +30,3 @@ def get_home_links_request() -> DBRequest:
 
 def get_navbar_routes_request(params: NavbarRoutesParams) -> DBRequest:
   return _request("db:system:public_links:get_navbar_routes:1", params)
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="get_home_links", version=1)
-  register_op(name="get_navbar_routes", version=1)

--- a/server/registry/system/models/__init__.py
+++ b/server/registry/system/models/__init__.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
 
 from .model import (
@@ -12,13 +9,9 @@ from .model import (
   ModelRecord,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "get_model_by_name_request",
   "list_models_request",
-  "register",
   "GetModelByNameParams",
   "ModelRecord",
 ]
@@ -36,14 +29,3 @@ def list_models_request() -> DBRequest:
 
 def get_model_by_name_request(name: str) -> DBRequest:
   return DBRequest(op=_op("get_by_name"), payload={"name": name})
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="get_by_name", version=1)
-  register_op(name="list", version=1)

--- a/server/registry/system/personas/__init__.py
+++ b/server/registry/system/personas/__init__.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
 
 from .model import (
@@ -14,14 +11,10 @@ from .model import (
   UpsertPersonaParams,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "delete_persona_request",
   "get_persona_by_name_request",
   "list_personas_request",
-  "register",
   "upsert_persona_request",
   "DeletePersonaParams",
   "PersonaRecord",
@@ -72,16 +65,3 @@ def delete_persona_request(*, recid: int | None = None, name: str | None = None)
       "name": name,
     },
   )
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="delete", version=1, implementation="delete_persona")
-  register_op(name="get_by_name", version=1)
-  register_op(name="list", version=1, implementation="list_personas")
-  register_op(name="upsert", version=1, implementation="upsert_persona")

--- a/server/registry/system/personas/mssql.py
+++ b/server/registry/system/personas/mssql.py
@@ -9,9 +9,12 @@ from server.registry.types import DBResponse
 
 __all__ = [
   "delete_persona_v1",
+  "delete_v1",
   "get_by_name_v1",
   "list_personas_v1",
+  "list_v1",
   "upsert_persona_v1",
+  "upsert_v1",
 ]
 
 
@@ -127,3 +130,15 @@ async def delete_persona_v1(args: dict[str, Any]) -> DBResponse:
   else:
     raise ValueError("Missing identifier for persona delete")
   return await run_exec(sql, params)
+
+
+async def delete_v1(args: dict[str, Any]) -> DBResponse:
+  return await delete_persona_v1(args)
+
+
+async def list_v1(args: dict[str, Any]) -> DBResponse:
+  return await list_personas_v1(args)
+
+
+async def upsert_v1(args: dict[str, Any]) -> DBResponse:
+  return await upsert_persona_v1(args)

--- a/server/registry/system/public_users/__init__.py
+++ b/server/registry/system/public_users/__init__.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from server.registry.types import DBRequest
 
@@ -14,9 +13,6 @@ from .model import (
   PublicUserProfile,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "GetProfileParams",
   "GetPublishedFilesParams",
@@ -24,7 +20,6 @@ __all__ = [
   "PublicUserProfile",
   "get_profile_request",
   "get_published_files_request",
-  "register",
 ]
 
 
@@ -40,14 +35,3 @@ def get_profile_request(*, guid: str) -> DBRequest:
 def get_published_files_request(*, guid: str) -> DBRequest:
   params: GetPublishedFilesParams = {"guid": guid}
   return _request("db:system:public_users:get_published_files:1", params)
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="get_profile", version=1)
-  register_op(name="get_published_files", version=1)

--- a/server/registry/system/public_vars/__init__.py
+++ b/server/registry/system/public_vars/__init__.py
@@ -2,20 +2,15 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from server.registry.types import DBRequest
 from .model import PublicVarRecord
-
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
 
 __all__ = [
   "get_hostname_request",
   "get_repo_request",
   "get_version_request",
-  "register",
   "PublicVarRecord",
 ]
 
@@ -34,15 +29,3 @@ def get_hostname_request() -> DBRequest:
 
 def get_repo_request() -> DBRequest:
   return _request("db:system:public_vars:get_repo:1")
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="get_version", version=1)
-  register_op(name="get_hostname", version=1)
-  register_op(name="get_repo", version=1)

--- a/server/registry/system/roles/__init__.py
+++ b/server/registry/system/roles/__init__.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
 from .model import (
   DeleteRoleParams,
@@ -13,16 +10,12 @@ from .model import (
   UpsertRoleParams,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "add_role_member_request",
   "delete_role_request",
   "get_role_members_request",
   "get_role_non_members_request",
   "list_roles_request",
-  "register",
   "remove_role_member_request",
   "upsert_role_request",
   "DeleteRoleParams",
@@ -76,19 +69,3 @@ def delete_role_request(params: DeleteRoleParams) -> DBRequest:
     op="db:system:roles:delete_role:1",
     payload=params.model_dump(),
   )
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="list", version=1, implementation="list_roles")
-  register_op(name="get_role_members", version=1)
-  register_op(name="get_role_non_members", version=1)
-  register_op(name="add_role_member", version=1)
-  register_op(name="remove_role_member", version=1)
-  register_op(name="upsert_role", version=1)
-  register_op(name="delete_role", version=1)

--- a/server/registry/system/roles/mssql.py
+++ b/server/registry/system/roles/mssql.py
@@ -13,6 +13,7 @@ __all__ = [
   "get_role_members_v1",
   "get_role_non_members_v1",
   "list_roles_v1",
+  "list_v1",
   "remove_role_member_v1",
   "upsert_role_v1",
 ]
@@ -26,6 +27,10 @@ async def list_roles_v1(_: dict[str, Any]) -> DBResponse:
     FOR JSON PATH;
   """
   return await run_json_many(sql)
+
+
+async def list_v1(args: dict[str, Any]) -> DBResponse:
+  return await list_roles_v1(args)
 
 
 async def get_role_members_v1(args: dict[str, Any]) -> DBResponse:

--- a/server/registry/system/routes/__init__.py
+++ b/server/registry/system/routes/__init__.py
@@ -2,18 +2,11 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
-
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
 
 __all__ = [
   "delete_route_request",
   "get_routes_request",
-  "register",
   "upsert_route_request",
 ]
 
@@ -41,15 +34,3 @@ def upsert_route_request(
 
 def delete_route_request(path: str) -> DBRequest:
   return DBRequest(op="db:system:routes:delete_route:1", payload={"path": path})
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="get_routes", version=1)
-  register_op(name="upsert_route", version=1)
-  register_op(name="delete_route", version=1)

--- a/server/registry/system/service_pages/__init__.py
+++ b/server/registry/system/service_pages/__init__.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from functools import partial
-from typing import TYPE_CHECKING
-
 from server.registry.types import DBRequest
 
 from .model import (
@@ -17,16 +14,12 @@ from .model import (
   UpdateServicePageParams,
 )
 
-if TYPE_CHECKING:
-  from server.registry import RegistryRouter
-
 __all__ = [
   "create_service_page_request",
   "delete_service_page_request",
   "get_service_page_by_route_request",
   "get_service_page_request",
   "list_service_pages_request",
-  "register",
   "update_service_page_request",
   "CreateServicePageParams",
   "DeleteServicePageParams",
@@ -118,18 +111,3 @@ def update_service_page_request(
 def delete_service_page_request(*, recid: int) -> DBRequest:
   payload: DeleteServicePageParams = {"recid": recid}
   return DBRequest(op=_op("delete"), payload=payload)
-
-
-def register(
-  router: "RegistryRouter",
-  *,
-  domain: str,
-  path: tuple[str, ...],
-) -> None:
-  register_op = partial(router.register_function, domain=domain, path=path)
-  register_op(name="list", version=1)
-  register_op(name="get", version=1)
-  register_op(name="get_by_route", version=1)
-  register_op(name="create", version=1)
-  register_op(name="update", version=1)
-  register_op(name="delete", version=1)

--- a/tests/test_registry_contracts.py
+++ b/tests/test_registry_contracts.py
@@ -3,26 +3,45 @@
 from __future__ import annotations
 
 import importlib
+import inspect
+import re
+from pathlib import Path
+
+from server.registry import get_handler_info, parse_db_op, try_get_handler_info
 
 
-def test_registered_ops_align_with_module_paths():
-  registry = importlib.import_module("server.registry")
-  providers = registry._registry_router._registry._providers
-  assert providers, "registry should have providers registered"
+def _iter_provider_operations():
+  base = Path("server/registry")
+  for module_path in base.rglob("mssql.py"):
+    if "providers" in module_path.parts:
+      continue
+    module_name = ".".join(module_path.with_suffix("").parts)
+    module = importlib.import_module(module_name)
+    parts = module_name.split(".")
+    registry_index = parts.index("registry")
+    domain = parts[registry_index + 1]
+    subpath = tuple(parts[registry_index + 2 : -1])
+    for name, func in inspect.getmembers(module, inspect.iscoroutinefunction):
+      match = re.fullmatch(r"(?P<operation>.+)_v(?P<version>\d+)", name)
+      if not match:
+        continue
+      operation = match.group("operation")
+      version = int(match.group("version"))
+      op = ":".join(("db", domain, *subpath, operation, str(version)))
+      yield op, domain, subpath, version, func
 
-  for provider, ops in providers.items():
-    assert ops, f"provider {provider} must register operations"
-    for op, spec in ops.items():
-      domain, path, version = registry.parse_db_op(op)
-      assert version > 0, f"{op} must use a positive version number"
-      module_parts = spec.module.split(".")
-      try:
-        reg_index = module_parts.index("registry")
-      except ValueError:  # pragma: no cover - defensive guard
-        raise AssertionError(f"handler module missing registry segment: {spec.module}")
-      package_parts = module_parts[reg_index + 1 : -1]
-      assert package_parts, f"{op} must live under server.registry.*"
-      assert domain == package_parts[0], f"{op} domain mismatch"
-      expected_path = tuple(package_parts[1:])
-      actual_path = tuple(path[:-1])
-      assert actual_path == expected_path, f"{op} subdomain path mismatch"
+
+def test_provider_modules_align_with_dynamic_resolution():
+  for op, domain, subpath, version, func in _iter_provider_operations():
+    info = try_get_handler_info(op, provider="mssql")
+    if info is None:
+      continue
+    handler = info.load()
+    assert handler is func, f"{op} should resolve to {func.__module__}.{func.__name__}"
+    resolved_domain, path, resolved_version = parse_db_op(op)
+    assert resolved_domain == domain
+    assert resolved_version == version
+    assert tuple(path[:-1]) == subpath
+    assert path[-1] == op.split(":")[-2]
+    info_direct = get_handler_info(op, provider="mssql", log_resolution=False)
+    assert info_direct.load() is handler


### PR DESCRIPTION
## Summary
- replace the registry router with parse-driven dynamic handler lookups
- simplify account, finance, and system registry packages by dropping register helpers and aligning provider exports
- update tests to cover the new resolution flow

## Testing
- pytest tests/test_registry_contracts.py

------
https://chatgpt.com/codex/tasks/task_e_69052c3fb4308325a46cd2d7592dc6e5