### PR TITLE
Remove duplicate privacy policy link from bottom bar

### DIFF
--- a/frontend/src/components/BottomBar.tsx
+++ b/frontend/src/components/BottomBar.tsx
@@ -59,9 +59,6 @@ const BottomBar = ({ info }: Props): JSX.Element => {
 					contact@elideusgroup.com
 				</Link>
 			</Typography>
-			<Typography variant="body1" sx={{ marginTop: '4px', width: '300px', mx: 'auto' }}>
-				<Link href="/privacy-policy" underline="none" sx={{ display: 'block' }}>Privacy Policy</Link>
-			</Typography>
 	</Box>
 );
 };


### PR DESCRIPTION
### Motivation

- The home page had two links to the Privacy Policy after adding a new Terms of Service row, causing a duplicate UI element. 
- The intent is to keep the Privacy Policy link only in the new button row and remove the redundant bottom-bar link for a cleaner footer. 

### Description

- Removed the bottom Privacy Policy link from `frontend/src/components/BottomBar.tsx` so the footer no longer shows a second Privacy Policy entry. 
- Kept the new `Terms of Service` / `Privacy Policy` button row in `frontend/src/pages/Home.tsx` unchanged. 
- Committed the change with message "Remove duplicate privacy policy link".

### Testing

- Started the frontend dev server with `npx vite --host 0.0.0.0 --port 4173` which successfully served the app. 
- Executed a Playwright script that opened the home page and captured a screenshot, confirming the bottom Privacy Policy link is gone. 
- No unit tests, linters, or type-checks were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb3dca1588325b2722958bf1d1da2)