### PR TITLE
Document queryregistry roles/links migration mapping

### DIFF
--- a/QUERYREGISTRY.md
+++ b/QUERYREGISTRY.md
@@ -78,6 +78,21 @@ Examples of currently scaffolded CRUD stubs:
 - Finance: `queryregistry/finance/handler.py`
 - Account (legacy): `queryregistry/account/handler.py`
 
+## Migration notes: links + roles registry cutover
+
+### Old → new handler mapping (with call chains)
+
+| DB op(s) | Old handler | New handler | Call chain |
+| --- | --- | --- | --- |
+| `db:system:links:get_navbar_routes:1` | `server/registry/system/links/mssql.py:get_navbar_routes_v1` | `queryregistry/system/links/mssql.py:get_navbar_routes` | `rpc/public/links/services.py` → `server/modules/public_links_module.py` |
+| `db:system:roles:list:1`, `db:system:roles:update:1`, `db:system:roles:delete:1` | `server/registry/system/roles/mssql.py` | `queryregistry/system/roles/mssql.py` | `server/modules/auth_module.py`, `server/modules/role_admin_module.py` |
+| `db:system:roles:get_role_members:1`, `db:system:roles:get_role_non_members:1`, `db:system:roles:add_role_member:1`, `db:system:roles:remove_role_member:1` | `server/registry/system/roles/mssql.py:get_role_members_v1` / `get_role_non_members_v1` / `add_role_member_v1` / `remove_role_member_v1` | `queryregistry/identity/role_memberships/mssql.py:list_role_members` / `list_role_non_members` / `add_role_member` / `remove_role_member` | `server/modules/role_admin_module.py` via helper builders in `server/modules/registry/helpers.py` |
+
+### Validation reminders
+
+- NavBar route filtering uses `auth_ctx.role_mask` from the RPC layer, and the query registry `get_navbar_routes` handler filters using the `role_mask` supplied in the payload. Keep these data flow assumptions intact when removing the legacy registry modules.
+- This migration assumes the legacy handlers are removed without aliasing or fallback shims once the query registry equivalents are live.
+
 ## OAuth provider coverage to reimplement
 
 The legacy OAuth provider tests were removed while migrating to the query


### PR DESCRIPTION
### Motivation

- Capture the handler cutover when moving links and roles logic from the legacy server registry into the QueryRegistry so future maintainers know where calls were redirected. 
- Make explicit the call chains from RPC → module → DB op to aid migration and removal of old registry modules. 
- Document the NavBar role filtering dataflow so the role mask propagation is validated during the cutover. 
- Emphasize that legacy aliasing/fallback shims must be removed once QueryRegistry handlers are live.

### Description

- Added a `Migration notes: links + roles registry cutover` section to `QUERYREGISTRY.md` containing an old→new handler mapping table that lists DB ops, old handlers, new handlers, and call chains. 
- Documented the `db:system:links:get_navbar_routes:1` mapping to `queryregistry/system/links/mssql.py:get_navbar_routes` and its callers via `rpc/public/links/services.py` → `server/modules/public_links_module.py`. 
- Documented system role mappings to `queryregistry/system/roles/mssql.py` and role membership operations to `queryregistry/identity/role_memberships/mssql.py`, and noted the helper builder call sites in `server/modules/registry/helpers.py`. 
- Added validation reminders about `auth_ctx.role_mask` usage in RPC and `role_mask` in the query payload and stated that no aliasing/fallbacks should remain after removal of legacy handlers.

### Testing

- Documentation-only change; no automated tests were executed. 
- No runtime or unit tests were modified or required for this change. 
- CI/lint were not run as part of this documentation patch. 
- Manual verification consisted of reviewing referenced call chains and files in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fff9a7d7483259dcbedecaecfbbd6)