### PR TITLE
Refactor server package imports to module paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,13 @@ import logging
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
-from server import lifespan, rpc_router, web_router, configure_root_logging
+from server.helpers.logging import configure_root_logging
+from server.lifespan import lifespan
+from server.routers import rpc_router, web_router
 
 configure_root_logging(4)
 
-app = FastAPI(lifespan=lifespan.lifespan)
+app = FastAPI(lifespan=lifespan)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 app.include_router(rpc_router.router, prefix="/rpc")
 app.include_router(web_router.router)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,11 +1,1 @@
-from . import lifespan
-from .routers import rpc_router, web_router
-from .helpers.logging import configure_root_logging
-
-
-__all__ = [
-  "rpc_router",
-  "web_router",
-  "lifespan",
-  "configure_root_logging",
-]
+"""Server package root."""


### PR DESCRIPTION
### Motivation

- Make package-level `server` re-exports unused and switch callers to fully-qualified module imports to avoid implicit dependencies.
- Reduce risk of import cycles and clarify origin of symbols by referencing module paths directly.
- Conform to repo guardrails that prefer direct module references over package aliases.
- Shrink the public surface of the `server` package and prevent accidental namespace pollution.

### Description

- Updated `main.py` to import `configure_root_logging` from `server.helpers.logging`, `lifespan` from `server.lifespan`, and `rpc_router`/`web_router` from `server.routers`, and to pass the `lifespan` callable to `FastAPI`.
- Replaced `server/__init__.py` contents with a short module docstring and removed the `__all__` re-export list.
- Adjusted startup call in `main.py` to use `lifespan` directly instead of `lifespan.lifespan`.

### Testing

- No automated tests were run against these changes.
- Please run `python scripts/run_tests.py` or `pytest` to validate linting, type checks, and test suite execution after review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c33c2c0a8832588dcb42e369b9869)