### PR TITLE
Refactor role resolution to use DbModule.run and AuthModule role cache

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -7,8 +7,6 @@ from fastapi import FastAPI, HTTPException, status
 from jose import jwt, JWTError, ExpiredSignatureError
 from typing import Any, Dict
 
-from queryregistry.handler import dispatch_query_request
-from queryregistry.models import DBRequest as QueryDBRequest, DBResponse
 from queryregistry.system.roles.models import DeleteRolePayload, UpsertRolePayload
 from server.modules import BaseModule
 from server.modules.env_module import EnvModule
@@ -19,12 +17,9 @@ from server.modules.providers.auth.google_provider import GoogleAuthProvider
 from server.modules.providers.auth.discord_provider import DiscordAuthProvider
 from server.modules.discord_bot_module import DiscordBotModule
 from server.modules.registry.helpers import (
-  delete_system_role_request,
-  get_identity_security_profile_request,
   get_rotkey_request,
-  list_system_roles_request,
-  update_system_role_request,
 )
+from server.registry.types import DBRequest, DBResponse
 
 DEFAULT_SESSION_TOKEN_EXPIRY = 15 # minutes
 DEFAULT_ROTATION_TOKEN_EXPIRY = 90 # days
@@ -48,16 +43,17 @@ class RoleCache:
       return [dict(payload)]
     return [dict(payload)]
 
-  async def _dispatch_system_role_request(self, request: QueryDBRequest) -> DBResponse:
-    provider_name = self.db.provider or "mssql"
-    return await dispatch_query_request(request, provider=provider_name)
+  async def _dispatch_system_role_request(self, request: DBRequest) -> DBResponse:
+    if not self.db:
+      raise RuntimeError("RoleCache database module not configured")
+    return await self.db.run(request)
 
   async def load_roles(self):
     logging.debug("[RoleCache] Loading roles from database")
     try:
       result = await self._dispatch_system_role_request(
-        list_system_roles_request(),
-    )
+        DBRequest(op="db:system:roles:list:1", payload={}),
+      )
     except Exception as e:
       logging.error("[RoleCache] Failed to load roles: %s", e)
       return
@@ -83,14 +79,14 @@ class RoleCache:
   async def upsert_role(self, name: str, mask: int, display: str | None):
     payload: UpsertRolePayload = {"name": name, "mask": mask, "display": display}
     await self._dispatch_system_role_request(
-      update_system_role_request(payload),
+      DBRequest(op="db:system:roles:update:1", payload=dict(payload)),
     )
     await self.refresh_role_cache()
 
   async def delete_role(self, name: str):
     payload: DeleteRolePayload = {"name": name}
     await self._dispatch_system_role_request(
-      delete_system_role_request(payload),
+      DBRequest(op="db:system:roles:delete:1", payload=dict(payload)),
     )
     await self.refresh_role_cache()
 
@@ -113,11 +109,12 @@ class RoleCache:
       logging.debug("[RoleCache] Returning cached roles for %s", guid)
       return self._user_roles[guid]
     logging.debug("[RoleCache] Fetching roles for %s", guid)
