### PR TITLE
Use SubdomainDispatcher for system handlers

### DIFF
--- a/queryregistry/system/__init__.py
+++ b/queryregistry/system/__init__.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Protocol, Sequence
-
-from queryregistry.models import DBRequest, DBResponse
+from queryregistry.system.dispatch import SubdomainDispatcher
 
 from .configuration.handler import handle_configuration_request
 from .config.handler import handle_config_request
@@ -19,17 +17,8 @@ from .service_pages.handler import handle_service_pages_request
 
 __all__ = ["HANDLERS"]
 
-class _SubdomainHandler(Protocol):
-  async def __call__(
-    self,
-    path: Sequence[str],
-    request: DBRequest,
-    *,
-    provider: str,
-  ) -> DBResponse: ...
 
-
-HANDLERS: dict[str, _SubdomainHandler] = {
+HANDLERS: dict[str, SubdomainDispatcher] = {
   "configuration": handle_configuration_request,
   "config": handle_config_request,
   "integrations": handle_integrations_request,


### PR DESCRIPTION
### Motivation
- Centralize and reuse the canonical `SubdomainDispatcher` type instead of maintaining a local `_SubdomainHandler` Protocol in `queryregistry/system/__init__.py`.
- Follow the module guidance in `queryregistry/AGENTS.md` to reuse `SubdomainDispatcher` from `queryregistry/system/dispatch.py`.
- Reduce duplicate type definitions and simplify handler annotations for clarity and maintainability.

### Description
- Removed the local `_SubdomainHandler` Protocol and the now-unneeded imports from `queryregistry/system/__init__.py`.
- Imported `SubdomainDispatcher` from `queryregistry.system.dispatch` and updated the file import list accordingly.
- Updated the `HANDLERS` annotation to use `dict[str, SubdomainDispatcher]` while leaving the handler mapping values unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954866867948325ae5805c7cf9f5d8b)