### PR TITLE
Add soft delete account operation to queryregistry identity providers

### DIFF
--- a/queryregistry/identity/providers/__init__.py
+++ b/queryregistry/identity/providers/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
   "link_provider_request",
   "relink_provider_request",
   "set_provider_request",
+  "soft_delete_account_request",
   "unlink_last_provider_request",
   "unlink_provider_request",
 ]
@@ -156,3 +157,13 @@ def relink_provider_request(
   if reauth_token is not None:
     payload["reauth_token"] = reauth_token
   return DBRequest(op="db:identity:providers:relink:1", payload=payload)
+
+
+def soft_delete_account_request(
+  *,
+  guid: str,
+) -> DBRequest:
+  return DBRequest(
+    op="db:identity:providers:soft_delete_account:1",
+    payload={"guid": guid},
+  )

--- a/queryregistry/identity/providers/handler.py
+++ b/queryregistry/identity/providers/handler.py
@@ -15,6 +15,7 @@ from .services import (
   link_provider_v1,
   relink_provider_v1,
   set_provider_v1,
+  soft_delete_account_v1,
   unlink_last_provider_v1,
   unlink_provider_v1,
 )
@@ -31,6 +32,7 @@ DISPATCHERS = {
   ("unlink_last_provider", "1"): unlink_last_provider_v1,
   ("set_provider", "1"): set_provider_v1,
   ("relink", "1"): relink_provider_v1,
+  ("soft_delete_account", "1"): soft_delete_account_v1,
 }
 
 

--- a/queryregistry/identity/providers/models.py
+++ b/queryregistry/identity/providers/models.py
@@ -25,6 +25,8 @@ __all__ = [
   "RelinkProviderRequestPayload",
   "SetProviderCallable",
   "SetProviderRequestPayload",
+  "SoftDeleteAccountCallable",
+  "SoftDeleteAccountRequestPayload",
   "UnlinkLastProviderCallable",
   "UnlinkLastProviderRequestPayload",
   "UnlinkProviderCallable",
@@ -109,6 +111,10 @@ class RelinkProviderRequestPayload(TypedDict, total=False):
   reauth_token: str
 
 
+class SoftDeleteAccountRequestPayload(TypedDict):
+  guid: str
+
+
 CreateFromProviderCallable = Callable[[CreateFromProviderRequestPayload], Awaitable[DBResponse]]
 GetAnyByProviderIdentifierCallable = Callable[[GetAnyByProviderIdentifierRequestPayload], Awaitable[DBResponse]]
 GetByProviderIdentifierCallable = Callable[[GetByProviderIdentifierRequestPayload], Awaitable[DBResponse]]
@@ -118,3 +124,4 @@ UnlinkProviderCallable = Callable[[UnlinkProviderRequestPayload], Awaitable[DBRe
 UnlinkLastProviderCallable = Callable[[UnlinkLastProviderRequestPayload], Awaitable[DBResponse]]
 SetProviderCallable = Callable[[SetProviderRequestPayload], Awaitable[DBResponse]]
 RelinkProviderCallable = Callable[[RelinkProviderRequestPayload], Awaitable[DBResponse]]
+SoftDeleteAccountCallable = Callable[[SoftDeleteAccountRequestPayload], Awaitable[DBResponse]]

--- a/queryregistry/identity/providers/mssql.py
+++ b/queryregistry/identity/providers/mssql.py
@@ -16,6 +16,7 @@ from .models import (
   LinkProviderRequestPayload,
   RelinkProviderRequestPayload,
   SetProviderRequestPayload,
+  SoftDeleteAccountRequestPayload,
   UnlinkLastProviderRequestPayload,
   UnlinkProviderRequestPayload,
 )
@@ -28,6 +29,7 @@ __all__ = [
   "link_provider",
   "relink_provider",
   "set_provider",
+  "soft_delete_account",
   "unlink_last_provider",
   "unlink_provider",
 ]
@@ -38,6 +40,13 @@ def _normalize_provider_identifier(identifier: str) -> str:
     return str(UUID(identifier))
   except (TypeError, ValueError):
     raise ValueError("provider_identifier must be a valid UUID") from None
+
+
+def _normalize_guid(guid: str) -> str:
+  try:
+    return str(UUID(guid))
+  except (TypeError, ValueError):
+    raise ValueError("guid must be a valid UUID") from None
 
 
 def _normalize_discord_identifier(discord_id: str) -> str:
@@ -305,3 +314,16 @@ async def relink_provider(
     "provider": provider,
     "provider_identifier": identifier,
   })
+
+
+async def soft_delete_account(
+  args: SoftDeleteAccountRequestPayload,
+) -> DBResponse:
+  guid = _normalize_guid(args["guid"])
+  sql = """
+    UPDATE account_users
+    SET element_soft_deleted_at = SYSDATETIMEOFFSET()
+    WHERE element_guid = ?;
+  """
+  response = await run_exec(sql, (guid,))
+  return DBResponse(payload={"rowcount": response.rowcount})

--- a/queryregistry/identity/providers/services.py
+++ b/queryregistry/identity/providers/services.py
@@ -13,6 +13,7 @@ from .models import (
   LinkProviderCallable,
   RelinkProviderCallable,
   SetProviderCallable,
+  SoftDeleteAccountCallable,
   UnlinkLastProviderCallable,
   UnlinkProviderCallable,
 )
@@ -25,6 +26,7 @@ __all__ = [
   "link_provider_v1",
   "relink_provider_v1",
   "set_provider_v1",
+  "soft_delete_account_v1",
   "unlink_last_provider_v1",
   "unlink_provider_v1",
 ]
@@ -63,6 +65,10 @@ _SET_PROVIDER_DISPATCHERS: dict[str, SetProviderCallable] = {
 
 _RELINK_PROVIDER_DISPATCHERS: dict[str, RelinkProviderCallable] = {
   "mssql": mssql.relink_provider,
+}
+
+_SOFT_DELETE_ACCOUNT_DISPATCHERS: dict[str, SoftDeleteAccountCallable] = {
+  "mssql": mssql.soft_delete_account,
 }
 
 
@@ -168,6 +174,18 @@ async def relink_provider_v1(
   provider: str,
 ) -> DBResponse:
   dispatcher = _RELINK_PROVIDER_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity providers registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)
+
+
+async def soft_delete_account_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _SOFT_DELETE_ACCOUNT_DISPATCHERS.get(provider)
   if dispatcher is None:
     raise KeyError(f"Unsupported provider '{provider}' for identity providers registry")
   result = await dispatcher(request.payload)

--- a/server/registry/account/providers/__init__.py
+++ b/server/registry/account/providers/__init__.py
@@ -9,12 +9,9 @@ from .model import (
   LinkProviderParams,
   ProviderIdentifierParams,
   SetProviderParams,
-  SoftDeleteAccountParams,
   UnlinkLastProviderParams,
   UnlinkProviderParams,
 )
-
-
 
 def _request(op: str, params: dict[str, object]) -> DBRequest:
   return DBRequest(op=op, payload=params)
@@ -58,13 +55,6 @@ def link_provider_request(params: LinkProviderParams) -> DBRequest:
 def set_provider_request(params: SetProviderParams) -> DBRequest:
   return _request(
     "db:account:providers:set_provider:1",
-    params.model_dump(),
-  )
-
-
-def soft_delete_account_request(params: SoftDeleteAccountParams) -> DBRequest:
-  return _request(
-    "db:account:providers:soft_delete_account:1",
     params.model_dump(),
   )
 

--- a/server/registry/account/providers/model.py
+++ b/server/registry/account/providers/model.py
@@ -15,7 +15,6 @@ __all__ = [
   "ProviderIdentifierParams",
   "ProviderUnlinkSummary",
   "SetProviderParams",
-  "SoftDeleteAccountParams",
   "UnlinkLastProviderParams",
   "UnlinkProviderParams",
 ]
@@ -82,10 +81,6 @@ class SetProviderParams(_GuidParams):
   """Parameters for setting an account's default provider."""
 
   provider: str
-
-
-class SoftDeleteAccountParams(_GuidParams):
-  """Parameters for soft-deleting an account."""
 
 
 class UnlinkProviderParams(_GuidParams):

--- a/server/registry/account/providers/mssql.py
+++ b/server/registry/account/providers/mssql.py
@@ -20,7 +20,6 @@ __all__ = [
   "get_user_by_email_v1",
   "link_provider_v1",
   "set_provider_v1",
-  "soft_delete_account_v1",
   "unlink_provider_v1",
   "unlink_last_provider_v1",
 ]
@@ -218,16 +217,6 @@ async def unlink_provider_v1(args: dict[str, Any]) -> DBResponse:
   return DBResponse(rows=[{"providers_remaining": cnt}], rowcount=1)
 
 
-async def soft_delete_account_v1(args: dict[str, Any]) -> DBResponse:
-  guid = str(UUID(args["guid"]))
-  sql = """
-    UPDATE account_users
-    SET element_soft_deleted_at = SYSDATETIMEOFFSET()
-    WHERE element_guid = ?;
-  """
-  return await run_exec(sql, (guid,))
-
-
 async def get_user_by_email_v1(args: dict[str, Any]) -> DBResponse:
   email = args["email"]
   sql = """
@@ -255,5 +244,4 @@ async def unlink_last_provider_v1(args: dict[str, Any]) -> DBResponse:
   provider = args["provider"]
   sql = "EXEC auth_unlink_last_provider @guid=?, @provider=?;"
   return await run_exec(sql, (guid, provider))
-
 


### PR DESCRIPTION
### Motivation

- Expose a soft-delete account operation through the QueryRegistry identity providers path so callers can use the canonical `queryregistry` APIs instead of legacy server registry requests. 
- Mirror the existing server-side SQL semantics for soft deletion (update `element_soft_deleted_at`) in the new queryregistry MSSQL provider implementation. 
- Provide typed request payloads and dispatcher wiring so the operation integrates with existing provider dispatch maps. 
- Remove the legacy server registry request/handler/model pieces now that the queryregistry flow is available.

### Description

- Added `SoftDeleteAccountRequestPayload` and `SoftDeleteAccountCallable` to `queryregistry/identity/providers/models.py`. 
- Implemented `soft_delete_account` in `queryregistry/identity/providers/mssql.py` (adds `_normalize_guid`, runs the same `UPDATE account_users SET element_soft_deleted_at = SYSDATETIMEOFFSET()` SQL and returns a `DBResponse`).
- Wired the operation into the service dispatchers with `_SOFT_DELETE_ACCOUNT_DISPATCHERS` and `soft_delete_account_v1` in `queryregistry/identity/providers/services.py`, and added the handler mapping `("soft_delete_account", "1")` in `queryregistry/identity/providers/handler.py`.
- Added a request builder `soft_delete_account_request` in `queryregistry/identity/providers/__init__.py` that produces `op="db:identity:providers:soft_delete_account:1` and removed the legacy server registry `SoftDeleteAccount` model, request builder, and MSSQL helper implementations under `server/registry/account/providers`.

### Testing

- No automated tests were executed as part of this change. 
- Static typing and linting were not run here; please run `python scripts/run_tests.py` or `pytest` in `tests/` when validating locally or in CI. 
- Manual verification is recommended against a development MSSQL instance to ensure the update affects `account_users.element_soft_deleted_at` as expected. 
- All modified files were committed to the branch and are ready for CI validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69658f2fc0d48325805957aec2ed130d)