### PR TITLE
Add identity.accounts queryregistry MSSQL dispatchers and models

### DIFF
--- a/queryregistry/identity/accounts/handler.py
+++ b/queryregistry/identity/accounts/handler.py
@@ -6,11 +6,15 @@ from typing import Sequence
 
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
-from queryregistry.stubs import build_stub_dispatchers
+
+from .services import account_exists_v1, read_accounts_v1
 
 __all__ = ["handle_accounts_request"]
 
-DISPATCHERS = build_stub_dispatchers("identity.accounts")
+DISPATCHERS = {
+  ("read", "1"): read_accounts_v1,
+  ("exists", "1"): account_exists_v1,
+}
 
 
 async def handle_accounts_request(

--- a/queryregistry/identity/accounts/models.py
+++ b/queryregistry/identity/accounts/models.py
@@ -1,0 +1,75 @@
+"""Identity accounts query registry service models."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, TypedDict
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "AccountExistsCallable",
+  "AccountExistsPayload",
+  "AccountExistsRequestPayload",
+  "AccountsReadCallable",
+  "SecurityProfilePayload",
+  "SecurityProfileRequestPayload",
+]
+
+
+class SecurityProfileRequestPayload(TypedDict, total=False):
+  guid: str
+  access_token: str
+  provider: str
+  provider_identifier: str
+  discord_id: str
+
+
+class SecurityProfilePayload(TypedDict, total=False):
+  user_guid: str
+  guid: str
+  user_roles: int
+  element_roles: int
+  user_created_on: str
+  user_modified_on: str
+  element_rotkey: str
+  rotkey: str
+  element_rotkey_iat: str
+  element_rotkey_exp: str
+  provider_name: str
+  provider_display: str
+  providers_recid: int
+  session_guid: str
+  session_created_on: str
+  session_created_at: str
+  session_modified_on: str
+  device_guid: str
+  device_created_on: str
+  device_modified_on: str
+  element_token: str
+  token: str
+  element_token_iat: str
+  issued_at: str
+  element_token_exp: str
+  expires_at: str
+  element_revoked_at: str
+  revoked_at: str
+  element_device_fingerprint: str
+  device_fingerprint: str
+  element_user_agent: str
+  user_agent: str
+  element_ip_last_seen: str
+  ip_last_seen: str
+  extra: dict[str, Any]
+
+
+class AccountExistsRequestPayload(TypedDict):
+  user_guid: str
+
+
+class AccountExistsPayload(TypedDict):
+  exists_flag: int
+
+
+AccountsReadCallable = Callable[[SecurityProfileRequestPayload], Awaitable[DBResponse]]
+AccountExistsCallable = Callable[[AccountExistsRequestPayload], Awaitable[DBResponse]]

--- a/queryregistry/identity/accounts/mssql.py
+++ b/queryregistry/identity/accounts/mssql.py
@@ -1,0 +1,143 @@
+"""MSSQL implementations for identity accounts query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+from uuid import UUID
+
+from server.registry.providers.mssql import run_json_one
+
+from queryregistry.models import DBResponse
+
+from .models import AccountExistsRequestPayload, SecurityProfileRequestPayload
+
+__all__ = [
+  "account_exists",
+  "get_security_profile",
+]
+
+_BASE_QUERY = """
+  SELECT TOP 1
+    v.user_guid,
+    v.user_guid AS guid,
+    v.user_roles,
+    v.user_roles AS element_roles,
+    v.user_created_on,
+    v.user_modified_on,
+    v.element_rotkey,
+    v.element_rotkey AS rotkey,
+    v.element_rotkey_iat,
+    v.element_rotkey_exp,
+    ap.element_name AS provider_name,
+    ap.element_display AS provider_display,
+    au.providers_recid,
+    v.session_guid,
+    v.session_created_on,
+    v.session_created_on AS session_created_at,
+    v.session_modified_on,
+    v.device_guid,
+    v.device_created_on,
+    v.device_modified_on,
+    v.element_token,
+    v.element_token AS token,
+    v.element_token_iat,
+    v.element_token_iat AS issued_at,
+    v.element_token_exp,
+    v.element_token_exp AS expires_at,
+    v.element_revoked_at,
+    v.element_revoked_at AS revoked_at,
+    v.element_device_fingerprint,
+    v.element_device_fingerprint AS device_fingerprint,
+    v.element_user_agent,
+    v.element_user_agent AS user_agent,
+    v.element_ip_last_seen,
+    v.element_ip_last_seen AS ip_last_seen
+  FROM vw_user_session_security v
+  LEFT JOIN account_users au ON au.element_guid = v.user_guid
+  LEFT JOIN auth_providers ap ON ap.recid = au.providers_recid
+"""
+
+_JOIN_USERS_AUTH = """
+  JOIN users_auth ua ON ua.users_guid = v.user_guid AND ua.element_linked = 1
+"""
+
+
+def _normalize_provider_identifier(identifier: str) -> str:
+  try:
+    return str(UUID(identifier))
+  except (TypeError, ValueError):
+    raise ValueError("provider_identifier must be a valid UUID") from None
+
+
+def _normalize_discord_identifier(discord_id: str) -> str:
+  from uuid import NAMESPACE_URL, uuid5
+
+  return str(UUID(str(uuid5(NAMESPACE_URL, f"discord:{discord_id}"))))
+
+
+def _unique(sequence: Iterable[str]) -> list[str]:
+  items: list[str] = []
+  seen: set[str] = set()
+  for entry in sequence:
+    if entry not in seen:
+      seen.add(entry)
+      items.append(entry)
+  return items
+
+
+async def get_security_profile(params: SecurityProfileRequestPayload) -> DBResponse:
+  """Return an operation that fetches security metadata for a user context."""
+
+  filters: list[str] = []
+  args: list[Any] = []
+  joins: list[str] = []
+
+  guid = params.get("user_guid") or params.get("guid")
+  if guid:
+    filters.append("v.user_guid = ?")
+    args.append(str(guid))
+
+  token = params.get("access_token") or params.get("token")
+  if token:
+    filters.append("v.element_token = ?")
+    args.append(str(token))
+
+  provider = params.get("provider")
+  provider_identifier = params.get("provider_identifier")
+  if provider and provider_identifier:
+    joins.append(_JOIN_USERS_AUTH)
+    filters.append("ap.element_name = ?")
+    args.append(str(provider))
+    normalised = _normalize_provider_identifier(str(provider_identifier))
+    filters.append("ua.element_identifier = ?")
+    args.append(normalised)
+
+  discord_id = params.get("discord_id")
+  if discord_id:
+    joins.append(_JOIN_USERS_AUTH)
+    filters.append("ap.element_name = ?")
+    args.append("discord")
+    filters.append("ua.element_identifier = ?")
+    args.append(_normalize_discord_identifier(str(discord_id)))
+
+  if not filters:
+    raise ValueError("get_security_profile requires a selection filter")
+
+  join_sql = "".join(_unique(joins))
+  where_sql = " AND\n    ".join(filters)
+  sql = f"{_BASE_QUERY}{join_sql}  WHERE {where_sql}\n  FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;"
+  response = await run_json_one(sql, args)
+  return DBResponse(payload=response.payload)
+
+
+async def account_exists(args: AccountExistsRequestPayload) -> DBResponse:
+  guid = str(UUID(args["user_guid"]))
+  sql = """
+    SELECT 1 AS exists_flag
+    FROM account_users
+    WHERE element_guid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  response = await run_json_one(sql, (guid,))
+  return DBResponse(payload=response.payload)

--- a/queryregistry/identity/accounts/services.py
+++ b/queryregistry/identity/accounts/services.py
@@ -1,0 +1,45 @@
+"""Identity accounts query registry service dispatchers."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import AccountExistsCallable, AccountsReadCallable
+
+__all__ = [
+  "account_exists_v1",
+  "read_accounts_v1",
+]
+
+_READ_DISPATCHERS: dict[str, AccountsReadCallable] = {
+  "mssql": mssql.get_security_profile,
+}
+
+_EXISTS_DISPATCHERS: dict[str, AccountExistsCallable] = {
+  "mssql": mssql.account_exists,
+}
+
+
+async def read_accounts_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _READ_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity accounts registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)
+
+
+async def account_exists_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _EXISTS_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity accounts registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)


