### PR TITLE
Add identity profile queryregistry handlers and consolidate profile updates

### DIFF
--- a/queryregistry/identity/profiles/__init__.py
+++ b/queryregistry/identity/profiles/__init__.py
@@ -1,1 +1,36 @@
-"""Identity profiles query registry stubs."""
+"""Identity profiles query registry helpers."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import GuidParams, UpdateIfUneditedParams, UpdateProfileParams
+
+__all__ = [
+  "get_profile_request",
+  "update_if_unedited_request",
+  "update_profile_request",
+]
+
+
+def get_profile_request(params: GuidParams) -> DBRequest:
+  return DBRequest(
+    op="db:identity:profiles:read:1",
+    payload=params.model_dump(),
+  )
+
+
+def update_profile_request(params: UpdateProfileParams) -> DBRequest:
+  payload = params.model_dump(exclude_none=True)
+  if params.provider is not None and "image_b64" not in payload:
+    payload["image_b64"] = params.image_b64
+  if params.display_email is not None:
+    payload["display_email"] = 1 if params.display_email else 0
+  return DBRequest(op="db:identity:profiles:update:1", payload=payload)
+
+
+def update_if_unedited_request(params: UpdateIfUneditedParams) -> DBRequest:
+  return DBRequest(
+    op="db:identity:profiles:update_if_unedited:1",
+    payload=params.model_dump(exclude_none=True),
+  )

--- a/queryregistry/identity/profiles/handler.py
+++ b/queryregistry/identity/profiles/handler.py
@@ -6,11 +6,19 @@ from typing import Sequence
 
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
-from queryregistry.stubs import build_stub_dispatchers
+from .services import (
+  read_profile_v1,
+  update_profile_if_unedited_v1,
+  update_profile_v1,
+)
 
 __all__ = ["handle_profiles_request"]
 
-DISPATCHERS = build_stub_dispatchers("identity.profiles")
+DISPATCHERS = {
+  ("read", "1"): read_profile_v1,
+  ("update", "1"): update_profile_v1,
+  ("update_if_unedited", "1"): update_profile_if_unedited_v1,
+}
 
 
 async def handle_profiles_request(

--- a/queryregistry/identity/profiles/models.py
+++ b/queryregistry/identity/profiles/models.py
@@ -2,17 +2,28 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any, TypedDict
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
+from queryregistry.models import DBResponse
+
 __all__ = [
   "GuidParams",
   "ProfileRecord",
+  "ProfileReadRequestPayload",
+  "ProfileUpdateCallable",
+  "ProfileUpdateIfUneditedCallable",
+  "ProfileUpdateRequestPayload",
+  "ProfileReadCallable",
   "SetDisplayParams",
   "SetOptInParams",
   "SetProfileImageParams",
   "SetRolesParams",
+  "UpdateIfUneditedCallable",
+  "UpdateIfUneditedRequestPayload",
+  "UpdateProfileParams",
   "UpdateIfUneditedParams",
 ]
 
@@ -66,6 +77,15 @@ class UpdateIfUneditedParams(GuidParams):
   email: str | None = None
 
 
+class UpdateProfileParams(GuidParams):
+  """Parameters for updating one or more profile fields."""
+
+  display_name: str | None = None
+  display_email: bool | None = None
+  provider: str | None = None
+  image_b64: str | None = None
+
+
 class ProfileRecord(TypedDict, total=False):
   """Projection returned by profile queries."""
 
@@ -78,3 +98,27 @@ class ProfileRecord(TypedDict, total=False):
   roles: int | None
   element_created_on: str | None
   element_modified_on: str | None
+
+
+class ProfileReadRequestPayload(TypedDict):
+  guid: str
+
+
+class ProfileUpdateRequestPayload(TypedDict, total=False):
+  guid: str
+  display_name: str | None
+  display_email: bool | int | None
+  provider: str | None
+  image_b64: str | None
+
+
+class UpdateIfUneditedRequestPayload(TypedDict, total=False):
+  guid: str
+  display_name: str | None
+  email: str | None
+
+
+ProfileReadCallable = Callable[[ProfileReadRequestPayload], Awaitable[DBResponse]]
+ProfileUpdateCallable = Callable[[ProfileUpdateRequestPayload], Awaitable[DBResponse]]
+UpdateIfUneditedCallable = Callable[[UpdateIfUneditedRequestPayload], Awaitable[DBResponse]]
+ProfileUpdateIfUneditedCallable = UpdateIfUneditedCallable

--- a/queryregistry/identity/profiles/mssql.py
+++ b/queryregistry/identity/profiles/mssql.py
@@ -1,0 +1,138 @@
+"""MSSQL implementations for identity profile query registry services."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec, run_json_one
+
+from .models import (
+  ProfileReadRequestPayload,
+  ProfileUpdateRequestPayload,
+  UpdateIfUneditedRequestPayload,
+)
+
+__all__ = [
+  "read_profile",
+  "update_if_unedited",
+  "update_profile",
+]
+
+
+def _normalize_guid(guid: str) -> str:
+  try:
+    return str(UUID(guid))
+  except (TypeError, ValueError):
+    raise ValueError("guid must be a valid UUID") from None
+
+
+async def _get_auth_provider_recid(provider: str) -> int:
+  response = await run_json_one(
+    "SELECT recid FROM auth_providers WHERE element_name = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
+    (provider,),
+  )
+  if not response.rows:
+    raise ValueError(f"Unknown auth provider: {provider}")
+  return response.rows[0]["recid"]
+
+
+async def read_profile(args: ProfileReadRequestPayload) -> DBResponse:
+  guid = str(args["guid"])
+  sql = """
+    SELECT TOP 1
+      v.user_guid AS guid,
+      v.display_name,
+      v.email,
+      v.opt_in AS display_email,
+      v.credits,
+      v.profile_image_base64 AS profile_image,
+      v.provider_name AS default_provider,
+      JSON_QUERY(
+        COALESCE(
+          (
+            SELECT
+              ap.element_name AS name,
+              ap.element_display AS display
+            FROM users_auth ua
+            JOIN auth_providers ap ON ap.recid = ua.providers_recid
+            WHERE ua.users_guid = v.user_guid AND ua.element_linked = 1
+            FOR JSON PATH
+          ),
+          '[]'
+        )
+      ) AS auth_providers
+    FROM vw_account_user_profile v
+    WHERE v.user_guid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  response = await run_json_one(sql, (guid,))
+  return DBResponse(payload=response.payload)
+
+
+async def update_profile(args: ProfileUpdateRequestPayload) -> DBResponse:
+  guid = _normalize_guid(args["guid"])
+  rowcount = 0
+
+  if "display_name" in args:
+    display_name = args.get("display_name")
+    res = await run_exec(
+      "UPDATE account_users SET element_display = ? WHERE element_guid = ?;",
+      (display_name, guid),
+    )
+    rowcount += res.rowcount
+
+  if "display_email" in args:
+    display_email = args.get("display_email")
+    display_email_value = int(bool(display_email))
+    res = await run_exec(
+      "UPDATE account_users SET element_optin = ? WHERE element_guid = ?;",
+      (display_email_value, guid),
+    )
+    rowcount += res.rowcount
+
+  if "image_b64" in args:
+    provider = args.get("provider")
+    if not provider:
+      raise ValueError("Profile image updates require provider")
+    image_b64 = args.get("image_b64")
+    ap_recid = await _get_auth_provider_recid(str(provider))
+    res = await run_exec(
+      "UPDATE users_profileimg SET element_base64 = ?, providers_recid = ? WHERE users_guid = ?;",
+      (image_b64, ap_recid, guid),
+    )
+    rowcount += res.rowcount
+    if res.rowcount == 0:
+      res = await run_exec(
+        "INSERT INTO users_profileimg (users_guid, element_base64, providers_recid) VALUES (?, ?, ?);",
+        (guid, image_b64, ap_recid),
+      )
+      rowcount += res.rowcount
+
+  return DBResponse(rowcount=rowcount)
+
+
+async def update_if_unedited(args: UpdateIfUneditedRequestPayload) -> DBResponse:
+  guid = _normalize_guid(args["guid"])
+  email = args.get("email")
+  display = args.get("display_name")
+  res = await run_exec(
+    """
+    UPDATE account_users
+    SET element_email = ?, element_display = ?
+    WHERE element_guid = ? AND (element_email <> ? OR element_display <> ?);
+    """,
+    (email, display, guid, email, display),
+  )
+  if res.rowcount > 0:
+    response = await run_json_one(
+      """
+      SELECT element_display AS display_name, element_email AS email
+      FROM account_users
+      WHERE element_guid = ?
+      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+      """,
+      (guid,),
+    )
+    return DBResponse(payload=response.payload, rowcount=response.rowcount)
+  return DBResponse()

--- a/queryregistry/identity/profiles/services.py
+++ b/queryregistry/identity/profiles/services.py
@@ -1,0 +1,91 @@
+"""Identity profiles query registry service dispatchers."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  ProfileReadCallable,
+  ProfileReadRequestPayload,
+  ProfileUpdateCallable,
+  ProfileUpdateIfUneditedCallable,
+  ProfileUpdateRequestPayload,
+  UpdateIfUneditedRequestPayload,
+)
+
+__all__ = [
+  "read_profile_v1",
+  "update_profile_v1",
+  "update_profile_if_unedited_v1",
+]
+
+_READ_DISPATCHERS: dict[str, ProfileReadCallable] = {
+  "mssql": mssql.read_profile,
+}
+
+_UPDATE_DISPATCHERS: dict[str, ProfileUpdateCallable] = {
+  "mssql": mssql.update_profile,
+}
+
+_UPDATE_IF_UNEDITED_DISPATCHERS: dict[str, ProfileUpdateIfUneditedCallable] = {
+  "mssql": mssql.update_if_unedited,
+}
+
+
+def _validate_update_payload(payload: ProfileUpdateRequestPayload) -> None:
+  has_display_name = "display_name" in payload
+  has_display_email = "display_email" in payload
+  has_image = "image_b64" in payload
+  if not (has_display_name or has_display_email or has_image):
+    raise ValueError("Profile update requires at least one field")
+  if has_image and not payload.get("provider"):
+    raise ValueError("Profile image updates require provider")
+
+
+async def read_profile_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _READ_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity profiles registry")
+  payload: ProfileReadRequestPayload = dict(request.payload)
+  result = await dispatcher(payload)
+  return DBResponse(op=request.op, payload=result.payload)
+
+
+async def update_profile_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _UPDATE_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity profiles registry")
+  payload: ProfileUpdateRequestPayload = dict(request.payload)
+  _validate_update_payload(payload)
+  result = await dispatcher(payload)
+  return DBResponse(
+    op=request.op,
+    payload=result.payload,
+    rowcount=result.rowcount,
+  )
+
+
+async def update_profile_if_unedited_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _UPDATE_IF_UNEDITED_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity profiles registry")
+  payload: UpdateIfUneditedRequestPayload = dict(request.payload)
+  result = await dispatcher(payload)
+  return DBResponse(
+    op=request.op,
+    payload=result.payload,
+    rowcount=result.rowcount,
+  )

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -5,10 +5,15 @@ from datetime import datetime, timezone, timedelta
 
 from fastapi import FastAPI, HTTPException
 from queryregistry.handler import dispatch_query_request
