### PR TITLE
Add check_status dispatchers for query registry subdomains

### DIFF
--- a/server/queryregistry/account/__init__.py
+++ b/server/queryregistry/account/__init__.py
@@ -1,1 +1,13 @@
 """Account query handler package."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import SubdomainDispatcher
+
+from .services import account_check_status_v1
+
+__all__ = ["DISPATCHERS"]
+
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("check_status", "1"): account_check_status_v1,
+}

--- a/server/queryregistry/account/handler.py
+++ b/server/queryregistry/account/handler.py
@@ -1,19 +1,28 @@
-"""Account domain handler stubs."""
+"""Account domain handler implementations."""
 
 from __future__ import annotations
 
 from typing import Sequence
 
+from fastapi import HTTPException
+
 from server.queryregistry.models import DBRequest, DBResponse
+
+from . import DISPATCHERS
+
+__all__ = ["handle_account_request"]
 
 
 async def handle_account_request(
   path: Sequence[str],
   request: DBRequest,
+  *,
   provider: str,
 ) -> DBResponse:
-  """Dispatch account registry requests.
-
-  This stub will be expanded with provider-specific logic.
-  """
-  raise NotImplementedError("Account registry handler not implemented yet")
+  if len(path) < 2:
+    raise HTTPException(status_code=404, detail="Unknown account registry operation")
+  key = tuple(path[:2])
+  handler = DISPATCHERS.get(key)
+  if handler is None:
+    raise HTTPException(status_code=404, detail="Unknown account registry operation")
+  return await handler(request, provider=provider)

--- a/server/queryregistry/account/models.py
+++ b/server/queryregistry/account/models.py
@@ -1,0 +1,20 @@
+"""Account query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from server.queryregistry.types import CheckStatusCallable
+
+__all__ = [
+  "AccountCheckStatusCallable",
+  "AccountCheckStatusPayload",
+]
+
+
+class AccountCheckStatusPayload(TypedDict):
+  status: str
+  provider: str
+
+
+AccountCheckStatusCallable = CheckStatusCallable

--- a/server/queryregistry/account/mssql.py
+++ b/server/queryregistry/account/mssql.py
@@ -1,0 +1,11 @@
+"""MSSQL implementations for account query registry services."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import CheckStatusPayload
+
+__all__ = ["check_status"]
+
+
+async def check_status() -> CheckStatusPayload:
+  return {"status": "ok", "provider": "mssql"}

--- a/server/queryregistry/account/services.py
+++ b/server/queryregistry/account/services.py
@@ -1,0 +1,26 @@
+"""Account query registry service dispatchers."""
+
+from __future__ import annotations
+
+from server.queryregistry.models import DBRequest, DBResponse
+from server.queryregistry.types import CheckStatusCallable
+
+from . import mssql
+
+__all__ = ["account_check_status_v1"]
+
+_PROVIDER_DISPATCHERS: dict[str, CheckStatusCallable] = {
+  "mssql": mssql.check_status,
+}
+
+
+async def account_check_status_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _PROVIDER_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for account registry")
+  payload = await dispatcher()
+  return DBResponse(op=request.op, payload=dict(payload))

--- a/server/queryregistry/finance/__init__.py
+++ b/server/queryregistry/finance/__init__.py
@@ -1,1 +1,13 @@
 """Finance query handler package."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import SubdomainDispatcher
+
+from .services import finance_check_status_v1
+
+__all__ = ["DISPATCHERS"]
+
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("check_status", "1"): finance_check_status_v1,
+}

--- a/server/queryregistry/finance/handler.py
+++ b/server/queryregistry/finance/handler.py
@@ -1,19 +1,28 @@
-"""Finance domain handler stubs."""
+"""Finance domain handler implementations."""
 
 from __future__ import annotations
 
 from typing import Sequence
 
+from fastapi import HTTPException
+
 from server.queryregistry.models import DBRequest, DBResponse
+
+from . import DISPATCHERS
+
+__all__ = ["handle_finance_request"]
 
 
 async def handle_finance_request(
   path: Sequence[str],
   request: DBRequest,
+  *,
   provider: str,
 ) -> DBResponse:
-  """Dispatch finance registry requests.
-
-  This stub will be expanded with provider-specific logic.
-  """
-  raise NotImplementedError("Finance registry handler not implemented yet")
+  if len(path) < 2:
+    raise HTTPException(status_code=404, detail="Unknown finance registry operation")
+  key = tuple(path[:2])
+  handler = DISPATCHERS.get(key)
+  if handler is None:
+    raise HTTPException(status_code=404, detail="Unknown finance registry operation")
+  return await handler(request, provider=provider)

