### PR TITLE
Fix queryregistry provider import cycle

### DIFF
--- a/queryregistry/providers/__init__.py
+++ b/queryregistry/providers/__init__.py
@@ -2,12 +2,38 @@
 
 from __future__ import annotations
 
-from . import mssql, mysql, postgres
+from collections.abc import Iterator, Mapping
+import importlib
+from typing import Any
 
-PROVIDERS = {
-  "mssql": mssql,
-  "mysql": mysql,
-  "postgres": postgres,
-}
+_PROVIDER_NAMES = ("mssql", "mysql", "postgres")
+
+
+def _load_provider(name: str) -> Any:
+  return importlib.import_module(f"{__name__}.{name}")
+
+
+class ProviderRegistry(Mapping[str, Any]):
+  def __getitem__(self, key: str) -> Any:
+    if key not in _PROVIDER_NAMES:
+      raise KeyError(key)
+    return _load_provider(key)
+
+  def __iter__(self) -> Iterator[str]:
+    return iter(_PROVIDER_NAMES)
+
+  def __len__(self) -> int:
+    return len(_PROVIDER_NAMES)
+
+
+def __getattr__(name: str) -> Any:
+  if name in _PROVIDER_NAMES:
+    module = _load_provider(name)
+    globals()[name] = module
+    return module
+  raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+PROVIDERS = ProviderRegistry()
 
 __all__ = ["PROVIDERS", "mssql", "mysql", "postgres"]

--- a/server/modules/providers/database/mssql_provider/__init__.py
+++ b/server/modules/providers/database/mssql_provider/__init__.py
@@ -1,8 +1,6 @@
 # providers/database/mssql_provider/__init__.py
 import logging
 from typing import Any
-
-from queryregistry.handler import dispatch_query_request
 from queryregistry.helpers import parse_query_operation
 from queryregistry.models import DBRequest, DBResponse
 
@@ -24,6 +22,8 @@ class MssqlProvider(DbProviderBase):
 
   async def _run(self, request: DBRequest) -> DBResponse:
     self.log_dispatch(request.op)
+    from queryregistry.handler import dispatch_query_request
+
     response = await dispatch_query_request(request, provider=self.provider)
     return self.normalize_response(request.op, response)
 


### PR DESCRIPTION
### Motivation
- Tests were failing during import with an ImportError caused by a circular import between `queryregistry.providers` and modules that import provider helpers, so provider modules must not be eagerly imported at module import time.
- The MSSQL provider imported the queryregistry dispatch at module scope which contributed to the circular dependency and needed to be deferred to runtime.

### Description
- Made `queryregistry.providers` lazy by implementing a `ProviderRegistry` mapping and a `__getattr__` loader so provider submodules (`mssql`, `mysql`, `postgres`) are imported on demand instead of at import time (`queryregistry/providers/__init__.py`).
- Deferred importing `dispatch_query_request` into the runtime path of the MSSQL provider `_run` method so the `queryregistry.handler` import happens only when the provider executes, breaking the cycle (`server/modules/providers/database/mssql_provider/__init__.py`).
- Kept the public API `PROVIDERS` and `__all__` stable while avoiding import-time side effects.

### Testing
- Ran `python -m pytest tests/test_account_user_services.py -q` and it passed (`1 passed`).
- After the change the module import-time circular ImportError was resolved and the previously failing test now collects and runs successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698654187cbc8325bfc904a3e6a33ec0)