### PR TITLE
Add queryregistry role dispatchers and MSSQL providers

### DIFF
--- a/queryregistry/identity/role_memberships/handler.py
+++ b/queryregistry/identity/role_memberships/handler.py
@@ -4,13 +4,24 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.dispatch import dispatch_subdomain_request, SubdomainDispatcher
 from queryregistry.models import DBRequest, DBResponse
-from queryregistry.stubs import build_stub_dispatchers
+
+from .services import (
+  add_role_member_v1,
+  list_role_members_v1,
+  list_role_non_members_v1,
+  remove_role_member_v1,
+)
 
 __all__ = ["handle_role_memberships_request"]
 
-DISPATCHERS = build_stub_dispatchers("identity.role_memberships")
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("list", "1"): list_role_members_v1,
+  ("list_non_members", "1"): list_role_non_members_v1,
+  ("create", "1"): add_role_member_v1,
+  ("delete", "1"): remove_role_member_v1,
+}
 
 
 async def handle_role_memberships_request(

--- a/queryregistry/identity/role_memberships/mssql.py
+++ b/queryregistry/identity/role_memberships/mssql.py
@@ -1,0 +1,42 @@
+"""MSSQL implementations for identity role memberships query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from server.registry.system.roles.mssql import (
+  add_role_member_v1,
+  get_role_members_v1,
+  get_role_non_members_v1,
+  remove_role_member_v1,
+)
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "add_role_member",
+  "list_role_members",
+  "list_role_non_members",
+  "remove_role_member",
+]
+
+
+async def list_role_members(args: Mapping[str, Any]) -> DBResponse:
+  response = await get_role_members_v1(dict(args))
+  return DBResponse(payload=response.payload)
+
+
+async def list_role_non_members(args: Mapping[str, Any]) -> DBResponse:
+  response = await get_role_non_members_v1(dict(args))
+  return DBResponse(payload=response.payload)
+
+
+async def add_role_member(args: Mapping[str, Any]) -> DBResponse:
+  response = await add_role_member_v1(dict(args))
+  return DBResponse(payload={"rowcount": response.rowcount})
+
+
+async def remove_role_member(args: Mapping[str, Any]) -> DBResponse:
+  response = await remove_role_member_v1(dict(args))
+  return DBResponse(payload={"rowcount": response.rowcount})

--- a/queryregistry/identity/role_memberships/services.py
+++ b/queryregistry/identity/role_memberships/services.py
@@ -1,0 +1,86 @@
+"""Identity role memberships query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+
+__all__ = [
+  "add_role_member_v1",
+  "list_role_members_v1",
+  "list_role_non_members_v1",
+  "remove_role_member_v1",
+]
+
+_ListMembersDispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+_ListNonMembersDispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+_AddMemberDispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+_RemoveMemberDispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_MEMBERS_DISPATCHERS: dict[str, _ListMembersDispatcher] = {
+  "mssql": mssql.list_role_members,
+}
+
+_LIST_NON_MEMBERS_DISPATCHERS: dict[str, _ListNonMembersDispatcher] = {
+  "mssql": mssql.list_role_non_members,
+}
+
+_ADD_MEMBER_DISPATCHERS: dict[str, _AddMemberDispatcher] = {
+  "mssql": mssql.add_role_member,
+}
+
+_REMOVE_MEMBER_DISPATCHERS: dict[str, _RemoveMemberDispatcher] = {
+  "mssql": mssql.remove_role_member,
+}
+
+
+async def list_role_members_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _LIST_MEMBERS_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity role_memberships registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)
+
+
+async def list_role_non_members_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _LIST_NON_MEMBERS_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity role_memberships registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)
+
+
+async def add_role_member_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _ADD_MEMBER_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity role_memberships registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)
+
+
+async def remove_role_member_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _REMOVE_MEMBER_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity role_memberships registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)

--- a/queryregistry/system/roles/handler.py
+++ b/queryregistry/system/roles/handler.py
@@ -6,11 +6,18 @@ from typing import Sequence
 
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
-from queryregistry.stubs import build_stub_dispatchers
+
+from .services import delete_role_v1, list_roles_v1, upsert_role_v1
+from ..dispatch import SubdomainDispatcher
 
 __all__ = ["handle_roles_request"]
 
