### PR TITLE
Use queryregistry-local payload models; add profiles and config models

### DIFF
--- a/queryregistry/identity/profiles/models.py
+++ b/queryregistry/identity/profiles/models.py
@@ -1,0 +1,80 @@
+"""Identity profile query registry service models."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+__all__ = [
+  "GuidParams",
+  "ProfileRecord",
+  "SetDisplayParams",
+  "SetOptInParams",
+  "SetProfileImageParams",
+  "SetRolesParams",
+  "UpdateIfUneditedParams",
+]
+
+
+def _normalize_uuid(value: Any) -> str:
+  return str(value)
+
+
+class GuidParams(BaseModel):
+  """Base payload carrying a profile guid."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str
+
+  @field_validator("guid")
+  @classmethod
+  def _normalize_guid(cls, value: Any) -> str:
+    return _normalize_uuid(value)
+
+
+class SetDisplayParams(GuidParams):
+  """Parameters for updating a user's display name."""
+
+  display_name: str
+
+
+class SetOptInParams(GuidParams):
+  """Parameters controlling opt-in email visibility."""
+
+  display_email: bool
+
+
+class SetProfileImageParams(GuidParams):
+  """Payload used to set or clear the user's profile image."""
+
+  provider: str
+  image_b64: str | None
+
+
+class SetRolesParams(GuidParams):
+  """Parameters used to update the user's role mask."""
+
+  roles: int
+
+
+class UpdateIfUneditedParams(GuidParams):
+  """Parameters for updating profile fields if untouched by the user."""
+
+  display_name: str | None = None
+  email: str | None = None
+
+
+class ProfileRecord(TypedDict, total=False):
+  """Projection returned by profile queries."""
+
+  guid: str
+  display_name: str | None
+  email: str | None
+  credits: int | None
+  profile_image: str | None
+  default_provider: str | None
+  roles: int | None
+  element_created_on: str | None
+  element_modified_on: str | None

--- a/queryregistry/identity/sessions/models.py
+++ b/queryregistry/identity/sessions/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from datetime import datetime
 from typing import Any, TypedDict
 
 from pydantic import BaseModel, ConfigDict, field_validator
@@ -10,10 +11,16 @@ from pydantic import BaseModel, ConfigDict, field_validator
 from queryregistry.models import DBResponse
 
 __all__ = [
+  "CreateSessionParams",
   "GuidParams",
+  "RevokeDeviceTokenParams",
+  "RevokeProviderTokensParams",
   "SecuritySnapshotCallable",
   "SecuritySnapshotRecord",
   "SecuritySnapshotRequestPayload",
+  "SetRotkeyParams",
+  "UpdateDeviceTokenParams",
+  "UpdateSessionParams",
 ]
 
 
@@ -32,6 +39,71 @@ class GuidParams(BaseModel):
   @classmethod
   def _normalize_guid(cls, value: Any) -> str:
     return _normalize_uuid(value)
+
+
+class CreateSessionParams(BaseModel):
+  """Payload required to create or refresh a device session."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  access_token: str
+  expires: datetime
+  fingerprint: str
+  user_guid: str
+  provider: str
+  user_agent: str | None = None
+  ip_address: str | None = None
+
+  @field_validator("user_guid")
+  @classmethod
+  def _normalize_user_guid(cls, value: Any) -> str:
+    return _normalize_uuid(value)
+
+
+class UpdateSessionParams(BaseModel):
+  """Metadata attached to an existing device session."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  access_token: str
+  user_agent: str | None
+  ip_address: str | None
+
+
+class UpdateDeviceTokenParams(BaseModel):
+  """Payload targeting a device token by guid."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  device_guid: str
+  access_token: str
+
+  @field_validator("device_guid")
+  @classmethod
+  def _normalize_guid(cls, value: Any) -> str:
+    return _normalize_uuid(value)
+
+
+class RevokeDeviceTokenParams(BaseModel):
+  """Payload targeting an access token for revocation."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  access_token: str
+
+
+class RevokeProviderTokensParams(GuidParams):
+  """Payload revoking tokens associated with a provider."""
+
+  provider: str
+
+
+class SetRotkeyParams(GuidParams):
+  """Rotation key payload for a user."""
+
+  rotkey: str
+  iat: datetime
+  exp: datetime
 
 
 class SecuritySnapshotRequestPayload(TypedDict):

--- a/queryregistry/system/config/models.py
+++ b/queryregistry/system/config/models.py
@@ -1,0 +1,34 @@
+"""System config query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "ConfigKeyParams",
+  "ConfigRecord",
+  "UpsertConfigParams",
+]
+
+
+class ConfigKeyParams(BaseModel):
+  """Payload targeting a single configuration entry."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  key: str
+
+
+class UpsertConfigParams(ConfigKeyParams):
+  """Parameters for inserting or updating a configuration value."""
+
+  value: str
+
+
+class ConfigRecord(TypedDict, total=False):
+  """Record representation returned by configuration queries."""
+
+  key: str
+  value: str | None

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -7,6 +7,8 @@ from fastapi import FastAPI
 import logging
 
 from queryregistry.handler import dispatch_query_request
