### PR TITLE
Pin aioodbc and add pyodbc dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,8 @@ azure-identity
 azure-containerregistry
 aiofiles
 aiohttp
-aioodbc
+aioodbc==0.4.1
+pyodbc==4.0.39
 python-dotenv
 asyncpg
 python-jose


### PR DESCRIPTION
## Summary
- pin aioodbc dependency to version 0.4.1
- add pyodbc 4.0.39 to runtime requirements

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932fc8482ec8325b4db690a80a44fc1)