### PR TITLE
Remove registry __all__ re-exports and update imports

### DIFF
--- a/server/helpers/__init__.py
+++ b/server/helpers/__init__.py
@@ -1,5 +1,1 @@
-from .strings import camel_case
-
-__all__ = [
-  "camel_case",
-]
+from .strings import camel_case  # noqa: F401

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -14,7 +14,7 @@ from server.modules.providers.auth.microsoft_provider import MicrosoftAuthProvid
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.providers.auth.discord_provider import DiscordAuthProvider
 from server.modules.discord_bot_module import DiscordBotModule
-from server.registry.account.profile import GuidParams
+from server.registry.account.profile.model import GuidParams
 from server.modules.registry.helpers import (
   delete_role_request,
   get_roles_request,
@@ -350,4 +350,3 @@ class AuthModule(BaseModule):
 
   async def refresh_user_roles(self, guid: str):
     await self.role_cache.refresh_user_roles(guid)
-

--- a/server/modules/bsky_module.py
+++ b/server/modules/bsky_module.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from atproto import AsyncClient as AsyncBskyClient, client_utils
 from fastapi import FastAPI
 
-from server.registry.system.config import ConfigKeyParams
+from server.registry.system.config.model import ConfigKeyParams
 from server.modules.registry.helpers import get_config_request
 from . import BaseModule
 from .db_module import DbModule

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -9,7 +9,7 @@ import logging
 from . import BaseModule
 from .env_module import EnvModule
 from .providers import DbProviderBase
-from .providers import DBRequest, DBResponse
+from server.registry.types import DBRequest, DBResponse
 from server.registry.account.cache.model import (
   CacheItemKey,
   DeleteCacheFolderParams,
@@ -17,7 +17,7 @@ from server.registry.account.cache.model import (
   ReplaceUserCacheParams,
   UpsertCacheItemParams,
 )
-from server.registry.system.config import ConfigKeyParams
+from server.registry.system.config.model import ConfigKeyParams
 from server.modules.registry.helpers import (
   account_exists_request,
   delete_cache_folder_request,
@@ -301,4 +301,3 @@ class DbModule(BaseModule):
   async def delete_storage_cache_folder(self, user_guid: str, path: str):
     params = DeleteCacheFolderParams(user_guid=user_guid, path=path)
     await self.run(delete_cache_folder_request(params))
-

--- a/server/modules/discord_bot_module.py
+++ b/server/modules/discord_bot_module.py
@@ -18,7 +18,7 @@ except ImportError:  # pragma: no cover - non-Windows platforms
 from . import BaseModule
 from .env_module import EnvModule
 from .db_module import DbModule
-from server.registry.system.config import ConfigKeyParams
+from server.registry.system.config.model import ConfigKeyParams
 from server.modules.registry.helpers import get_config_request
 
 from server.helpers.logging import configure_discord_logging, remove_discord_logging, update_logging_level
@@ -270,4 +270,3 @@ class DiscordBotModule(BaseModule):
 
 class DiscordModule(DiscordBotModule):
   """Backward-compatible alias for the DiscordBotModule."""
-

--- a/server/modules/models/__init__.py
+++ b/server/modules/models/__init__.py
@@ -1,11 +1,5 @@
-from .system_config import (
+from .system_config import (  # noqa: F401
   SystemConfigDeleteResult,
   SystemConfigItem,
   SystemConfigList,
 )
-
-__all__ = [
-  'SystemConfigDeleteResult',
-  'SystemConfigItem',
-  'SystemConfigList',
-]

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -12,20 +12,20 @@ except Exception:
   DEFAULT_SESSION_TOKEN_EXPIRY = 15
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
-from server.registry.account.profile import (
+from server.registry.account.profile.model import (
   GuidParams,
   SetProfileImageParams,
   UpdateIfUneditedParams,
 )
-from server.registry.account.session import (
+from server.registry.account.session.model import (
   CreateSessionParams,
   RevokeProviderTokensParams,
   SetRotkeyParams,
   UpdateDeviceTokenParams,
 )
-from server.registry.system.config import ConfigKeyParams
+from server.registry.system.config.model import ConfigKeyParams
 from server.registry.types import DBRequest
-from server.registry.account.providers import (
+from server.registry.account.providers.model import (
   CreateFromProviderParams,
   GetUserByEmailParams,
   LinkProviderParams,
@@ -656,4 +656,3 @@ class OauthModule(BaseModule):
       "user": user,
       "profile": profile,
     }
-

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -9,7 +9,7 @@ from openai import AsyncOpenAI
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
-from server.registry.system.config import ConfigKeyParams
+from server.registry.system.config.model import ConfigKeyParams
 from server.modules.registry.helpers import (
   delete_persona_request,
   find_recent_request,

--- a/server/modules/profile_module.py
+++ b/server/modules/profile_module.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 
 from . import BaseModule
 from .db_module import DbModule
-from server.registry.account.profile import (
+from server.registry.account.profile.model import (
   GuidParams,
   ProfileRecord,
   SetDisplayParams,

--- a/server/modules/providers/__init__.py
+++ b/server/modules/providers/__init__.py
@@ -13,15 +13,6 @@ import logging
 
 from server.registry.types import DBRequest, DBResponse
 
-__all__ = [
-  "AuthProvider",
-  "BaseProvider",
-  "LifecycleProvider",
-  "AuthProviderBase",
-  "DbProviderBase",
-  "DBRequest",
-  "DBResponse",
-]
 
 class BaseProvider(ABC):
   def __init__(self, **config: Any):

--- a/server/modules/providers/social/__init__.py
+++ b/server/modules/providers/social/__init__.py
@@ -8,8 +8,6 @@ from typing import Any, Callable, TYPE_CHECKING
 
 from .. import LifecycleProvider
 
-__all__ = ["SocialInputProvider"]
-
 if TYPE_CHECKING:  # pragma: no cover
   from ...social_input_module import SocialInputModule
 

--- a/server/modules/providers/storage/__init__.py
+++ b/server/modules/providers/storage/__init__.py
@@ -8,31 +8,6 @@ from typing import Any, Sequence
 
 from .. import LifecycleProvider
 
-__all__ = [
-  "StorageProvider",
-  "StorageBlobItem",
-  "StorageReindexRequest",
-  "StorageReindexResponse",
-  "StorageUploadFile",
-  "StorageUploadRequest",
-  "StorageUploadResult",
-  "StorageUploadResponse",
-  "StorageDeleteRequest",
-  "StorageDeleteResponse",
-  "StorageDeleteFolderRequest",
-  "StorageDeletedEntry",
-  "StorageDeleteFolderResponse",
-  "StorageCreateFolderRequest",
-  "StorageCreateFolderResult",
-  "StorageMoveRequest",
-  "StorageBlobProperties",
-  "StorageMoveResult",
-  "StorageRenameRequest",
-  "StorageRenameOperation",
-  "StorageRenameResponse",
-  "StorageStatsRequest",
-  "StorageStats",
-]
 
 
 @dataclass(slots=True)

--- a/server/modules/registry/helpers.py
+++ b/server/modules/registry/helpers.py
@@ -91,7 +91,7 @@ from server.registry.system.roles import (
   remove_role_member_request,
   upsert_role_request,
 )
-from server.registry.system.vars import (
+from server.registry.system.public_vars import (
   get_hostname_request,
   get_repo_request,
   get_version_request,

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -3,7 +3,7 @@ from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.auth_module import AuthModule
 from server.modules.discord_bot_module import DiscordBotModule
-from server.registry.system.roles import (
+from server.registry.system.roles.model import (
   ModifyRoleMemberParams,
   RoleScopeParams,
 )

--- a/server/modules/session_module.py
+++ b/server/modules/session_module.py
@@ -8,8 +8,8 @@ from server.modules.auth_module import AuthModule, DEFAULT_SESSION_TOKEN_EXPIRY
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
 from server.modules.discord_bot_module import DiscordBotModule
-from server.registry.account.profile import SetProfileImageParams
-from server.registry.account.session import (
+from server.registry.account.profile.model import SetProfileImageParams
+from server.registry.account.session.model import (
   CreateSessionParams,
   GuidParams,
   RevokeDeviceTokenParams,

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -5,7 +5,7 @@ from typing import Any
 from datetime import datetime, timezone
 from uuid import UUID
 from fastapi import FastAPI
-from server.registry.system.config import ConfigKeyParams
+from server.registry.system.config.model import ConfigKeyParams
 from server.modules.registry.helpers import (
   count_rows_request,
   get_config_request,

--- a/server/modules/system_config_module.py
+++ b/server/modules/system_config_module.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import logging
 from fastapi import FastAPI
-from server.registry.system.config import ConfigKeyParams, UpsertConfigParams
+from server.registry.system.config.model import ConfigKeyParams, UpsertConfigParams
 from server.modules.registry.helpers import (
   delete_config_request,
   get_configs_request,
@@ -10,7 +10,7 @@ from server.modules.registry.helpers import (
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
-from .models import (
+from server.modules.models.system_config import (
   SystemConfigDeleteResult,
   SystemConfigItem,
   SystemConfigList,

--- a/server/modules/user_admin_module.py
+++ b/server/modules/user_admin_module.py
@@ -2,8 +2,8 @@ from fastapi import FastAPI, HTTPException
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
-from server.registry.account.profile import GuidParams, SetDisplayParams
-from server.registry.finance.credits import SetCreditsParams
+from server.registry.account.profile.model import GuidParams, SetDisplayParams
+from server.registry.finance.credits.model import SetCreditsParams
 from server.modules.registry.helpers import (
   get_profile_request,
   set_credits_request,

--- a/server/registry/__init__.py
+++ b/server/registry/__init__.py
@@ -11,15 +11,6 @@ from .models import DBRequest
 
 logger = logging.getLogger(__name__)
 
-__all__ = [
-  "HandlerInfo",
-  "get_handler",
-  "get_handler_info",
-  "try_get_handler_info",
-  "parse_db_op",
-]
-
-
 @dataclass(slots=True)
 class HandlerInfo:
   module: str
@@ -45,6 +36,8 @@ def parse_db_op(op: str) -> tuple[str, tuple[str, ...], int]:
     raise ValueError(f"Invalid DB operation version: {op}") from exc
   domain, *path = segments
   return domain, tuple(path), version
+
+
 def _build_handler_info(
   op: str,
   *,

--- a/server/registry/account/__init__.py
+++ b/server/registry/account/__init__.py
@@ -2,13 +2,4 @@
 
 from __future__ import annotations
 
-from . import actions, accounts, content, enablements, oauth, providers, session
-
-__all__ = [
-  "actions",
-  "accounts",
-  "content",
-  "enablements",
-  "providers",
-  "session",
-]
+from . import actions, accounts, content, enablements, oauth, providers, session  # noqa: F401

--- a/server/registry/account/accounts/__init__.py
+++ b/server/registry/account/accounts/__init__.py
@@ -6,10 +6,6 @@ from typing import Any
 
 from server.registry.types import DBRequest
 
-__all__ = [
-  "account_exists_request",
-  "get_security_profile_request",
-]
 
 
 def get_security_profile_request(

--- a/server/registry/account/actions/__init__.py
+++ b/server/registry/account/actions/__init__.py
@@ -11,15 +11,6 @@ from .model import (
   UserActionLogRecord,
 )
 
-__all__ = [
-  "list_user_actions_request",
-  "log_user_action_request",
-  "update_user_action_request",
-  "ListUserActionsParams",
-  "LogUserActionParams",
-  "UpdateUserActionParams",
-  "UserActionLogRecord",
-]
 
 _OP_PREFIX = "db:account:actions"
 

--- a/server/registry/account/cache/__init__.py
+++ b/server/registry/account/cache/__init__.py
@@ -21,27 +21,6 @@ from .model import (
   normalize_content_cache_item,
 )
 
-__all__ = [
-  "delete_cache_folder_request",
-  "delete_cache_item_request",
-  "set_public_request",
-  "set_reported_request",
-  "list_cache_request",
-  "list_public_request",
-  "list_reported_request",
-  "replace_user_cache_request",
-  "upsert_cache_item_request",
-  "count_rows_request",
-  "ContentCacheItem",
-  "CacheItemKey",
-  "DeleteCacheFolderParams",
-  "ListCacheParams",
-  "ReplaceUserCacheParams",
-  "SetPublicParams",
-  "SetReportedParams",
-  "UpsertCacheItemParams",
-  "normalize_content_cache_item",
-]
 
 
 def _normalize_cache_item_payload(

--- a/server/registry/account/content/__init__.py
+++ b/server/registry/account/content/__init__.py
@@ -2,11 +2,4 @@
 
 from __future__ import annotations
 
-from server.registry.account import cache, files, profile, public
-
-__all__ = [
-  "cache",
-  "files",
-  "profile",
-  "public",
-]
+from server.registry.account import cache, files, profile, public  # noqa: F401

--- a/server/registry/account/content/cache/__init__.py
+++ b/server/registry/account/content/cache/__init__.py
@@ -1,3 +1,25 @@
 """Compatibility layer for moved cache registry bindings."""
 
-from server.registry.account.cache import *  # noqa: F401,F403
+from server.registry.account.cache import (  # noqa: F401
+  count_rows_request,
+  delete_cache_folder_request,
+  delete_cache_item_request,
+  list_cache_request,
+  list_public_request,
+  list_reported_request,
+  replace_user_cache_request,
+  set_public_request,
+  set_reported_request,
+  upsert_cache_item_request,
+)
+from server.registry.account.cache.model import (  # noqa: F401
+  CacheItemKey,
+  ContentCacheItem,
+  DeleteCacheFolderParams,
+  ListCacheParams,
+  ReplaceUserCacheParams,
+  SetPublicParams,
+  SetReportedParams,
+  UpsertCacheItemParams,
+  normalize_content_cache_item,
+)

--- a/server/registry/account/content/cache/model.py
+++ b/server/registry/account/content/cache/model.py
@@ -1,3 +1,13 @@
 """Compatibility proxy for cache model definitions."""
 
-from server.registry.account.cache.model import *  # noqa: F401,F403
+from server.registry.account.cache.model import (  # noqa: F401
+  CacheItemKey,
+  ContentCacheItem,
+  DeleteCacheFolderParams,
+  ListCacheParams,
+  ReplaceUserCacheParams,
+  SetPublicParams,
+  SetReportedParams,
+  UpsertCacheItemParams,
+  normalize_content_cache_item,
+)

--- a/server/registry/account/content/cache/mssql.py
+++ b/server/registry/account/content/cache/mssql.py
@@ -1,3 +1,14 @@
 """Compatibility proxy for cache MSSQL implementations."""
 
-from server.registry.account.cache.mssql import *  # noqa: F401,F403
+from server.registry.account.cache.mssql import (  # noqa: F401
+  count_rows_v1,
+  delete_folder_v1,
+  delete_v1,
+  list_public_v1,
+  list_reported_v1,
+  list_v1,
+  replace_user_v1,
+  set_public_v1,
+  set_reported_v1,
+  upsert_v1,
+)

--- a/server/registry/account/content/files/__init__.py
+++ b/server/registry/account/content/files/__init__.py
@@ -1,3 +1,3 @@
 """Compatibility layer for moved files registry bindings."""
 
-from server.registry.account.files import *  # noqa: F401,F403
+from server.registry.account.files import set_gallery_request  # noqa: F401

--- a/server/registry/account/content/files/mssql.py
+++ b/server/registry/account/content/files/mssql.py
@@ -1,3 +1,3 @@
 """Compatibility proxy for files MSSQL implementations."""
 
-from server.registry.account.files.mssql import *  # noqa: F401,F403
+from server.registry.account.files.mssql import set_gallery_v1  # noqa: F401

--- a/server/registry/account/content/profile/__init__.py
+++ b/server/registry/account/content/profile/__init__.py
@@ -1,3 +1,20 @@
 """Compatibility layer for moved profile registry bindings."""
 
-from server.registry.account.profile import *  # noqa: F401,F403
+from server.registry.account.profile import (  # noqa: F401
+  get_profile_request,
+  get_roles_request,
+  set_display_request,
+  set_optin_request,
+  set_profile_image_request,
+  set_roles_request,
+  update_if_unedited_request,
+)
+from server.registry.account.profile.model import (  # noqa: F401
+  GuidParams,
+  ProfileRecord,
+  SetDisplayParams,
+  SetOptInParams,
+  SetProfileImageParams,
+  SetRolesParams,
+  UpdateIfUneditedParams,
+)

--- a/server/registry/account/content/profile/mssql.py
+++ b/server/registry/account/content/profile/mssql.py
@@ -1,3 +1,10 @@
 """Compatibility proxy for profile MSSQL implementations."""
 
-from server.registry.account.profile.mssql import *  # noqa: F401,F403
+from server.registry.account.profile.mssql import (  # noqa: F401
+  get_profile_v1,
+  set_display_v1,
+  set_optin_v1,
+  set_profile_image_v1,
+  set_roles_v1,
+  update_if_unedited_v1,
+)

--- a/server/registry/account/content/public/__init__.py
+++ b/server/registry/account/content/public/__init__.py
@@ -1,3 +1,7 @@
 """Compatibility layer for moved public registry bindings."""
 
-from server.registry.account.public import *  # noqa: F401,F403
+from server.registry.account.public import (  # noqa: F401
+  get_public_files_request,
+  list_public_request,
+  list_reported_request,
+)

--- a/server/registry/account/content/public/mssql.py
+++ b/server/registry/account/content/public/mssql.py
@@ -1,3 +1,7 @@
 """Compatibility proxy for public MSSQL implementations."""
 
-from server.registry.account.public.mssql import *  # noqa: F401,F403
+from server.registry.account.public.mssql import (  # noqa: F401
+  get_public_files_v1,
+  list_public_v1,
+  list_reported_v1,
+)

--- a/server/registry/account/enablements/__init__.py
+++ b/server/registry/account/enablements/__init__.py
@@ -11,12 +11,6 @@ from .model import (
   UserEnablementsRecord,
 )
 
-__all__ = [
-  "get_user_enablements_request",
-  "upsert_user_enablements_request",
-  "UpsertUserEnablementsParams",
-  "UserEnablementsRecord",
-]
 
 _OP_PREFIX = "db:account:enablements"
 

--- a/server/registry/account/files/__init__.py
+++ b/server/registry/account/files/__init__.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from server.registry.types import DBRequest
 
-__all__ = [
-  "set_gallery_request",
-]
 
 
 def set_gallery_request(user_guid: str, name: str, gallery: bool) -> DBRequest:

--- a/server/registry/account/oauth/__init__.py
+++ b/server/registry/account/oauth/__init__.py
@@ -6,11 +6,6 @@ from typing import Any
 
 from server.registry.types import DBRequest
 
-__all__ = [
-  "relink_discord_request",
-  "relink_google_request",
-  "relink_microsoft_request",
-]
 
 
 def _relink_request(name: str, params: dict[str, Any]) -> DBRequest:

--- a/server/registry/account/profile/__init__.py
+++ b/server/registry/account/profile/__init__.py
@@ -13,22 +13,6 @@ from .model import (
   UpdateIfUneditedParams,
 )
 
-__all__ = [
-  "get_profile_request",
-  "get_roles_request",
-  "set_display_request",
-  "set_optin_request",
-  "set_profile_image_request",
-  "set_roles_request",
-  "update_if_unedited_request",
-  "GuidParams",
-  "ProfileRecord",
-  "SetDisplayParams",
-  "SetOptInParams",
-  "SetProfileImageParams",
-  "SetRolesParams",
-  "UpdateIfUneditedParams",
-]
 
 
 def _request(name: str, params: dict[str, object]) -> DBRequest:

--- a/server/registry/account/providers/__init__.py
+++ b/server/registry/account/providers/__init__.py
@@ -14,25 +14,6 @@ from .model import (
   UnlinkProviderParams,
 )
 
-__all__ = [
-  "create_from_provider_request",
-  "get_any_by_provider_identifier_request",
-  "get_by_provider_identifier_request",
-  "get_user_by_email_request",
-  "link_provider_request",
-  "set_provider_request",
-  "soft_delete_account_request",
-  "unlink_provider_request",
-  "unlink_last_provider_request",
-  "CreateFromProviderParams",
-  "GetUserByEmailParams",
-  "LinkProviderParams",
-  "ProviderIdentifierParams",
-  "SetProviderParams",
-  "SoftDeleteAccountParams",
-  "UnlinkLastProviderParams",
-  "UnlinkProviderParams",
-]
 
 
 def _request(op: str, params: dict[str, object]) -> DBRequest:

--- a/server/registry/account/public/__init__.py
+++ b/server/registry/account/public/__init__.py
@@ -6,11 +6,6 @@ from typing import Any
 
 from server.registry.types import DBRequest
 
-__all__ = [
-  "get_public_files_request",
-  "list_public_request",
-  "list_reported_request",
-]
 
 
 def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:

--- a/server/registry/account/session/__init__.py
+++ b/server/registry/account/session/__init__.py
@@ -15,27 +15,6 @@ from .model import (
   UpdateSessionParams,
 )
 
-__all__ = [
-  "create_session_request",
-  "get_rotkey_request",
-  "revoke_all_device_tokens_request",
-  "revoke_device_token_request",
-  "revoke_provider_tokens_request",
-  "get_security_snapshot_request",
-  "set_rotkey_request",
-  "list_session_snapshots_request",
-  "update_device_token_request",
-  "update_session_request",
-  "CreateSessionParams",
-  "GuidParams",
-  "ListSessionSnapshotsParams",
-  "RevokeAllDeviceTokensParams",
-  "RevokeDeviceTokenParams",
-  "RevokeProviderTokensParams",
-  "SetRotkeyParams",
-  "UpdateDeviceTokenParams",
-  "UpdateSessionParams",
-]
 
 
 def _request(name: str, params: dict[str, object]) -> DBRequest:

--- a/server/registry/finance/__init__.py
+++ b/server/registry/finance/__init__.py
@@ -2,8 +2,4 @@
 
 from __future__ import annotations
 
-from . import credits
-
-__all__ = [
-  "credits",
-]
+from . import credits  # noqa: F401

--- a/server/registry/finance/credits/__init__.py
+++ b/server/registry/finance/credits/__init__.py
@@ -10,10 +10,6 @@ from server.registry.types import DBRequest
 
 from .model import SetCreditsParams
 
-__all__ = [
-  "SetCreditsParams",
-  "set_credits_request",
-]
 
 
 def _request(name: str, params: SetCreditsParams) -> DBRequest:

--- a/server/registry/system/__init__.py
+++ b/server/registry/system/__init__.py
@@ -14,18 +14,4 @@ from . import (
   roles,
   routes,
   service_pages,
-)
-
-__all__ = [
-  "config",
-  "conversations",
-  "guilds",
-  "links",
-  "models",
-  "personas",
-  "public_users",
-  "public_vars",
-  "roles",
-  "routes",
-  "service_pages",
-]
+)  # noqa: F401

--- a/server/registry/system/config/__init__.py
+++ b/server/registry/system/config/__init__.py
@@ -5,14 +5,6 @@ from __future__ import annotations
 from server.registry.types import DBRequest
 from .model import ConfigKeyParams, UpsertConfigParams
 
-__all__ = [
-  "delete_config_request",
-  "get_config_request",
-  "get_configs_request",
-  "upsert_config_request",
-  "ConfigKeyParams",
-  "UpsertConfigParams",
-]
 
 
 def get_config_request(params: ConfigKeyParams) -> DBRequest:

--- a/server/registry/system/conversations/__init__.py
+++ b/server/registry/system/conversations/__init__.py
@@ -14,18 +14,6 @@ from .model import (
   UpdateConversationOutputParams,
 )
 
-__all__ = [
-  "find_recent_request",
-  "insert_conversation_request",
-  "list_by_time_request",
-  "list_recent_request",
-  "update_output_request",
-  "ConversationRecord",
-  "FindRecentConversationParams",
-  "InsertConversationParams",
-  "ListByTimeParams",
-  "UpdateConversationOutputParams",
-]
 
 _OP_PREFIX = "db:system:conversations"
 

--- a/server/registry/system/guilds/__init__.py
+++ b/server/registry/system/guilds/__init__.py
@@ -7,11 +7,6 @@ from typing import Any
 
 from server.registry.types import DBRequest
 
-__all__ = [
-  "get_guild_request",
-  "list_guilds_request",
-  "upsert_guild_request",
-]
 
 
 _DEF_PROVIDER_KEY = "db:system:discord_guilds"

--- a/server/registry/system/links/__init__.py
+++ b/server/registry/system/links/__init__.py
@@ -10,13 +10,6 @@ from server.registry.types import DBRequest
 
 from .model import HomeLink, NavbarRoute, NavbarRoutesParams
 
-__all__ = [
-  "HomeLink",
-  "NavbarRoute",
-  "NavbarRoutesParams",
-  "get_home_links_request",
-  "get_navbar_routes_request",
-]
 
 
 def _request(op: str, params: NavbarRoutesParams | None = None) -> DBRequest:

--- a/server/registry/system/models/__init__.py
+++ b/server/registry/system/models/__init__.py
@@ -9,12 +9,6 @@ from .model import (
   ModelRecord,
 )
 
-__all__ = [
-  "get_model_by_name_request",
-  "list_models_request",
-  "GetModelByNameParams",
-  "ModelRecord",
-]
 
 _OP_PREFIX = "db:system:models"
 

--- a/server/registry/system/personas/__init__.py
+++ b/server/registry/system/personas/__init__.py
@@ -11,16 +11,6 @@ from .model import (
   UpsertPersonaParams,
 )
 
-__all__ = [
-  "delete_persona_request",
-  "get_persona_by_name_request",
-  "list_personas_request",
-  "upsert_persona_request",
-  "DeletePersonaParams",
-  "PersonaRecord",
-  "PersonaSummary",
-  "UpsertPersonaParams",
-]
 
 _OP_PREFIX = "db:system:personas"
 

--- a/server/registry/system/public_users/__init__.py
+++ b/server/registry/system/public_users/__init__.py
@@ -13,14 +13,6 @@ from .model import (
   PublicUserProfile,
 )
 
-__all__ = [
-  "GetProfileParams",
-  "GetPublishedFilesParams",
-  "PublicUserFile",
-  "PublicUserProfile",
-  "get_profile_request",
-  "get_published_files_request",
-]
 
 
 def _request(op: str, params: dict[str, Any]) -> DBRequest:

--- a/server/registry/system/public_vars/__init__.py
+++ b/server/registry/system/public_vars/__init__.py
@@ -7,12 +7,6 @@ from typing import Any
 from server.registry.types import DBRequest
 from .model import PublicVarRecord
 
-__all__ = [
-  "get_hostname_request",
-  "get_repo_request",
-  "get_version_request",
-  "PublicVarRecord",
-]
 
 
 def _request(op: str, params: dict[str, Any] | None = None) -> DBRequest:

--- a/server/registry/system/roles/__init__.py
+++ b/server/registry/system/roles/__init__.py
@@ -10,19 +10,6 @@ from .model import (
   UpsertRoleParams,
 )
 
-__all__ = [
-  "add_role_member_request",
-  "delete_role_request",
-  "get_role_members_request",
-  "get_role_non_members_request",
-  "list_roles_request",
-  "remove_role_member_request",
-  "upsert_role_request",
-  "DeleteRoleParams",
-  "ModifyRoleMemberParams",
-  "RoleScopeParams",
-  "UpsertRoleParams",
-]
 
 
 def list_roles_request() -> DBRequest:

--- a/server/registry/system/routes/__init__.py
+++ b/server/registry/system/routes/__init__.py
@@ -4,11 +4,6 @@ from __future__ import annotations
 
 from server.registry.types import DBRequest
 
-__all__ = [
-  "delete_route_request",
-  "get_routes_request",
-  "upsert_route_request",
-]
 
 
 def get_routes_request() -> DBRequest:

--- a/server/registry/system/service_pages/__init__.py
+++ b/server/registry/system/service_pages/__init__.py
@@ -14,21 +14,6 @@ from .model import (
   UpdateServicePageParams,
 )
 
-__all__ = [
-  "create_service_page_request",
-  "delete_service_page_request",
-  "get_service_page_by_route_request",
-  "get_service_page_request",
-  "list_service_pages_request",
-  "update_service_page_request",
-  "CreateServicePageParams",
-  "DeleteServicePageParams",
-  "GetServicePageByRouteParams",
-  "GetServicePageParams",
-  "ListServicePagesParams",
-  "ServicePageRecord",
-  "UpdateServicePageParams",
-]
 
 _OP_PREFIX = "db:system:service_pages"
 

--- a/server/registry/system/vars/__init__.py
+++ b/server/registry/system/vars/__init__.py
@@ -2,14 +2,8 @@
 
 from __future__ import annotations
 
-from server.registry.system.public_vars import (
+from server.registry.system.public_vars import (  # noqa: F401
   get_hostname_request,
   get_repo_request,
   get_version_request,
 )
-
-__all__ = [
-  "get_hostname_request",
-  "get_repo_request",
-  "get_version_request",
-]

--- a/server/routers/discord_events.py
+++ b/server/routers/discord_events.py
@@ -4,7 +4,8 @@ import logging
 from typing import TYPE_CHECKING
 
 from discord.ext import commands
-from server.registry.system.config import ConfigKeyParams, get_config_request
+from server.registry.system.config import get_config_request
+from server.registry.system.config.model import ConfigKeyParams
 
 if TYPE_CHECKING:  # pragma: no cover - runtime import cycle guard
   from server.modules.discord_bot_module import DiscordBotModule

--- a/tests/test_system_config_services.py
+++ b/tests/test_system_config_services.py
@@ -25,6 +25,8 @@ models_pkg = types.ModuleType('server.models')
 
 modules_pkg = types.ModuleType('server.modules')
 modules_models_pkg = types.ModuleType('server.modules.models')
+modules_models_pkg.__path__ = []
+system_config_models_pkg = types.ModuleType('server.modules.models.system_config')
 
 @dataclass
 class SystemConfigItem:
@@ -62,13 +64,15 @@ models_pkg.RPCRequest = RPCRequest
 models_pkg.AuthContext = AuthContext
 server_pkg.models = models_pkg
 modules_pkg.models = modules_models_pkg
-modules_models_pkg.SystemConfigItem = SystemConfigItem
-modules_models_pkg.SystemConfigList = SystemConfigList
-modules_models_pkg.SystemConfigDeleteResult = SystemConfigDeleteResult
+modules_models_pkg.system_config = system_config_models_pkg
+system_config_models_pkg.SystemConfigItem = SystemConfigItem
+system_config_models_pkg.SystemConfigList = SystemConfigList
+system_config_models_pkg.SystemConfigDeleteResult = SystemConfigDeleteResult
 sys.modules.setdefault('server', server_pkg)
 sys.modules.setdefault('server.models', models_pkg)
 sys.modules.setdefault('server.modules', modules_pkg)
 sys.modules.setdefault('server.modules.models', modules_models_pkg)
+sys.modules.setdefault('server.modules.models.system_config', system_config_models_pkg)
 
 import importlib.util
 
@@ -99,16 +103,16 @@ class DummySystemConfigModule:
     self.calls = []
   async def get_configs(self, user_guid, roles):
     self.calls.append(('get_configs', user_guid, roles))
-    from server.modules.models import SystemConfigItem, SystemConfigList
+    from server.modules.models.system_config import SystemConfigItem, SystemConfigList
     item = SystemConfigItem(key='LoggingLevel', value='4')
     return SystemConfigList(items=[item])
   async def upsert_config(self, user_guid, roles, key, value):
     self.calls.append(('upsert_config', key, value))
-    from server.modules.models import SystemConfigItem
+    from server.modules.models.system_config import SystemConfigItem
     return SystemConfigItem(key=key, value=value)
   async def delete_config(self, user_guid, roles, key):
     self.calls.append(('delete_config', key))
-    from server.modules.models import SystemConfigDeleteResult
+    from server.modules.models.system_config import SystemConfigDeleteResult
     return SystemConfigDeleteResult(key=key)
 
 app = FastAPI()


### PR DESCRIPTION
### Motivation
- Eliminate fragile wildcard exports and `__all__` reliance across the registry and module packages to make imports explicit and easier to reason about.  
- Prevent accidental symbol exposure and improve static analysis / IDE support by referencing concrete model paths.  
- Clean up compatibility shim modules so callers no longer depend on implicit `__all__` behavior.  
- Prepare the codebase for safer refactors of registry/provider boundaries and provider isolation.

### Description
- Removed many `__all__` export lists across `server/registry/*` and `server/modules/*` and deleted selected re-export arrays in helper `__init__.py` files.  
- Replaced wildcard compatibility imports such as `from ... import *` with explicit symbol imports in `server/registry/account/content/*` and other compatibility proxies (for example `get_public_files_request`, `list_public_request`, `get_profile_request`, MSSQL functions like `get_profile_v1`, etc.).  
- Updated import sites to reference concrete model modules (for example `server.registry.account.profile.model.ConfigKeyParams` patterns -> `from server.registry.account.profile.model import GuidParams`, and `server.registry.system.config.model import ConfigKeyParams`).  
- Adjusted tests and stubs to import the new concrete paths (notably `tests/test_system_config_services.py` now registers `server.modules.models.system_config`) and added `# noqa: F401` to maintain intended re-exports where appropriate.

### Testing
- No automated test suite was executed as part of this change.  
- Repository searches (`rg`) and file edits were used to locate and update `__all__` and wildcard import sites.  
- Unit test files were updated to match the new import layout (e.g. `tests/test_system_config_services.py`), but `pytest` was not run.  
- Manual verification steps (lint/type-check/test runs) are recommended before merging to CI to ensure no runtime regressions remain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c2f93c2348325a3bb0a0ba479ceff)