### PR TITLE
Fix MSSQL CLI f-string causing import SyntaxError

### DIFF
--- a/server/modules/database_cli/mssql_cli.py
+++ b/server/modules/database_cli/mssql_cli.py
@@ -64,7 +64,7 @@ async def list_tables(conn) -> list[str]:
   async with conn.cursor() as cur:
     await cur.execute(query)
     rows = await cur.fetchall()
-  return [f\"{row[0]}.{row[1]}\" for row in rows]
+  return [f"{row[0]}.{row[1]}" for row in rows]
 
 
 async def list_table_names(conn) -> list[str]:


### PR DESCRIPTION
### Motivation
- Fix a SyntaxError in `server/modules/database_cli/mssql_cli.py` that prevented the module from importing and caused application startup to fail.

### Description
- Replace the malformed f-string `f\"{row[0]}.{row[1]}\"` with the correct `f"{row[0]}.{row[1]}"` (written in code as `f"{row[0]}.{row[1]}"` -> `f"{row[0]}.{row[1]}"`) in the `list_tables` function so the file imports cleanly.

### Testing
- No automated tests were run; this is a one-line syntax fix that resolves the import error and was committed to `server/modules/database_cli/mssql_cli.py`. Please run `python scripts/run_tests.py` or `pytest` if you want CI-style validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863616e72c8325a4f6819c7ad1798f)