### PR TITLE
docs(database_cli): refresh EDT_MAPPINGS for v0.8.0 and clarify temporal canonicalization

### DIFF
--- a/server/modules/database_cli/EDT_MAPPINGS.md
+++ b/server/modules/database_cli/EDT_MAPPINGS.md
@@ -3,21 +3,29 @@
 This document defines the canonical type system stored in `system_edt_mappings` for
 cross-provider compatibility in the database CLI/provider abstraction layer.
 
-## Schema Inventory (v0.7.2.0)
+## Schema Inventory (v0.8.0.0)
 
 The following native SQL Server data types are used across all table and view-backed
-objects in `scripts/v0.7.2.0_20250918.sql`:
+objects in `scripts/v0.8.0.0_20260217.sql`:
 
 - `int`
 - `bigint`
 - `bigint identity(1,1)`
 - `bit`
 - `uniqueidentifier`
-- `datetime2`
 - `datetimeoffset`
 - `nvarchar(<n>)`
 - `nvarchar(max)`
 - `varchar(<n>)`
+
+Notes:
+
+- Registry/system temporal metadata columns are canonicalized as
+  `element_created_on` and `element_modified_on`.
+- The storage standard for those `element_*` temporal metadata columns is
+  `datetimeoffset`.
+- `datetime2` is non-default and only retained for non-element or external
+  compatibility cases when it appears in imported/legacy schema edges.
 
 ## `system_edt_mappings` Table Shape
 
@@ -79,7 +87,11 @@ objects in `scripts/v0.7.2.0_20250918.sql`:
 
 ## Alignment with `database_cli`
 
-The current `server/modules/database_cli` implementation lists table metadata via ODBC
-and is intentionally provider-aware at the connector boundary. The EDT table gives that
-layer a canonical normalization target without changing existing introspection logic in
-this phase.
+`system_schema_tables`, `system_schema_columns`, `system_schema_indexes`, and
+`system_schema_foreign_keys` are the source of truth for schema metadata used by
+`database_cli` generation flows. There is no introspection dependency when registry
+tables are populated.
+
+The current `server/modules/database_cli` implementation remains provider-aware at the
+connector boundary; `system_edt_mappings` provides the canonical normalization target
+for cross-provider handling.


### PR DESCRIPTION
### Motivation

- Bring the EDT mappings doc in line with the current schema source by referencing `scripts/v0.8.0.0_20260217.sql` and updating the schema inventory header to v0.8.0.0.
- Make temporal metadata handling explicit so consumers know which columns are canonical and which storage type is preferred. 
- Remove ambiguity about runtime generation by documenting that registry tables are the source of truth and generation does not depend on live DB introspection when those tables are populated.

### Description

- Updated `server/modules/database_cli/EDT_MAPPINGS.md` header and source reference from v0.7.2.0 to v0.8.0.0 and pointed to `scripts/v0.8.0.0_20260217.sql`.
- Removed `datetime2` from the primary inventory list and added clear notes that `datetime2` is non-default and retained only for non-element or external compatibility cases.
- Added explicit guidance that registry/system temporal metadata columns are canonicalized as `element_created_on` and `element_modified_on` and that their storage standard is `datetimeoffset`.
- Added registry-first wording stating that `system_schema_tables`, `system_schema_columns`, `system_schema_indexes`, and `system_schema_foreign_keys` are the source of truth and that there is no introspection dependency when those registry tables are populated, while preserving that connector-level introspection remains provider-aware and `system_edt_mappings` is the canonical normalization target.

### Testing

- Ran `git diff --check` with no reported issues.
- Ran `git status --short` to verify the modified file is staged/committed in the working branch.
- No unit tests were changed as part of this documentation update; run `python scripts/run_tests.py` for repository-wide verification if needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699781e56ac08325b5d82ad404638b56)