### PR TITLE
Migrate role membership ops to QueryRegistry and add request builders

### DIFF
--- a/server/modules/registry/helpers.py
+++ b/server/modules/registry/helpers.py
@@ -88,6 +88,7 @@ from server.registry.system.roles import (
   remove_role_member_request,
   upsert_role_request,
 )
+from server.registry.system.roles.model import ModifyRoleMemberParams, RoleScopeParams
 from server.registry.system.public_vars import (
   get_hostname_request,
   get_repo_request,
@@ -122,17 +123,46 @@ def identity_account_exists_request(user_guid: str) -> QueryDBRequest:
     payload={"user_guid": user_guid},
   )
 
+def list_role_memberships_request(params: RoleScopeParams) -> QueryDBRequest:
+  return QueryDBRequest(
+    op="db:identity:role_memberships:list:1",
+    payload=params.model_dump(),
+  )
+
+
+def list_role_non_memberships_request(params: RoleScopeParams) -> QueryDBRequest:
+  return QueryDBRequest(
+    op="db:identity:role_memberships:list_non_members:1",
+    payload=params.model_dump(),
+  )
+
+
+def create_role_membership_request(params: ModifyRoleMemberParams) -> QueryDBRequest:
+  return QueryDBRequest(
+    op="db:identity:role_memberships:create:1",
+    payload=params.model_dump(),
+  )
+
+
+def delete_role_membership_request(params: ModifyRoleMemberParams) -> QueryDBRequest:
+  return QueryDBRequest(
+    op="db:identity:role_memberships:delete:1",
+    payload=params.model_dump(),
+  )
+
 
 get_profile_request = _profile_get_profile_request
 
 __all__ = sorted([
   "add_role_member_request",
   "count_rows_request",
+  "create_role_membership_request",
   "create_from_provider_request",
   "create_session_request",
   "delete_cache_folder_request",
   "delete_cache_item_request",
   "delete_config_request",
+  "delete_role_membership_request",
   "delete_persona_request",
   "delete_route_request",
   "delete_role_request",
@@ -164,6 +194,8 @@ __all__ = sorted([
   "list_by_time_request",
   "list_cache_request",
   "list_models_request",
+  "list_role_memberships_request",
+  "list_role_non_memberships_request",
   "list_personas_request",
   "list_public_request",
   "list_reported_request",

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -1,4 +1,8 @@
+from collections.abc import Mapping
+from typing import Any
+
 from fastapi import FastAPI, HTTPException
+from queryregistry.handler import dispatch_query_request
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.auth_module import AuthModule
@@ -8,12 +12,22 @@ from server.registry.system.roles.model import (
   RoleScopeParams,
 )
 from server.modules.registry.helpers import (
-  add_role_member_request,
-  get_role_members_request,
-  get_role_non_members_request,
+  create_role_membership_request,
+  delete_role_membership_request,
+  list_role_memberships_request,
+  list_role_non_memberships_request,
   list_roles_request,
-  remove_role_member_request,
 )
+
+
+def _normalize_payload(payload: Any | None) -> list[dict[str, Any]]:
+  if payload is None:
+    return []
+  if isinstance(payload, list):
+    return [dict(item) for item in payload]
+  if isinstance(payload, Mapping):
+    return [dict(payload)]
+  return [dict(payload)]
 
 
 class RoleAdminModule(BaseModule):
@@ -62,15 +76,22 @@ class RoleAdminModule(BaseModule):
     return roles
 
   async def get_role_members(self, role: str) -> tuple[list[dict], list[dict]]:
-    mem_res = await self.db.run(get_role_members_request(RoleScopeParams(role=role)))
-    non_res = await self.db.run(get_role_non_members_request(RoleScopeParams(role=role)))
+    provider_name = self.db.provider or "mssql"
+    mem_res = await dispatch_query_request(
+      list_role_memberships_request(RoleScopeParams(role=role)),
+      provider=provider_name,
+    )
+    non_res = await dispatch_query_request(
+      list_role_non_memberships_request(RoleScopeParams(role=role)),
+      provider=provider_name,
+    )
     members = [
       {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
-      for r in mem_res.rows
+      for r in _normalize_payload(mem_res.payload)
     ]
     non_members = [
       {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
-      for r in non_res.rows
+      for r in _normalize_payload(non_res.payload)
     ]
     return members, non_members
 
@@ -78,7 +99,11 @@ class RoleAdminModule(BaseModule):
     if actor_mask is not None:
       role_mask = self.auth.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
-    await self.db.run(add_role_member_request(ModifyRoleMemberParams(role=role, user_guid=user_guid)))
+    provider_name = self.db.provider or "mssql"
+    await dispatch_query_request(
+      create_role_membership_request(ModifyRoleMemberParams(role=role, user_guid=user_guid)),
+      provider=provider_name,
+    )
     await self.auth.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 
@@ -86,7 +111,11 @@ class RoleAdminModule(BaseModule):
     if actor_mask is not None:
       role_mask = self.auth.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
-    await self.db.run(remove_role_member_request(ModifyRoleMemberParams(role=role, user_guid=user_guid)))
+    provider_name = self.db.provider or "mssql"
+    await dispatch_query_request(
+      delete_role_membership_request(ModifyRoleMemberParams(role=role, user_guid=user_guid)),
+      provider=provider_name,
+    )
     await self.auth.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 


### PR DESCRIPTION
### Motivation
- Centralize identity role membership database operations through the QueryRegistry dispatcher to unify provider handling.
- Replace legacy module-level `DbModule.run()` usage for role membership reads/writes with the new queryregistry dispatch path.
- Provide typed request builders for identity `role_memberships` operations so modules can create requests consistently.
- Preserve existing API shapes by normalizing payloads returned from queryregistry responses.

### Description
- Added `list_role_memberships_request`, `list_role_non_memberships_request`, `create_role_membership_request`, and `delete_role_membership_request` to `server/modules/registry/helpers.py` using `server.registry.system.roles.model` types.
- Updated `server/modules/role_admin_module.py` to call `queryregistry.handler.dispatch_query_request` (via `dispatch_query_request`) with `provider=self.db.provider` instead of calling `self.db.run(...)` for role membership operations.
- Introduced `_normalize_payload` in `RoleAdminModule` to coerce `DBResponse.payload` into a list of dicts and adjusted member/non-member mapping to iterate over the normalized payload.
- Replaced legacy `add_role_member_request`/`remove_role_member_request` call sites in `RoleAdminModule` with the new request builders and retained the `self.auth.refresh_user_roles` call after modifications.

### Testing
- No automated tests were run.
- Recommended follow-up: run the unified harness via `python scripts/run_tests.py` and `pytest` under `tests/` to validate integration and type/lint checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c79790750832590dcb5f1ec6447d8)