### PR TITLE
Clarify architecture: modules = business logic, queryregistry = data-access

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,21 +10,25 @@ flowchart TD
   Client --> RPC
   RPC --> Services
   Services --> Modules
-  Modules --> Providers
-  Services --> DbModule
+  Modules --> DbModule
   DbModule --> QueryRegistry
   QueryRegistry --> Providers
+  Providers --> QueryRegistry
+  QueryRegistry --> Modules
+  Modules --> Services
   Security --> RPC
   Security --> Services
 ```
 
 * **Client** – User owned frontend or external application.
 * **RPC** – Typed boundary that exposes the public namespace. Only bearer tokens are accepted.
-* **Services** – Business logic invoked by RPC handlers.
-* **Modules** – Internal runtime modules loaded by the server. Modules communicate only through their contracts and, by default, invoke providers directly. The `DbModule` is the exception: it forwards URN-formatted operations to the query registry so data providers stay focused on connection lifecycles and response helpers.
-* **Query Registry** – Dedicated translation layer (see `queryregistry/`) that maps URN-formatted operations from the `DbModule` to provider-specific handlers. It routes the request to the correct provider implementation and normalizes responses so callers receive a consistent payload regardless of the backing engine.
-* **Providers** – External systems such as databases and identity services. SQL logic remains centralized in the provider directories (for example `server/registry/.../mssql.py` files), but the query registry ensures those implementations expose a uniform shape back to the modules.
+* **Services** – RPC-facing orchestration that validates/request-shapes and delegates application rules to modules.
+* **Modules** – Internal runtime modules loaded by the server and the **application/business logic layer**. Modules make decisions, orchestrate workflows, and enforce application rules. For data access, modules call the `DbModule`/query registry path rather than embedding provider-specific SQL.
+* **Query Registry** – Canonical **data-access translation layer** (see `queryregistry/`) that accepts typed requests from modules, maps URN-formatted operations to provider-specific SQL handlers, and returns normalized typed responses. It contains no business logic, conditional workflows, or application rules.
+* **Providers** – Connection/transport adapters for external systems such as databases and identity services. Providers own pooling, connectivity, and execution mechanics while queryregistry owns data-access translation and modules own business logic.
 * **Security** – Cross cutting layer enforcing authentication, authorization, and privacy rules. Data marked internal never leaves the server.
+
+Layer responsibility rule: **Modules (business logic) → QueryRegistry (data-access translation) → Providers (connection/transport execution)**. Logic flows down this chain; data and results flow back up.
 
 ## Security Model
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,42 +1,60 @@
 # Frontend AGENT Instructions
 
-Guidance for the Vite/React application under `frontend/`.
+Guidance for the Vite + React + TypeScript app under `frontend/`.
 
 ---
 
-## Project Layout
+## What this layer IS
 
-- Place shared, reusable UI pieces in `src/components`. Route-level screens live
-  in `src/pages`.
-- Configuration for runtime services (feature flags, themes) belongs in
-  `src/shared`. Keep RPC adapters in `src/rpc`; those files are generated—do not
-  edit them by hand.
+- A presentation/UI layer for rendering state and collecting user intent.
+- React components, route pages, and composition of generated RPC clients.
 
----
+## What this layer is NOT
 
-## Build & Tooling
-
-- The Vite config (`vite.config.ts`) groups chunks by top-level route prefixes
-  such as `system-*` and `admin-*`. When adding new route groups or changing
-  directory structure, update the `manualChunks` logic to keep bundles stable.
-- Run `npm lint`, `npm type-check`, and `npm test` before submitting changes.
-  Vitest specs live in `frontend/tests`.
+- Not a home for backend business rules.
+- Not a place to hand-maintain API schema bindings.
+- Not a place to mirror query registry dispatch logic.
 
 ---
 
-## UI & State Conventions
+## Key files and directories
 
-- Prefer functional components with hooks. Shared context providers reside in
-  `src/shared`; extend them instead of adding ad-hoc global state.
-- Co-locate component-specific styles with the component. Follow the theme tokens
-  defined in `src/shared/ElideusTheme.tsx` when adding new colors or spacing.
+- `frontend/src/components` – reusable UI building blocks.
+- `frontend/src/pages` – route-level screens.
+- `frontend/src/shared` – shared contexts, theme, and runtime frontend configuration.
+- `frontend/src/rpc` – generated TypeScript RPC bindings (**do not edit manually**).
+- `frontend/vite.config.ts` – chunking/build strategy (route-group chunk mapping).
+
+Adjacent guidance:
+- Root `AGENTS.md` for repository-wide workflow/test expectations.
+- `rpc/AGENTS.md` for backend RPC definitions that drive generated frontend bindings.
+- `queryregistry/AGENTS.md` for canonical server-side query dispatch conventions.
 
 ---
 
-## RPC Integration
+## Component patterns and naming
 
-- Consume backend APIs through the generated helpers in `src/rpc`. If a helper is
-  missing, add the corresponding dispatcher in the RPC layer and rerun
+- Prefer functional components with hooks.
+- Keep components focused/presentational; pass business decisions in via props/hooks.
+- Component naming:
+  - files/components: `PascalCase.tsx` for exported components.
+  - hooks/utilities local to UI: `camelCase.ts`.
+- Co-locate view-specific styles/assets with their components when practical.
+
+---
+
+## RPC and typing workflow
+
+- Use generated clients in `src/rpc`; do not hand-edit generated files.
+- When RPC contracts change, regenerate bindings from Python RPC definitions using
   `python scripts/generate_rpc_bindings.py`.
-- Keep request/response typing in sync with Pydantic models—regenerate bindings
-  rather than editing TypeScript signatures manually.
+- Keep TypeScript types aligned with backend models via regeneration, not manual patching.
+
+---
+
+## Anti-patterns (forbidden)
+
+- Embedding backend/domain business logic in components.
+- Creating frontend-side compatibility shims for deprecated backend operation names.
+- Bypassing generated RPC clients with ad-hoc request shapes when bindings exist.
+- Introducing aliases where direct references already exist.

--- a/queryregistry/AGENTS.md
+++ b/queryregistry/AGENTS.md
@@ -1,3 +1,107 @@
-# Queryregistry module instructions
+# Query Registry AGENT Instructions (Canonical)
 
-- Reuse `SubdomainDispatcher` from `queryregistry/system/dispatch.py` for new system subdomain dispatcher maps instead of redefining local Protocols.
+`queryregistry/` is the **canonical query registry** and the target destination for all
+new registry work. `server/registry/` is legacy and being deleted domain-by-domain.
+Do not add new code to `server/registry/`.
+
+---
+
+## What this layer IS
+
+- A provider abstraction and **data access translation layer** for canonical DB operations.
+- A translation boundary that accepts typed requests from modules, maps canonical
+  operation names to provider-specific SQL handlers, and returns typed responses.
+- Domain/subdomain operation routing using canonical operation names:
+  `db:domain:subdomain:operation:version`
+- A layer with **zero business logic**.
+
+## What this layer is NOT
+
+- Not a compatibility wrapper for legacy naming schemes.
+- Not a place to add aliases/fallback shims to legacy `server/registry` operations.
+- Not a module/provider lifecycle layer (see `server/modules/AGENTS.md`).
+- Not a place for business logic, conditional workflows, or application rules;
+  those belong in `server/modules/`.
+
+---
+
+## Core files and dispatch flow
+
+- `queryregistry/models.py` – canonical `DBRequest` / `DBResponse` contracts.
+- `queryregistry/helpers.py` – operation parsing helpers.
+- `queryregistry/dispatch.py` – top-level domain dispatch map.
+- `queryregistry/<domain>/handler.py` – domain-level subdomain dispatch.
+- `queryregistry/system/dispatch.py` – shared `SubdomainDispatcher` protocol.
+- `queryregistry/stubs.py` – CRUD stub dispatcher generator for greenfield domains.
+
+Dispatch pattern:
+1. Parse `db_request.op` with `parse_query_operation`.
+2. Route by domain in `queryregistry/dispatch.py`.
+3. Route by subdomain in domain `handler.py`.
+4. Route operation/version inside subdomain handlers (often via dispatch map keys such as
+   `("create", "1")`, `("read", "1")`, etc.).
+
+---
+
+## SubdomainDispatcher usage
+
+- Reuse `SubdomainDispatcher` from `queryregistry/system/dispatch.py` where protocol typing is needed.
+- Do not redefine local Protocol variants for equivalent dispatcher signatures.
+- Keep dispatcher call signature consistent:
+  `async def __call__(request: DBRequest, *, provider: str) -> DBResponse`.
+
+---
+
+## Typed contract pattern
+
+- Define typed payload models in subdomain `models.py` when a domain needs structured inputs.
+- Convert incoming `request.payload` into typed params before provider-specific
+  data access calls.
+- Return canonical `DBResponse` objects (or provider-normalizable equivalents) with explicit
+  payload/rowcount behavior.
+
+---
+
+## Adding a new domain or subdomain
+
+1. Add domain package and `handler.py`.
+2. Register domain handler in `queryregistry/dispatch.py`.
+3. Add subdomain package with:
+   - `handler.py` (subdomain routing)
+   - `models.py` (typed payload contracts, when needed)
+   - `services.py` for translation/data-access helpers only (no business rules)
+   - `mssql.py` (or provider-specific adapters) for SQL execution paths
+4. Wire operation/version dispatch maps using canonical op fragments.
+5. Ensure callers use canonical `db:domain:subdomain:operation:version` names.
+
+---
+
+## CRUD stub structure
+
+- For new-but-not-implemented paths, use `queryregistry/stubs.py` to expose consistent
+  `create/read/update/delete/list` + version dispatcher entries.
+- Stub responses should fail explicitly (e.g., HTTP 501) rather than silently aliasing to
+  unrelated handlers.
+
+---
+
+## Naming and schema conventions
+
+- Maintain DB metadata naming conventions in payloads/results:
+  - `element_*` fields.
+  - `recid` as `bigint` IDs.
+  - `datetimeoffset` for temporal metadata.
+
+---
+
+## Anti-patterns (forbidden)
+
+- Alias maps that translate new operation names back to legacy names.
+- New fallbacks to `server/registry/` for greenfield features.
+- Business logic, conditional workflows, or application rule enforcement.
+- Mixing module lifecycle concerns into query handlers.
+
+Adjacent guidance:
+- `server/modules/AGENTS.md`
+- `server/modules/providers/AGENTS.md`
+- `server/registry/AGENTS.md` (legacy/deprecation-only context)

--- a/server/modules/AGENTS.md
+++ b/server/modules/AGENTS.md
@@ -1,0 +1,69 @@
+# Server Modules AGENT Instructions
+
+Guidance for runtime services under `server/modules/`.
+
+---
+
+## What modules ARE
+
+- The **application/business logic layer** of the server.
+- Runtime service objects with explicit lifecycle (`startup`, `shutdown`).
+- `BaseModule` subclasses that are auto-discovered by `ModuleManager`.
+- The place where decisions are made, workflows are orchestrated, and application
+  rules are enforced.
+- Callers of `queryregistry/` for data access translation while keeping business
+  logic in modules.
+
+## What modules are NOT
+
+- Not query handlers.
+- Not raw SQL containers.
+- Not a place to embed provider-specific queries; use `queryregistry/` for all
+  data access.
+
+---
+
+## Key files
+
+- `server/modules/__init__.py`
+  - `BaseModule` contract.
+  - `mark_ready()` / `on_ready()` readiness synchronization.
+  - `ModuleManager` auto-discovery of `*_module.py` files and `CamelCaseModule` classes.
+- `server/lifespan.py` – module manager startup/shutdown integration.
+- `server/modules/db_module.py` – DB runtime dispatch and migration-aware behavior.
+
+Adjacent guidance:
+- `server/modules/providers/AGENTS.md` for provider boundaries.
+- `queryregistry/AGENTS.md` for canonical query operation and dispatcher patterns.
+- `server/registry/AGENTS.md` for legacy/deprecation context.
+
+---
+
+## Required patterns
+
+- Inherit from `BaseModule` for all modules.
+- Set readiness with `mark_ready()` after startup initialization completes.
+- Await dependent modules with `await other_module.on_ready()` before use.
+- Let `ModuleManager` discovery/load modules; follow naming contract:
+  - file: `snake_case_module.py`
+  - class: `CamelCaseModule`
+- For new query work, dispatch through `queryregistry` flows
+  (`dispatch_query_request` / canonical DB ops), not direct `server/registry` calls.
+
+---
+
+## Naming and data conventions
+
+- Preserve DB naming conventions in module-facing payloads and docs:
+  - `element_*` metadata fields.
+  - `recid` values as `bigint` identifiers.
+  - `datetimeoffset` for temporal audit columns.
+
+---
+
+## Anti-patterns (forbidden)
+
+- Calling providers directly from RPC/router layers and bypassing modules.
+- Embedding SQL directly in modules for new features.
+- Adding aliases/compatibility shims to keep legacy op names alive.
+- Creating global singleton state outside module instances/app.state wiring.

--- a/server/modules/database_cli/AGENTS.md
+++ b/server/modules/database_cli/AGENTS.md
@@ -1,0 +1,73 @@
+# Database CLI AGENT Instructions
+
+Guidance for `server/modules/database_cli/` tooling and schema introspection flows.
+
+---
+
+## What this layer IS
+
+- Operator/developer tooling for DB connectivity and schema metadata workflows.
+- Utilities for schema-registry introspection and dump generation.
+- A provider-aware CLI surface that complements runtime modules.
+
+## What this layer is NOT
+
+- Not the canonical query handler registry.
+- Not a place for business-domain logic; business rules live in `server/modules/`.
+- Not a place to define canonical data-access operations; those belong in `queryregistry/`.
+- Not a compatibility shim layer for legacy registry naming.
+
+---
+
+## Key files
+
+- `server/modules/database_cli/cli.py` – interactive REPL-style command loop.
+- `server/modules/database_cli/mssql_cli.py` – MSSQL connection/reconnect/table-list helpers.
+- `server/modules/database_cli/SCHEMA_REGISTRY.md` – schema registry table model and generation flow.
+- `server/modules/database_cli/EDT_MAPPINGS.md` – canonical `system_edt_mappings` guidance.
+
+Adjacent guidance:
+- `server/modules/AGENTS.md` for module lifecycle boundaries.
+- `server/modules/providers/AGENTS.md` for provider/pooling expectations.
+- `queryregistry/AGENTS.md` for canonical query dispatch conventions.
+
+---
+
+## Schema registry expectations
+
+- Treat schema registry as canonical metadata source for dump generation:
+  - `system_schema_tables`
+  - `system_schema_columns`
+  - `system_schema_indexes`
+  - `system_schema_foreign_keys`
+- Type normalization is driven by `system_edt_mappings`.
+- SQL dump generation should prefer registry-driven deterministic output over ad-hoc DB
+  introspection when registry data is available.
+
+---
+
+## Naming conventions
+
+- Schema metadata fields should follow `element_*` naming.
+- Primary IDs and FK references use `recid` with `bigint` semantics.
+- Temporal metadata columns use `datetimeoffset` with UTC defaults.
+
+---
+
+## Common patterns
+
+- Keep connector logic provider-aware and isolated (`mssql_cli.py` now, future providers later).
+- Fail fast with contextual logs when DSN/driver requirements are missing.
+- Keep CLI command behavior explicit (`connect`, `reconnect`, `list tables`).
+
+Future direction:
+- Evolve toward a richer REPL/workbench interface while preserving stable command semantics
+  and registry-first schema generation workflows.
+
+---
+
+## Anti-patterns (forbidden)
+
+- Adding aliases to bridge old/new registry operation names.
+- Embedding domain business logic into CLI helpers.
+- Treating `server/registry/` as canonical for new schema/query features.

--- a/server/modules/providers/AGENTS.md
+++ b/server/modules/providers/AGENTS.md
@@ -1,0 +1,60 @@
+# Server Provider AGENT Instructions
+
+Guidance for provider abstractions under `server/modules/providers/`.
+
+---
+
+## What providers ARE
+
+- Infrastructure adapters for external systems (DB, auth, storage, social).
+- Lifecycle-managed integrations created and owned by modules.
+- The place for connection pooling, transaction boundaries, and protocol-specific I/O.
+
+## What providers are NOT
+
+- Not domain business logic.
+- Not registry/domain dispatch map definitions.
+- Not a place to introduce operation-name compatibility aliases.
+
+---
+
+## Database provider focus
+
+Key files:
+- `server/modules/providers/__init__.py` – `DbProviderBase` and shared provider contracts.
+- `server/modules/providers/database/mssql_provider/__init__.py` – provider entrypoint,
+  normalization, and queryregistry dispatch path.
+- `server/modules/providers/database/mssql_provider/logic.py` – pool lifecycle and
+  transaction context manager.
+
+Patterns to preserve:
+- Initialize and close pooled DB connections in provider `startup()` / `shutdown()`.
+- Use provider-level helpers for execution flows such as:
+  - `run_exec(...)` for command/rowcount-oriented operations.
+  - `run_json_one(...)` for single-object JSON payload retrieval.
+- Keep explicit transaction handling via context managers (`commit`/`rollback` behavior).
+- Providers are shared by both registries during migration, but **new operations must target
+  `queryregistry/` contracts**.
+
+---
+
+## Naming and schema conventions
+
+- Keep DB payload conventions stable:
+  - `element_*` metadata fields.
+  - `recid` as `bigint` IDs.
+  - `datetimeoffset` temporal values.
+
+---
+
+## Anti-patterns (forbidden)
+
+- Adding provider-side aliases for legacy/new operation names.
+- Silently swallowing provider exceptions; include contextual logs.
+- Embedding domain routing rules in providers.
+- Adding new work that depends on `server/registry/` as a target layer.
+
+Adjacent guidance:
+- `server/modules/AGENTS.md` for lifecycle and module boundaries.
+- `queryregistry/AGENTS.md` for canonical registry dispatch and contracts.
+- `server/registry/AGENTS.md` for legacy/deprecation constraints.

--- a/server/registry/AGENTS.md
+++ b/server/registry/AGENTS.md
@@ -1,0 +1,63 @@
+# **DEPRECATED: `server/registry/` is legacy and is being deleted domain-by-domain in favor of `queryregistry/`.**
+
+Do **not** add new handlers, models, or operation names under this directory.
+Do **not** maintain aliases, compatibility shims, or new fallbacks that keep this
+layer alive. Each migrated domain is removed once its `queryregistry/` equivalent
+is live.
+
+For canonical query-registry patterns, read `queryregistry/AGENTS.md`.
+
+---
+
+## What this layer IS
+
+- A **temporary legacy registry** that still serves unmigrated operations.
+- A compatibility surface used only until equivalent operations exist in
+  `queryregistry/`.
+
+## What this layer IS NOT
+
+- Not the canonical place for new query work.
+- Not the right place to add naming aliases or dual-write compatibility.
+- Not a long-term abstraction.
+
+---
+
+## Key files and entry points
+
+- `server/registry/__init__.py` – legacy operation parsing and handler lookup.
+- `server/registry/types.py` and `server/registry/models.py` – legacy request/response
+  contracts.
+- `server/registry/providers/` – legacy provider adapter hooks.
+
+Adjacent guidance:
+- `server/modules/AGENTS.md` for module lifecycle and runtime boundaries.
+- `server/modules/providers/AGENTS.md` for DB provider behavior during migration.
+- `queryregistry/AGENTS.md` for all new registry design and dispatch rules.
+
+---
+
+## Naming and schema conventions (when touching migration-only code)
+
+- Keep SQL/object naming aligned with existing DB conventions:
+  - `element_*` columns for metadata payloads.
+  - `recid` as `bigint` for identifiers.
+  - temporal metadata in `datetimeoffset` columns.
+- Do not rename legacy operations to create compatibility layers; migrate callers to
+  canonical `db:domain:subdomain:operation:version` ops in `queryregistry/`.
+
+---
+
+## Allowed changes in this directory
+
+- Bug fixes required to keep currently unmigrated flows operational.
+- Deletion/refactor work that removes legacy registry usage.
+- Migration helpers that move domains to `queryregistry/` without introducing new
+  aliases.
+
+## Anti-patterns (forbidden)
+
+- Adding new domain/subdomain handlers here.
+- Introducing alias operations or compatibility wrappers.
+- Adding fresh code paths that target legacy registry first.
+- Preserving dead legacy code “just in case” after migration completes.


### PR DESCRIPTION
### Motivation

- Previous documentation implied business logic could live in `queryregistry/`, which conflicts with the intended migration and layering model.  
- Make layer responsibilities explicit so modules own application rules and `queryregistry` remains a provider-agnostic data-access translation boundary.  
- Prevent accidental embedding of SQL or conditional business workflows outside of the module layer during the registry migration.

### Description

- Update `ARCHITECTURE.md` to clarify the canonical flow and responsibilities: **Modules → QueryRegistry → Providers**, update the mermaid diagram, and emphasize that logic flows down while data flows up.  
- Revise `queryregistry/AGENTS.md` to define it as a provider abstraction/data-access translation layer that accepts typed requests, translates to provider-specific SQL handlers, returns typed responses, and contains zero business logic.  
- Revise `server/modules/AGENTS.md` to explicitly state modules are the application/business-logic layer where decisions, workflows, and rules are enforced, and to forbid embedding provider-specific SQL in modules.  
- Update `server/modules/database_cli/AGENTS.md` wording to separate business-rule ownership (modules) from canonical data-access ownership (`queryregistry/`).

### Testing

- Ran `git diff --check` to validate whitespace/patch problems and it passed.  
- Inspected repository state with `git status --short` to confirm the intended files were modified.  
- No runtime or unit test changes were required for these documentation updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699642078110832587ed19bcd1c36c66)