### PR TITLE
Route public links through queryregistry

### DIFF
--- a/server/modules/public_links_module.py
+++ b/server/modules/public_links_module.py
@@ -3,10 +3,14 @@ from collections.abc import Mapping
 from typing import Any
 
 from fastapi import FastAPI
-from server.registry.types import DBRequest
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
+from server.modules.registry.helpers import (
+  dispatch_query_request_with_fallback,
+  get_home_links_request,
+  get_navbar_routes_request,
+)
 
 
 def _normalize_payload(payload: Any | None) -> list[dict[str, Any]]:
@@ -38,15 +42,16 @@ class PublicLinksModule(BaseModule):
 
   async def get_home_links(self):
     assert self.db
-    res = await self.db.run(DBRequest(op="db:system:links:get_home_links:1"))
-    return _normalize_payload(res.payload)
+    res = await dispatch_query_request_with_fallback(
+      get_home_links_request(),
+      provider=self.db.provider,
+    )
+    return _normalize_payload(res.rows)
 
   async def get_navbar_routes(self, role_mask: int):
     assert self.db
-    res = await self.db.run(
-      DBRequest(
-        op="db:system:links:get_navbar_routes:1",
-        payload={"role_mask": role_mask},
-      )
+    res = await dispatch_query_request_with_fallback(
+      get_navbar_routes_request(role_mask),
+      provider=self.db.provider,
     )
-    return _normalize_payload(res.payload)
+    return _normalize_payload(res.rows)


### PR DESCRIPTION
### Motivation
- Map the public links caller to QueryRegistry helpers instead of reimplementing legacy database providers to keep registry layering correct and avoid duplicating provider logic.
- Remove the unused system registry `links` package since the public links module no longer depends on those handlers.

### Description
- Update `server/modules/public_links_module.py` to import and use `dispatch_query_request_with_fallback`, `get_home_links_request`, and `get_navbar_routes_request` from `server.modules.registry.helpers`, and return normalized `res.rows` from `get_home_links` and `get_navbar_routes`.
- Remove the `server/registry/system/links` package and MSSQL handlers and delete the `links` export from `server/registry/system/__init__.py` so resolution no longer expects legacy handlers.

### Testing
- No automated tests were run as part of this change; please run the unified harness with `python scripts/run_tests.py` or run `pytest` in `tests/` to validate the repository and CI behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698640b69da8832588b747e85363c5b5)