### PR TITLE
Add identity sessions query registry read support (MSSQL)

### DIFF
--- a/queryregistry/identity/sessions/handler.py
+++ b/queryregistry/identity/sessions/handler.py
@@ -6,11 +6,14 @@ from typing import Sequence
 
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
-from queryregistry.stubs import build_stub_dispatchers
+
+from .services import read_sessions_v1
 
 __all__ = ["handle_sessions_request"]
 
-DISPATCHERS = build_stub_dispatchers("identity.sessions")
+DISPATCHERS = {
+  ("read", "1"): read_sessions_v1,
+}
 
 
 async def handle_sessions_request(

--- a/queryregistry/identity/sessions/models.py
+++ b/queryregistry/identity/sessions/models.py
@@ -1,0 +1,37 @@
+"""Identity sessions query registry service models."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TypedDict
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "SecuritySnapshotCallable",
+  "SecuritySnapshotRecord",
+  "SecuritySnapshotRequestPayload",
+]
+
+
+class SecuritySnapshotRequestPayload(TypedDict):
+  guid: str
+
+
+class SecuritySnapshotRecord(TypedDict, total=False):
+  user_guid: str
+  element_rotkey: str | None
+  element_rotkey_iat: str | None
+  element_rotkey_exp: str | None
+  session_guid: str | None
+  device_guid: str | None
+  element_token: str | None
+  element_token_iat: str | None
+  element_token_exp: str | None
+  element_revoked_at: str | None
+  element_device_fingerprint: str | None
+  element_user_agent: str | None
+  element_ip_last_seen: str | None
+
+
+SecuritySnapshotCallable = Callable[[SecuritySnapshotRequestPayload], Awaitable[DBResponse]]

--- a/queryregistry/identity/sessions/mssql.py
+++ b/queryregistry/identity/sessions/mssql.py
@@ -1,0 +1,41 @@
+"""MSSQL implementations for identity sessions query registry services."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from server.registry.providers.mssql import run_json_many
+
+from queryregistry.models import DBResponse
+
+from .models import SecuritySnapshotRequestPayload
+
+__all__ = [
+  "get_security_snapshot_v1",
+]
+
+
+async def get_security_snapshot_v1(params: SecuritySnapshotRequestPayload) -> DBResponse:
+  guid = str(UUID(params["guid"]))
+  sql = """
+    SELECT
+      aus.user_guid,
+      aus.element_rotkey,
+      aus.element_rotkey_iat,
+      aus.element_rotkey_exp,
+      aus.session_guid,
+      aus.device_guid,
+      aus.element_token,
+      aus.element_token_iat,
+      aus.element_token_exp,
+      aus.element_revoked_at,
+      aus.element_device_fingerprint,
+      aus.element_user_agent,
+      aus.element_ip_last_seen
+    FROM vw_user_session_security aus
+    WHERE aus.user_guid = ?
+    ORDER BY aus.element_token_iat DESC
+    FOR JSON PATH;
+  """
+  response = await run_json_many(sql, (guid,))
+  return DBResponse(payload=response.payload)

--- a/queryregistry/identity/sessions/services.py
+++ b/queryregistry/identity/sessions/services.py
@@ -1,0 +1,28 @@
+"""Identity sessions query registry service dispatchers."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import SecuritySnapshotCallable
+
+__all__ = [
+  "read_sessions_v1",
+]
+
+_READ_DISPATCHERS: dict[str, SecuritySnapshotCallable] = {
+  "mssql": mssql.get_security_snapshot_v1,
+}
+
+
+async def read_sessions_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _READ_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity sessions registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)


### PR DESCRIPTION
### Motivation

- Provide support for the `db:identity:sessions:read:1` operation to return security snapshots for a user context.
- Base the registry MSSQL logic on the existing `server/registry/account/session/mssql.py#get_security_snapshot_v1` implementation to reuse proven SQL and helpers.
- Replace stub dispatchers so the identity sessions handler dispatches a concrete read implementation instead of returning stubs.
- Add typed request and record models so the registry surface has explicit payload types for the snapshot API.

### Description

- Added `queryregistry/identity/sessions/models.py` with `SecuritySnapshotRequestPayload`, `SecuritySnapshotRecord`, and `SecuritySnapshotCallable` types.
- Added `queryregistry/identity/sessions/services.py` which exposes `read_sessions_v1` and maps provider name `"mssql"` to the concrete implementation.
- Added `queryregistry/identity/sessions/mssql.py` implementing `get_security_snapshot_v1` that normalizes the `guid`, runs the SQL via `run_json_many`, and returns a `DBResponse` payload.
- Updated `queryregistry/identity/sessions/handler.py` to dispatch the `("read", "1")` operation to `read_sessions_v1` instead of using stub dispatchers.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c63c2dadc8325882f495e7ffd58b2)