+from queryregistry.identity.profiles import (
+  get_profile_request,
+  update_if_unedited_request,
+  update_profile_request,
+)
 from queryregistry.identity.profiles.models import (
   GuidParams,
-  SetProfileImageParams,
   UpdateIfUneditedParams,
+  UpdateProfileParams,
 )
 from server.registry.account.session.model import (
   CreateSessionParams,
@@ -40,11 +45,8 @@ from queryregistry.identity.providers import (
 from server.modules.registry.helpers import (
   create_session_request,
   get_config_request,
-  get_profile_request,
   revoke_provider_tokens_request,
-  set_profile_image_request,
   update_device_token_request,
-  update_if_unedited_request,
 )
 
 
@@ -209,7 +211,7 @@ class OauthModule(BaseModule):
         email=email,
         display_name=display_name,
       )
-      await self.db.run(update_if_unedited_request(params))
+      await self._dispatch_provider_request(update_if_unedited_request(params))
     return original
 
   async def link_user_provider(
@@ -256,7 +258,7 @@ class OauthModule(BaseModule):
     *,
     new_default: str | None = None,
   ) -> dict:
-    res_prof = await self.db.run(
+    res_prof = await self._dispatch_provider_request(
       get_profile_request(GuidParams(guid=user_guid))
     )
     default_provider = res_prof.rows[0].get("default_provider") if res_prof.rows else None
@@ -600,9 +602,9 @@ class OauthModule(BaseModule):
     user_guid = user["guid"]
     new_img = profile.get("profilePicture")
     if new_img and new_img != user.get("profile_image"):
-      await self.db.run(
-        set_profile_image_request(
-          SetProfileImageParams(
+      await self._dispatch_provider_request(
+        update_profile_request(
+          UpdateProfileParams(
             guid=user_guid,
             provider=provider,
             image_b64=new_img,
@@ -616,9 +618,10 @@ class OauthModule(BaseModule):
         email=profile["email"],
         display_name=profile["username"],
       )
-      res_prof = await self.db.run(update_if_unedited_request(params))
-      if res_prof.rows:
-        updated = res_prof.rows[0]
+      res_prof = await self._dispatch_provider_request(update_if_unedited_request(params))
+      rows = self._normalize_query_payload(res_prof.payload)
+      if rows:
+        updated = rows[0]
         if updated.get("display_name"):
           user["display_name"] = updated["display_name"]
         if updated.get("email"):

--- a/server/modules/profile_module.py
+++ b/server/modules/profile_module.py
@@ -7,19 +7,14 @@ from fastapi import FastAPI
 from . import BaseModule
 from .auth_module import AuthModule
 from .db_module import DbModule
-from server.registry.account.profile.model import (
+from queryregistry.handler import dispatch_query_request
+from queryregistry.identity.profiles import get_profile_request, update_profile_request
+from queryregistry.identity.profiles.models import (
   GuidParams,
   ProfileRecord,
-  SetDisplayParams,
-  SetOptInParams,
-  SetProfileImageParams,
+  UpdateProfileParams,
 )
-from server.modules.registry.helpers import (
-  get_profile_request,
-  set_display_request,
-  set_optin_request,
-  set_profile_image_request,
-)
+from queryregistry.models import DBRequest, DBResponse
 
 
 class ProfileModule(BaseModule):
@@ -39,21 +34,26 @@ class ProfileModule(BaseModule):
     self.db = None
     self.auth = None
 
-  async def get_profile(self, guid: str) -> ProfileRecord | None:
+  async def _dispatch_profile_request(
+    self,
+    request: DBRequest,
+  ) -> DBResponse:
     assert self.db
+    provider_name = self.db.provider or "mssql"
+    return await dispatch_query_request(request, provider=provider_name)
+
+  async def get_profile(self, guid: str) -> ProfileRecord | None:
     params = GuidParams(guid=guid)
-    res = await self.db.run(get_profile_request(params))
+    res = await self._dispatch_profile_request(get_profile_request(params))
     return res.rows[0] if res.rows else None
 
   async def set_display(self, guid: str, display_name: str) -> None:
-    assert self.db
-    params = SetDisplayParams(guid=guid, display_name=display_name)
-    await self.db.run(set_display_request(params))
+    params = UpdateProfileParams(guid=guid, display_name=display_name)
+    await self._dispatch_profile_request(update_profile_request(params))
 
   async def set_optin(self, guid: str, display_email: bool) -> None:
-    assert self.db
-    params = SetOptInParams(guid=guid, display_email=display_email)
-    await self.db.run(set_optin_request(params))
+    params = UpdateProfileParams(guid=guid, display_email=display_email)
+    await self._dispatch_profile_request(update_profile_request(params))
 
   async def get_roles(self, guid: str) -> int:
     assert self.auth
@@ -61,6 +61,5 @@ class ProfileModule(BaseModule):
     return mask
 
   async def set_profile_image(self, guid: str, provider: str, image_b64: str | None) -> None:
-    assert self.db
-    params = SetProfileImageParams(guid=guid, provider=provider, image_b64=image_b64)
-    await self.db.run(set_profile_image_request(params))
+    params = UpdateProfileParams(guid=guid, provider=provider, image_b64=image_b64)
+    await self._dispatch_profile_request(update_profile_request(params))

--- a/server/modules/session_module.py
+++ b/server/modules/session_module.py
@@ -13,7 +13,8 @@ from server.modules.auth_module import (
 from server.modules.db_module import DbModule
 from server.modules.oauth_module import OauthModule
 from server.modules.discord_bot_module import DiscordBotModule
-from queryregistry.identity.profiles.models import SetProfileImageParams
+from queryregistry.identity.profiles import update_profile_request
+from queryregistry.identity.profiles.models import UpdateProfileParams
 from queryregistry.handler import dispatch_query_request
 from queryregistry.identity.sessions import get_rotkey_request
 from queryregistry.identity.sessions.models import RotkeyLookupParams
@@ -28,7 +29,6 @@ from server.registry.types import DBRequest
 from server.modules.registry.helpers import (
   create_session_request,
   revoke_device_token_request,
-  set_profile_image_request,
   set_rotkey_request,
   update_device_token_request,
   update_session_request,
@@ -99,14 +99,15 @@ class SessionModule(BaseModule):
 
     new_img = provider_profile.get("profilePicture")
     if new_img and new_img != user.get("profile_image"):
-      await self.db.run(
-        set_profile_image_request(
-          SetProfileImageParams(
+      await dispatch_query_request(
+        update_profile_request(
+          UpdateProfileParams(
             guid=user["guid"],
             provider=provider,
             image_b64=new_img,
           ),
         ),
+        provider=self.db.provider or "mssql",
       )
       user["profile_image"] = new_img
 

--- a/server/modules/user_admin_module.py
+++ b/server/modules/user_admin_module.py
@@ -2,13 +2,11 @@ from fastapi import FastAPI, HTTPException
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
-from server.registry.account.profile.model import GuidParams, SetDisplayParams
+from queryregistry.handler import dispatch_query_request
+from queryregistry.identity.profiles import get_profile_request, update_profile_request
+from queryregistry.identity.profiles.models import GuidParams, UpdateProfileParams
 from server.registry.finance.credits.model import SetCreditsParams
-from server.modules.registry.helpers import (
-  get_profile_request,
-  set_credits_request,
-  set_display_request,
-)
+from server.modules.registry.helpers import set_credits_request
 
 
 class UserAdminModule(BaseModule):
@@ -29,7 +27,10 @@ class UserAdminModule(BaseModule):
 
   async def get_displayname(self, guid: str) -> str:
     params = GuidParams(guid=guid)
-    res = await self.db.run(get_profile_request(params))
+    res = await dispatch_query_request(
+      get_profile_request(params),
+      provider=self.db.provider or "mssql",
+    )
     if not res.rows:
       raise HTTPException(status_code=404, detail="Profile not found")
     row = res.rows[0]
@@ -37,7 +38,10 @@ class UserAdminModule(BaseModule):
 
   async def get_credits(self, guid: str) -> int:
     params = GuidParams(guid=guid)
-    res = await self.db.run(get_profile_request(params))
+    res = await dispatch_query_request(
+      get_profile_request(params),
+      provider=self.db.provider or "mssql",
+    )
     if not res.rows:
       raise HTTPException(status_code=404, detail="Profile not found")
     row = res.rows[0]
@@ -52,5 +56,8 @@ class UserAdminModule(BaseModule):
     )
 
   async def reset_display(self, guid: str) -> None:
-    params = SetDisplayParams(guid=guid, display_name="Default User")
-    await self.db.run(set_display_request(params))
+    params = UpdateProfileParams(guid=guid, display_name="Default User")
+    await dispatch_query_request(
+      update_profile_request(params),
+      provider=self.db.provider or "mssql",
+    )


### PR DESCRIPTION
### Motivation

- Replace the previous stub dispatchers for identity profiles with explicit handlers to expose read/update/update-if-unedited operations under the `db:identity:profiles:<operation>:1` naming.
- Consolidate multiple small profile update helpers into a single `update` op to reduce API surface and centralize validation and image/opt-in/display updates.
- Provide provider-specific implementations (MSSQL) and a conditional `update_if_unedited` flow to preserve legacy behavior for provider-driven updates.
- Migrate server modules to use the new queryregistry builders/ops and remove direct reliance on `server.registry.account.profile` request builders.

### Description

- Added queryregistry request builders in `queryregistry/identity/profiles/__init__.py` for `read`, `update`, and `update_if_unedited` ops using `db:identity:profiles:<op>:1` op names.
- Implemented explicit dispatchers in `queryregistry/identity/profiles/handler.py` and service routing in `queryregistry/identity/profiles/services.py` with payload validation for consolidated updates.
- Added MSSQL provider handlers in `queryregistry/identity/profiles/mssql.py` to implement profile read, profile update (display name, opt-in, profile image), and conditional `update_if_unedited` semantics.
- Extended models in `queryregistry/identity/profiles/models.py` with `UpdateProfileParams`, TypedDict request payloads, and callable types to support the new APIs.
- Updated server modules to use the new queryregistry builders/ops and dispatch helpers: `server/modules/profile_module.py`, `server/modules/user_admin_module.py`, `server/modules/oauth_module.py`, and `server/modules/session_module.py`, consolidating previous `set_*` calls into `update` where applicable.

### Testing

- No automated tests were executed as part of this change (no test harness or CI run was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a8ef6a7508325848f878626ea3740)