### PR TITLE
Align queryregistry models with legacy registry types

### DIFF
--- a/queryregistry/models.py
+++ b/queryregistry/models.py
@@ -1,23 +1,90 @@
-"""Data models for the QueryRegistry namespace."""
+"""Data models for the QueryRegistry namespace.
+
+These local models are canonical for QueryRegistry and should be preferred
+over legacy registry types to prevent mixed imports.
+"""
 
 from __future__ import annotations
 
-from typing import Any
-
-from pydantic import BaseModel, Field
+from typing import Any, Dict, Iterator, Mapping, Sequence
 
 __all__ = ["DBRequest", "DBResponse"]
 
 
-class DBRequest(BaseModel):
-  """Representation of a query registry request."""
+class DBRequest:
+  """Representation of a query registry request (canonical QueryRegistry type)."""
 
-  op: str
-  payload: dict[str, Any] = Field(default_factory=dict)
+  __slots__ = ("op", "payload")
+
+  def __init__(
+    self,
+    *,
+    op: str,
+    payload: Mapping[str, Any],
+  ) -> None:
+    if not op:
+      raise ValueError("op is required for DBRequest")
+    self.op = op
+    self.payload: Dict[str, Any] = dict(payload)
+
+  def copy(self) -> "DBRequest":
+    return DBRequest(op=self.op, payload=dict(self.payload))
+
+  def with_payload(self, data: Mapping[str, Any]) -> "DBRequest":
+    new = self.copy()
+    new.payload.update(data)
+    return new
 
 
-class DBResponse(BaseModel):
-  """Representation of a query registry response."""
+class DBResponse:
+  """Representation of a query registry response (canonical QueryRegistry type)."""
 
-  op: str = ""
-  payload: Any | None = None
+  __slots__ = ("op", "payload", "rowcount")
+
+  def __init__(
+    self,
+    *,
+    op: str = "",
+    payload: Any | None = None,
+    rows: Sequence[Mapping[str, Any]] | None = None,
+    rowcount: int | None = None,
+  ) -> None:
+    if rows is not None:
+      payload = [dict(row) for row in rows]
+      if rowcount is None:
+        rowcount = len(payload)
+    self.op = op
+    if payload is None:
+      payload = []
+    self.payload = payload
+    if rowcount is None:
+      rowcount = 0
+    self.rowcount = rowcount
+
+  @property
+  def rows(self) -> list[Mapping[str, Any]]:
+    data = self.payload
+    if data is None:
+      return []
+    if isinstance(data, list):
+      return data
+    if isinstance(data, (tuple, set)):
+      return [dict(item) if isinstance(item, Mapping) else item for item in data]
+    if isinstance(data, Mapping):
+      return [data]
+    return [data]
+
+  def attach_op(self, op: str) -> "DBResponse":
+    self.op = op
+    return self
+
+  def model_dump(self) -> dict[str, Any]:
+    return {
+      "op": self.op,
+      "payload": self.payload,
+      "rowcount": self.rowcount,
+      "rows": self.rows,
+    }
+
+  def __iter__(self) -> Iterator[tuple[str, Any]]:  # type: ignore[override]
+    yield from {"rows": self.rows, "rowcount": self.rowcount}.items()


### PR DESCRIPTION
### Motivation

- Prevent mixed imports between QueryRegistry and the legacy registry by making QueryRegistry types canonical.
- Preserve legacy `server/registry` behavior so QueryRegistry handlers and adapters can interact consistently with provider code.

### Description

- Replaced the `pydantic`-based `DBRequest`/`DBResponse` in `queryregistry/models.py` with canonical, non-pydantic classes mirroring `server/registry/models.py` and added a header docstring explaining the canonical status.
- Implemented `DBRequest` methods `copy` and `with_payload` and `DBResponse` functionality including `rows` property, `attach_op`, `model_dump`, and iterator compatibility to match legacy semantics.
- Updated typing imports to include `Dict`, `Iterator`, `Mapping`, and `Sequence` and kept the public API as `DBRequest`/`DBResponse` so existing QueryRegistry code continues to import the local types.
- Committed the change to `queryregistry/models.py` and preserved legacy registry locations (no renames/removals) to maintain backward compatibility.

### Testing

- No automated tests were run as part of this change (to run the project harness use `python scripts/run_tests.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696582fd7e108325a2b7683f60b098a7)