### PR TITLE
Refactor finance subdomain dispatching

### DIFF
--- a/queryregistry/finance/__init__.py
+++ b/queryregistry/finance/__init__.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from .services import finance_check_status_v1
+from .status.handler import handle_status_request
 
-__all__ = ["DISPATCHERS"]
+__all__ = ["HANDLERS"]
 
-DISPATCHERS = {
-  ("check_status", "1"): finance_check_status_v1,
+HANDLERS = {
+  "status": handle_status_request,
 }

--- a/queryregistry/finance/handler.py
+++ b/queryregistry/finance/handler.py
@@ -8,7 +8,7 @@ from fastapi import HTTPException
 
 from queryregistry.models import DBRequest, DBResponse
 
-from . import DISPATCHERS
+from . import HANDLERS
 
 __all__ = ["handle_finance_request"]
 
@@ -19,10 +19,10 @@ async def handle_finance_request(
   *,
   provider: str,
 ) -> DBResponse:
-  if len(path) < 2:
+  if not path:
     raise HTTPException(status_code=404, detail="Unknown finance registry operation")
-  key = tuple(path[:2])
-  handler = DISPATCHERS.get(key)
+  subdomain = path[0]
+  handler = HANDLERS.get(subdomain)
   if handler is None:
     raise HTTPException(status_code=404, detail="Unknown finance registry operation")
-  return await handler(request, provider=provider)
+  return await handler(path[1:], request, provider=provider)

--- a/queryregistry/finance/status/__init__.py
+++ b/queryregistry/finance/status/__init__.py
@@ -1,0 +1,11 @@
+"""Finance status subdomain dispatchers."""
+
+from __future__ import annotations
+
+from ..services import finance_check_status_v1
+
+__all__ = ["DISPATCHERS"]
+
+DISPATCHERS = {
+  ("check_status", "1"): finance_check_status_v1,
+}

--- a/queryregistry/finance/status/handler.py
+++ b/queryregistry/finance/status/handler.py
@@ -1,0 +1,27 @@
+"""Finance status subdomain handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from . import DISPATCHERS
+
+__all__ = ["handle_status_request"]
+
+
+async def handle_status_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown finance status operation",
+  )


### PR DESCRIPTION
### Motivation

- Align the finance domain with existing domains by introducing a subdomain handler layer and reusing the shared `dispatch_subdomain_request` helper.
- Separate provider-specific dispatcher maps into a dedicated subdomain package so provider dispatchers live one level below the subdomain handler.
- Make request routing consistent with other domains (route to subdomain handlers, then to provider dispatchers).

### Description

- Replace the tuple-keyed `DISPATCHERS` in `queryregistry/finance/__init__.py` with a `HANDLERS` mapping that maps the `"status"` subdomain to `handle_status_request`.
- Update `queryregistry/finance/handler.py` to select a subdomain from `path[0]`, look it up in `HANDLERS`, and forward the remainder of the path to the subdomain handler.
- Add `queryregistry/finance/status/__init__.py` that contains the original tuple-keyed `DISPATCHERS` mapping to `finance_check_status_v1` and add `queryregistry/finance/status/handler.py` which uses `dispatch_subdomain_request` to dispatch to provider-specific handlers.

### Testing

- No automated tests were executed for this change; run `python scripts/run_tests.py` or `pytest` to validate the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695488bd1aa08325a526381d39229d6c)