### PR TITLE
Clarify run_tests harness usage in AGENT guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,93 +1,71 @@
-# AGENT Instructions
+# Repository-wide AGENT Instructions
 
-This document provides concise rules and operational guidance for the Codex CLI code agent. It is focused on coding agent rules; detailed architectural and security design is documented separately in **ARCHITECTURE.md**.
-
----
-
-## Automation and Scripting
-
-* **`dev.cmd`** – Use for build/test actions on Windows.
-* **`run_tests.py`** – Canonical entry point for running tests.
-* **`mssql_cli.py`** and **`scriptlib.py`** – Utilities for schema migrations and maintenance tasks.
-* **Docker builds** – No automated test coverage; modify with caution.
+This document sets the ground rules for any change that spans the repository.
+Component-specific expectations now live beside the code they regulate; see the
+"Component Guides" section below before editing a feature area.
 
 ---
 
-## Coding Standards
+## Orientation
 
-* Python → 2-space indentation.
-* TypeScript → 4-space tabs.
-* Update tests, scripts, and docs with code changes.
-* Run `npm lint` and `npm type-check` for frontend.
-
----
-
-## Database Management
-
-* For data loads, generate a `.sql` file. Human developers will import manually using **SSMS**.
+- Review **ARCHITECTURE.md** for the layer boundaries (RPC → Service → Module →
+  Provider) and the security model.
+- Domain-specific design notes are captured in the markdown files that live next
+  to the related code (for example **RPC.md** and documents under `server/`).
 
 ---
 
-## Testing Details
+## Workflow Guardrails
 
-* Always regenerate RPC bindings before running tests.
-* Frontend: `npm lint`, `npm type-check`, `npm test`.
-* Backend: `pytest` in `/tests`.
-
----
-
-## Tech Stack
-
-* **Node 18 / React / TypeScript** – Frontend.
-* **FastAPI (Python 3.12)** – Backend RPC server.
-* **Docker** – Containerization.
+- Update tests, scripts, and documentation alongside code changes.
+- Database loads must be delivered as `.sql` files—humans run them through
+  **SSMS**.
+- Prefer existing automation helpers when they exist instead of ad-hoc scripts.
+- Docker builds have no automated coverage—plan manual validation when touching
+  the Dockerfile or startup scripts.
 
 ---
 
-## Module and Provider Rules
+## Common Pitfalls to Avoid
 
-* **Modules** = business logic. Implement modules when new functionality is required.
-* **Providers** = interchangeable backends. Implement when multiple providers are possible (e.g., Azure vs. AWS, MSSQL vs. Postgres).
-* Respect layering: **RPC → Service → Module → Provider → Data**.
-
----
-
-## RPC Layer Rules
-
-* Keep RPC thin: expressive, mapping, and security-only.
-* Primary **role security** check occurs at the **domain level** (e.g., `urn:domain`).
-* **Feature enablement** check occurs at the **subdomain level** (e.g., `urn:domain:subdomain`).
-* Business logic must live in services/modules, never in RPC handlers.
+- Do not add aliases when a direct reference is already available.
+- Do not suppress errors; surface them with contextual logging.
+- Do not invent new environment variables without updating configuration docs
+  and module startup code.
 
 ---
 
-## Module Initialization
+## Build & Test Entry Points
 
-* Two-phase startup:
-
-  * **Instantiation**: load all `_module.py` files, attach to `app.state`.
-  * **Startup**: run `startup()` coroutines, await dependencies with `on_ready()`, call `mark_ready()`.
-* Always inherit from `BaseModule`.
-* Always `await on_ready()` before using a module in startup.
-
----
-
-## Solutions To Avoid
-
-* Don’t add aliases when direct references exist.
-* Don’t suppress errors.
-* Don’t invent environment variables.
-* Don’t put business logic in RPC.
-* Don’t bypass modules by calling providers directly.
+- **Unified harness** – run `python scripts/run_tests.py` to execute the
+  standard lint, type-check, and test pipeline shared by local, CI, and YAML
+  automation environments.
+- **Python / FastAPI** – run `pytest` from the `tests/` directory when iterating
+  on backend code; the unified harness calls into this command.
+- **Frontend** – run `npm lint`, `npm type-check`, and `npm test` for focused
+  feedback; these steps are orchestrated automatically by the unified harness.
+- **Tooling** – prefer `python scripts/run_tests.py` over ad-hoc shell
+  sequences. Use `dev.cmd` for Windows workflows that need parity with the
+  harness.
 
 ---
 
-## File Structure
+## Coding Conventions
 
