### PR TITLE
Standardize module startup logging

### DIFF
--- a/server/modules/__init__.py
+++ b/server/modules/__init__.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from fastapi import FastAPI
 from typing import Type, Dict, List
 from server.helpers.strings import camel_case
-import asyncio, os, importlib
+import asyncio, logging, os, importlib
 
 MODULES_FOLDER = os.path.dirname(__file__)
 
@@ -49,7 +49,14 @@ class ModuleManager:
       self.instances[module_name] = instance
 
   async def startup_all(self):
-    await asyncio.gather(*(mod.startup() for mod in self.instances.values()))
+    async def _startup_module(name: str, module: BaseModule):
+      await module.startup()
+      logging.info("[Module] %s loaded", name)
+
+    await asyncio.gather(*(
+      _startup_module(name, module)
+      for name, module in self.instances.items()
+    ))
 
   async def shutdown_all(self):
     await asyncio.gather(*(mod.shutdown() for mod in self.instances.values()))

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -209,7 +209,7 @@ class AuthModule(BaseModule):
         self.providers["discord"] = provider
         logging.debug("[AuthModule] Discord provider ready")
       await self.role_cache.load_roles()
-      logging.info("Auth module loaded")
+      logging.debug("Auth module loaded")
       self.mark_ready()
     except Exception as e:
       logging.exception("[AuthModule] Failed to load providers: %s", e)

--- a/server/modules/discord_bot_module.py
+++ b/server/modules/discord_bot_module.py
@@ -101,7 +101,7 @@ class DiscordBotModule(BaseModule):
       if getattr(self.app.state, "discord_bot", None) is self:
         self.app.state.discord_bot = None
       raise
-    logging.info("Discord bot module loaded")
+    logging.debug("Discord bot module loaded")
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/discord_chat_module.py
+++ b/server/modules/discord_chat_module.py
@@ -19,7 +19,7 @@ class DiscordChatModule(BaseModule):
     if self.discord:
       await self.discord.on_ready()
     self.app.state.discord_chat = self
-    logging.info("[DiscordChatModule] loaded")
+    logging.debug("[DiscordChatModule] loaded")
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/discord_output_module.py
+++ b/server/modules/discord_output_module.py
@@ -43,7 +43,7 @@ class DiscordOutputModule(BaseModule):
       if register:
         register(self)
     self.app.state.discord_output = self
-    logging.info("[DiscordOutputModule] loaded")
+    logging.debug("[DiscordOutputModule] loaded")
     if not self._worker_task:
       self._worker_task = asyncio.create_task(self._queue_worker(), name="discord-output-worker")
     self.mark_ready()

--- a/server/modules/env_module.py
+++ b/server/modules/env_module.py
@@ -29,7 +29,7 @@ class EnvModule(BaseModule):
       self._getenv("MYSQL_SQL_CONNECTION_STRING", "MISSING_MYSQL_SQL_CONNECTION_STRING")
     self._getenv("AZURE_BLOB_CONNECTION_STRING", "MISSING_ENV_AZURE_BLOB_CONNECTION_STRING")
 
-    logging.info("Environment module loaded")
+    logging.debug("Environment module loaded")
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -88,7 +88,7 @@ class OpenaiModule(BaseModule):
       await self.discord_output.on_ready()
     self.client = await self.init_openai_client()
     self.app.state.openai = self
-    logging.info("[OpenaiModule] loaded")
+    logging.debug("[OpenaiModule] loaded")
     self.mark_ready()
 
   async def shutdown(self):

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -90,7 +90,7 @@ class StorageModule(BaseModule):
     except Exception as e:
       logging.error("[StorageModule] Failed to load StorageCacheTime: %s", e)
     self._reindex_task = asyncio.create_task(self._reindex_loop())
-    logging.info("Storage module loaded")
+    logging.debug("Storage module loaded")
     self.mark_ready()
 
   async def shutdown(self):


### PR DESCRIPTION
### Motivation
- Ensure a single, consistent INFO-level message is emitted when each module finishes starting up to avoid duplicate or inconsistent logs.
- Surface module-ready events centrally from the `ModuleManager` so operators can reliably see module lifecycle transitions.
- Keep provider- and implementation-specific logs as supplemental detail instead of primary startup signals.

### Description
- Add a `_startup_module(name, module)` helper in `server/modules/__init__.py` and call it from `ModuleManager.startup_all()` to run each module's `startup()` and then emit `logging.info("[Module] %s loaded", name)`.
- Import `logging` in `server/modules/__init__.py` to support centralized logging.
- Downgrade per-module `logging.info("... loaded")` messages to `logging.debug(...)` in `server/modules/openai_module.py`, `server/modules/discord_chat_module.py`, `server/modules/discord_output_module.py`, `server/modules/discord_bot_module.py`, `server/modules/env_module.py`, `server/modules/storage_module.py`, and `server/modules/auth_module.py` to avoid duplicates.
- Preserve provider-specific and detailed logs (they remain at debug/info as appropriate) so implementation details are still available.

### Testing
- No automated tests were executed as part of this change.
- To validate locally, run the unified harness with `python scripts/run_tests.py` or run backend tests with `pytest` from the `tests/` directory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960059a40a48325b8970d2fd7df93aa)