### PR TITLE
Dispatch identity DB ops through queryregistry and update tests

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI, HTTPException, status
 from jose import jwt, JWTError, ExpiredSignatureError
 from typing import Dict
 
+from queryregistry.handler import dispatch_query_request
 from server.modules import BaseModule
 from server.modules.env_module import EnvModule
 from server.modules.db_module import DbModule
@@ -18,8 +19,8 @@ from server.registry.account.profile.model import GuidParams
 from server.modules.registry.helpers import (
   delete_role_request,
   get_roles_request,
+  get_identity_security_profile_request,
   get_rotkey_request,
-  get_security_profile_request,
   list_roles_request,
   upsert_role_request,
 )
@@ -331,12 +332,14 @@ class AuthModule(BaseModule):
     return self.role_cache.get_role_names(exclude_registered)
 
   async def get_discord_user_security(self, discord_id: str) -> tuple[str, list[str], int]:
-    res = await self.db.run(
-      get_security_profile_request(discord_id=discord_id),
+    res = await dispatch_query_request(
+      get_identity_security_profile_request(discord_id=discord_id),
+      provider=self.db.provider,
     )
-    if not res.rows:
+    payload = res.payload if isinstance(res.payload, dict) else {}
+    if not payload:
       return "", [], 0
-    row = res.rows[0]
+    row = payload
     guid = row.get("user_guid")
     mask = int(row.get("user_roles", 0) or 0)
     names = self.role_cache.mask_to_names(mask)

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -6,6 +6,7 @@ import inspect
 from fastapi import FastAPI
 import logging
 
+from queryregistry.handler import dispatch_query_request
 from . import BaseModule
 from .env_module import EnvModule
 from .providers import DbProviderBase
@@ -19,16 +20,16 @@ from server.registry.account.cache.model import (
 )
 from server.registry.system.config.model import ConfigKeyParams
 from server.modules.registry.helpers import (
-  account_exists_request,
   delete_cache_folder_request,
   delete_cache_item_request,
   get_config_request,
+  identity_account_exists_request,
   list_cache_request,
   replace_user_cache_request,
   upsert_cache_item_request,
 )
 from server.helpers.logging import update_logging_level
-from server.registry import get_handler_info, parse_db_op, try_get_handler_info
+from server.registry import get_handler_info, parse_db_op
 
 
 class DbModule(BaseModule):
@@ -261,17 +262,18 @@ class DbModule(BaseModule):
     await self.run(replace_user_cache_request(params))
 
   async def user_exists(self, user_guid: str) -> bool:
-    request = account_exists_request(user_guid=user_guid)
+    request = identity_account_exists_request(user_guid=user_guid)
     provider_name = self.provider or "mssql"
-    handler_info = try_get_handler_info(request.op, provider=provider_name)
-    if not handler_info:
+    try:
+      res = await dispatch_query_request(request, provider=provider_name)
+    except KeyError:
       logging.getLogger("server.registry").warning(
-        "Registry handler missing for user lookup",
+        "Query registry handler missing for user lookup",
         extra={"db_op": request.op, "db_provider": provider_name},
       )
       return await self._fallback_user_exists(user_guid=user_guid)
-    res = await self.run(request)
-    return bool(res.rows)
+    payload = res.payload if isinstance(res.payload, dict) else {}
+    return bool(payload.get("exists_flag"))
 
   async def _fallback_user_exists(self, *, user_guid: str) -> bool:
     provider_name = self.provider or "mssql"
@@ -281,14 +283,15 @@ class DbModule(BaseModule):
       )
       return False
     try:
-      from server.registry.account.accounts.mssql import account_exists_v1
+      from queryregistry.identity.accounts.mssql import account_exists
     except ModuleNotFoundError:
       logging.getLogger("server.registry").error(
         "MSSQL account exists handler unavailable"
       )
       return False
-    response = await account_exists_v1({"user_guid": user_guid})
-    return bool(response.rows)
+    response = await account_exists({"user_guid": user_guid})
+    payload = response.payload if isinstance(response.payload, dict) else {}
+    return bool(payload.get("exists_flag"))
 
   async def upsert_storage_cache(self, item: Dict[str, Any]) -> DBResponse:
     params = UpsertCacheItemParams.model_validate(item)

--- a/server/modules/registry/helpers.py
+++ b/server/modules/registry/helpers.py
@@ -1,9 +1,6 @@
 """Re-export registry request builders for use within modules."""
 
