### PR TITLE
Update CI workflows to use unified RPC binding generator

### DIFF
--- a/.github/workflows/main_elideus-group.yml
+++ b/.github/workflows/main_elideus-group.yml
@@ -42,8 +42,7 @@ jobs:
 
     - name: Generate RPC bindings
       run: |
-        python scripts/generate_rpc_library.py
-        python scripts/generate_rpc_client.py
+        python scripts/generate_rpc_bindings.py
 
     - name: Install MSSQL ODBC Driver
       run: |

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -37,8 +37,7 @@ jobs:
 
     - name: Generate RPC bindings
       run: |
-        python scripts/generate_rpc_library.py
-        python scripts/generate_rpc_client.py
+        python scripts/generate_rpc_bindings.py
 
     - name: Run tests
       run: python scripts/run_tests.py --test

--- a/.github/workflows/test_elideus-group-test.yml
+++ b/.github/workflows/test_elideus-group-test.yml
@@ -42,8 +42,7 @@ jobs:
 
     - name: Generate RPC bindings
       run: |
-        python scripts/generate_rpc_library.py
-        python scripts/generate_rpc_client.py
+        python scripts/generate_rpc_bindings.py
 
     - name: Install MSSQL ODBC Driver
       run: |


### PR DESCRIPTION
## Summary
- update CI workflows to call the unified `generate_rpc_bindings.py` script for RPC code generation

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69446d6870fc832585dc9c35bc68cd62)