### PR TITLE
Use Python 3.11 for builds

### DIFF
--- a/.github/workflows/main_elideus-group.yml
+++ b/.github/workflows/main_elideus-group.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.12'
+        python-version: '3.11'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.12'
+        python-version: '3.11'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/test_elideus-group-test.yml
+++ b/.github/workflows/test_elideus-group-test.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.12'
+        python-version: '3.11'
 
     - name: Install Python dependencies
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN npm run build
 # ────────────────────────────────────────────────────────────────────────────────
 # Python build
 # ────────────────────────────────────────────────────────────────────────────────
-FROM python:3.12
+FROM python:3.11
 
 # RUN apt-get update && apt-get install -y ffmpeg libodbc2 unixodbc
 


### PR DESCRIPTION
## Summary
- switch container build to Python 3.11 to align with available ODBC wheels
- set GitHub workflows to install Python 3.11 during CI builds

## Testing
- not run (configuration changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69446bf7098c8325b13b2bd505dfcdce)