### PR TITLE
Adjust queryregistry dispatch imports

### DIFF
--- a/queryregistry/__init__.py
+++ b/queryregistry/__init__.py
@@ -5,7 +5,6 @@ Routes query operations to domain-specific handlers.
 
 from .content.handler import handle_content_request
 from .finance.handler import handle_finance_request
-from .handler import dispatch_query_request
 from .identity.handler import handle_identity_request
 from .system.handler import handle_system_request
 
@@ -18,5 +17,4 @@ HANDLERS: dict[str, callable] = {
 
 __all__ = [
   "HANDLERS",
-  "dispatch_query_request",
 ]

--- a/server/modules/public_links_module.py
+++ b/server/modules/public_links_module.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from fastapi import FastAPI
-from queryregistry import dispatch_query_request
+from queryregistry.handler import dispatch_query_request
 from queryregistry.models import DBRequest
 from . import BaseModule
 from .db_module import DbModule

--- a/server/modules/public_vars_module.py
+++ b/server/modules/public_vars_module.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import asyncio, subprocess
 from fastapi import FastAPI
-from queryregistry import dispatch_query_request
+from queryregistry.handler import dispatch_query_request
 from queryregistry.models import DBRequest
 from . import BaseModule
 from .db_module import DbModule


### PR DESCRIPTION
### Motivation
- Remove the exported alias for `dispatch_query_request` from the `queryregistry` package root to avoid indirect imports.
- Ensure callers import the dispatcher directly from its implementation module to make dependencies explicit.
- Preserve the package-level `HANDLERS` mapping so domain handler lookup remains available at the package root.

### Description
- Deleted `from .handler import dispatch_query_request` from `queryregistry/__init__.py` and removed `dispatch_query_request` from `__all__`.
- Updated `server/modules/public_vars_module.py` to import `dispatch_query_request` from `queryregistry.handler`.
- Updated `server/modules/public_links_module.py` to import `dispatch_query_request` from `queryregistry.handler`.
- Left `HANDLERS` defined in `queryregistry/__init__.py` unchanged.

### Testing
- No automated tests were executed as part of this change.
- To run the standard pipeline locally, use `python scripts/run_tests.py` or run `pytest` inside the `tests/` directory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695483436ef483259ed4cfc9af891bd6)