-* `/` – Build automation, config, FastAPI entrypoint.
-* `server/` – Modules, routes, helpers.
-* `rpc/` – RPC handlers and services.
-* `frontend/` – React app.
-* `static/` – Generated frontend. 
-* `tests/` – Unit/process tests. NOT A PYTHON MODULE! 
-* `scripts/` – RPC-to-TS generation, schema, automation. NOT A PYTHON MODULE!
+- Python uses **2-space** indentation.
+- TypeScript uses **4-space tabs**.
+- Keep formatting and lint passes clean before opening a PR.
+
+---
+
+## Component Guides
+
+Consult these scoped instruction files when working in a given area:
+
+- `frontend/AGENTS.md` – React/Vite codebase.
+- `rpc/AGENTS.md` – RPC handlers and services.
+- `server/AGENTS.md` – FastAPI app startup, modules, and providers.
+- `scripts/AGENTS.md` – Automation and RPC binding generation.
+- `tests/AGENTS.md` – Python test suite structure.
+
+Always obey the most specific AGENTS.md covering the files you modify.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,4 +1,42 @@
 # Frontend AGENT Instructions
 
-- Keep shared, reusable pieces in `src/components` and route-level views in `src/pages`.
-- The Vite config (`vite.config.ts`) groups chunks by top-level route prefixes such as `system-*` and `admin-*`. When adding new route groups or modifying existing ones, update `manualChunks` accordingly.
+Guidance for the Vite/React application under `frontend/`.
+
+---
+
+## Project Layout
+
+- Place shared, reusable UI pieces in `src/components`. Route-level screens live
+  in `src/pages`.
+- Configuration for runtime services (feature flags, themes) belongs in
+  `src/shared`. Keep RPC adapters in `src/rpc`; those files are generated—do not
+  edit them by hand.
+
+---
+
+## Build & Tooling
+
+- The Vite config (`vite.config.ts`) groups chunks by top-level route prefixes
+  such as `system-*` and `admin-*`. When adding new route groups or changing
+  directory structure, update the `manualChunks` logic to keep bundles stable.
+- Run `npm lint`, `npm type-check`, and `npm test` before submitting changes.
+  Vitest specs live in `frontend/tests`.
+
+---
+
+## UI & State Conventions
+
+- Prefer functional components with hooks. Shared context providers reside in
+  `src/shared`; extend them instead of adding ad-hoc global state.
+- Co-locate component-specific styles with the component. Follow the theme tokens
+  defined in `src/shared/ElideusTheme.tsx` when adding new colors or spacing.
+
+---
+
+## RPC Integration
+
+- Consume backend APIs through the generated helpers in `src/rpc`. If a helper is
+  missing, add the corresponding dispatcher in the RPC layer and rerun
+  `python scripts/generate_rpc_bindings.py`.
+- Keep request/response typing in sync with Pydantic models—regenerate bindings
+  rather than editing TypeScript signatures manually.

