### PR TITLE
Skip DB checks in test mode for run_tests

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import subprocess, os, sys, importlib.util, asyncio, aioodbc, argparse
+import subprocess, os, sys, importlib.util, asyncio, argparse
 from pathlib import Path
 from scriptlib import parse_version, next_build
 
@@ -71,6 +71,8 @@ async def update_build_version() -> None:
 
   print(f'Using {source} for build version update in {environment} environment')
 
+  import aioodbc
+
   pool = None
   try:
     pool = await asyncio.wait_for(aioodbc.create_pool(dsn=dsn, autocommit=True), timeout=10)
@@ -131,7 +133,9 @@ def main() -> None:
   ROOT = Path(__file__).resolve().parent.parent
 
   args = _parse_args()
-  if not args.test:
+  if args.test:
+    print('Test flag set; skipping database connectivity checks.')
+  else:
     asyncio.run(update_build_version())
 
   subprocess.check_call([sys.executable, 'scripts/generate_rpc_bindings.py'], cwd=ROOT)


### PR DESCRIPTION
### Motivation
- Avoid importing `aioodbc` at module import time when running the test harness locally or in environments without DB connectivity.
- Prevent `scripts/run_tests.py --test` from failing due to missing DB credentials or network access during local/Codex runs.
- Make the skip behavior explicit in logs so it's obvious when DB checks are not performed.
- Preserve CI and default behavior so full DB connectivity checks still run when the flag is not set.

### Description
- Removed the top-level `import aioodbc` and instead `import aioodbc` inside `update_build_version()` immediately before calling `aioodbc.create_pool`.
- Added a guard in `main()` to skip calling `update_build_version()` when `--test` is supplied and emit the log line `Test flag set; skipping database connectivity checks.`
- Left the existing DB connection logic, timeout handling, and update statements unchanged.
- No other functional or workflow changes were introduced.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d6aec049c83259baf2b96885852f4)