### PR TITLE
Add MySQL and Postgres provider stubs to queryregistry

### DIFF
--- a/queryregistry/providers/__init__.py
+++ b/queryregistry/providers/__init__.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from . import mssql
+from . import mssql, mysql, postgres
 
 PROVIDERS = {
   "mssql": mssql,
+  "mysql": mysql,
+  "postgres": postgres,
 }
 
-__all__ = ["PROVIDERS", "mssql"]
+__all__ = ["PROVIDERS", "mssql", "mysql", "postgres"]

--- a/queryregistry/providers/mysql.py
+++ b/queryregistry/providers/mysql.py
@@ -1,0 +1,25 @@
+"""Stubbed MySQL query registry provider helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Tuple
+
+
+async def run_exec(sql: str, params: Iterable[Any] | Tuple[Any, ...] = ()) -> Any:
+  raise NotImplementedError("MySQL query execution is not implemented.")
+
+
+async def run_json_one(sql: str, params: Iterable[Any] | Tuple[Any, ...] = ()) -> Any:
+  raise NotImplementedError("MySQL JSON query execution is not implemented.")
+
+
+async def run_json_many(sql: str, params: Iterable[Any] | Tuple[Any, ...] = ()) -> Any:
+  raise NotImplementedError("MySQL JSON query execution is not implemented.")
+
+
+async def run_rows_one(sql: str, params: Iterable[Any] | Tuple[Any, ...] = ()) -> Any:
+  raise NotImplementedError("MySQL row query execution is not implemented.")
+
+
+async def run_rows_many(sql: str, params: Iterable[Any] | Tuple[Any, ...] = ()) -> Any:
+  raise NotImplementedError("MySQL row query execution is not implemented.")

--- a/queryregistry/providers/postgres.py
+++ b/queryregistry/providers/postgres.py
@@ -1,0 +1,25 @@
+"""Stubbed Postgres query registry provider helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Tuple
+
+
+async def run_exec(sql: str, params: Iterable[Any] | Tuple[Any, ...] = ()) -> Any:
+  raise NotImplementedError("Postgres query execution is not implemented.")
+
+
+async def run_json_one(sql: str, params: Iterable[Any] | Tuple[Any, ...] = ()) -> Any:
+  raise NotImplementedError("Postgres JSON query execution is not implemented.")
+
+
+async def run_json_many(sql: str, params: Iterable[Any] | Tuple[Any, ...] = ()) -> Any:
+  raise NotImplementedError("Postgres JSON query execution is not implemented.")
+
+
+async def run_rows_one(sql: str, params: Iterable[Any] | Tuple[Any, ...] = ()) -> Any:
+  raise NotImplementedError("Postgres row query execution is not implemented.")
+
+
+async def run_rows_many(sql: str, params: Iterable[Any] | Tuple[Any, ...] = ()) -> Any:
+  raise NotImplementedError("Postgres row query execution is not implemented.")


### PR DESCRIPTION
### Motivation
- Introduce explicit placeholders for MySQL and Postgres providers to document intent and enable future implementations.
- Provide the same callable interface as the existing `mssql` provider so dispatchers can reference these providers uniformly.
- Prevent missing-provider errors when the provider map is examined or extended before concrete implementations exist.

### Description
- Added `queryregistry/providers/mysql.py` containing async stub functions `run_exec`, `run_json_one`, `run_json_many`, `run_rows_one`, and `run_rows_many` that raise `NotImplementedError`.
- Added `queryregistry/providers/postgres.py` with the same async stub functions and behavior as the MySQL stub.
- Updated `queryregistry/providers/__init__.py` to import and register `mysql` and `postgres` in the `PROVIDERS` map and to expose them via `__all__`.
- No concrete database logic was implemented; these files serve as explicit stubs for future work.

### Testing
- No automated tests were executed for this change.
- No test failures were observed because no tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c833e375c83259c8dff992dfdcf54)