### PR TITLE
Dispatch system role queries via QueryRegistry with legacy fallback

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -1,12 +1,14 @@
 """Authentication module handling login and token workflows."""
 
 import base64, logging, uuid
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from fastapi import FastAPI, HTTPException, status
 from jose import jwt, JWTError, ExpiredSignatureError
-from typing import Dict
+from typing import Any, Dict
 
 from queryregistry.handler import dispatch_query_request
+from queryregistry.models import DBResponse
 from server.modules import BaseModule
 from server.modules.env_module import EnvModule
 from server.modules.db_module import DbModule
@@ -16,13 +18,16 @@ from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.providers.auth.discord_provider import DiscordAuthProvider
 from server.modules.discord_bot_module import DiscordBotModule
 from server.registry.account.profile.model import GuidParams
+from server.registry.models import DBRequest
+from server.registry.system.roles.model import DeleteRoleParams, UpsertRoleParams
 from server.modules.registry.helpers import (
-  delete_role_request,
+  delete_system_role_request,
+  dispatch_query_request_with_fallback,
   get_roles_request,
   get_identity_security_profile_request,
   get_rotkey_request,
-  list_roles_request,
-  upsert_role_request,
+  list_system_roles_request,
+  update_system_role_request,
 )
 
 DEFAULT_SESSION_TOKEN_EXPIRY = 15 # minutes
@@ -37,20 +42,51 @@ class RoleCache:
     self.role_registered: int = 0
     self._user_roles: dict[str, tuple[list[str], int]] = {}
 
+  @staticmethod
+  def _normalize_payload(payload: Any | None) -> list[dict[str, Any]]:
+    if payload is None:
+      return []
+    if isinstance(payload, list):
+      return [dict(item) for item in payload]
+    if isinstance(payload, Mapping):
+      return [dict(payload)]
+    return [dict(payload)]
+
+  async def _dispatch_system_role_request(self, request, *, fallback_op: str) -> DBResponse:
+    provider_name = self.db.provider or "mssql"
+
+    async def fallback() -> DBResponse:
+      legacy_response = await self.db.run(
+        DBRequest(op=fallback_op, payload=request.payload),
+      )
+      return DBResponse(op=request.op, payload=legacy_response.payload)
+
+    return await dispatch_query_request_with_fallback(
+      request,
+      provider=provider_name,
+      fallback=fallback,
+    )
+
   async def load_roles(self):
     logging.debug("[RoleCache] Loading roles from database")
     try:
-      result = await self.db.run(list_roles_request())
+      result = await self._dispatch_system_role_request(
+        list_system_roles_request(),
+        fallback_op="db:system:roles:list:1",
+      )
     except Exception as e:
       logging.error("[RoleCache] Failed to load roles: %s", e)
       return
-    rows = result.rows
+    rows = self._normalize_payload(result.payload)
     if not rows:
       logging.debug("[RoleCache] No roles returned")
       return
     self.roles.clear()
     for r in rows:
-      self.roles[r["name"]] = int(r["mask"])
+      name = r.get("name")
+      if not name:
+        continue
+      self.roles[name] = int(r.get("mask", 0) or 0)
     self.role_registered = self.roles.get("ROLE_REGISTERED", 0)
     self.role_names = [n for n in self.roles.keys() if n != "ROLE_REGISTERED"]
     self._user_roles.clear()
@@ -61,13 +97,19 @@ class RoleCache:
     await self.load_roles()
 
   async def upsert_role(self, name: str, mask: int, display: str | None):
