### PR TITLE
Fix public vars module DB request routing

### DIFF
--- a/server/modules/public_vars_module.py
+++ b/server/modules/public_vars_module.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 import asyncio, subprocess
 from fastapi import FastAPI
-from queryregistry.handler import dispatch_query_request
-from queryregistry.models import DBRequest
 from . import BaseModule
 from .db_module import DbModule
 from .auth_module import AuthModule
 from .discord_bot_module import DiscordBotModule
+from .registry.helpers import (
+  get_hostname_request,
+  get_repo_request,
+  get_version_request,
+)
 
 class PublicVarsModule(BaseModule):
   def __init__(self, app: FastAPI):
@@ -43,28 +46,19 @@ class PublicVarsModule(BaseModule):
 
   async def get_version(self) -> str:
     assert self.db
-    res = await dispatch_query_request(
-      DBRequest(op="db:system:public_vars:get_version:1"),
-      provider=self.db.provider,
-    )
+    res = await self.db.run(get_version_request())
     payload = res.payload if isinstance(res.payload, dict) else {}
     return payload.get("version", "")
 
   async def get_hostname(self) -> str:
     assert self.db
-    res = await dispatch_query_request(
-      DBRequest(op="db:system:public_vars:get_hostname:1"),
-      provider=self.db.provider,
-    )
+    res = await self.db.run(get_hostname_request())
     payload = res.payload if isinstance(res.payload, dict) else {}
     return payload.get("hostname", "")
 
   async def get_repo(self) -> str:
     assert self.db
-    res = await dispatch_query_request(
-      DBRequest(op="db:system:public_vars:get_repo:1"),
-      provider=self.db.provider,
-    )
+    res = await self.db.run(get_repo_request())
     payload = res.payload if isinstance(res.payload, dict) else {}
     return payload.get("repo", "")
 


### PR DESCRIPTION
### Motivation
- Use `DbModule.run` with registry request builders to ensure public vars queries are constructed consistently and their payloads are available. 
- Remove manual construction of `DBRequest` and direct calls to `dispatch_query_request` to align with the existing `DbModule` access pattern.

### Description
- Replace `dispatch_query_request(DBRequest(...), provider=...)` calls with `self.db.run(get_*_request())` for `get_version`, `get_hostname`, and `get_repo` lookups. 
- Import `get_version_request`, `get_hostname_request`, and `get_repo_request` from `.registry.helpers`. 
- Remove unused imports of `queryregistry.handler` and `queryregistry.models.DBRequest` while preserving the existing payload extraction logic and return values.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698676e2f978832581dc6d0614f17d3f)