### PR TITLE
Share system SubdomainDispatcher and add system links and public_vars handlers

### DIFF
--- a/queryregistry/AGENTS.md
+++ b/queryregistry/AGENTS.md
@@ -1,0 +1,3 @@
+# Queryregistry module instructions
+
+- Reuse `SubdomainDispatcher` from `queryregistry/system/dispatch.py` for new system subdomain dispatcher maps instead of redefining local Protocols.

--- a/queryregistry/system/__init__.py
+++ b/queryregistry/system/__init__.py
@@ -9,6 +9,7 @@ from queryregistry.models import DBRequest, DBResponse
 from .configuration.handler import handle_configuration_request
 from .config.handler import handle_config_request
 from .integrations.handler import handle_integrations_request
+from .links.handler import handle_links_request
 from .models.handler import handle_models_request
 from .personas.handler import handle_personas_request
 from .public_vars.handler import handle_public_vars_request
@@ -32,6 +33,7 @@ HANDLERS: dict[str, _SubdomainHandler] = {
   "configuration": handle_configuration_request,
   "config": handle_config_request,
   "integrations": handle_integrations_request,
+  "links": handle_links_request,
   "models": handle_models_request,
   "personas": handle_personas_request,
   "public_vars": handle_public_vars_request,

--- a/queryregistry/system/configuration/__init__.py
+++ b/queryregistry/system/configuration/__init__.py
@@ -2,18 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Protocol
-
-from queryregistry.models import DBRequest, DBResponse
-
 from .services import system_check_status_v1
+from ..dispatch import SubdomainDispatcher
 
 __all__ = ["DISPATCHERS"]
 
-class _SubdomainDispatcher(Protocol):
-  async def __call__(self, request: DBRequest, *, provider: str) -> DBResponse: ...
-
-
-DISPATCHERS: dict[tuple[str, str], _SubdomainDispatcher] = {
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
   ("check_status", "1"): system_check_status_v1,
 }

--- a/queryregistry/system/dispatch.py
+++ b/queryregistry/system/dispatch.py
@@ -1,0 +1,12 @@
+"""Shared protocol helpers for system subdomain dispatchers."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from queryregistry.models import DBRequest, DBResponse
+
+__all__ = ["SubdomainDispatcher"]
+
+class SubdomainDispatcher(Protocol):
+  async def __call__(self, request: DBRequest, *, provider: str) -> DBResponse: ...

--- a/queryregistry/system/links/__init__.py
+++ b/queryregistry/system/links/__init__.py
@@ -1,0 +1,13 @@
+"""System links query handler package."""
+
+from __future__ import annotations
+
+from .services import get_home_links_v1, get_navbar_routes_v1
+from ..dispatch import SubdomainDispatcher
+
+__all__ = ["DISPATCHERS"]
+
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("get_home_links", "1"): get_home_links_v1,
+  ("get_navbar_routes", "1"): get_navbar_routes_v1,
+}

--- a/queryregistry/system/links/handler.py
+++ b/queryregistry/system/links/handler.py
@@ -1,0 +1,27 @@
+"""System links handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from . import DISPATCHERS
+
+__all__ = ["handle_links_request"]
+
+
+async def handle_links_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown system links operation",
+  )

--- a/queryregistry/system/links/mssql.py
+++ b/queryregistry/system/links/mssql.py
@@ -1,0 +1,49 @@
+"""MSSQL implementations for system links query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from server.registry.providers.mssql import run_json_many
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "get_home_links",
+  "get_navbar_routes",
+]
+
+
+def _normalize_payload(rows: list[Any]) -> list[dict[str, Any]]:
+  return [dict(row) for row in rows]
+
+
+async def get_home_links(_: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      element_title AS title,
+      element_url AS url
+    FROM frontend_links
+    ORDER BY element_sequence
+    FOR JSON PATH;
+  """
+  response = await run_json_many(sql)
+  return DBResponse(payload=_normalize_payload(response.rows))
+
+
+async def get_navbar_routes(args: Mapping[str, Any]) -> DBResponse:
+  role_mask = int(args.get("role_mask", 0) or 0)
+  sql = """
+    SELECT
+      element_path AS path,
+      element_name AS name,
+      element_icon AS icon,
+      element_sequence AS sequence
+    FROM frontend_routes
+    WHERE element_roles = 0 OR (element_roles & ?) = element_roles
+    ORDER BY element_sequence
+    FOR JSON PATH;
+  """
+  response = await run_json_many(sql, (role_mask,))
+  return DBResponse(payload=_normalize_payload(response.rows))