### PR DESCRIPTION
### Motivation
- Provide concrete queryregistry support for identity account lookups and existence checks instead of stubs.
- Reuse existing MSSQL SQL used by the legacy account registry to ensure behavior parity with the server side.
- Expose typed payload shapes to match the legacy `get_security_profile_request` keys and account existence calls.

### Description
- Added request/response models in `queryregistry/identity/accounts/models.py` describing the security profile and existence payloads and callable types.
- Implemented MSSQL-backed providers in `queryregistry/identity/accounts/mssql.py` by porting the SQL and logic from `server/registry/account/accounts/mssql.py` into `get_security_profile` and `account_exists` functions.
- Added service dispatchers in `queryregistry/identity/accounts/services.py` (`read_accounts_v1` and `account_exists_v1`) that select the provider implementation (currently `mssql`).
- Updated `queryregistry/identity/accounts/handler.py` to replace the stub dispatcher map with concrete handlers for `("read","1")` and `("exists","1")`.

### Testing
- No automated tests were executed as part of this change.
- Existing test harness entry points remain `python scripts/run_tests.py` for full verification and `pytest` for backend tests.
- Manual inspection ensured the MSSQL SQL was copied from `server/registry/account/accounts/mssql.py` and signatures were aligned with `server` helpers.
- Static typing and linting should be validated via the repository`s standard CI/harness before merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c6175b898832597602e7cfa87577d)