### PR TITLE
Use query registry for public links and public vars modules

### DIFF
--- a/server/modules/public_links_module.py
+++ b/server/modules/public_links_module.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
+from collections.abc import Mapping
+from typing import Any
+
 from fastapi import FastAPI
-from server.registry.system.links import NavbarRoutesParams
-from server.modules.registry.helpers import (
-  get_home_links_request,
-  get_navbar_routes_request,
-)
+from queryregistry import dispatch_query_request
+from queryregistry.models import DBRequest
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
+
+
+def _normalize_payload(payload: Any | None) -> list[dict[str, Any]]:
+  if payload is None:
+    return []
+  if isinstance(payload, list):
+    return [dict(item) for item in payload]
+  if isinstance(payload, Mapping):
+    return [dict(payload)]
+  return [dict(payload)]
 
 class PublicLinksModule(BaseModule):
   def __init__(self, app: FastAPI):
@@ -28,12 +38,19 @@ class PublicLinksModule(BaseModule):
 
   async def get_home_links(self):
     assert self.db
-    res = await self.db.run(get_home_links_request())
-    return res.rows
+    res = await dispatch_query_request(
+      DBRequest(op="db:system:links:get_home_links:1"),
+      provider=self.db.provider,
+    )
+    return _normalize_payload(res.payload)
 
   async def get_navbar_routes(self, role_mask: int):
     assert self.db
-    res = await self.db.run(
-      get_navbar_routes_request(NavbarRoutesParams(role_mask=role_mask))
+    res = await dispatch_query_request(
+      DBRequest(
+        op="db:system:links:get_navbar_routes:1",
+        payload={"role_mask": role_mask},
+      ),
+      provider=self.db.provider,
     )
-    return res.rows
+    return _normalize_payload(res.payload)

--- a/server/modules/public_vars_module.py
+++ b/server/modules/public_vars_module.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 import asyncio, subprocess
 from fastapi import FastAPI
-from server.modules.registry.helpers import (
-  get_hostname_request,
-  get_repo_request,
-  get_version_request,
-)
+from queryregistry import dispatch_query_request
+from queryregistry.models import DBRequest
 from . import BaseModule
 from .db_module import DbModule
 from .auth_module import AuthModule
@@ -46,18 +43,30 @@ class PublicVarsModule(BaseModule):
 
   async def get_version(self) -> str:
     assert self.db
-    res = await self.db.run(get_version_request())
-    return res.rows[0].get("version") if res.rows else ""
+    res = await dispatch_query_request(
+      DBRequest(op="db:system:public_vars:get_version:1"),
+      provider=self.db.provider,
+    )
+    payload = res.payload if isinstance(res.payload, dict) else {}
+    return payload.get("version", "")
 
   async def get_hostname(self) -> str:
     assert self.db
-    res = await self.db.run(get_hostname_request())
-    return res.rows[0].get("hostname") if res.rows else ""
+    res = await dispatch_query_request(
+      DBRequest(op="db:system:public_vars:get_hostname:1"),
+      provider=self.db.provider,
+    )
+    payload = res.payload if isinstance(res.payload, dict) else {}
+    return payload.get("hostname", "")
 
   async def get_repo(self) -> str:
     assert self.db
-    res = await self.db.run(get_repo_request())
-    return res.rows[0].get("repo") if res.rows else ""
+    res = await dispatch_query_request(
+      DBRequest(op="db:system:public_vars:get_repo:1"),
+      provider=self.db.provider,
+    )
+    payload = res.payload if isinstance(res.payload, dict) else {}
+    return payload.get("repo", "")
 
   async def get_ffmpeg_version(self) -> str:
     try:


### PR DESCRIPTION
### Motivation
- Centralize registry access by routing public lookups through the query registry rather than module helper requests.
- Ensure provider selection continues to use the running `DbModule` configuration by passing `provider=self.db.provider` to registry dispatchers.
- Preserve the existing list-of-rows contract consumed by RPC code for public links.
- Avoid changing role-mask branching or other security-related logic in `get_versions`.

### Description
- Replaced calls to `get_home_links_request`/`get_navbar_routes_request` and `DbModule.run` with `queryregistry.dispatch_query_request` and `queryregistry.models.DBRequest` in `server/modules/public_links_module.py`.
- Added `_normalize_payload` to `public_links_module` to normalize `DBResponse.payload` into a list of dicts before returning.
- Replaced `get_version_request`/`get_hostname_request`/`get_repo_request` usage with `dispatch_query_request` + `DBRequest` in `server/modules/public_vars_module.py`, and read values from `DBResponse.payload` instead of `.rows`.
- Updated imports and kept existing role-mask and permission logic unchanged.

### Testing
- Ran `python -m py_compile server/modules/public_links_module.py server/modules/public_vars_module.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954688119888325a81b2b04d8f1a490)