--- a/rpc/AGENTS.md
+++ b/rpc/AGENTS.md
@@ -1,0 +1,52 @@
+# RPC AGENT Instructions
+
+Rules for the RPC surface (`rpc/`), including request dispatchers, services,
+and payload models.
+
+---
+
+## Handler Structure
+
+- Domains register a top-level handler in `rpc/__init__.py`. Each domain module
+  exposes a `HANDLERS` dict mapping the second URN segment to a handler
+  function.
+- Domain handlers select an operation-specific coroutine from their
+  `DISPATCHERS` map. Dispatchers live in `__init__.py` next to `services.py` and
+  are keyed by `(operation, version)` tuples.
+- Service functions live in `services.py`. They must:
+  - Call `unbox_request(request)` exactly once to obtain the parsed
+    `RPCRequest` and `AuthContext`.
+  - Pull modules from `request.app.state`, waiting on their `on_ready()` hooks
+    if necessary before invoking business logic.
+
+---
+
+## Security & Validation
+
+- Keep RPC handlers thin—authorization logic belongs in modules/services.
+- Respect the domain-level role requirements documented in **ARCHITECTURE.md**
+  and **RPC.md**. Only `auth.*` and `public.*` URNs may skip bearer token
+  validation.
+- Propagate FastAPI `HTTPException` instances; do not blanket catch exceptions
+  without logging.
+
+---
+
+## Payload Contracts
+
+- Define request/response models in `models.py` using Pydantic. These models are
+  exported to TypeScript via the RPC generation scripts.
+- When adding or changing URNs, update **RPC.md** and regenerate bindings by
+  running `python scripts/generate_rpc_bindings.py` (or the individual
+  `generate_rpc_client.py` / `generate_rpc_library.py` scripts).
+- Version bumps should add a new dispatcher entry instead of mutating the
+  existing function in place.
+
+---
+
+## Anti-Patterns To Avoid
+
+- Do **not** embed database access in RPC services—delegate to modules instead.
+- Do **not** mutate global `HANDLERS`/`DISPATCHERS` state from tests without
+  restoring it (see fixtures in `tests/`).
+- Do **not** create ad-hoc URN shapes; follow `urn:{domain}:{subsystem}:{op}:{version}`.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,36 @@
+# Scripts AGENT Instructions
+
+Guidelines for automation under `scripts/`, including RPC code generation and
+operational tooling.
+
+---
+
+## General Rules
+
+- Scripts are entry points, not importable packages. Keep them side-effect free
+  on import—put work behind a `main()` guard.
+- Reuse helpers from `scriptlib.py` for path resolution, version math, and
+  Pydantic→TypeScript translation instead of re-implementing them.
+- Prefer extending existing scripts over adding new ad-hoc utilities.
+
+---
+
+## RPC Code Generation
+
+- `generate_rpc_library.py` emits `frontend/src/shared/RpcModels.tsx` with
+  Pydantic models harvested from `rpc/**/models.py`.
+- `generate_rpc_client.py` walks dispatcher maps to build `frontend/src/rpc/*/index.ts`.
+- `generate_rpc_bindings.py` runs both generation steps; execute it whenever
+  URNs, payload models, or service signatures change.
+- Generated files include a banner from `HEADER_COMMENT`. Never edit the outputs
+  manually—regenerate instead.
+
+---
+
+## Database & Maintenance Utilities
+
+- Use `mssql_cli.py` and helpers in `scriptlib.py` for schema work. Emit SQL to
+  versioned files (e.g., `v0.x.y.z_timestamp.sql`) so humans can apply them via
+  SSMS.
+- `run_tests.py` is the canonical orchestration script for CI-style runs; keep it
+  aligned with the commands listed in the root AGENT guide.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,59 @@
+# Server AGENT Instructions
+
+These rules cover the FastAPI application (`server/`), including modules,
+providers, routers, and helper utilities.
+
+---
+
+## Layering Expectations
+
+- Respect the project layering from **ARCHITECTURE.md**: RPC → Service → Module
+  → Provider. Server code owns the Module and Provider layers.
+- FastAPI routers (`server/routers`) should forward requests to modules or RPC
+  handlers without embedding business logic.
+
+---
+
+## Module Lifecycle
+
+- Modules live in `server/modules` and must define a `CamelCaseModule` class in a
+  `*_module.py` file. The `ModuleManager` instantiates them automatically during
+  app startup (`server/lifespan.py`).
+- Always inherit from `BaseModule`. Call `mark_ready()` once initialization
+  completes so other modules can await `on_ready()` safely.
+- Acquire dependencies from `app.state.<module_name>` and `await on_ready()`
+  before using them inside `startup()`.
+- Avoid global singletons; store runtime state on the module instance.
+
+---
+
+## Providers and Registry Usage
+
+- Provider implementations live under `server/modules/providers`. Keep them
+  focused on connection management and external API interactions.
+- Database SQL stays in the registry layer (`server/registry`). Modules should
+  call `DbModule.run()` with registry request objects rather than embedding raw
+  queries.
+- When adding a provider, expose configuration through `EnvModule` and wire it
+  into the owning module's startup routine.
+
+---
+
+## Operational Guidance
+
+- Changes that touch authentication or role resolution must preserve the
+  security contracts described in **AUTHENTICATION_DIAGRAMS.md**.
+- If module startup requires migrations or seed data, produce `.sql` files under
+  `scripts/` and document manual steps.
+- Keep logging structured (`[Module] message`). Avoid suppressing exceptions—log
+  and re-raise so RPC callers receive accurate errors.
+
+---
+
+## Anti-Patterns To Avoid
+
+- Do **not** bypass modules by importing providers directly from RPC code.
+- Do **not** perform blocking I/O in startup without `await`; use async helpers
+  from existing providers.
+- Do **not** mutate `app.state` outside of the module manager unless you are
+  intentionally registering a module-level API.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,35 @@
+# Tests AGENT Instructions
+
+This directory hosts the pytest suite for the backend and RPC layers.
+
+---
+
+## Structure & Conventions
+
+- Tests are plain pytest modules; keep helper utilities inline or in
+  `conftest.py` rather than creating new packages.
+- Mirror the production layout: module-focused tests live next to their domain
+  (e.g., `test_public_users_service.py`). Add new files following that naming
+  pattern.
+- Prefer `pytest.mark.asyncio` or `asyncio.run()` for coroutine helpers—stay
+  consistent with surrounding tests.
+
+---
+
+## Fixture Guidance
+
+- `tests/conftest.py` restores `rpc.helpers` between tests. If you monkeypatch
+  global dispatcher tables (`HANDLERS`/`DISPATCHERS`), clean them up in a `try`
+  / `finally` block.
+- When stubbing modules, populate `app.state` with lightweight fakes that expose
+  the same async API. Avoid importing heavy FastAPI modules unless required.
+
+---
+
+## When Adding Coverage
+
+- Exercise the full request path: parse → service → module. Use fixtures to
+  isolate external providers instead of calling real network or database code.
+- Update **RPC.md** or other design docs when tests highlight new behavior.
+- Keep assertions focused on security boundaries (roles, tokens) and serialized
+  payload shapes so RPC generators stay accurate.


### PR DESCRIPTION
## Summary
- update the repository-wide AGENTS guide to highlight `python scripts/run_tests.py` as the canonical unified harness
- document how the harness orchestrates the backend and frontend commands and when to run focused commands directly

## Testing
- not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e74f1b9208325a0d408168750b801)