-from server.registry.account.accounts import (
-  account_exists_request,
-  get_security_profile_request,
-)
+from queryregistry.models import DBRequest as QueryDBRequest
 from server.registry.account.cache import (
   count_rows_request,
   delete_cache_folder_request,
@@ -97,10 +94,38 @@ from server.registry.system.public_vars import (
   get_version_request,
 )
 
+def get_identity_security_profile_request(
+  *,
+  guid: str | None = None,
+  access_token: str | None = None,
+  provider: str | None = None,
+  provider_identifier: str | None = None,
+  discord_id: str | None = None,
+) -> QueryDBRequest:
+  params: dict[str, object] = {}
+  if guid is not None:
+    params["guid"] = guid
+  if access_token is not None:
+    params["access_token"] = access_token
+  if provider is not None:
+    params["provider"] = provider
+  if provider_identifier is not None:
+    params["provider_identifier"] = provider_identifier
+  if discord_id is not None:
+    params["discord_id"] = discord_id
+  return QueryDBRequest(op="db:identity:accounts:read:1", payload=params)
+
+
+def identity_account_exists_request(user_guid: str) -> QueryDBRequest:
+  return QueryDBRequest(
+    op="db:identity:accounts:exists:1",
+    payload={"user_guid": user_guid},
+  )
+
+
 get_profile_request = _profile_get_profile_request
 
 __all__ = sorted([
-  "account_exists_request",
   "add_role_member_request",
   "count_rows_request",
   "create_from_provider_request",
@@ -130,9 +155,10 @@ __all__ = sorted([
   "get_roles_request",
   "get_rotkey_request",
   "get_routes_request",
-  "get_security_profile_request",
+  "get_identity_security_profile_request",
   "get_user_by_email_request",
   "get_version_request",
+  "identity_account_exists_request",
   "insert_conversation_request",
   "link_provider_request",
   "list_by_time_request",

--- a/tests/test_db_module_run.py
+++ b/tests/test_db_module_run.py
@@ -1,4 +1,5 @@
 import asyncio
+import uuid
 
 from fastapi import FastAPI
 
@@ -11,19 +12,21 @@ def test_user_exists_dispatches_exists_handler(monkeypatch):
 
   requests = []
 
-  async def fake_run(request):
+  async def fake_dispatch(request, *, provider):
     requests.append(request)
-    return DBResponse(op=request.op, rows=[{"result": True}], rowcount=1)
+    return DBResponse(op=request.op, payload={"exists_flag": 1})
 
-  monkeypatch.setattr(db, "run", fake_run)
+  monkeypatch.setattr("server.modules.db_module.dispatch_query_request", fake_dispatch)
+
+  user_guid = str(uuid.uuid4())
 
   async def run_scenario():
-    result = await db.user_exists("guid-123")
+    result = await db.user_exists(user_guid)
     assert result is True
 
   asyncio.run(run_scenario())
 
   assert requests, "DbModule.user_exists should dispatch a DB request"
   request = requests[0]
-  assert request.op == "db:account:accounts:exists:1"
-  assert request.payload == {"user_guid": "guid-123"}
+  assert request.op == "db:identity:accounts:exists:1"
+  assert request.payload == {"user_guid": user_guid}


### PR DESCRIPTION
### Motivation
- Move identity-related DB interactions onto the `queryregistry` dispatch path so modules emit `db:identity:*` ops handled by the new query registry layer.
- Replace legacy request builders with queryregistry-style request objects to centralize identity lookups and enable handler dispatching.

### Description
- Added `get_identity_security_profile_request` and `identity_account_exists_request` that return `QueryDBRequest` objects with ops `db:identity:accounts:read:1` and `db:identity:accounts:exists:1` respectively in `server/modules/registry/helpers.py`.
- Updated `AuthModule.get_discord_user_security` to call `dispatch_query_request` with `get_identity_security_profile_request(...)` and to read from `res.payload` instead of `res.rows`.
- Updated `DbModule.user_exists` to dispatch `identity_account_exists_request(...)` via `dispatch_query_request`, handle missing query handlers by falling back to the MSSQL handler at `queryregistry.identity.accounts.mssql.account_exists`, and interpret the response `payload` key `exists_flag` for the result.
- Adjusted imports and removed the legacy `try_get_handler_info` usage, and updated logging messages to reference the query registry dispatch path.

### Testing
- Prior test run failed with `1 failed, 226 passed` where `tests/test_db_module_run.py::test_user_exists_dispatches_exists_handler` errored due to an invalid UUID and mismatched dispatch expectations.
- Updated `tests/test_db_module_run.py` to mock `server.modules.db_module.dispatch_query_request`, return `DBResponse` with `payload={'exists_flag': 1}`, use a valid `uuid.uuid4()` value, and assert the op is `db:identity:accounts:exists:1`.
- No automated test suite was executed after the test update in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c6fc5ea8c8325840fdc5573f4f13f)