--- a/server/queryregistry/finance/models.py
+++ b/server/queryregistry/finance/models.py
@@ -1,0 +1,20 @@
+"""Finance query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from server.queryregistry.types import CheckStatusCallable
+
+__all__ = [
+  "FinanceCheckStatusCallable",
+  "FinanceCheckStatusPayload",
+]
+
+
+class FinanceCheckStatusPayload(TypedDict):
+  status: str
+  provider: str
+
+
+FinanceCheckStatusCallable = CheckStatusCallable

--- a/server/queryregistry/finance/mssql.py
+++ b/server/queryregistry/finance/mssql.py
@@ -1,0 +1,11 @@
+"""MSSQL implementations for finance query registry services."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import CheckStatusPayload
+
+__all__ = ["check_status"]
+
+
+async def check_status() -> CheckStatusPayload:
+  return {"status": "ok", "provider": "mssql"}

--- a/server/queryregistry/finance/services.py
+++ b/server/queryregistry/finance/services.py
@@ -1,0 +1,26 @@
+"""Finance query registry service dispatchers."""
+
+from __future__ import annotations
+
+from server.queryregistry.models import DBRequest, DBResponse
+from server.queryregistry.types import CheckStatusCallable
+
+from . import mssql
+
+__all__ = ["finance_check_status_v1"]
+
+_PROVIDER_DISPATCHERS: dict[str, CheckStatusCallable] = {
+  "mssql": mssql.check_status,
+}
+
+
+async def finance_check_status_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _PROVIDER_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for finance registry")
+  payload = await dispatcher()
+  return DBResponse(op=request.op, payload=dict(payload))

--- a/server/queryregistry/public/gallery/__init__.py
+++ b/server/queryregistry/public/gallery/__init__.py
@@ -1,1 +1,13 @@
 """Public gallery query handlers."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import SubdomainDispatcher
+
+from .services import public_gallery_check_status_v1
+
+__all__ = ["DISPATCHERS"]
+
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("check_status", "1"): public_gallery_check_status_v1,
+}

--- a/server/queryregistry/public/gallery/handler.py
+++ b/server/queryregistry/public/gallery/handler.py
@@ -1,10 +1,16 @@
-"""Public gallery query handler stubs."""
+"""Public gallery query handler implementations."""
 
 from __future__ import annotations
 
 from typing import Sequence
 
+from fastapi import HTTPException
+
 from server.queryregistry.models import DBRequest, DBResponse
+
+from . import DISPATCHERS
+
+__all__ = ["handle_gallery_request"]
 
 
 async def handle_gallery_request(
@@ -13,6 +19,10 @@ async def handle_gallery_request(
   *,
   provider: str,
 ) -> DBResponse:
-  """Handle public gallery query requests."""
-
-  raise NotImplementedError("Public gallery query handler not implemented yet")
+  if len(path) < 2:
+    raise HTTPException(status_code=404, detail="Unknown public gallery operation")
+  key = tuple(path[:2])
+  handler = DISPATCHERS.get(key)
+  if handler is None:
+    raise HTTPException(status_code=404, detail="Unknown public gallery operation")
+  return await handler(request, provider=provider)

--- a/server/queryregistry/public/gallery/models.py
+++ b/server/queryregistry/public/gallery/models.py
@@ -1,0 +1,20 @@
+"""Public gallery query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from server.queryregistry.types import CheckStatusCallable
+
+__all__ = [
+  "PublicGalleryCheckStatusCallable",
+  "PublicGalleryCheckStatusPayload",
+]
+
+
+class PublicGalleryCheckStatusPayload(TypedDict):
+  status: str
+  provider: str
+
+
+PublicGalleryCheckStatusCallable = CheckStatusCallable

--- a/server/queryregistry/public/gallery/mssql.py
+++ b/server/queryregistry/public/gallery/mssql.py
@@ -1,0 +1,11 @@
+"""MSSQL implementations for public gallery query registry services."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import CheckStatusPayload
+
+__all__ = ["check_status"]
+
+
+async def check_status() -> CheckStatusPayload:
+  return {"status": "ok", "provider": "mssql"}

--- a/server/queryregistry/public/gallery/services.py
+++ b/server/queryregistry/public/gallery/services.py
@@ -1,0 +1,26 @@
+"""Public gallery query registry service dispatchers."""
+
+from __future__ import annotations
+
+from server.queryregistry.models import DBRequest, DBResponse
+from server.queryregistry.types import CheckStatusCallable
+
+from . import mssql
+
+__all__ = ["public_gallery_check_status_v1"]
+
+_PROVIDER_DISPATCHERS: dict[str, CheckStatusCallable] = {
+  "mssql": mssql.check_status,
+}
+
+
+async def public_gallery_check_status_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _PROVIDER_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for public gallery registry")
+  payload = await dispatcher()
+  return DBResponse(op=request.op, payload=dict(payload))

--- a/server/queryregistry/public/links/__init__.py
+++ b/server/queryregistry/public/links/__init__.py
@@ -1,1 +1,13 @@
 """Public links query handlers."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import SubdomainDispatcher
