### PR TITLE
Refactor server AGENTS into thin delegation index

### DIFF
--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,59 +1,54 @@
 # Server AGENT Instructions
 
-These rules cover the FastAPI application (`server/`), including modules,
-providers, routers, and helper utilities.
+This file covers the FastAPI application entry point, startup sequence, and
+other top-level server concerns.
 
 ---
 
 ## Layering Expectations
 
-- Respect the project layering from **ARCHITECTURE.md**: RPC → Service → Module
-  → Provider. Server code owns the Module and Provider layers.
-- FastAPI routers (`server/routers`) should forward requests to modules or RPC
-  handlers without embedding business logic.
-
----
-
-## Module Lifecycle
-
-- Modules live in `server/modules` and must define a `CamelCaseModule` class in a
-  `*_module.py` file. The `ModuleManager` instantiates them automatically during
-  app startup (`server/lifespan.py`).
-- Always inherit from `BaseModule`. Call `mark_ready()` once initialization
-  completes so other modules can await `on_ready()` safely.
-- Acquire dependencies from `app.state.<module_name>` and `await on_ready()`
-  before using them inside `startup()`.
-- Avoid global singletons; store runtime state on the module instance.
-
----
-
-## Providers and Registry Usage
-
-- Provider implementations live under `server/modules/providers`. Keep them
-  focused on connection management and external API interactions.
-- Database SQL stays in the registry layer (`server/registry`). Modules should
-  call `DbModule.run()` with registry request objects rather than embedding raw
-  queries.
-- When adding a provider, expose configuration through `EnvModule` and wire it
-  into the owning module's startup routine.
+- Follow **ARCHITECTURE.md** for layer boundaries and responsibilities.
+- Apply the server rule: Modules (business logic) → QueryRegistry
+  (data-access translation) → Providers (connection/transport).
 
 ---
 
 ## Operational Guidance
 
-- Changes that touch authentication or role resolution must preserve the
-  security contracts described in **AUTHENTICATION_DIAGRAMS.md**.
-- If module startup requires migrations or seed data, produce `.sql` files under
-  `scripts/` and document manual steps.
-- Keep logging structured (`[Module] message`). Avoid suppressing exceptions—log
-  and re-raise so RPC callers receive accurate errors.
+- Changes to authentication or role resolution must preserve contracts in
+  **AUTHENTICATION_DIAGRAMS.md**.
+- Database loads and seed/migration handoffs must be delivered as `.sql` files
+  for manual execution in **SSMS**.
+- Keep logs structured with contextual module/service prefixes, and re-raise
+  exceptions after logging so upstream callers receive accurate failures.
 
 ---
 
 ## Anti-Patterns To Avoid
 
-- Do **not** bypass modules by importing providers directly from RPC code.
-- Do **not** perform blocking I/O in startup without `await`; use async helpers
-  from existing providers.
-- Do **not** mutate `app.state` outside of the module manager unless you are
-  intentionally registering a module-level API.
+- Do **not** bypass module boundaries from routers/RPC handlers.
+- Do **not** perform blocking startup work without async-aware patterns.
+- Do **not** add new query handlers to `server/registry/`; use
+  `queryregistry/` for all new data access.
+
+---
+
+## Layer-Specific Guidance
+
+- `server/modules/AGENTS.md` - module lifecycle and business logic patterns.
+- `server/modules/providers/AGENTS.md` - provider boundaries and connection
+  management.
+- `server/registry/AGENTS.md` - **DEPRECATED** legacy registry (migration
+  context only).
+- `queryregistry/AGENTS.md` - canonical data-access translation layer.
+
+---
+
+## Read This First By Edit Type
+
+- If editing a `*_module.py` file → read `server/modules/AGENTS.md` first.
+- If editing under `server/modules/providers/` → read
+  `server/modules/providers/AGENTS.md` first.
+- If editing under `server/registry/` → read `server/registry/AGENTS.md` first
+  (deprecation rules).
+- If adding new data access operations → read `queryregistry/AGENTS.md` first.


### PR DESCRIPTION
### Motivation
- Remove duplicated, layer-specific guidance from `server/AGENTS.md` so every detail lives in the correct, local AGENTS file and server docs only cover startup/top-level concerns.
- Correct an outdated registry claim and steer new data-access work toward the canonical `queryregistry/` layer.

### Description
- Rewrote `server/AGENTS.md` to be a short index focused on the FastAPI entry point, startup sequence, and top-level server concerns.
- Replaced the verbose layering section with a concise `ARCHITECTURE.md` reference and the rule: Modules → QueryRegistry → Providers.
- Removed the `Module Lifecycle` and `Providers and Registry Usage` sections and trimmed `Operational Guidance` to authentication contracts, `.sql` delivery, and structured logging with re-raise behavior.
- Added updated anti-patterns (including an explicit prohibition on adding new query handlers to `server/registry/`) plus a `Layer-Specific Guidance` list and "Read This First" directives linking to `server/modules/AGENTS.md`, `server/modules/providers/AGENTS.md`, `server/registry/AGENTS.md` (DEPRECATED), and `queryregistry/AGENTS.md`.

### Testing
- Ran `wc -l server/AGENTS.md` to confirm the file is under 60 lines; the command returned `54` lines and succeeded.
- Reviewed the change with `git diff -- server/AGENTS.md` to validate the diff contains only the intended content edits and the review succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69964b622d048325b836e2951424ef1f)