### PR TITLE
Migrate content cache registry operations to queryregistry/content/cache

### DIFF
--- a/queryregistry/content/cache/__init__.py
+++ b/queryregistry/content/cache/__init__.py
@@ -1,1 +1,107 @@
-"""Content cache query registry stubs."""
+"""Content cache query registry request builders."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from queryregistry.models import DBRequest
+
+from .models import (
+  CacheItemKey,
+  ContentCacheItem,
+  DeleteCacheFolderParams,
+  GetPublishedFilesParams,
+  ListCacheParams,
+  ReplaceUserCacheParams,
+  SetGalleryParams,
+  SetPublicParams,
+  SetReportedParams,
+  UpsertCacheItemParams,
+  normalize_content_cache_item,
+)
+
+__all__ = [
+  "count_rows_request",
+  "delete_cache_folder_request",
+  "delete_cache_item_request",
+  "get_published_files_request",
+  "list_cache_request",
+  "list_public_request",
+  "list_reported_request",
+  "replace_user_cache_request",
+  "set_gallery_request",
+  "set_public_request",
+  "set_reported_request",
+  "upsert_cache_item_request",
+]
+
+
+def _normalize_cache_item_payload(
+  item: Mapping[str, Any] | ContentCacheItem,
+  *,
+  default_user_guid: str | None = None,
+) -> dict[str, Any]:
+  payload = normalize_content_cache_item(item, default_user_guid=default_user_guid)
+  if default_user_guid and not payload.get("user_guid"):
+    payload["user_guid"] = default_user_guid
+  return payload
+
+
+def list_cache_request(params: ListCacheParams) -> DBRequest:
+  return DBRequest(op="db:content:cache:list:1", payload=params.model_dump())
+
+
+def list_public_request() -> DBRequest:
+  return DBRequest(op="db:content:cache:list_public:1", payload={})
+
+
+def list_reported_request() -> DBRequest:
+  return DBRequest(op="db:content:cache:list_reported:1", payload={})
+
+
+def replace_user_cache_request(params: ReplaceUserCacheParams) -> DBRequest:
+  payload = params.model_dump()
+  payload["items"] = [item.model_dump() for item in params.items]
+  return DBRequest(op="db:content:cache:replace_user:1", payload=payload)
+
+
+def upsert_cache_item_request(item: UpsertCacheItemParams | dict[str, Any]) -> DBRequest:
+  if isinstance(item, UpsertCacheItemParams):
+    normalized = item.model_dump()
+  else:
+    normalized = _normalize_cache_item_payload(item)
+  return DBRequest(op="db:content:cache:upsert:1", payload=normalized)
+
+
+def delete_cache_item_request(params: CacheItemKey) -> DBRequest:
+  return DBRequest(op="db:content:cache:delete:1", payload=params.model_dump())
+
+
+def delete_cache_folder_request(params: DeleteCacheFolderParams) -> DBRequest:
+  return DBRequest(op="db:content:cache:delete_folder:1", payload=params.model_dump())
+
+
+def set_public_request(params: SetPublicParams) -> DBRequest:
+  payload = params.model_dump(exclude_none=True)
+  payload["public"] = 1 if params.public else 0
+  return DBRequest(op="db:content:cache:set_public:1", payload=payload)
+
+
+def set_reported_request(params: SetReportedParams) -> DBRequest:
+  payload = params.model_dump()
+  payload["reported"] = 1 if params.reported else 0
+  return DBRequest(op="db:content:cache:set_reported:1", payload=payload)
+
+
+def count_rows_request() -> DBRequest:
+  return DBRequest(op="db:content:cache:count_rows:1", payload={})
+
+
+def set_gallery_request(params: SetGalleryParams) -> DBRequest:
+  payload = params.model_dump(exclude_none=True)
+  payload["gallery"] = 1 if params.gallery else 0
+  return DBRequest(op="db:content:cache:set_gallery:1", payload=payload)
+
+
+def get_published_files_request(params: GetPublishedFilesParams) -> DBRequest:
+  return DBRequest(op="db:content:cache:get_published_files:1", payload=params.model_dump())

--- a/queryregistry/content/cache/handler.py
+++ b/queryregistry/content/cache/handler.py
@@ -6,11 +6,38 @@ from typing import Sequence
 
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
-from queryregistry.stubs import build_stub_dispatchers
+
+from .services import (
+  count_rows_v1,
+  delete_folder_v1,
+  delete_v1,
+  get_published_files_v1,
+  list_public_v1,
+  list_reported_v1,
+  list_v1,
+  replace_user_v1,
+  set_gallery_v1,
+  set_public_v1,
+  set_reported_v1,
+  upsert_v1,
+)
 
 __all__ = ["handle_cache_request"]
 
-DISPATCHERS = build_stub_dispatchers("content.cache")
+DISPATCHERS = {
+  ("list", "1"): list_v1,
+  ("list_public", "1"): list_public_v1,
+  ("list_reported", "1"): list_reported_v1,
+  ("replace_user", "1"): replace_user_v1,
+  ("upsert", "1"): upsert_v1,
+  ("delete", "1"): delete_v1,
+  ("delete_folder", "1"): delete_folder_v1,
+  ("set_public", "1"): set_public_v1,
+  ("set_reported", "1"): set_reported_v1,
+  ("count_rows", "1"): count_rows_v1,
+  ("set_gallery", "1"): set_gallery_v1,
+  ("get_published_files", "1"): get_published_files_v1,
+}
 
 
 async def handle_cache_request(

--- a/queryregistry/content/cache/models.py
+++ b/queryregistry/content/cache/models.py
@@ -1,0 +1,215 @@
+"""Pydantic models for content cache query registry interactions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping, MutableMapping, Sequence
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+__all__ = [
+  "CacheItemKey",
+  "ContentCacheItem",
+  "DeleteCacheFolderParams",
+  "GetPublishedFilesParams",
+  "ListCacheParams",
+  "ReplaceUserCacheParams",
+  "SetGalleryParams",
+  "SetPublicParams",
+  "SetReportedParams",
+  "UpsertCacheItemParams",
+  "normalize_content_cache_item",
+]
+
+
+def _coerce_flag(value: Any) -> int:
+  if value is None:
+    return 0
+  return 1 if bool(value) else 0
+
+
+class ContentCacheItem(BaseModel):
+  """Typed representation of a content cache row."""
+
+  model_config = ConfigDict(extra="allow")
+
+  user_guid: str
+  filename: str
+  path: str = ""
+  content_type: str = "application/octet-stream"
+  public: int = 0
+  element_created_on: datetime | None = None
+  element_modified_on: datetime | None = None
+  url: str | None = None
+  reported: int = 0
+  moderation_recid: Any | None = None
+
+  @model_validator(mode="before")
+  @classmethod
+  def _normalize(cls, value: Any) -> MutableMapping[str, Any]:
+    if isinstance(value, cls):
+      return value.model_dump()
+    if not isinstance(value, Mapping):
+      raise TypeError("ContentCacheItem expects a mapping of values")
+    data: MutableMapping[str, Any] = dict(value)
+    user_guid = data.get("user_guid") or data.get("users_guid")
+    if not user_guid:
+      raise ValueError("user_guid is required for content cache items")
+    data["user_guid"] = user_guid
+    name = data.get("filename") or data.get("name")
+    if name is None:
+      raise ValueError("filename is required for content cache items")
+    data["filename"] = name
+    data["path"] = data.get("path") or ""
+    data["content_type"] = data.get("content_type") or "application/octet-stream"
+    data["public"] = _coerce_flag(data.get("public", 0))
+    data["reported"] = _coerce_flag(data.get("reported", 0))
+    if data.get("moderation_recid") == "":
+      data["moderation_recid"] = None
+    return data
+
+  @classmethod
+  def from_mapping(
+    cls,
+    data: Mapping[str, Any],
+    *,
+    default_user_guid: str | None = None,
+  ) -> "ContentCacheItem":
+    payload = dict(data)
+    if default_user_guid and not payload.get("user_guid"):
+      payload["user_guid"] = default_user_guid
+    return cls.model_validate(payload)
+
+  @field_validator("element_created_on", "element_modified_on", mode="before")
+  @classmethod
+  def _normalize_temporal_fields(cls, value: Any) -> datetime | None:
+    if value is None or value == "":
+      return None
+    parsed = value
+    if isinstance(parsed, str):
+      candidate = parsed.strip()
+      if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+      parsed = datetime.fromisoformat(candidate)
+    if not isinstance(parsed, datetime):
+      raise TypeError(f"Temporal field expects datetime-compatible value, got {type(parsed).__name__}")
+    if parsed.tzinfo is None:
+      return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+class ListCacheParams(BaseModel):
+  """Parameters required to list a user's cached items."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  user_guid: str
+
+
+class CacheItemKey(BaseModel):
+  """Coordinates for identifying a cached item."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  user_guid: str
+  path: str = ""
+  filename: str
+
+
+class DeleteCacheFolderParams(BaseModel):
+  """Parameters required to delete every item within a folder."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  user_guid: str
+  path: str = ""
+
+
+class ReplaceUserCacheParams(BaseModel):
+  """Payload used to replace a user's cache rows with provided items."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  user_guid: str
+  items: list[ContentCacheItem] = Field(default_factory=list)
+
+  @model_validator(mode="before")
+  @classmethod
+  def _apply_defaults(cls, value: Any) -> Mapping[str, Any]:
+    if isinstance(value, cls):
+      return value.model_dump()
+    if not isinstance(value, Mapping):
+      raise TypeError("ReplaceUserCacheParams expects a mapping")
+    data = dict(value)
+    user_guid = data.get("user_guid")
+    raw_items: Sequence[Any] = data.get("items", [])
+    normalized: list[Any] = []
+    for item in raw_items:
+      if isinstance(item, Mapping):
+        payload = dict(item)
+        if user_guid and not payload.get("user_guid"):
+          payload["user_guid"] = user_guid
+        normalized.append(payload)
+      else:
+        normalized.append(item)
+    data["items"] = normalized
+    return data
+
+
+class UpsertCacheItemParams(ContentCacheItem):
+  """Validated payload for inserting or updating a cache item."""
+
+
+class SetPublicParams(BaseModel):
+  """Parameters used to toggle the public flag for a cached item."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  user_guid: str
+  public: bool
+  name: str | None = None
+  path: str | None = None
+  filename: str | None = None
+
+
+class SetReportedParams(CacheItemKey):
+  """Parameters used to toggle the reported flag for a cached item."""
+
+  reported: bool = True
+
+
+class SetGalleryParams(BaseModel):
+  """Parameters used to toggle the gallery/public flag for a cached item."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  user_guid: str
+  gallery: bool
+  name: str | None = None
+  path: str | None = None
+  filename: str | None = None
+
+
+class GetPublishedFilesParams(BaseModel):
+  """Parameters used to retrieve published files for a user."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str
+
+
+def normalize_content_cache_item(
+  item: Mapping[str, Any] | ContentCacheItem,
+  *,
+  default_user_guid: str | None = None,
+) -> dict[str, Any]:
+  """Normalize arbitrary cache data into the canonical payload shape."""
+
+  if isinstance(item, ContentCacheItem):
+    payload = item.model_dump()
+  else:
+    payload = dict(item)
+  if default_user_guid and not payload.get("user_guid"):
+    payload["user_guid"] = default_user_guid
+  normalized = ContentCacheItem.model_validate(payload)
+  return normalized.model_dump()

--- a/queryregistry/content/cache/mssql.py
+++ b/queryregistry/content/cache/mssql.py
@@ -1,0 +1,317 @@
+"""MSSQL implementations for content cache query registry services."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+from typing import Any
+from uuid import UUID
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one, transaction
+
+from .models import GetPublishedFilesParams
+
+__all__ = [
+  "count_rows_v1",
+  "delete_folder_v1",
+  "delete_v1",
+  "get_published_files_v1",
+  "list_public_v1",
+  "list_reported_v1",
+  "list_v1",
+  "replace_user_v1",
+  "set_gallery_v1",
+  "set_public_v1",
+  "set_reported_v1",
+  "upsert_v1",
+]
+
+
+def _as_utc(value: Any | None) -> datetime | None:
+  if value is None:
+    return None
+  if not isinstance(value, datetime):
+    raise TypeError(f"Expected datetime value, received {type(value).__name__}")
+  if value.tzinfo is None:
+    return value.replace(tzinfo=timezone.utc)
+  return value.astimezone(timezone.utc)
+
+
+async def _get_storage_type_recid(mimetype: str, *, allow_folder: bool) -> int:
+  async def _fetch_type(target: str) -> DBResponse:
+    return await run_json_one(
+      "SELECT recid FROM storage_types WHERE element_mimetype = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
+      (target,),
+    )
+
+  response = await _fetch_type(mimetype)
+  if response.rows:
+    return response.rows[0]["recid"]
+
+  if not allow_folder:
+    raise ValueError(f"Unknown storage mimetype: {mimetype}")
+
+  if mimetype == "path/folder":
+    await run_exec(
+      """
+      MERGE storage_types AS target
+      USING (SELECT 16 AS recid, 'path/folder' AS element_mimetype, 'Folder' AS element_displaytype) AS src
+      ON target.element_mimetype = src.element_mimetype
+      WHEN NOT MATCHED THEN
+        INSERT (recid, element_mimetype, element_displaytype)
+        VALUES (src.recid, src.element_mimetype, src.element_displaytype);
+      """,
+    )
+    response = await _fetch_type(mimetype)
+    if response.rows:
+      return response.rows[0]["recid"]
+    return 16
+
+  fallback = await _fetch_type("application/octet-stream")
+  if fallback.rows:
+    return fallback.rows[0]["recid"]
+  return 1
+
+
+async def list_v1(args: dict[str, Any]) -> DBResponse:
+  user_guid = args["user_guid"]
+  sql = """
+    SELECT
+      usc.element_path AS path,
+      usc.element_filename AS filename,
+      st.element_mimetype AS content_type,
+      usc.element_url AS url,
+      usc.element_public AS [public]
+    FROM users_storage_cache usc
+    JOIN storage_types st ON st.recid = usc.types_recid
+    WHERE usc.users_guid = ? AND usc.element_deleted = 0
+    ORDER BY usc.element_path, usc.element_filename
+    FOR JSON PATH;
+  """
+  response = await run_json_many(sql, (user_guid,))
+  return DBResponse(payload=response.payload)
+
+
+async def list_public_v1(_: dict[str, Any]) -> DBResponse:
+  sql = """
+    SELECT usc.users_guid AS user_guid,
+           au.element_display AS display_name,
+           usc.element_path AS path,
+           usc.element_filename AS name,
+           usc.element_url AS url,
+           st.element_mimetype AS content_type
+    FROM users_storage_cache usc
+    JOIN account_users au ON au.element_guid = usc.users_guid
+    JOIN storage_types st ON st.recid = usc.types_recid
+    WHERE usc.element_public = 1 AND usc.element_deleted = 0 AND ISNULL(usc.element_reported,0) = 0
+    ORDER BY usc.element_created_on
+    FOR JSON PATH;
+  """
+  response = await run_json_many(sql)
+  return DBResponse(payload=response.payload)
+
+
+async def list_reported_v1(_: dict[str, Any]) -> DBResponse:
+  sql = """
+    SELECT usc.users_guid AS user_guid,
+           usc.element_path AS path,
+           usc.element_filename AS name,
+           usc.element_url AS url,
+           st.element_mimetype AS content_type
+    FROM users_storage_cache usc
+    JOIN storage_types st ON st.recid = usc.types_recid
+    WHERE usc.element_reported = 1 AND usc.element_deleted = 0
+    ORDER BY usc.element_created_on
+    FOR JSON PATH;
+  """
+  response = await run_json_many(sql)
+  return DBResponse(payload=response.payload)
+
+
+async def replace_user_v1(args: dict[str, Any]) -> DBResponse:
+  user_guid = args["user_guid"]
+  items: list[dict[str, Any]] = args.get("items", [])
+  async with transaction() as cur:
+    await cur.execute("DELETE FROM users_storage_cache WHERE users_guid = ?;", (user_guid,))
+    for item in items:
+      path = item.get("path", "")
+      filename = item.get("filename", "")
+      mimetype = item.get("content_type", "application/octet-stream")
+      type_recid = await _get_storage_type_recid(mimetype, allow_folder=False)
+      await cur.execute(
+        """INSERT INTO users_storage_cache
+          (users_guid, types_recid, element_path, element_filename, element_public, element_modified_on, element_deleted)
+          VALUES (?, ?, ?, ?, ?, NULL, 0);""",
+        (user_guid, type_recid, path, filename, item.get("public", 0)),
+      )
+  return DBResponse(rows=[], rowcount=len(items))
+
+
+async def upsert_v1(args: dict[str, Any]) -> DBResponse:
+  user_guid = args["user_guid"]
+  path = args.get("path", "")
+  filename = args.get("filename", "")
+  mimetype = args.get("content_type", "application/octet-stream")
+  public = args.get("public", 0)
+  element_created_on = args.get("element_created_on")
+  if element_created_on is None:
+    element_created_on = datetime.now(timezone.utc)
+  element_created_on = _as_utc(element_created_on)
+  element_modified_on = _as_utc(args.get("element_modified_on"))
+  url = args.get("url")
+  reported = args.get("reported", 0)
+  moderation_recid = args.get("moderation_recid")
+  type_recid = await _get_storage_type_recid(mimetype, allow_folder=True)
+  sql = """
+    MERGE users_storage_cache AS target
+    USING (SELECT ? AS users_guid, ? AS types_recid, ? AS element_path, ? AS element_filename,
+                  ? AS element_public, ? AS element_created_on, ? AS element_modified_on,
+                  ? AS element_deleted, ? AS element_url, ? AS element_reported, ? AS moderation_recid) AS src
+    ON target.users_guid = src.users_guid AND target.element_path = src.element_path AND target.element_filename = src.element_filename
+    WHEN MATCHED THEN UPDATE SET
+      types_recid = src.types_recid,
+      element_public = src.element_public,
+      element_created_on = src.element_created_on,
+      element_modified_on = src.element_modified_on,
+      element_deleted = src.element_deleted,
+      element_url = src.element_url,
+      element_reported = src.element_reported,
+      moderation_recid = src.moderation_recid
+    WHEN NOT MATCHED THEN
+      INSERT (users_guid, types_recid, element_path, element_filename, element_public,
+              element_created_on, element_modified_on, element_deleted, element_url,
+              element_reported, moderation_recid)
+      VALUES (src.users_guid, src.types_recid, src.element_path, src.element_filename,
+              src.element_public, src.element_created_on, src.element_modified_on,
+              src.element_deleted, src.element_url, src.element_reported, src.moderation_recid);
+  """
+  params = (
+    user_guid,
+    type_recid,
+    path,
+    filename,
+    public,
+    element_created_on,
+    element_modified_on,
+    0,
+    url,
+    reported,
+    moderation_recid,
+  )
+  response = await run_exec(sql, params)
+  if response.rowcount == 0:
+    logging.error(
+      "[MSSQL] storage_cache_upsert affected 0 rows for %s/%s",
+      path or ".",
+      filename,
+    )
+  return DBResponse(payload=response.payload, rowcount=response.rowcount)
+
+
+async def delete_v1(args: dict[str, Any]) -> DBResponse:
+  user_guid = args["user_guid"]
+  path = args.get("path", "")
+  filename = args.get("filename", "")
+  sql = """
+    DELETE FROM users_storage_cache
+    WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
+  """
+  response = await run_exec(sql, (user_guid, path, filename))
+  return DBResponse(payload=response.payload, rowcount=response.rowcount)
+
+
+async def delete_folder_v1(args: dict[str, Any]) -> DBResponse:
+  user_guid = args["user_guid"]
+  path = args.get("path", "").lstrip("/")
+  parent, name = path.rsplit("/", 1) if "/" in path else ("", path)
+  like = f"{path}/%" if path else "%"
+  sql = """
+    DELETE FROM users_storage_cache
+    WHERE users_guid = ? AND (
+      (element_path = ? AND element_filename = ?)
+      OR element_path = ?
+      OR element_path LIKE ?
+    );
+  """
+  response = await run_exec(sql, (user_guid, parent, name, path, like))
+  return DBResponse(payload=response.payload, rowcount=response.rowcount)
+
+
+async def set_public_v1(args: dict[str, Any]) -> DBResponse:
+  guid = str(UUID(args["user_guid"]))
+  name = args.get("name")
+  if name:
+    path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
+  else:
+    path = args.get("path", "")
+    filename = args.get("filename", "")
+  flag_value = 1 if args.get("public") else 0
+  sql = """
+    UPDATE users_storage_cache
+    SET element_public = ?
+    WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
+  """
+  response = await run_exec(sql, (flag_value, guid, path, filename))
+  return DBResponse(payload=response.payload, rowcount=response.rowcount)
+
+
+async def set_reported_v1(args: dict[str, Any]) -> DBResponse:
+  guid = str(UUID(args["user_guid"]))
+  path = args.get("path", "")
+  filename = args.get("filename", "")
+  reported = 1 if args.get("reported") else 0
+  sql = """
+    UPDATE users_storage_cache
+    SET element_reported = ?
+    WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
+  """
+  response = await run_exec(sql, (reported, guid, path, filename))
+  return DBResponse(payload=response.payload, rowcount=response.rowcount)
+
+
+async def count_rows_v1(_: dict[str, Any]) -> DBResponse:
+  sql = """
+    SELECT COUNT(*) AS count
+    FROM users_storage_cache
+    WHERE element_deleted = 0
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  response = await run_json_one(sql)
+  return DBResponse(payload=response.payload)
+
+
+async def set_gallery_v1(args: dict[str, Any]) -> DBResponse:
+  guid = str(UUID(args["user_guid"]))
+  name = args.get("name")
+  if name:
+    path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
+  else:
+    path = args.get("path", "")
+    filename = args.get("filename", "")
+  gallery = 1 if args.get("gallery") else 0
+  sql = """
+    UPDATE users_storage_cache
+    SET element_public = ?
+    WHERE users_guid = ? AND element_path = ? AND element_filename = ?;
+  """
+  response = await run_exec(sql, (gallery, guid, path, filename))
+  return DBResponse(payload=response.payload, rowcount=response.rowcount)
+
+
+async def get_published_files_v1(args: GetPublishedFilesParams | dict[str, Any]) -> DBResponse:
+  guid = str(UUID(args["guid"]))
+  sql = """
+    SELECT
+      usc.element_path AS path,
+      usc.element_filename AS filename,
+      usc.element_url AS url,
+      st.element_mimetype AS content_type
+    FROM users_storage_cache usc
+    JOIN storage_types st ON st.recid = usc.types_recid
+    WHERE usc.users_guid = ? AND usc.element_public = 1 AND usc.element_deleted = 0 AND ISNULL(usc.element_reported,0) = 0
+    ORDER BY usc.element_created_on
+    FOR JSON PATH;
+  """
+  response = await run_json_many(sql, (guid,))
+  return DBResponse(payload=response.payload)

--- a/queryregistry/content/cache/services.py
+++ b/queryregistry/content/cache/services.py
@@ -1,0 +1,133 @@
+"""Content cache query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  CacheItemKey,
+  DeleteCacheFolderParams,
+  GetPublishedFilesParams,
+  ListCacheParams,
+  ReplaceUserCacheParams,
+  SetGalleryParams,
+  SetPublicParams,
+  SetReportedParams,
+  UpsertCacheItemParams,
+)
+
+__all__ = [
+  "count_rows_v1",
+  "delete_folder_v1",
+  "delete_v1",
+  "get_published_files_v1",
+  "list_public_v1",
+  "list_reported_v1",
+  "list_v1",
+  "replace_user_v1",
+  "set_gallery_v1",
+  "set_public_v1",
+  "set_reported_v1",
+  "upsert_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_v1}
+_LIST_PUBLIC_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_public_v1}
+_LIST_REPORTED_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_reported_v1}
+_REPLACE_USER_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.replace_user_v1}
+_UPSERT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_v1}
+_DELETE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_v1}
+_DELETE_FOLDER_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_folder_v1}
+_SET_PUBLIC_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.set_public_v1}
+_SET_REPORTED_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.set_reported_v1}
+_COUNT_ROWS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.count_rows_v1}
+_SET_GALLERY_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.set_gallery_v1}
+_GET_PUBLISHED_FILES_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_published_files_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for content cache registry")
+  return dispatcher
+
+
+async def list_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListCacheParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_public_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  result = await _select_dispatcher(provider, _LIST_PUBLIC_DISPATCHERS)(request.payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_reported_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  result = await _select_dispatcher(provider, _LIST_REPORTED_DISPATCHERS)(request.payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def replace_user_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ReplaceUserCacheParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _REPLACE_USER_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def upsert_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpsertCacheItemParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPSERT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = CacheItemKey.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_folder_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = DeleteCacheFolderParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_FOLDER_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def set_public_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = SetPublicParams.model_validate(request.payload)
+  payload = params.model_dump(exclude_none=True)
+  payload["public"] = 1 if params.public else 0
+  result = await _select_dispatcher(provider, _SET_PUBLIC_DISPATCHERS)(payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def set_reported_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = SetReportedParams.model_validate(request.payload)
+  payload = params.model_dump()
+  payload["reported"] = 1 if params.reported else 0
+  result = await _select_dispatcher(provider, _SET_REPORTED_DISPATCHERS)(payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def count_rows_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  result = await _select_dispatcher(provider, _COUNT_ROWS_DISPATCHERS)(request.payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def set_gallery_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = SetGalleryParams.model_validate(request.payload)
+  payload = params.model_dump(exclude_none=True)
+  payload["gallery"] = 1 if params.gallery else 0
+  result = await _select_dispatcher(provider, _SET_GALLERY_DISPATCHERS)(payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_published_files_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = GetPublishedFilesParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_PUBLISHED_FILES_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)


### PR DESCRIPTION
### Motivation

- Migrate legacy cache/files/public operations targeting `users_storage_cache` and `storage_types` from `server/registry/` into the canonical `queryregistry/` layer to follow the repository dispatch pattern and remove legacy surface area. 

### Description

- Added `queryregistry/content/cache/models.py` by porting the Pydantic models from the legacy module and adding `SetGalleryParams` and `GetPublishedFilesParams`, plus `normalize_content_cache_item` for payload normalization. 
- Implemented provider adapter `queryregistry/content/cache/mssql.py` by migrating SQL implementations from legacy modules and switched to `queryregistry.providers.mssql` helpers and `queryregistry.models.DBResponse`. 
- Added `queryregistry/content/cache/services.py` with service-level dispatchers that validate payloads and map operations to provider-specific functions following the `handler -> services -> mssql` pattern. 
- Replaced stub handler and request builders by updating `queryregistry/content/cache/handler.py` (operation/version dispatch map) and `queryregistry/content/cache/__init__.py` (canonical `DBRequest` builders using `db:content:cache:*:1`).

### Testing

- Compiled the new modules with `python -m compileall queryregistry/content/cache queryregistry/content/handler.py` and the files compiled successfully. 
- Ran the unified harness with `python scripts/run_tests.py`, which completed and reported the test suite passing (66 tests passed) though the run emitted an environment warning about a missing ODBC driver during a DB connectivity step; tests succeeded despite that warning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0a62fe0ec8325997b23540f99d7ec)