### PR TITLE
Update registry MSSQL queries to new security and content views

### DIFF
--- a/server/registry/account/session/mssql.py
+++ b/server/registry/account/session/mssql.py
@@ -247,7 +247,7 @@ async def list_snapshots_v1(params: dict[str, Any]) -> DBResponse:
       aus.element_device_fingerprint,
       aus.element_user_agent,
       aus.element_ip_last_seen
-    FROM vw_account_user_sessions aus
+    FROM vw_user_session_security aus
     WHERE aus.user_guid = ?
     ORDER BY aus.session_created_on DESC, aus.device_created_on DESC
     FOR JSON PATH;
@@ -272,7 +272,7 @@ async def get_security_snapshot_v1(params: dict[str, Any]) -> DBResponse:
       aus.element_device_fingerprint,
       aus.element_user_agent,
       aus.element_ip_last_seen
-    FROM vw_account_user_security aus
+    FROM vw_user_session_security aus
     WHERE aus.user_guid = ?
     ORDER BY aus.element_token_iat DESC
     FOR JSON PATH;

--- a/server/registry/system/personas/mssql.py
+++ b/server/registry/system/personas/mssql.py
@@ -37,7 +37,7 @@ async def get_by_name_v1(args: dict[str, Any]) -> DBResponse:
       vp.model_name AS element_model,
       vp.element_created_on,
       vp.element_modified_on
-    FROM vw_personas vp
+    FROM vw_content_personas vp
     JOIN assistant_personas ap ON ap.element_name = vp.persona_name
     WHERE vp.persona_name = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
@@ -63,7 +63,7 @@ async def list_personas_v1(_: dict[str, Any]) -> DBResponse:
       vp.model_name AS element_model,
       vp.element_created_on,
       vp.element_modified_on
-    FROM vw_personas vp
+    FROM vw_content_personas vp
     JOIN assistant_personas ap ON ap.element_name = vp.persona_name
     ORDER BY vp.persona_name
     FOR JSON PATH;

--- a/tests/test_mssql_personas_registry.py
+++ b/tests/test_mssql_personas_registry.py
@@ -20,7 +20,7 @@ def test_persona_lookup_query_targets_element_name(monkeypatch):
   result = asyncio.run(handler({"name": "stark"}))
 
   sql = captured["sql"]
-  assert "FROM vw_personas vp" in sql
+  assert "FROM vw_content_personas vp" in sql
   assert "JOIN assistant_personas ap ON ap.element_name = vp.persona_name" in sql
   assert "WHERE vp.persona_name = ?" in sql
   assert "FOR JSON PATH" in sql

--- a/tests/test_provider_queries.py
+++ b/tests/test_provider_queries.py
@@ -229,7 +229,7 @@ def test_account_session_list_snapshots_uses_view(monkeypatch):
   handler = get_handler("db:account:session:list_snapshots:1")
   asyncio.run(handler({"guid": guid}))
   sql = captured["sql"].lower()
-  assert "vw_account_user_sessions" in sql
+  assert "vw_user_session_security" in sql
   assert "for json path" in sql
 
 
@@ -247,7 +247,7 @@ def test_account_session_security_snapshot_uses_view(monkeypatch):
   handler = get_handler("db:account:session:get_security_snapshot:1")
   asyncio.run(handler({"guid": guid}))
   sql = captured["sql"].lower()
-  assert "vw_account_user_security" in sql
+  assert "vw_user_session_security" in sql
   assert "order by" in sql
 
 


### PR DESCRIPTION
## Summary
- update account session registry queries to read from vw_user_session_security
- switch persona registry queries to vw_content_personas
- adjust provider query tests to assert the new view names

## Testing
- pytest tests/test_provider_queries.py tests/test_mssql_personas_registry.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691105c39e6c8325a0ac382225e70c1c)