### PR TITLE
Adjust RPC auth cookie security and logging

### DIFF
--- a/rpc/auth/discord/services.py
+++ b/rpc/auth/discord/services.py
@@ -5,7 +5,7 @@ from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
-from rpc.helpers import unbox_request
+from rpc.helpers import is_secure_request, unbox_request
 from server.models import RPCResponse
 from server.modules.oauth_module import OauthModule
 from .models import AuthDiscordOauthLogin1, AuthDiscordOauthLoginPayload1
@@ -58,9 +58,8 @@ async def auth_discord_oauth_login_v1(request: Request):
     "rotation_token",
     rotation_token,
     httponly=True,
-    secure=True,
+    secure=is_secure_request(request),
     samesite="lax",
     expires=rot_exp,
   )
   return response
-

--- a/rpc/auth/google/services.py
+++ b/rpc/auth/google/services.py
@@ -3,7 +3,7 @@ import logging
 from fastapi import HTTPException, Request
 from pydantic import ValidationError
 
-from rpc.helpers import unbox_request
+from rpc.helpers import is_secure_request, unbox_request
 from server.models import RPCResponse
 from server.modules.oauth_module import OauthModule
 from .models import AuthGoogleOauthLogin1, AuthGoogleOauthLoginPayload1
@@ -57,7 +57,7 @@ async def auth_google_oauth_login_v1(request: Request):
     "rotation_token",
     rotation_token,
     httponly=True,
-    secure=True,
+    secure=is_secure_request(request),
     samesite="lax",
     expires=rot_exp,
   )

--- a/rpc/auth/microsoft/services.py
+++ b/rpc/auth/microsoft/services.py
@@ -4,7 +4,7 @@ from fastapi import Request
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 
-from rpc.helpers import unbox_request
+from rpc.helpers import is_secure_request, unbox_request
 from server.models import RPCResponse
 from server.modules.oauth_module import OauthModule
 from .models import AuthMicrosoftOauthLogin1
@@ -59,9 +59,8 @@ async def auth_microsoft_oauth_login_v1(request: Request):
     "rotation_token",
     rotation_token,
     httponly=True,
-    secure=True,
+    secure=is_secure_request(request),
     samesite="lax",
     expires=rot_exp,
   )
   return response
-

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -1,7 +1,7 @@
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
-from rpc.helpers import unbox_request
+from rpc.helpers import is_secure_request, unbox_request
 from server.models import RPCResponse
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -41,18 +41,18 @@ async def auth_session_get_token_v1(request: Request):
     "rotation_token",
     rotation_token,
     httponly=True,
-    secure=True,
+    secure=is_secure_request(request),
     samesite="lax",
     expires=rot_exp,
   )
   return response
 
 async def auth_session_refresh_token_v1(request: Request):
-  rotation_token = request.cookies.get("rotation_token")
-  if not rotation_token:
-    raise HTTPException(status_code=401, detail="Missing rotation token")
   rpc_request, _auth_ctx, _ = await unbox_request(request)
   req_payload = rpc_request.payload or {}
+  rotation_token = request.cookies.get("rotation_token") or req_payload.get("rotationToken") or req_payload.get("rotation_token")
+  if not rotation_token:
+    raise HTTPException(status_code=401, detail="Missing rotation token")
   fingerprint = req_payload.get("fingerprint")
   if not fingerprint:
     raise HTTPException(status_code=400, detail="Missing fingerprint")

--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -55,6 +55,10 @@ async def _dispatch_rpc_request(request, rpc_request: RPCRequest, parts: list[st
     response = await handler(remainder, request)
     logging.info(f"RPC completed: {rpc_request.op}")
     return response
+  except HTTPException as exc:
+    status_code = getattr(exc, "status_code", None)
+    logging.info("RPC rejected: %s (status=%s)", rpc_request.op, status_code)
+    raise
   except Exception:
     logging.exception(f"RPC failed: {rpc_request.op}")
     raise
@@ -116,4 +120,3 @@ async def _resolve_auth_context(app, rpc_request: RPCRequest, discord_ctx) -> Au
     raise HTTPException(status_code=401, detail='Missing or invalid authorization header')
 
   return auth_ctx
-

--- a/rpc/helpers.py
+++ b/rpc/helpers.py
@@ -93,3 +93,15 @@ async def unbox_request(request):
     request.state.auth_ctx = auth_ctx
   parts = rpc_request.op.split(':')
   return rpc_request, auth_ctx, parts
+
+
+def is_secure_request(request: Request) -> bool:
+  forwarded_proto = request.headers.get("x-forwarded-proto")
+  if forwarded_proto:
+    proto = forwarded_proto.split(",", 1)[0].strip().lower()
+    if proto:
+      return proto == "https"
+  url = getattr(request, "url", None)
+  if url:
+    return url.scheme == "https"
+  return False


### PR DESCRIPTION
### Motivation
- Rotation cookies were always being set with `secure=True`, causing the browser to drop them in non-HTTPS development or proxied requests and leading to missing rotation-token errors during refresh flows. 
- Refresh flows relied solely on the cookie and failed when the cookie was not present, causing noisy 401 stack traces in logs. 
- Expected `HTTPException` rejects were logged as full exceptions, producing noisy stack traces for normal client errors.

### Description
- Added `is_secure_request(request: Request) -> bool` in `rpc/helpers.py` to detect HTTPS via `x-forwarded-proto` or `request.url.scheme` and exported it for use by services. 
- Switched cookie `secure` flag to use `is_secure_request(request)` in OAuth/session login handlers at `rpc/auth/{microsoft,google,discord,session}/services.py` so rotation cookies are only marked secure for HTTPS requests. 
- Updated `auth_session_refresh_token_v1` in `rpc/auth/session/services.py` to accept a rotation token from either the cookie or the RPC payload (`rotationToken` / `rotation_token`) before rejecting with 401. 
- Adjusted RPC dispatcher in `rpc/handler.py` to log `HTTPException` rejections at info level and re-raise them without emitting a full stack trace, keeping real exceptions logged as errors.

### Testing
- No automated tests were executed as part of this change; please run the unified harness with `python scripts/run_tests.py` or run targeted tests with `pytest tests/` to validate behavior. 
- The change is localized to RPC helpers and auth services and should be covered by `tests/test_auth_session_refresh_provider.py` and `tests/test_public_links_service.py` when run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863a5ad5f48325a6f6be99396edf59)