-DISPATCHERS = build_stub_dispatchers("system.roles")
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("list", "1"): list_roles_v1,
+  ("create", "1"): upsert_role_v1,
+  ("update", "1"): upsert_role_v1,
+  ("delete", "1"): delete_role_v1,
+}
 
 
 async def handle_roles_request(

--- a/queryregistry/system/roles/mssql.py
+++ b/queryregistry/system/roles/mssql.py
@@ -1,0 +1,59 @@
+"""MSSQL implementations for system roles query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from server.registry.providers.mssql import run_exec, run_json_many
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "delete_role",
+  "list_roles",
+  "upsert_role",
+]
+
+
+def _normalize_payload(rows: list[Any]) -> list[dict[str, Any]]:
+  return [dict(row) for row in rows]
+
+
+async def list_roles(_: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT element_name AS name, element_mask AS mask, element_display AS display
+    FROM system_roles
+    ORDER BY element_mask
+    FOR JSON PATH;
+  """
+  response = await run_json_many(sql)
+  return DBResponse(payload=_normalize_payload(response.rows))
+
+
+async def upsert_role(args: Mapping[str, Any]) -> DBResponse:
+  name = args["name"]
+  mask = int(args["mask"])
+  display = args.get("display")
+  response = await run_exec(
+    "UPDATE system_roles SET element_mask = ?, element_display = ? WHERE element_name = ?;",
+    (mask, display, name),
+  )
+  if response.rowcount == 0:
+    response = await run_exec(
+      "INSERT INTO system_roles (element_name, element_mask, element_display) VALUES (?, ?, ?);",
+      (name, mask, display),
+    )
+  return DBResponse(payload={"rowcount": response.rowcount})
+
+
+async def delete_role(args: Mapping[str, Any]) -> DBResponse:
+  name = args["name"]
+  sql = """
+    DECLARE @mask BIGINT;
+    SELECT @mask = element_mask FROM system_roles WHERE element_name = ?;
+    UPDATE users_roles SET element_roles = element_roles & ~@mask;
+    DELETE FROM system_roles WHERE element_name = ?;
+  """
+  response = await run_exec(sql, (name, name))
+  return DBResponse(payload={"rowcount": response.rowcount})

--- a/queryregistry/system/roles/services.py
+++ b/queryregistry/system/roles/services.py
@@ -1,0 +1,68 @@
+"""System roles query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+
+__all__ = [
+  "delete_role_v1",
+  "list_roles_v1",
+  "upsert_role_v1",
+]
+
+_ListRolesDispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+_UpsertRoleDispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+_DeleteRoleDispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_DISPATCHERS: dict[str, _ListRolesDispatcher] = {
+  "mssql": mssql.list_roles,
+}
+
+_UPSERT_DISPATCHERS: dict[str, _UpsertRoleDispatcher] = {
+  "mssql": mssql.upsert_role,
+}
+
+_DELETE_DISPATCHERS: dict[str, _DeleteRoleDispatcher] = {
+  "mssql": mssql.delete_role,
+}
+
+
+async def list_roles_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _LIST_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for system roles registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)
+
+
+async def upsert_role_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _UPSERT_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for system roles registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)
+
+
+async def delete_role_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _DELETE_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for system roles registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)


### PR DESCRIPTION
### Motivation
- Implement concrete dispatchers for `system.roles` operations (`list`, `create`/`update` via upsert, `delete`) so the registry is no longer a stub.
- Implement `identity.role_memberships` operations to manage role assignments (list members/non-members, add/remove) per the domain split in `QUERYREGISTRY.md`.
- Reuse existing MSSQL registry logic in `server/registry/system/roles/mssql.py` to avoid duplicating SQL and preserve provider behavior.
- Wire handlers to the new dispatchers so requests are routed to real implementations instead of raising 501 stubs.

### Description
- Added `queryregistry/system/roles/services.py` and `queryregistry/system/roles/mssql.py` to provide `list_roles_v1`, `upsert_role_v1`, and `delete_role_v1` service dispatchers and MSSQL provider adapters returning `DBResponse` payloads.
- Added `queryregistry/identity/role_memberships/services.py` and `queryregistry/identity/role_memberships/mssql.py` to implement `list`/`list_non_members` and `create`/`delete` membership operations, delegating to `server.registry.system.roles` SQL helpers (`get_role_members_v1`, `get_role_non_members_v1`, `add_role_member_v1`, `remove_role_member_v1`).
- Updated `queryregistry/system/roles/handler.py` and `queryregistry/identity/role_memberships/handler.py` to register concrete `SubdomainDispatcher` mappings for the supported operations and versions.
- Ensured responses normalize to `DBResponse` shapes and preserved the separation of role definitions (system) vs assignments (identity).

### Testing
- No automated tests were executed for this change.
- To run the repository-wide pipeline locally, use `python scripts/run_tests.py` (or `pytest` under `tests/` for backend-focused iteration).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c65b58d0883259a9b547cc014a83b)