+
+from .services import public_links_check_status_v1
+
+__all__ = ["DISPATCHERS"]
+
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("check_status", "1"): public_links_check_status_v1,
+}

--- a/server/queryregistry/public/links/handler.py
+++ b/server/queryregistry/public/links/handler.py
@@ -1,10 +1,16 @@
-"""Public links query handler stubs."""
+"""Public links query handler implementations."""
 
 from __future__ import annotations
 
 from typing import Sequence
 
+from fastapi import HTTPException
+
 from server.queryregistry.models import DBRequest, DBResponse
+
+from . import DISPATCHERS
+
+__all__ = ["handle_links_request"]
 
 
 async def handle_links_request(
@@ -13,6 +19,10 @@ async def handle_links_request(
   *,
   provider: str,
 ) -> DBResponse:
-  """Handle public links query requests."""
-
-  raise NotImplementedError("Public links query handler not implemented yet")
+  if len(path) < 2:
+    raise HTTPException(status_code=404, detail="Unknown public links operation")
+  key = tuple(path[:2])
+  handler = DISPATCHERS.get(key)
+  if handler is None:
+    raise HTTPException(status_code=404, detail="Unknown public links operation")
+  return await handler(request, provider=provider)

--- a/server/queryregistry/public/links/models.py
+++ b/server/queryregistry/public/links/models.py
@@ -1,0 +1,20 @@
+"""Public links query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from server.queryregistry.types import CheckStatusCallable
+
+__all__ = [
+  "PublicLinksCheckStatusCallable",
+  "PublicLinksCheckStatusPayload",
+]
+
+
+class PublicLinksCheckStatusPayload(TypedDict):
+  status: str
+  provider: str
+
+
+PublicLinksCheckStatusCallable = CheckStatusCallable

--- a/server/queryregistry/public/links/mssql.py
+++ b/server/queryregistry/public/links/mssql.py
@@ -1,0 +1,11 @@
+"""MSSQL implementations for public links query registry services."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import CheckStatusPayload
+
+__all__ = ["check_status"]
+
+
+async def check_status() -> CheckStatusPayload:
+  return {"status": "ok", "provider": "mssql"}

--- a/server/queryregistry/public/links/services.py
+++ b/server/queryregistry/public/links/services.py
@@ -1,0 +1,26 @@
+"""Public links query registry service dispatchers."""
+
+from __future__ import annotations
+
+from server.queryregistry.models import DBRequest, DBResponse
+from server.queryregistry.types import CheckStatusCallable
+
+from . import mssql
+
+__all__ = ["public_links_check_status_v1"]
+
+_PROVIDER_DISPATCHERS: dict[str, CheckStatusCallable] = {
+  "mssql": mssql.check_status,
+}
+
+
+async def public_links_check_status_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _PROVIDER_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for public links registry")
+  payload = await dispatcher()
+  return DBResponse(op=request.op, payload=dict(payload))

--- a/server/queryregistry/public/users/__init__.py
+++ b/server/queryregistry/public/users/__init__.py
@@ -1,1 +1,13 @@
 """Public users query handlers."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import SubdomainDispatcher
+
+from .services import public_users_check_status_v1
+
+__all__ = ["DISPATCHERS"]
+
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("check_status", "1"): public_users_check_status_v1,
+}

--- a/server/queryregistry/public/users/handler.py
+++ b/server/queryregistry/public/users/handler.py
@@ -1,10 +1,16 @@
-"""Public users query handler stubs."""
+"""Public users query handler implementations."""
 
 from __future__ import annotations
 
 from typing import Sequence
 
+from fastapi import HTTPException
+
 from server.queryregistry.models import DBRequest, DBResponse
+
+from . import DISPATCHERS
+
+__all__ = ["handle_users_request"]
 
 
 async def handle_users_request(
@@ -13,6 +19,10 @@ async def handle_users_request(
   *,
   provider: str,
 ) -> DBResponse:
-  """Handle public users query requests."""
-
-  raise NotImplementedError("Public users query handler not implemented yet")
+  if len(path) < 2:
+    raise HTTPException(status_code=404, detail="Unknown public users operation")
+  key = tuple(path[:2])
+  handler = DISPATCHERS.get(key)
+  if handler is None:
+    raise HTTPException(status_code=404, detail="Unknown public users operation")
+  return await handler(request, provider=provider)

--- a/server/queryregistry/public/users/models.py
+++ b/server/queryregistry/public/users/models.py
@@ -1,0 +1,20 @@
+"""Public users query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from server.queryregistry.types import CheckStatusCallable
+
+__all__ = [
+  "PublicUsersCheckStatusCallable",
+  "PublicUsersCheckStatusPayload",
+]
+
+
+class PublicUsersCheckStatusPayload(TypedDict):
+  status: str
+  provider: str
+
+
+PublicUsersCheckStatusCallable = CheckStatusCallable

--- a/server/queryregistry/public/users/mssql.py
+++ b/server/queryregistry/public/users/mssql.py
@@ -1,0 +1,11 @@
+"""MSSQL implementations for public users query registry services."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import CheckStatusPayload
+
+__all__ = ["check_status"]
+
+
+async def check_status() -> CheckStatusPayload:
+  return {"status": "ok", "provider": "mssql"}

--- a/server/queryregistry/public/users/services.py
+++ b/server/queryregistry/public/users/services.py
@@ -1,0 +1,26 @@
+"""Public users query registry service dispatchers."""
+
+from __future__ import annotations
+
+from server.queryregistry.models import DBRequest, DBResponse
+from server.queryregistry.types import CheckStatusCallable
+
+from . import mssql
+
+__all__ = ["public_users_check_status_v1"]
+
+_PROVIDER_DISPATCHERS: dict[str, CheckStatusCallable] = {
+  "mssql": mssql.check_status,
+}
+
+
+async def public_users_check_status_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _PROVIDER_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for public users registry")
+  payload = await dispatcher()
+  return DBResponse(op=request.op, payload=dict(payload))

--- a/server/queryregistry/public/vars/__init__.py
+++ b/server/queryregistry/public/vars/__init__.py
@@ -1,1 +1,13 @@
 """Public vars query handlers."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import SubdomainDispatcher
+
+from .services import public_vars_check_status_v1
+
+__all__ = ["DISPATCHERS"]
+
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("check_status", "1"): public_vars_check_status_v1,
+}

