### PR TITLE
Migrate OAuth provider DB ops to QueryRegistry and add request builders

### DIFF
--- a/queryregistry/identity/providers/__init__.py
+++ b/queryregistry/identity/providers/__init__.py
@@ -1,1 +1,158 @@
-"""Identity providers query registry stubs."""
+"""Identity providers query registry helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from queryregistry.models import DBRequest
+
+__all__ = [
+  "create_from_provider_request",
+  "get_any_by_provider_identifier_request",
+  "get_by_provider_identifier_request",
+  "get_user_by_email_request",
+  "link_provider_request",
+  "relink_provider_request",
+  "set_provider_request",
+  "unlink_last_provider_request",
+  "unlink_provider_request",
+]
+
+
+def get_by_provider_identifier_request(
+  *,
+  provider: str,
+  provider_identifier: str,
+) -> DBRequest:
+  return DBRequest(
+    op="db:identity:providers:get_by_provider_identifier:1",
+    payload={
+      "provider": provider,
+      "provider_identifier": provider_identifier,
+    },
+  )
+
+
+def get_any_by_provider_identifier_request(
+  *,
+  provider_identifier: str,
+) -> DBRequest:
+  return DBRequest(
+    op="db:identity:providers:get_any_by_provider_identifier:1",
+    payload={
+      "provider_identifier": provider_identifier,
+    },
+  )
+
+
+def get_user_by_email_request(
+  *,
+  email: str,
+) -> DBRequest:
+  return DBRequest(
+    op="db:identity:providers:get_user_by_email:1",
+    payload={"email": email},
+  )
+
+
+def create_from_provider_request(
+  *,
+  provider: str,
+  provider_identifier: str,
+  provider_email: str,
+  provider_displayname: str,
+  provider_profile_image: str | None = None,
+) -> DBRequest:
+  payload: dict[str, Any] = {
+    "provider": provider,
+    "provider_identifier": provider_identifier,
+    "provider_email": provider_email,
+    "provider_displayname": provider_displayname,
+  }
+  if provider_profile_image is not None:
+    payload["provider_profile_image"] = provider_profile_image
+  return DBRequest(op="db:identity:providers:create_from_provider:1", payload=payload)
+
+
+def link_provider_request(
+  *,
+  guid: str,
+  provider: str,
+  provider_identifier: str,
+) -> DBRequest:
+  return DBRequest(
+    op="db:identity:providers:link_provider:1",
+    payload={
+      "guid": guid,
+      "provider": provider,
+      "provider_identifier": provider_identifier,
+    },
+  )
+
+
+def unlink_provider_request(
+  *,
+  guid: str,
+  provider: str,
+  new_provider_recid: int | None = None,
+) -> DBRequest:
+  payload: dict[str, Any] = {
+    "guid": guid,
+    "provider": provider,
+  }
+  if new_provider_recid is not None:
+    payload["new_provider_recid"] = new_provider_recid
+  return DBRequest(op="db:identity:providers:unlink_provider:1", payload=payload)
+
+
+def unlink_last_provider_request(
+  *,
+  guid: str,
+  provider: str,
+) -> DBRequest:
+  return DBRequest(
+    op="db:identity:providers:unlink_last_provider:1",
+    payload={
+      "guid": guid,
+      "provider": provider,
+    },
+  )
+
+
+def set_provider_request(
+  *,
+  guid: str,
+  provider: str,
+) -> DBRequest:
+  return DBRequest(
+    op="db:identity:providers:set_provider:1",
+    payload={
+      "guid": guid,
+      "provider": provider,
+    },
+  )
+
+
+def relink_provider_request(
+  *,
+  provider: str,
+  provider_identifier: str,
+  email: str,
+  display_name: str,
+  profile_image: str | None = None,
+  confirm: bool | None = None,
+  reauth_token: str | None = None,
+) -> DBRequest:
+  payload: dict[str, Any] = {
+    "provider": provider,
+    "provider_identifier": provider_identifier,
+    "email": email,
+    "display_name": display_name,
+  }
+  if profile_image is not None:
+    payload["profile_image"] = profile_image
+  if confirm is not None:
+    payload["confirm"] = confirm
+  if reauth_token is not None:
+    payload["reauth_token"] = reauth_token
+  return DBRequest(op="db:identity:providers:relink:1", payload=payload)

--- a/queryregistry/identity/providers/models.py
+++ b/queryregistry/identity/providers/models.py
@@ -105,6 +105,8 @@ class RelinkProviderRequestPayload(TypedDict, total=False):
   email: str
   display_name: str
   profile_image: str
+  confirm: bool
+  reauth_token: str
 
 
 CreateFromProviderCallable = Callable[[CreateFromProviderRequestPayload], Awaitable[DBResponse]]

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -18,11 +18,12 @@ async def users_providers_set_provider_v1(request: Request):
     payload = UsersProvidersSetProvider1(**(rpc_request.payload or {}))
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
+  provider = payload.provider.lower()
   oauth: OauthModule = request.app.state.oauth
   await oauth.on_ready()
   result = await oauth.set_user_default_provider(
     auth_ctx.user_guid,
-    payload.provider,
+    provider,
     code=payload.code,
     id_token=payload.id_token,
     access_token=payload.access_token,
@@ -39,11 +40,12 @@ async def users_providers_link_provider_v1(request: Request):
     payload = UsersProvidersLinkProvider1(**(rpc_request.payload or {}))
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
+  provider = payload.provider.lower()
   oauth: OauthModule = request.app.state.oauth
   await oauth.on_ready()
   result = await oauth.link_user_provider(
     auth_ctx.user_guid,
-    payload.provider,
+    provider,
     code=payload.code,
     id_token=payload.id_token,
     access_token=payload.access_token,
@@ -56,11 +58,12 @@ async def users_providers_unlink_provider_v1(request: Request):
     payload = UsersProvidersUnlinkProvider1(**(rpc_request.payload or {}))
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
+  provider = payload.provider.lower()
   oauth: OauthModule = request.app.state.oauth
   await oauth.on_ready()
   result = await oauth.unlink_user_provider(
     auth_ctx.user_guid,
-    payload.provider,
+    provider,
     new_default=payload.new_default,
   )
   return RPCResponse(op=rpc_request.op, payload=result, version=rpc_request.version)
@@ -71,10 +74,11 @@ async def users_providers_get_by_provider_identifier_v1(request: Request):
     payload = UsersProvidersGetByProviderIdentifier1(**(rpc_request.payload or {}))
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
+  provider = payload.provider.lower()
   oauth: OauthModule = request.app.state.oauth
   await oauth.on_ready()
   row = await oauth.get_user_by_provider_identifier(
-    payload.provider, payload.provider_identifier
+    provider, payload.provider_identifier
   )
   return RPCResponse(op=rpc_request.op, payload=row, version=rpc_request.version)
 
@@ -84,14 +88,14 @@ async def users_providers_create_from_provider_v1(request: Request):
     payload = UsersProvidersCreateFromProvider1(**(rpc_request.payload or {}))
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
+  provider = payload.provider.lower()
   oauth: OauthModule = request.app.state.oauth
   await oauth.on_ready()
   row = await oauth.create_user_from_provider(
-    payload.provider,
+    provider,
     payload.provider_identifier,
     payload.provider_email,
     payload.provider_displayname,
     payload.provider_profile_image,
   )
   return RPCResponse(op=rpc_request.op, payload=row, version=rpc_request.version)
-

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -1,8 +1,11 @@
 import base64, logging, uuid
+from collections.abc import Mapping
 import aiohttp
 from datetime import datetime, timezone, timedelta
 
 from fastapi import FastAPI, HTTPException
+from queryregistry.handler import dispatch_query_request
+from queryregistry.models import DBRequest as QueryDBRequest, DBResponse as QueryDBResponse
 from . import BaseModule
 
 from server.modules.auth_module import AuthModule
@@ -24,34 +27,24 @@ from server.registry.account.session.model import (
   UpdateDeviceTokenParams,
 )
 from server.registry.system.config.model import ConfigKeyParams
-from server.registry.types import DBRequest
-from server.registry.account.providers.model import (
-  CreateFromProviderParams,
-  GetUserByEmailParams,
-  LinkProviderParams,
-  ProviderIdentifierParams,
-  SetProviderParams,
-  UnlinkLastProviderParams,
-  UnlinkProviderParams,
-)
-from server.modules.registry.helpers import (
+from queryregistry.identity.providers import (
   create_from_provider_request,
-  create_session_request,
   get_any_by_provider_identifier_request,
   get_by_provider_identifier_request,
-  get_config_request,
-  get_profile_request,
   get_user_by_email_request,
   link_provider_request,
-  relink_discord_request,
-  relink_google_request,
-  relink_microsoft_request,
-  revoke_provider_tokens_request,
-  set_profile_image_request,
+  relink_provider_request,
   set_provider_request,
-  set_rotkey_request,
   unlink_last_provider_request,
   unlink_provider_request,
+)
+from server.modules.registry.helpers import (
+  create_session_request,
+  get_config_request,
+  get_profile_request,
+  revoke_provider_tokens_request,
+  set_profile_image_request,
+  set_rotkey_request,
   update_device_token_request,
   update_if_unedited_request,
 )
@@ -85,6 +78,22 @@ class OauthModule(BaseModule):
 
   async def shutdown(self):
     pass
+
+  def _normalize_query_payload(self, payload: object | None) -> list[dict]:
+    if payload is None:
+      return []
+    if isinstance(payload, list):
+      return [dict(item) for item in payload]
+    if isinstance(payload, Mapping):
+      return [dict(payload)]
+    return [dict(payload)]
+
+  async def _dispatch_provider_request(
+    self,
+    request: QueryDBRequest,
+  ) -> QueryDBResponse:
+    provider_name = self.db.provider or "mssql"
+    return await dispatch_query_request(request, provider=provider_name)
 
   def _provider_title(self, provider: str) -> str:
     return {"google": "Google", "microsoft": "Microsoft", "discord": "Discord"}.get(
@@ -189,10 +198,8 @@ class OauthModule(BaseModule):
       _, profile, _ = await self.auth.handle_auth_login(
         provider, id_token, access_token
       )
-    await self.db.run(
-      set_provider_request(
-        SetProviderParams(guid=user_guid, provider=provider)
-      )
+    await self._dispatch_provider_request(
+      set_provider_request(guid=user_guid, provider=provider),
     )
     if profile:
       raw_email = (profile.get("email") or "").strip()
@@ -226,23 +233,21 @@ class OauthModule(BaseModule):
       provider, id_token, access_token
     )
     provider_uid = self.normalize_provider_identifier(provider_uid)
-    res = await self.db.run(
+    res = await self._dispatch_provider_request(
       get_by_provider_identifier_request(
-        ProviderIdentifierParams(
-          provider=provider, provider_identifier=provider_uid
-        )
-      )
+        provider=provider,
+        provider_identifier=provider_uid,
+      ),
     )
-    if res.rows and res.rows[0].get("guid") != user_guid:
+    rows = self._normalize_query_payload(res.payload)
+    if rows and rows[0].get("guid") != user_guid:
       raise HTTPException(status_code=409, detail="Provider already linked")
-    await self.db.run(
+    await self._dispatch_provider_request(
       link_provider_request(
-        LinkProviderParams(
-          guid=user_guid,
-          provider=provider,
-          provider_identifier=provider_uid,
-        )
-      )
+        guid=user_guid,
+        provider=provider,
+        provider_identifier=provider_uid,
+      ),
     )
     return {"provider": provider}
 
@@ -257,25 +262,20 @@ class OauthModule(BaseModule):
       get_profile_request(GuidParams(guid=user_guid))
     )
     default_provider = res_prof.rows[0].get("default_provider") if res_prof.rows else None
-    res = await self.db.run(
-      unlink_provider_request(
-        UnlinkProviderParams(guid=user_guid, provider=provider)
-      )
+    res = await self._dispatch_provider_request(
+      unlink_provider_request(guid=user_guid, provider=provider),
     )
-    remaining = res.rows[0].get("providers_remaining") if res.rows else 0
+    rows = self._normalize_query_payload(res.payload)
+    remaining = rows[0].get("providers_remaining") if rows else 0
     if remaining == 0:
-      await self.db.run(
-        unlink_last_provider_request(
-          UnlinkLastProviderParams(guid=user_guid, provider=provider)
-        )
+      await self._dispatch_provider_request(
+        unlink_last_provider_request(guid=user_guid, provider=provider),
       )
     elif provider == default_provider:
       if not new_default:
         raise HTTPException(status_code=400, detail="new_default required")
-      await self.db.run(
-        set_provider_request(
-          SetProviderParams(guid=user_guid, provider=new_default)
-        )
+      await self._dispatch_provider_request(
+        set_provider_request(guid=user_guid, provider=new_default),
       )
       await self.db.run(
         revoke_provider_tokens_request(
@@ -286,23 +286,21 @@ class OauthModule(BaseModule):
 
   async def unlink_last_provider_record(self, guid: str, provider: str) -> None:
     assert self.db
-    await self.db.run(
-      unlink_last_provider_request(
-        UnlinkLastProviderParams(guid=guid, provider=provider)
-      )
+    await self._dispatch_provider_request(
+      unlink_last_provider_request(guid=guid, provider=provider),
     )
 
   async def get_user_by_provider_identifier(
     self, provider: str, provider_identifier: str
   ):
-    res = await self.db.run(
+    res = await self._dispatch_provider_request(
       get_by_provider_identifier_request(
-        ProviderIdentifierParams(
-          provider=provider, provider_identifier=provider_identifier
-        )
-      )
+        provider=provider,
+        provider_identifier=provider_identifier,
+      ),
     )
-    return res.rows[0] if res.rows else None
+    rows = self._normalize_query_payload(res.payload)
+    return rows[0] if rows else None
 
   async def create_user_from_provider(
     self,
@@ -312,25 +310,23 @@ class OauthModule(BaseModule):
     provider_displayname: str,
     provider_profile_image: str | None = None,
   ):
-    res = await self.db.run(
-      get_user_by_email_request(
-        GetUserByEmailParams(email=provider_email)
-      )
+    res = await self._dispatch_provider_request(
+      get_user_by_email_request(email=provider_email),
     )
-    if res.rows:
+    rows = self._normalize_query_payload(res.payload)
+    if rows:
       raise HTTPException(status_code=409, detail="Email already registered")
-    res = await self.db.run(
+    res = await self._dispatch_provider_request(
       create_from_provider_request(
-        CreateFromProviderParams(
-          provider=provider,
-          provider_identifier=provider_identifier,
-          provider_email=provider_email,
-          provider_displayname=provider_displayname,
-          provider_profile_image=provider_profile_image,
-        )
-      )
+        provider=provider,
+        provider_identifier=provider_identifier,
+        provider_email=provider_email,
+        provider_displayname=provider_displayname,
+        provider_profile_image=provider_profile_image,
+      ),
     )
-    return res.rows[0] if res.rows else None
+    rows = self._normalize_query_payload(res.payload)
+    return rows[0] if rows else None
 
   async def exchange_code_for_tokens(
     self,
@@ -453,14 +449,16 @@ class OauthModule(BaseModule):
         continue
       checked.add(uid)
       logging.debug(f"[lookup_user] checking identifier={pid[:40]}")
-      res = await self.db.run(
+      res = await self._dispatch_provider_request(
         get_by_provider_identifier_request(
-          ProviderIdentifierParams(provider=provider, provider_identifier=uid),
+          provider=provider,
+          provider_identifier=uid,
         ),
       )
-      if res.rows:
+      rows = self._normalize_query_payload(res.payload)
+      if rows:
         logging.debug(f"[lookup_user] user found with identifier={pid[:40]}")
-        return res.rows[0]
+        return rows[0]
     return None
 
   async def create_session(
@@ -524,64 +522,48 @@ class OauthModule(BaseModule):
     if user and user.get("element_soft_deleted_at"):
       needs_relink = True
     elif not user:
-      await self.db.run(
+      await self._dispatch_provider_request(
         get_any_by_provider_identifier_request(
-          ProviderIdentifierParams(provider=provider, provider_identifier=provider_uid),
+          provider_identifier=provider_uid,
         ),
       )
       needs_relink = True
 
     if needs_relink:
-      relink_builders = {
-        "discord": relink_discord_request,
-        "google": relink_google_request,
-        "microsoft": relink_microsoft_request,
-      }
-      relink_builder = relink_builders.get(provider)
-      if relink_builder:
-        request = relink_builder(
-          provider_identifier=provider_uid,
-          email=profile["email"],
-          display_name=profile["username"],
-          profile_image=profile.get("profilePicture"),
-          confirm=confirm,
-          reauth_token=reauth_token,
-        )
-      else:
-        request = DBRequest(
-          op=f"db:account:oauth:relink_{provider}:1",
-          payload={
-            "provider_identifier": provider_uid,
-            "email": profile["email"],
-            "display_name": profile["username"],
-            "profile_image": profile.get("profilePicture"),
-            "confirm": confirm,
-            "reauth_token": reauth_token,
-          },
-        )
-      res = await self.db.run(request)
-      user = res.rows[0] if res.rows else None
+      request = relink_provider_request(
+        provider=provider,
+        provider_identifier=provider_uid,
+        email=profile["email"],
+        display_name=profile["username"],
+        profile_image=profile.get("profilePicture"),
+        confirm=confirm,
+        reauth_token=reauth_token,
+      )
+      res = await self._dispatch_provider_request(request)
+      rows = self._normalize_query_payload(res.payload)
+      user = rows[0] if rows else None
 
     if not user:
-      res = await self.db.run(
+      res = await self._dispatch_provider_request(
         create_from_provider_request(
-          CreateFromProviderParams(
-            provider=provider,
-            provider_identifier=provider_uid,
-            provider_email=profile["email"],
-            provider_displayname=profile["username"],
-            provider_profile_image=profile.get("profilePicture"),
-          ),
+          provider=provider,
+          provider_identifier=provider_uid,
+          provider_email=profile["email"],
+          provider_displayname=profile["username"],
+          provider_profile_image=profile.get("profilePicture"),
         ),
       )
-      user = res.rows[0] if res.rows else None
+      rows = self._normalize_query_payload(res.payload)
+      user = rows[0] if rows else None
       if not user:
-        res = await self.db.run(
+        res = await self._dispatch_provider_request(
           get_by_provider_identifier_request(
-            ProviderIdentifierParams(provider=provider, provider_identifier=provider_uid),
+            provider=provider,
+            provider_identifier=provider_uid,
           ),
         )
-        user = res.rows[0] if res.rows else None
+        rows = self._normalize_query_payload(res.payload)
+        user = rows[0] if rows else None
       if not user:
         logging.debug("[resolve_user] failed to create user")
         raise HTTPException(status_code=500, detail="Unable to create user")


### PR DESCRIPTION
### Motivation

- Move OAuth-related database lookups/mutations off the legacy server registry path and onto the new QueryRegistry dispatch surface.
- Provide typed request builder helpers for identity provider operations to centralize URN construction and payload shapes.
- Ensure RPC callers and the OAuth module no longer perform direct legacy registry operations.
- Preserve provider handling for `microsoft`, `google`, and `discord` and keep identifier normalization logic intact.

### Description

- Added QueryRegistry request builders under `queryregistry/identity/providers/__init__.py` for all OAuth provider operations such as `get_by_provider_identifier`, `get_any_by_provider_identifier`, `get_user_by_email`, `create_from_provider`, `link_provider`, `unlink_provider`, `unlink_last_provider`, `set_provider`, and `relink`.
- Extended the relink payload model in `queryregistry/identity/providers/models.py` to include `confirm` and `reauth_token` fields.
- Reworked `server/modules/oauth_module.py` to dispatch OAuth provider operations via `queryregistry.handler.dispatch_query_request`, introduced `_dispatch_provider_request` and `_normalize_query_payload` helpers, and removed usage of legacy registry request builders.
- Updated RPC handlers in `rpc/users/providers/services.py` to normalize provider names to lowercase before invoking `OauthModule` APIs so provider enum handling and identifier normalization remain consistent.

### Testing

- No automated test suite was executed for this change (no `pytest`/unified harness run was performed).
- Static inspection and local file checks were used to validate imports and call sites updated across `queryregistry`, `server/modules/oauth_module.py`, and `rpc/users/providers/services.py`.
- Manual review ensured provider names (`microsoft`, `google`, `discord`) and identifier normalization paths were preserved.
- Recommend running `python scripts/run_tests.py` (or `pytest` under `tests/`) in CI before merging to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dba39f4588325a092aafa2fb28e15)