-    response = await dispatch_query_request(
-      get_identity_security_profile_request(guid=guid),
-      provider=self.db.provider or "mssql",
+    if not self.db:
+      raise RuntimeError("RoleCache database module not configured")
+    response = await self.db.run(
+      DBRequest(op="db:identity:accounts:read:1", payload={"guid": guid}),
     )
-    rows = self._normalize_payload(response.payload)
+    rows = self._normalize_payload(response.rows)
     row = rows[0] if rows else {}
     mask = int(row.get("user_roles") or row.get("element_roles") or 0)
     names = self.mask_to_names(mask)
@@ -360,14 +357,13 @@ class AuthModule(BaseModule):
     return self.role_cache.get_role_names(exclude_registered)
 
   async def get_discord_user_security(self, discord_id: str) -> tuple[str, list[str], int]:
-    res = await dispatch_query_request(
-      get_identity_security_profile_request(discord_id=discord_id),
-      provider=self.db.provider,
+    res = await self.db.run(
+      DBRequest(op="db:identity:accounts:read:1", payload={"discord_id": discord_id}),
     )
-    payload = res.payload if isinstance(res.payload, dict) else {}
-    if not payload:
+    rows = res.rows
+    if not rows:
       return "", [], 0
-    row = payload
+    row = rows[0]
     guid = row.get("user_guid")
     mask = int(row.get("user_roles", 0) or 0)
     names = self.role_cache.mask_to_names(mask)

--- a/server/modules/profile_module.py
+++ b/server/modules/profile_module.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from . import BaseModule
+from .auth_module import AuthModule
 from .db_module import DbModule
 from server.registry.account.profile.model import (
   GuidParams,
@@ -15,7 +16,6 @@ from server.registry.account.profile.model import (
 )
 from server.modules.registry.helpers import (
   get_profile_request,
-  get_roles_request,
   set_display_request,
   set_optin_request,
   set_profile_image_request,
@@ -26,14 +26,18 @@ class ProfileModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.db: DbModule | None = None
+    self.auth: AuthModule | None = None
 
   async def startup(self):
     self.db = self.app.state.db
     await self.db.on_ready()
+    self.auth = self.app.state.auth
+    await self.auth.on_ready()
     self.mark_ready()
 
   async def shutdown(self):
     self.db = None
+    self.auth = None
 
   async def get_profile(self, guid: str) -> ProfileRecord | None:
     assert self.db
@@ -52,14 +56,9 @@ class ProfileModule(BaseModule):
     await self.db.run(set_optin_request(params))
 
   async def get_roles(self, guid: str) -> int:
-    assert self.db
-    params = GuidParams(guid=guid)
-    res = await self.db.run(get_roles_request(params))
-    if not res.rows:
-      return 0
-    row = res.rows[0]
-    value = row.get("element_roles") if isinstance(row, dict) else None
-    return int(value or 0)
+    assert self.auth
+    _, mask = await self.auth.get_user_roles(guid)
+    return mask
 
   async def set_profile_image(self, guid: str, provider: str, image_b64: str | None) -> None:
     assert self.db

--- a/server/modules/registry/helpers.py
+++ b/server/modules/registry/helpers.py
@@ -91,28 +91,6 @@ from server.registry.system.public_vars import (
   get_version_request,
 )
 
-def get_identity_security_profile_request(
-  *,
-  guid: str | None = None,
-  access_token: str | None = None,
-  provider: str | None = None,
-  provider_identifier: str | None = None,
-  discord_id: str | None = None,
-) -> QueryDBRequest:
-  params: dict[str, object] = {}
-  if guid is not None:
-    params["guid"] = guid
-  if access_token is not None:
-    params["access_token"] = access_token
-  if provider is not None:
-    params["provider"] = provider
-  if provider_identifier is not None:
-    params["provider_identifier"] = provider_identifier
-  if discord_id is not None:
-    params["discord_id"] = discord_id
-  return QueryDBRequest(op="db:identity:accounts:read:1", payload=params)
-
-
 def identity_account_exists_request(user_guid: str) -> QueryDBRequest:
   return QueryDBRequest(
     op="db:identity:accounts:exists:1",
@@ -259,7 +237,6 @@ __all__ = sorted([
   "get_roles_request",
   "get_rotkey_request",
   "get_routes_request",
-  "get_identity_security_profile_request",
   "get_user_by_email_request",
   "get_version_request",
   "identity_account_exists_request",


### PR DESCRIPTION
### Motivation
- Ensure role resolution uses the module layer (`DbModule.run`) instead of direct queryregistry dispatches to centralize DB access and respect module boundaries.
- Confirm the identity security profile includes the bitmask fields used by the role cache (`user_roles` / `element_roles`).
- Route role-dependent callers to the `AuthModule` cache instead of legacy registry helpers to avoid duplicated lookups.
- Remove the legacy helper that exposed `db:identity:accounts:read:1` request builders from module helpers to prevent further direct use.

### Description
- Verified `queryregistry/identity/accounts/mssql.py::get_security_profile` selects `user_roles` and `element_roles` for role resolution.
- Reworked `RoleCache` in `server/modules/auth_module.py` to call `self.db.run(DBRequest(op="db:system:roles:list:1", payload={}))` and `DBRequest(op="db:identity:accounts:read:1", payload=...)` instead of using `dispatch_query_request` and registry helpers.
- Updated `AuthModule.get_discord_user_security` to use `DbModule.run` with `DBRequest(op="db:identity:accounts:read:1", ...)` and adjusted payload/row handling.
- Changed `ProfileModule.get_roles` to rely on `AuthModule.get_user_roles` rather than issuing its own registry role query, and removed the `get_identity_security_profile_request` helper from `server/modules/registry/helpers.py` and its export.

### Testing
- No automated test suite was executed as part of this change set (no `pytest` or `python scripts/run_tests.py` runs were performed).
- Changes were linted by inspection and validated by running repository searches and reading modified files to ensure callsite updates were consistent.
- Runtime integration (module startup or DB provider behavior) was not exercised in this rollout.
- Recommend running `python scripts/run_tests.py` or `pytest` in `tests/` to validate behavior before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655c52aae483258bf4901a2a0b2ae3)