### PR TITLE
Fix tests for db module dispatch and role admin provider

### DIFF
--- a/tests/test_db_module_run.py
+++ b/tests/test_db_module_run.py
@@ -3,6 +3,7 @@ import uuid
 
 from fastapi import FastAPI
 
+import server.modules.db_module as db_module
 from server.modules.db_module import DbModule
 from server.modules.providers import DBResponse
 
@@ -16,7 +17,7 @@ def test_user_exists_dispatches_exists_handler(monkeypatch):
     requests.append(request)
     return DBResponse(op=request.op, payload={"exists_flag": 1})
 
-  monkeypatch.setattr("server.modules.db_module.dispatch_query_request", fake_dispatch)
+  monkeypatch.setattr(db_module, "dispatch_query_request", fake_dispatch)
 
   user_guid = str(uuid.uuid4())
 

--- a/tests/test_role_admin_module.py
+++ b/tests/test_role_admin_module.py
@@ -7,6 +7,7 @@ from server.modules.role_admin_module import RoleAdminModule
 class DummyDb:
   def __init__(self, roles=None):
     self.roles = roles or []
+    self.provider = "mssql"
   async def on_ready(self):
     pass
   async def run(self, op, args=None):


### PR DESCRIPTION
### Motivation
- Two unit tests were failing in CI due to incorrect monkeypatch target and a missing provider attribute on a test double.
- The goal is to make the tests correctly simulate the runtime wiring used by the modules so they stop failing.

### Description
- Updated `tests/test_db_module_run.py` to import the module as `db_module` and monkeypatch `db_module.dispatch_query_request` instead of a string target.
- Added `self.provider = "mssql"` to the `DummyDb` test double in `tests/test_role_admin_module.py` so the module code can read `db.provider` during the test.
- Kept changes limited to test code to adjust how the tests interact with existing module APIs.

### Testing
- No automated tests were run as part of this patch.
- The change addresses the two previously reported failing tests (`test_user_exists_dispatches_exists_handler` and `test_list_roles_filters_and_sorts`) so they should pass when CI is re-run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d7b5f40b0832588cde2eb62bb3d4f)