### PR TITLE
Add metadata discovery APIs to DatabaseCliModule

### DIFF
--- a/server/modules/database_cli_module.py
+++ b/server/modules/database_cli_module.py
@@ -1,5 +1,7 @@
 """Database CLI module exposing management helpers."""
 
+import ast
+from pathlib import Path
 from fastapi import FastAPI
 import logging
 from . import BaseModule
@@ -11,14 +13,16 @@ class DatabaseCliModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self._dsn: str | None = None
+    self._queryregistry_root = Path(__file__).resolve().parents[2] / "queryregistry"
 
   async def startup(self):
     env: EnvModule = self.app.state.env
     await env.on_ready()
     self._dsn = env.get("AZURE_SQL_CONNECTION_STRING")
     if not self._dsn:
-      logging.error("[DatabaseCli] Missing AZURE_SQL_CONNECTION_STRING")
-      raise RuntimeError("AZURE_SQL_CONNECTION_STRING not configured")
+      logging.warning(
+        "[DatabaseCli] Missing AZURE_SQL_CONNECTION_STRING; metadata-only APIs remain available"
+      )
     logging.info("[DatabaseCli] module ready")
     self.mark_ready()
 
@@ -27,12 +31,122 @@ class DatabaseCliModule(BaseModule):
 
   async def connect(self, dbname: str | None = None):
     await self.on_ready()
+    if not self._dsn:
+      logging.error("[DatabaseCli] connect requested without AZURE_SQL_CONNECTION_STRING")
+      raise RuntimeError("AZURE_SQL_CONNECTION_STRING not configured")
     return await mssql_cli.connect(dsn=self._dsn, dbname=dbname)
 
   async def reconnect(self, conn, dbname: str):
     await self.on_ready()
+    if not self._dsn:
+      logging.error("[DatabaseCli] reconnect requested without AZURE_SQL_CONNECTION_STRING")
+      raise RuntimeError("AZURE_SQL_CONNECTION_STRING not configured")
     return await mssql_cli.reconnect(conn, dsn=self._dsn, dbname=dbname)
 
   async def list_tables(self, conn):
     await self.on_ready()
     return await mssql_cli.list_tables(conn)
+
+  async def get_database_rpc_namespace(self) -> dict[str, object]:
+    operations = self._discover_queryregistry_operations()
+    return {
+      "namespace": "db",
+      "operationCount": len(operations),
+      "operations": operations,
+    }
+
+  async def list_queryregistry_models(self) -> list[dict[str, str]]:
+    return self._discover_queryregistry_models()
+
+  def _discover_queryregistry_operations(self) -> list[dict[str, str]]:
+    operations: list[dict[str, str]] = []
+    try:
+      for handler_path in sorted(self._queryregistry_root.rglob("handler.py")):
+        for operation in self._parse_handler_dispatchers(handler_path):
+          operations.append(operation)
+    except Exception:
+      logging.exception("[DatabaseCli] Failed to discover queryregistry operations")
+      raise
+    return operations
+
+  def _parse_handler_dispatchers(self, handler_path: Path) -> list[dict[str, str]]:
+    with handler_path.open("r", encoding="utf-8") as source_file:
+      tree = ast.parse(source_file.read(), filename=str(handler_path))
+
+    rel_dir = handler_path.parent.relative_to(self._queryregistry_root)
+    parts = [] if str(rel_dir) == "." else list(rel_dir.parts)
+
+    operations: list[dict[str, str]] = []
+    for node in tree.body:
+      targets: list[str] = []
+      value = None
+      if isinstance(node, ast.Assign):
+        targets = [target.id for target in node.targets if isinstance(target, ast.Name)]
+        value = node.value
+      elif isinstance(node, ast.AnnAssign):
+        if isinstance(node.target, ast.Name):
+          targets = [node.target.id]
+        value = node.value
+      if "DISPATCHERS" not in targets or not isinstance(value, ast.Dict):
+        continue
+
+      for key, dispatcher in zip(value.keys, value.values):
+        if not isinstance(key, ast.Tuple) or len(key.elts) != 2:
+          continue
+        op, version = key.elts
+        if not isinstance(op, ast.Constant) or not isinstance(version, ast.Constant):
+          continue
+        if isinstance(dispatcher, ast.Name):
+          func_name = dispatcher.id
+        elif isinstance(dispatcher, ast.Attribute):
+          func_name = dispatcher.attr
+        else:
+          continue
+
+        operations.append(
+          {
+            "op": f"db:{':'.join(parts + [str(op.value), str(version.value)])}",
+            "function": func_name,
+            "handler": str(handler_path.relative_to(self._queryregistry_root.parent)).replace("\\", "/"),
+          }
+        )
+    return operations
+
+  def _discover_queryregistry_models(self) -> list[dict[str, str]]:
+    models: list[dict[str, str]] = []
+    try:
+      for models_path in sorted(self._queryregistry_root.rglob("models.py")):
+        models.extend(self._parse_models_file(models_path))
+    except Exception:
+      logging.exception("[DatabaseCli] Failed to discover queryregistry models")
+      raise
+    return models
+
+  def _parse_models_file(self, models_path: Path) -> list[dict[str, str]]:
+    with models_path.open("r", encoding="utf-8") as source_file:
+      tree = ast.parse(source_file.read(), filename=str(models_path))
+
+    module_name = ".".join(models_path.relative_to(self._queryregistry_root.parent).with_suffix("").parts)
+    discovered: list[dict[str, str]] = []
+
+    for node in tree.body:
+      if not isinstance(node, ast.ClassDef):
+        continue
+      if not self._is_basemodel_subclass(node):
+        continue
+      discovered.append(
+        {
+          "name": node.name,
+          "module": module_name,
+          "path": str(models_path.relative_to(self._queryregistry_root.parent)).replace("\\", "/"),
+        }
+      )
+    return discovered
+
+  def _is_basemodel_subclass(self, node: ast.ClassDef) -> bool:
+    for base in node.bases:
+      if isinstance(base, ast.Name) and base.id == "BaseModel":
+        return True
+      if isinstance(base, ast.Attribute) and base.attr == "BaseModel":
+        return True
+    return False