--- a/queryregistry/system/links/services.py
+++ b/queryregistry/system/links/services.py
@@ -1,0 +1,50 @@
+"""System links query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+
+__all__ = [
+  "get_home_links_v1",
+  "get_navbar_routes_v1",
+]
+
+_HomeLinksDispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+_NavbarRoutesDispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_HOME_LINKS_DISPATCHERS: dict[str, _HomeLinksDispatcher] = {
+  "mssql": mssql.get_home_links,
+}
+
+_NAVBAR_ROUTES_DISPATCHERS: dict[str, _NavbarRoutesDispatcher] = {
+  "mssql": mssql.get_navbar_routes,
+}
+
+
+async def get_home_links_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _HOME_LINKS_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for system links registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)
+
+
+async def get_navbar_routes_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _NAVBAR_ROUTES_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for system links registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)

--- a/queryregistry/system/public_vars/__init__.py
+++ b/queryregistry/system/public_vars/__init__.py
@@ -1,9 +1,14 @@
-"""System public_vars query registry stubs."""
+"""System public_vars query handler package."""
 
 from __future__ import annotations
 
-from queryregistry.stubs import build_stub_dispatchers
+from .services import get_hostname_v1, get_repo_v1, get_version_v1
+from ..dispatch import SubdomainDispatcher
 
 __all__ = ["DISPATCHERS"]
 
-DISPATCHERS = build_stub_dispatchers("system.public_vars")
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("get_version", "1"): get_version_v1,
+  ("get_hostname", "1"): get_hostname_v1,
+  ("get_repo", "1"): get_repo_v1,
+}

--- a/queryregistry/system/public_vars/mssql.py
+++ b/queryregistry/system/public_vars/mssql.py
@@ -1,0 +1,52 @@
+"""MSSQL implementations for system public_vars query registry services."""
+
+from __future__ import annotations
+
+from server.registry.providers.mssql import run_json_one
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "get_hostname",
+  "get_repo",
+  "get_version",
+]
+
+
+def _normalize_payload(rows: list[object]) -> dict:
+  if not rows:
+    return {}
+  return dict(rows[0])
+
+
+async def get_hostname() -> DBResponse:
+  sql = """
+    SELECT element_value AS hostname
+    FROM system_config
+    WHERE element_key = 'hostname'
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  response = await run_json_one(sql)
+  return DBResponse(payload=_normalize_payload(response.rows))
+
+
+async def get_version() -> DBResponse:
+  sql = """
+    SELECT element_value AS version
+    FROM system_config
+    WHERE element_key = 'version'
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  response = await run_json_one(sql)
+  return DBResponse(payload=_normalize_payload(response.rows))
+
+
+async def get_repo() -> DBResponse:
+  sql = """
+    SELECT element_value AS repo
+    FROM system_config
+    WHERE element_key = 'repo'
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  response = await run_json_one(sql)
+  return DBResponse(payload=_normalize_payload(response.rows))

--- a/queryregistry/system/public_vars/services.py
+++ b/queryregistry/system/public_vars/services.py
@@ -1,0 +1,71 @@
+"""System public_vars query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+
+__all__ = [
+  "get_hostname_v1",
+  "get_repo_v1",
+  "get_version_v1",
+]
+
+_PublicVarDispatcher = Callable[[], Awaitable[DBResponse]]
+
+_PROVIDER_DISPATCHERS: dict[str, dict[str, _PublicVarDispatcher]] = {
+  "get_hostname": {
+    "mssql": mssql.get_hostname,
+  },
+  "get_version": {
+    "mssql": mssql.get_version,
+  },
+  "get_repo": {
+    "mssql": mssql.get_repo,
+  },
+}
+
+
+def _get_dispatcher(provider: str, operation: str) -> _PublicVarDispatcher:
+  dispatchers = _PROVIDER_DISPATCHERS.get(operation)
+  if dispatchers is None:
+    raise KeyError(f"Unsupported public_vars operation '{operation}'")
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(
+      f"Unsupported provider '{provider}' for system public_vars {operation}"
+    )
+  return dispatcher
+
+
+async def get_hostname_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _get_dispatcher(provider, "get_hostname")
+  result = await dispatcher()
+  return DBResponse(op=request.op, payload=result.payload)
+
+
+async def get_version_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _get_dispatcher(provider, "get_version")
+  result = await dispatcher()
+  return DBResponse(op=request.op, payload=result.payload)
+
+
+async def get_repo_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _get_dispatcher(provider, "get_repo")
+  result = await dispatcher()
+  return DBResponse(op=request.op, payload=result.payload)


### PR DESCRIPTION
### Motivation

- Consolidate the subdomain dispatcher protocol to avoid duplicate local `Protocol` definitions across system subdomains.
- Add system-level `links` support so callers can request `get_home_links` and `get_navbar_routes` via the query registry.
- Replace the `public_vars` stub with real, MSSQL-backed operations to expose `get_version`, `get_hostname`, and `get_repo` through the registry.
- Provide guidance for future contributors to reuse the shared dispatcher protocol.

### Description

- Added `queryregistry/system/dispatch.py` defining the shared `SubdomainDispatcher` `Protocol` and updated `system/*/__init__.py` modules to use `SubdomainDispatcher` instead of local `Protocol` types.
- Implemented a new `links` subdomain with `queryregistry/system/links/__init__.py`, `handler.py`, `services.py`, and `mssql.py`, and registered `links` in `queryregistry/system/__init__.py` to expose `get_home_links` and `get_navbar_routes`.
- Replaced the `public_vars` stubs with `queryregistry/system/public_vars/services.py` and `mssql.py` implementations and updated `queryregistry/system/public_vars/__init__.py` to register `get_version`, `get_hostname`, and `get_repo` service entries.
- Added `queryregistry/AGENTS.md` documenting that system subdomains should reuse the `SubdomainDispatcher` from `queryregistry/system/dispatch.py`.

### Testing

- No automated tests were executed for these changes.
- No linting or type-check/test harness (`pytest` or `python scripts/run_tests.py`) was run as part of this change.
- Changes were limited to adding shared types, handlers, and provider implementations so no runtime test results are available.
- Manual verification (file creation and imports) was performed during the rollout but no automated validation was recorded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695458d269e08325adffc78b2056b5a3)