-    await self.db.run(
-      upsert_role_request(name=name, mask=mask, display=display),
+    await self._dispatch_system_role_request(
+      update_system_role_request(
+        UpsertRoleParams(name=name, mask=mask, display=display),
+      ),
+      fallback_op="db:system:roles:upsert_role:1",
     )
     await self.refresh_role_cache()
 
   async def delete_role(self, name: str):
-    await self.db.run(delete_role_request(name=name))
+    await self._dispatch_system_role_request(
+      delete_system_role_request(DeleteRoleParams(name=name)),
+      fallback_op="db:system:roles:delete_role:1",
+    )
     await self.refresh_role_cache()
 
   def mask_to_names(self, mask: int) -> list[str]:

--- a/server/modules/registry/helpers.py
+++ b/server/modules/registry/helpers.py
@@ -1,6 +1,11 @@
 """Re-export registry request builders for use within modules."""
 
-from queryregistry.models import DBRequest as QueryDBRequest
+import logging
+from collections.abc import Awaitable, Callable
+
+from fastapi import HTTPException
+from queryregistry.handler import dispatch_query_request
+from queryregistry.models import DBRequest as QueryDBRequest, DBResponse as QueryDBResponse
 from server.registry.account.cache import (
   count_rows_request,
   delete_cache_folder_request,
@@ -81,14 +86,16 @@ from server.registry.system.routes import (
 )
 from server.registry.system.roles import (
   add_role_member_request,
-  delete_role_request,
   get_role_members_request,
   get_role_non_members_request,
-  list_roles_request,
   remove_role_member_request,
-  upsert_role_request,
 )
-from server.registry.system.roles.model import ModifyRoleMemberParams, RoleScopeParams
+from server.registry.system.roles.model import (
+  DeleteRoleParams,
+  ModifyRoleMemberParams,
+  RoleScopeParams,
+  UpsertRoleParams,
+)
 from server.registry.system.public_vars import (
   get_hostname_request,
   get_repo_request,
@@ -123,6 +130,7 @@ def identity_account_exists_request(user_guid: str) -> QueryDBRequest:
     payload={"user_guid": user_guid},
   )
 
+
 def list_role_memberships_request(params: RoleScopeParams) -> QueryDBRequest:
   return QueryDBRequest(
     op="db:identity:role_memberships:list:1",
@@ -151,6 +159,74 @@ def delete_role_membership_request(params: ModifyRoleMemberParams) -> QueryDBReq
   )
 
 
+def list_system_roles_request() -> QueryDBRequest:
+  return QueryDBRequest(op="db:system:roles:list:1", payload={})
+
+
+def create_system_role_request(params: UpsertRoleParams) -> QueryDBRequest:
+  return QueryDBRequest(
+    op="db:system:roles:create:1",
+    payload=params.model_dump(),
+  )
+
+
+def update_system_role_request(params: UpsertRoleParams) -> QueryDBRequest:
+  return QueryDBRequest(
+    op="db:system:roles:update:1",
+    payload=params.model_dump(),
+  )
+
+
+def delete_system_role_request(params: DeleteRoleParams) -> QueryDBRequest:
+  return QueryDBRequest(
+    op="db:system:roles:delete:1",
+    payload=params.model_dump(),
+  )
+
+
+def _log_registry_fallback(op: str, provider: str, reason: str) -> None:
+  registry_logger = logging.getLogger("server.registry")
+  registry_logger.warning(
+    "Registry handler fallback triggered",
+    extra={
+      "db_op": op,
+      "db_provider": provider,
+      "db_fallback_reason": reason,
+    },
+  )
+  metrics_logger = logging.getLogger("metrics.registry")
+  metrics_logger.info(
+    "db_registry_fallback",
+    extra={
+      "db_op": op,
+      "db_provider": provider,
+      "db_fallback_reason": reason,
+    },
+  )
+
+
+async def dispatch_query_request_with_fallback(
+  request: QueryDBRequest,
+  *,
+  provider: str,
+  fallback: Callable[[], Awaitable[QueryDBResponse]] | None = None,
+) -> QueryDBResponse:
+  try:
+    response = await dispatch_query_request(request, provider=provider)
+  except (KeyError, HTTPException) as exc:
+    if isinstance(exc, HTTPException) and exc.status_code != 404:
+      raise
+    _log_registry_fallback(request.op, provider, "missing_handler")
+    if fallback is None:
+      raise
+    return await fallback()
+  logging.getLogger("server.registry").info(
+    "Registry handler resolved",
+    extra={"db_op": request.op, "db_provider": provider},
+  )
+  return response
+
+
 get_profile_request = _profile_get_profile_request
 
 __all__ = sorted([
@@ -165,7 +241,8 @@ __all__ = sorted([
   "delete_role_membership_request",
   "delete_persona_request",
   "delete_route_request",
-  "delete_role_request",
+  "delete_system_role_request",
+  "dispatch_query_request_with_fallback",
   "find_recent_request",
   "get_any_by_provider_identifier_request",
   "get_by_provider_identifier_request",
@@ -199,7 +276,7 @@ __all__ = sorted([
   "list_personas_request",
   "list_public_request",
   "list_reported_request",
-  "list_roles_request",
+  "list_system_roles_request",
   "relink_discord_request",
   "relink_google_request",
   "relink_microsoft_request",
@@ -207,6 +284,7 @@ __all__ = sorted([
   "replace_user_cache_request",
   "revoke_device_token_request",
   "revoke_provider_tokens_request",
+  "create_system_role_request",
   "set_credits_request",
   "set_display_request",
   "set_gallery_request",
@@ -221,9 +299,9 @@ __all__ = sorted([
   "update_if_unedited_request",
   "update_output_request",
   "update_session_request",
+  "update_system_role_request",
   "upsert_cache_item_request",
   "upsert_config_request",
   "upsert_persona_request",
   "upsert_route_request",
-  "upsert_role_request",
 ])

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -3,20 +3,23 @@ from typing import Any
 
 from fastapi import FastAPI, HTTPException
 from queryregistry.handler import dispatch_query_request
+from queryregistry.models import DBResponse
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.auth_module import AuthModule
 from server.modules.discord_bot_module import DiscordBotModule
+from server.registry.models import DBRequest
 from server.registry.system.roles.model import (
   ModifyRoleMemberParams,
   RoleScopeParams,
 )
 from server.modules.registry.helpers import (
   create_role_membership_request,
+  dispatch_query_request_with_fallback,
   delete_role_membership_request,
   list_role_memberships_request,
   list_role_non_memberships_request,
-  list_roles_request,
+  list_system_roles_request,
 )
 
 
@@ -28,6 +31,27 @@ def _normalize_payload(payload: Any | None) -> list[dict[str, Any]]:
   if isinstance(payload, Mapping):
     return [dict(payload)]
   return [dict(payload)]
+
+
+async def _dispatch_role_request(
+  db: DbModule,
+  request,
+  *,
+  fallback_op: str,
+) -> DBResponse:
+  provider_name = db.provider or "mssql"
+
+  async def fallback() -> DBResponse:
+    legacy_response = await db.run(
+      DBRequest(op=fallback_op, payload=request.payload),
+    )
+    return DBResponse(op=request.op, payload=legacy_response.payload)
+
+  return await dispatch_query_request_with_fallback(
+    request,
+    provider=provider_name,
+    fallback=fallback,
+  )
 
 
 class RoleAdminModule(BaseModule):
@@ -59,14 +83,18 @@ class RoleAdminModule(BaseModule):
       raise HTTPException(status_code=403, detail="Forbidden")
 
   async def list_roles(self, actor_mask: int | None = None) -> list[dict]:
-    res = await self.db.run(list_roles_request())
+    res = await _dispatch_role_request(
+      self.db,
+      list_system_roles_request(),
+      fallback_op="db:system:roles:list:1",
+    )
     roles = [
       {
         "name": r.get("name", ""),
         "mask": str(r.get("mask", "")),
         "display": r.get("display"),
       }
-      for r in res.rows
+      for r in _normalize_payload(res.payload)
       if r.get("name") != "ROLE_REGISTERED"
     ]
     roles.sort(key=lambda r: int(r.get("mask", 0)))


### PR DESCRIPTION
### Motivation
- Route system role operations through the QueryRegistry path (`db:system:roles:*`) so role admin and cache flows can use unified registry dispatch logic.
- Preserve the existing fallback behavior and logging when a registry handler is not present so provider-backed handlers continue to work.
- Normalize queryregistry payload shapes for existing callers so role parsing remains robust.

### Description
- Added request builders in `server/modules/registry/helpers.py`: `list_system_roles_request`, `create_system_role_request`, `update_system_role_request`, and `delete_system_role_request`.
- Implemented `dispatch_query_request_with_fallback` and `_log_registry_fallback` in `server/modules/registry/helpers.py` to call `queryregistry.handler.dispatch_query_request` and fall back to `DbModule.run` with the same logging/metrics semantics when a handler is missing.
- Updated `AuthModule.RoleCache` in `server/modules/auth_module.py` to use `_dispatch_system_role_request` (via the new dispatch helper), use the new request builders for upsert/delete, and normalize payload parsing from queryregistry responses.
- Updated `RoleAdminModule.list_roles` in `server/modules/role_admin_module.py` to dispatch system role list requests through QueryRegistry with the same legacy fallback and normalized payload handling.

### Testing
- No automated tests were run against these changes.
- Developers should run `python scripts/run_tests.py` or `pytest` in `tests/` to validate behavior in CI or local environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c7bb9ff2083258d29b6e6744ee193)