+from queryregistry.identity.accounts.models import AccountExistsRequestPayload
+from queryregistry.system.config.models import ConfigKeyParams
 from . import BaseModule
 from .env_module import EnvModule
 from .providers import DbProviderBase
@@ -18,7 +20,6 @@ from server.registry.account.cache.model import (
   ReplaceUserCacheParams,
   UpsertCacheItemParams,
 )
-from server.registry.system.config.model import ConfigKeyParams
 from server.modules.registry.helpers import (
   delete_cache_folder_request,
   delete_cache_item_request,
@@ -262,7 +263,8 @@ class DbModule(BaseModule):
     await self.run(replace_user_cache_request(params))
 
   async def user_exists(self, user_guid: str) -> bool:
-    request = identity_account_exists_request(user_guid=user_guid)
+    params: AccountExistsRequestPayload = {"user_guid": user_guid}
+    request = identity_account_exists_request(params)
     provider_name = self.provider or "mssql"
     try:
       res = await dispatch_query_request(request, provider=provider_name)

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -5,7 +5,19 @@ from datetime import datetime, timezone, timedelta
 
 from fastapi import FastAPI, HTTPException
 from queryregistry.handler import dispatch_query_request
+from queryregistry.identity.profiles.models import (
+  GuidParams,
+  SetProfileImageParams,
+  UpdateIfUneditedParams,
+)
+from queryregistry.identity.sessions.models import (
+  CreateSessionParams,
+  RevokeProviderTokensParams,
+  SetRotkeyParams,
+  UpdateDeviceTokenParams,
+)
 from queryregistry.models import DBRequest as QueryDBRequest, DBResponse as QueryDBResponse
+from queryregistry.system.config.models import ConfigKeyParams
 from . import BaseModule
 
 from server.modules.auth_module import AuthModule
@@ -15,18 +27,6 @@ except Exception:
   DEFAULT_SESSION_TOKEN_EXPIRY = 15
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
-from server.registry.account.profile.model import (
-  GuidParams,
-  SetProfileImageParams,
-  UpdateIfUneditedParams,
-)
-from server.registry.account.session.model import (
-  CreateSessionParams,
-  RevokeProviderTokensParams,
-  SetRotkeyParams,
-  UpdateDeviceTokenParams,
-)
-from server.registry.system.config.model import ConfigKeyParams
 from queryregistry.identity.providers import (
   create_from_provider_request,
   get_any_by_provider_identifier_request,

--- a/server/modules/registry/helpers.py
+++ b/server/modules/registry/helpers.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable, Callable
 
 from fastapi import HTTPException
 from queryregistry.handler import dispatch_query_request
+from queryregistry.identity.accounts.models import AccountExistsRequestPayload
 from queryregistry.identity.role_memberships.models import (
   ModifyRoleMemberPayload,
   RoleScopePayload,
@@ -91,10 +92,10 @@ from server.registry.system.public_vars import (
   get_version_request,
 )
 
-def identity_account_exists_request(user_guid: str) -> QueryDBRequest:
+def identity_account_exists_request(params: AccountExistsRequestPayload) -> QueryDBRequest:
   return QueryDBRequest(
     op="db:identity:accounts:exists:1",
-    payload={"user_guid": user_guid},
+    payload=dict(params),
   )
 
 

--- a/server/modules/session_module.py
+++ b/server/modules/session_module.py
@@ -8,8 +8,8 @@ from server.modules.auth_module import AuthModule, DEFAULT_SESSION_TOKEN_EXPIRY
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
 from server.modules.discord_bot_module import DiscordBotModule
-from server.registry.account.profile.model import SetProfileImageParams
-from server.registry.account.session.model import (
+from queryregistry.identity.profiles.models import SetProfileImageParams
+from queryregistry.identity.sessions.models import (
   CreateSessionParams,
   GuidParams,
   RevokeDeviceTokenParams,


### PR DESCRIPTION
### Motivation

- Consolidate registry payload types under the `queryregistry` package so module helpers accept canonical, queryregistry-local models and return `queryregistry.models.DBRequest` payloads.
- Avoid cross-imports from server-local registry models into modules and make registry request builders consume queryregistry types.
- Preserve legacy server-local payload model copies for backward compatibility while updating new imports to the queryregistry versions.

### Description

- Added `queryregistry/identity/profiles/models.py` with `GuidParams`, `SetDisplayParams`, `SetOptInParams`, `SetProfileImageParams`, `SetRolesParams`, `UpdateIfUneditedParams`, and `ProfileRecord`.
- Added `queryregistry/system/config/models.py` with `ConfigKeyParams`, `UpsertConfigParams`, and `ConfigRecord`.
- Extended `queryregistry/identity/sessions/models.py` to include `CreateSessionParams`, `UpdateSessionParams`, `UpdateDeviceTokenParams`, `RevokeDeviceTokenParams`, `RevokeProviderTokensParams`, and `SetRotkeyParams`.
- Updated server modules to use queryregistry-local types and signatures, including `server/modules/registry/helpers.py` (changed `identity_account_exists_request` to accept `AccountExistsRequestPayload`), `server/modules/db_module.py` (builds `AccountExistsRequestPayload` when calling helper), `server/modules/oauth_module.py`, and `server/modules/session_module.py` to import profile/session/config payloads from `queryregistry`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69658486ac78832594687f762cecb57d)