--- a/tests/test_database_cli_module.py
+++ b/tests/test_database_cli_module.py
@@ -1,0 +1,63 @@
+import asyncio
+import sys
+import types
+
+from fastapi import FastAPI
+
+
+fake_mssql_cli = types.SimpleNamespace(
+  connect=None,
+  reconnect=None,
+  list_tables=None,
+)
+sys.modules.setdefault("server.modules.database_cli.mssql_cli", fake_mssql_cli)
+
+from server.modules.database_cli_module import DatabaseCliModule
+
+
+class _FakeEnv:
+  def __init__(self, dsn=None):
+    self._dsn = dsn
+
+  async def on_ready(self):
+    return None
+
+  def get(self, key: str):
+    if key == "AZURE_SQL_CONNECTION_STRING":
+      return self._dsn
+    return None
+
+
+def test_startup_without_dsn_keeps_metadata_apis_available():
+  app = FastAPI()
+  app.state.env = _FakeEnv(dsn=None)
+  module = DatabaseCliModule(app)
+
+  async def run_scenario():
+    await module.startup()
+    namespace = await module.get_database_rpc_namespace()
+    models = await module.list_queryregistry_models()
+
+    assert namespace["namespace"] == "db"
+    assert namespace["operationCount"] == len(namespace["operations"])
+    assert namespace["operationCount"] > 0
+    assert isinstance(models, list)
+    assert len(models) > 0
+
+  asyncio.run(run_scenario())
+
+
+def test_connect_requires_configured_dsn():
+  app = FastAPI()
+  app.state.env = _FakeEnv(dsn=None)
+  module = DatabaseCliModule(app)
+
+  async def run_scenario():
+    await module.startup()
+    try:
+      await module.connect()
+      assert False, "connect should fail without DSN"
+    except RuntimeError as exc:
+      assert "AZURE_SQL_CONNECTION_STRING not configured" in str(exc)
+
+  asyncio.run(run_scenario())


### PR DESCRIPTION
### Motivation
- Enable generator tooling to obtain DB namespace and QueryRegistry model metadata without requiring a live DB connection.
- Provide a metadata-only surface for tooling that mirrors the behavior of `scripts/generate_db_namespace.py` and `scripts/generate_rpc_bindings.py` by walking the `queryregistry/` tree.
- Preserve operational behavior for runtime DB operations while keeping logging structured and errors visible.

### Description
- Added `get_database_rpc_namespace()` and `list_queryregistry_models()` to `DatabaseCliModule` to expose discovered DB operations and QueryRegistry models respectively.
- Implemented AST-based discovery helpers (`_discover_queryregistry_operations`, `_parse_handler_dispatchers`, `_discover_queryregistry_models`, `_parse_models_file`, `_is_basemodel_subclass`) that walk `queryregistry/` and parse `handler.py` `DISPATCHERS` and `models.py` `BaseModel` subclasses similar to the existing generator scripts, with `Path`/`rglob` traversal.
- Updated startup/connect behavior so `startup()` no longer fails when `AZURE_SQL_CONNECTION_STRING` is missing (logs a `[DatabaseCli]` warning and stays ready), while `connect()` and `reconnect()` still log `[DatabaseCli]` errors and raise `RuntimeError` if called without a configured DSN.
- Kept structured logging statements prefixed with `[DatabaseCli]` and used `logging.exception(...); raise` in discovery helpers so exceptions are logged and not suppressed.
- Added focused tests (`tests/test_database_cli_module.py`) which inject a lightweight fake `mssql_cli` module to avoid importing the problematic runtime `mssql_cli` during collection.

### Testing
- Ran `pytest -q tests/test_database_cli_module.py` to validate metadata APIs and DSN enforcement, and it passed (`2 passed`).
- Ran `python -m py_compile server/modules/database_cli_module.py tests/test_database_cli_module.py` to check for syntax issues, and it succeeded.
- Ran the full harness via `python scripts/run_tests.py` as a validation step but it exited non-zero due to unrelated pre-existing failures and environment limits (one failing test `tests/test_role_admin_module.py::test_list_roles_filters_and_sorts` and a missing ODBC driver error in this environment); these failures are external to the introduced changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69840c4dc814832594a33dcdbec8bce0)