### PR TITLE
Use GuidParams for rotkey lookup and centralize model in queryregistry

### DIFF
--- a/queryregistry/identity/sessions/models.py
+++ b/queryregistry/identity/sessions/models.py
@@ -3,15 +3,35 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TypedDict
+from typing import Any, TypedDict
+
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from queryregistry.models import DBResponse
 
 __all__ = [
+  "GuidParams",
   "SecuritySnapshotCallable",
   "SecuritySnapshotRecord",
   "SecuritySnapshotRequestPayload",
 ]
+
+
+def _normalize_uuid(value: Any) -> str:
+  return str(value)
+
+
+class GuidParams(BaseModel):
+  """Generic payload carrying a user guid."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str
+
+  @field_validator("guid")
+  @classmethod
+  def _normalize_guid(cls, value: Any) -> str:
+    return _normalize_uuid(value)
 
 
 class SecuritySnapshotRequestPayload(TypedDict):

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -19,6 +19,7 @@ from server.modules.discord_bot_module import DiscordBotModule
 from server.modules.registry.helpers import (
   get_rotkey_request,
 )
+from server.registry.account.session.model import GuidParams
 from server.registry.types import DBRequest, DBResponse
 
 DEFAULT_SESSION_TOKEN_EXPIRY = 15 # minutes
@@ -286,7 +287,7 @@ class AuthModule(BaseModule):
     if not guid or not session_guid or not device_guid:
       raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Subject not found", headers={"WWW-Authenticate": "Bearer"})
 
-    res = await self.db.run(get_rotkey_request(guid=guid))
+    res = await self.db.run(get_rotkey_request(GuidParams(guid=guid)))
     rotkey = res.rows[0].get("rotkey") if res.rows else None
     derived_secret = f"{self.jwt_secret}:{rotkey}:{guid}:{session_guid}:{device_guid}" if rotkey else None
     try:

--- a/server/registry/account/session/model.py
+++ b/server/registry/account/session/model.py
@@ -7,6 +7,8 @@ from typing import Any, NotRequired, TypedDict
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
+from queryregistry.identity.sessions.models import GuidParams
+
 __all__ = [
   "CreateSessionParams",
   "GuidParams",
@@ -26,19 +28,6 @@ __all__ = [
 
 def _normalize_uuid(value: Any) -> str:
   return str(value)
-
-
-class GuidParams(BaseModel):
-  """Generic payload carrying a user guid."""
-
-  model_config = ConfigDict(extra="forbid")
-
-  guid: str
-
-  @field_validator("guid")
-  @classmethod
-  def _normalize_guid(cls, value: Any) -> str:
-    return _normalize_uuid(value)
 
 
 class ListSessionSnapshotsParams(GuidParams):
@@ -184,4 +173,3 @@ class SecuritySnapshotRecord(TypedDict, total=False):
 
 class RevokeAllDeviceTokensParams(GuidParams):
   """Payload revoking every token for a user."""
-


### PR DESCRIPTION
### Motivation

- Ensure `get_rotkey_request` is called with the expected `GuidParams` payload object rather than a raw kwarg to match the registry API signature.
- Centralize the `GuidParams` model in the queryregistry namespace so other modules can import a single canonical type.
- Remove duplicated local `GuidParams` definitions to avoid drift and inconsistent validation behavior.

### Description

- Added `GuidParams` Pydantic model to `queryregistry/identity/sessions/models.py` and exported it in `__all__` for reuse.
- Replaced the local `GuidParams` definition in `server/registry/account/session/model.py` with an import from `queryregistry.identity.sessions.models`.
- Updated `server/modules/auth_module.py` to import `GuidParams` and call `get_rotkey_request(GuidParams(guid=guid))` when decoding session tokens.
- Minor cleanup to align the rotkey lookup call with the `get_rotkey_request` signature in `server/modules/registry/helpers.py`.

### Testing

- No automated test suite was executed for this change.
- No `pytest` or `python scripts/run_tests.py` runs were performed.
- Changes compile as plain Python edits (no runtime validation was performed in CI as part of this PR).
- Manual inspection of modified files confirmed updated imports and call sites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656fc2405c832582491ad3f862595b)