--- a/server/queryregistry/public/vars/handler.py
+++ b/server/queryregistry/public/vars/handler.py
@@ -1,10 +1,16 @@
-"""Public vars query handler stubs."""
+"""Public vars query handler implementations."""
 
 from __future__ import annotations
 
 from typing import Sequence
 
+from fastapi import HTTPException
+
 from server.queryregistry.models import DBRequest, DBResponse
+
+from . import DISPATCHERS
+
+__all__ = ["handle_vars_request"]
 
 
 async def handle_vars_request(
@@ -13,6 +19,10 @@ async def handle_vars_request(
   *,
   provider: str,
 ) -> DBResponse:
-  """Handle public vars query requests."""
-
-  raise NotImplementedError("Public vars query handler not implemented yet")
+  if len(path) < 2:
+    raise HTTPException(status_code=404, detail="Unknown public vars operation")
+  key = tuple(path[:2])
+  handler = DISPATCHERS.get(key)
+  if handler is None:
+    raise HTTPException(status_code=404, detail="Unknown public vars operation")
+  return await handler(request, provider=provider)

--- a/server/queryregistry/public/vars/models.py
+++ b/server/queryregistry/public/vars/models.py
@@ -1,0 +1,20 @@
+"""Public vars query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from server.queryregistry.types import CheckStatusCallable
+
+__all__ = [
+  "PublicVarsCheckStatusCallable",
+  "PublicVarsCheckStatusPayload",
+]
+
+
+class PublicVarsCheckStatusPayload(TypedDict):
+  status: str
+  provider: str
+
+
+PublicVarsCheckStatusCallable = CheckStatusCallable

--- a/server/queryregistry/public/vars/mssql.py
+++ b/server/queryregistry/public/vars/mssql.py
@@ -1,0 +1,11 @@
+"""MSSQL implementations for public vars query registry services."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import CheckStatusPayload
+
+__all__ = ["check_status"]
+
+
+async def check_status() -> CheckStatusPayload:
+  return {"status": "ok", "provider": "mssql"}

--- a/server/queryregistry/public/vars/services.py
+++ b/server/queryregistry/public/vars/services.py
@@ -1,0 +1,26 @@
+"""Public vars query registry service dispatchers."""
+
+from __future__ import annotations
+
+from server.queryregistry.models import DBRequest, DBResponse
+from server.queryregistry.types import CheckStatusCallable
+
+from . import mssql
+
+__all__ = ["public_vars_check_status_v1"]
+
+_PROVIDER_DISPATCHERS: dict[str, CheckStatusCallable] = {
+  "mssql": mssql.check_status,
+}
+
+
+async def public_vars_check_status_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _PROVIDER_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for public vars registry")
+  payload = await dispatcher()
+  return DBResponse(op=request.op, payload=dict(payload))

--- a/server/queryregistry/system/__init__.py
+++ b/server/queryregistry/system/__init__.py
@@ -1,1 +1,13 @@
 """System query handler package."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import SubdomainDispatcher
+
+from .services import system_check_status_v1
+
+__all__ = ["DISPATCHERS"]
+
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("check_status", "1"): system_check_status_v1,
+}

--- a/server/queryregistry/system/handler.py
+++ b/server/queryregistry/system/handler.py
@@ -1,19 +1,28 @@
-"""System domain handler stubs."""
+"""System domain handler implementations."""
 
 from __future__ import annotations
 
 from typing import Sequence
 
+from fastapi import HTTPException
+
 from server.queryregistry.models import DBRequest, DBResponse
+
+from . import DISPATCHERS
+
+__all__ = ["handle_system_request"]
 
 
 async def handle_system_request(
   path: Sequence[str],
   request: DBRequest,
+  *,
   provider: str,
 ) -> DBResponse:
-  """Dispatch system registry requests.
-
-  This stub will be expanded with provider-specific logic.
-  """
-  raise NotImplementedError("System registry handler not implemented yet")
+  if len(path) < 2:
+    raise HTTPException(status_code=404, detail="Unknown system registry operation")
+  key = tuple(path[:2])
+  handler = DISPATCHERS.get(key)
+  if handler is None:
+    raise HTTPException(status_code=404, detail="Unknown system registry operation")
+  return await handler(request, provider=provider)

--- a/server/queryregistry/system/models.py
+++ b/server/queryregistry/system/models.py
@@ -1,0 +1,20 @@
+"""System query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from server.queryregistry.types import CheckStatusCallable
+
+__all__ = [
+  "SystemCheckStatusCallable",
+  "SystemCheckStatusPayload",
+]
+
+
+class SystemCheckStatusPayload(TypedDict):
+  status: str
+  provider: str
+
+
+SystemCheckStatusCallable = CheckStatusCallable

--- a/server/queryregistry/system/mssql.py
+++ b/server/queryregistry/system/mssql.py
@@ -1,0 +1,11 @@
+"""MSSQL implementations for system query registry services."""
+
+from __future__ import annotations
+
+from server.queryregistry.types import CheckStatusPayload
+
+__all__ = ["check_status"]
+
+
+async def check_status() -> CheckStatusPayload:
+  return {"status": "ok", "provider": "mssql"}

--- a/server/queryregistry/system/services.py
+++ b/server/queryregistry/system/services.py
@@ -1,0 +1,26 @@
+"""System query registry service dispatchers."""
+
+from __future__ import annotations
+
+from server.queryregistry.models import DBRequest, DBResponse
+from server.queryregistry.types import CheckStatusCallable
+
+from . import mssql
+
+__all__ = ["system_check_status_v1"]
+
+_PROVIDER_DISPATCHERS: dict[str, CheckStatusCallable] = {
+  "mssql": mssql.check_status,
+}
+
+
+async def system_check_status_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _PROVIDER_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for system registry")
+  payload = await dispatcher()
+  return DBResponse(op=request.op, payload=dict(payload))

--- a/server/queryregistry/types.py
+++ b/server/queryregistry/types.py
@@ -1,0 +1,23 @@
+"""Shared type definitions for QueryRegistry dispatchers."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol
+
+from .models import DBRequest, DBResponse
+
+__all__ = [
+  "CheckStatusCallable",
+  "CheckStatusPayload",
+  "SubdomainDispatcher",
+]
+
+CheckStatusPayload = Mapping[str, Any]
+
+
+class CheckStatusCallable(Protocol):
+  async def __call__(self) -> CheckStatusPayload: ...
+
+
+class SubdomainDispatcher(Protocol):
+  async def __call__(self, request: DBRequest, *, provider: str) -> DBResponse: ...


### PR DESCRIPTION
## Summary
- add typed dispatcher mappings for the query registry domains and subdomains
- implement check_status services backed by provider stubs for each subdomain
- introduce shared dispatcher typings for the query registry package

## Testing
- python -m compileall server/queryregistry

------
https://chatgpt.com/codex/tasks/task_e_690696693e4883258f88b471e6e67893