### PR TITLE
Use QueryRegistry for role lookup in auth module

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -17,13 +17,11 @@ from server.modules.providers.auth.microsoft_provider import MicrosoftAuthProvid
 from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.providers.auth.discord_provider import DiscordAuthProvider
 from server.modules.discord_bot_module import DiscordBotModule
-from server.registry.account.profile.model import GuidParams
 from server.registry.models import DBRequest
 from server.registry.system.roles.model import DeleteRoleParams, UpsertRoleParams
 from server.modules.registry.helpers import (
   delete_system_role_request,
   dispatch_query_request_with_fallback,
-  get_roles_request,
   get_identity_security_profile_request,
   get_rotkey_request,
   list_system_roles_request,
@@ -131,9 +129,13 @@ class RoleCache:
       logging.debug("[RoleCache] Returning cached roles for %s", guid)
       return self._user_roles[guid]
     logging.debug("[RoleCache] Fetching roles for %s", guid)
-    params = GuidParams(guid=guid)
-    res = await self.db.run(get_roles_request(params))
-    mask = int(res.rows[0].get("element_roles", 0)) if res.rows else 0
+    response = await dispatch_query_request(
+      get_identity_security_profile_request(guid=guid),
+      provider=self.db.provider or "mssql",
+    )
+    rows = self._normalize_payload(response.payload)
+    row = rows[0] if rows else {}
+    mask = int(row.get("user_roles") or row.get("element_roles") or 0)
     names = self.mask_to_names(mask)
     self._user_roles[guid] = (names, mask)
     logging.debug("[RoleCache] Roles for %s: %s (mask=%#018x)", guid, names, mask)


### PR DESCRIPTION
### Motivation
- Migrate the legacy role lookup to the QueryRegistry identity account endpoints to centralize and modernize role resolution.
- Ensure the role mask is read from the new identity security profile response fields instead of the old profile request.
- Remove dependency on the legacy `GuidParams`/`get_roles_request` path in the auth module.
- Use the current DB provider when dispatching registry queries via `self.db.provider or "mssql"`.

### Description
- Replaced the legacy `GuidParams` + `self.db.run(get_roles_request(...))` logic with a call to `dispatch_query_request(get_identity_security_profile_request(guid=guid))` in `server/modules/auth_module.py`.
- Normalized the returned payload with the module helper and extract the role mask from `user_roles` or `element_roles` (fallback), then convert it to role names with the existing `mask_to_names` logic.
- Removed the unused import of `GuidParams` and the `get_roles_request` helper from the auth module.
- Updated `RoleCache.get_user_roles` to use the QueryRegistry response and caching semantics unchanged.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dc1605cc08325aec1892abd542773)