### PR TITLE
Migrate identity session lifecycle operations into queryregistry

### DIFF
--- a/queryregistry/identity/sessions/__init__.py
+++ b/queryregistry/identity/sessions/__init__.py
@@ -4,13 +4,72 @@ from __future__ import annotations
 
 from queryregistry.models import DBRequest
 
-from .models import RotkeyLookupParams
+from .models import (
+  CreateSessionParams,
+  GuidParams,
+  ListSessionSnapshotsParams,
+  RevokeAllDeviceTokensParams,
+  RevokeDeviceTokenParams,
+  RevokeProviderTokensParams,
+  RotkeyLookupParams,
+  SetRotkeyParams,
+  UpdateDeviceTokenParams,
+  UpdateSessionParams,
+)
 
 __all__ = [
+  "create_session_request",
   "get_rotkey_request",
+  "list_snapshots_request",
+  "read_sessions_request",
+  "revoke_all_device_tokens_request",
+  "revoke_device_token_request",
+  "revoke_provider_tokens_request",
+  "set_rotkey_request",
+  "update_device_token_request",
+  "update_session_request",
 ]
 
 
+def _request(name: str, payload: dict[str, object]) -> DBRequest:
+  return DBRequest(op=f"db:identity:sessions:{name}:1", payload=payload)
+
+
 def get_rotkey_request(params: RotkeyLookupParams) -> DBRequest:
-  payload = params.model_dump(exclude_none=True)
-  return DBRequest(op="db:identity:sessions:get_rotkey:1", payload=payload)
+  return _request("get_rotkey", params.model_dump(exclude_none=True))
+
+
+def read_sessions_request(params: GuidParams) -> DBRequest:
+  return _request("read", params.model_dump())
+
+
+def create_session_request(params: CreateSessionParams) -> DBRequest:
+  return _request("create_session", params.model_dump(exclude_none=True))
+
+
+def update_session_request(params: UpdateSessionParams) -> DBRequest:
+  return _request("update_session", params.model_dump())
+
+
+def update_device_token_request(params: UpdateDeviceTokenParams) -> DBRequest:
+  return _request("update_device_token", params.model_dump())
+
+
+def revoke_device_token_request(params: RevokeDeviceTokenParams) -> DBRequest:
+  return _request("revoke_device_token", params.model_dump())
+
+
+def revoke_all_device_tokens_request(params: RevokeAllDeviceTokensParams) -> DBRequest:
+  return _request("revoke_all_device_tokens", params.model_dump())
+
+
+def revoke_provider_tokens_request(params: RevokeProviderTokensParams) -> DBRequest:
+  return _request("revoke_provider_tokens", params.model_dump())
+
+
+def set_rotkey_request(params: SetRotkeyParams) -> DBRequest:
+  return _request("set_rotkey", params.model_dump(exclude_none=True))
+
+
+def list_snapshots_request(params: ListSessionSnapshotsParams) -> DBRequest:
+  return _request("list_snapshots", params.model_dump())

--- a/queryregistry/identity/sessions/handler.py
+++ b/queryregistry/identity/sessions/handler.py
@@ -7,13 +7,32 @@ from typing import Sequence
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
 
-from .services import get_rotkey_v1, read_sessions_v1
+from .services import (
+  create_session_v1,
+  get_rotkey_v1,
+  list_snapshots_v1,
+  read_sessions_v1,
+  revoke_all_device_tokens_v1,
+  revoke_device_token_v1,
+  revoke_provider_tokens_v1,
+  set_rotkey_v1,
+  update_device_token_v1,
+  update_session_v1,
+)
 
 __all__ = ["handle_sessions_request"]
 
 DISPATCHERS = {
   ("read", "1"): read_sessions_v1,
   ("get_rotkey", "1"): get_rotkey_v1,
+  ("create_session", "1"): create_session_v1,
+  ("update_session", "1"): update_session_v1,
+  ("update_device_token", "1"): update_device_token_v1,
+  ("revoke_device_token", "1"): revoke_device_token_v1,
+  ("revoke_all_device_tokens", "1"): revoke_all_device_tokens_v1,
+  ("revoke_provider_tokens", "1"): revoke_provider_tokens_v1,
+  ("set_rotkey", "1"): set_rotkey_v1,
+  ("list_snapshots", "1"): list_snapshots_v1,
 }
 
 

--- a/queryregistry/identity/sessions/models.py
+++ b/queryregistry/identity/sessions/models.py
@@ -13,11 +13,15 @@ from queryregistry.models import DBResponse
 __all__ = [
   "CreateSessionParams",
   "GuidParams",
+  "ListSessionSnapshotsParams",
   "RotkeyLookupParams",
   "RotkeyRecord",
+  "RevokeAllDeviceTokensParams",
   "RevokeDeviceTokenParams",
   "RevokeProviderTokensParams",
   "RotkeyCallable",
+  "SessionCreationResult",
+  "SessionSnapshotRecord",
   "SecuritySnapshotCallable",
   "SecuritySnapshotRecord",
   "SecuritySnapshotRequestPayload",
@@ -104,6 +108,14 @@ class RevokeProviderTokensParams(GuidParams):
   provider: str
 
 
+class RevokeAllDeviceTokensParams(GuidParams):
+  """Payload revoking all device tokens for a user."""
+
+
+class ListSessionSnapshotsParams(GuidParams):
+  """Parameters used for listing session snapshot rows."""
+
+
 class RotkeyLookupParams(GuidParams):
   """Lookup payload for a device rotation key."""
 
@@ -177,6 +189,41 @@ class SecuritySnapshotRecord(TypedDict, total=False):
   element_device_rotkey_exp: str | None
   session_guid: str | None
   device_guid: str | None
+  element_token: str | None
+  element_token_iat: str | None
+  element_token_exp: str | None
+  element_revoked_at: str | None
+  element_device_fingerprint: str | None
+  element_user_agent: str | None
+  element_ip_last_seen: str | None
+
+
+class SessionCreationResult(TypedDict, total=False):
+  """Result payload returned after creating a session."""
+
+  session_guid: str
+  device_guid: str
+
+
+class SessionSnapshotRecord(TypedDict, total=False):
+  """Historical session snapshot entry."""
+
+  user_guid: str
+  user_roles: int | None
+  user_created_on: str | None
+  user_modified_on: str | None
+  element_rotkey: str | None
+  element_rotkey_iat: str | None
+  element_rotkey_exp: str | None
+  element_device_rotkey: str | None
+  element_device_rotkey_iat: str | None
+  element_device_rotkey_exp: str | None
+  session_guid: str | None
+  session_created_on: str | None
+  session_modified_on: str | None
+  device_guid: str | None
+  device_created_on: str | None
+  device_modified_on: str | None
   element_token: str | None
   element_token_iat: str | None
   element_token_exp: str | None

--- a/queryregistry/identity/sessions/mssql.py
+++ b/queryregistry/identity/sessions/mssql.py
@@ -2,18 +2,250 @@
 
 from __future__ import annotations
 
-from uuid import UUID
+from typing import Any
+from uuid import UUID, uuid4
 
-from queryregistry.providers.mssql import run_json_many, run_json_one
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one, transaction
 
 from queryregistry.models import DBResponse
 
-from .models import RotkeyRequestPayload, SecuritySnapshotRequestPayload
+from .models import (
+  CreateSessionParams,
+  GuidParams,
+  RevokeDeviceTokenParams,
+  RevokeProviderTokensParams,
+  RotkeyRequestPayload,
+  SecuritySnapshotRequestPayload,
+  SetRotkeyParams,
+  UpdateDeviceTokenParams,
+  UpdateSessionParams,
+)
 
 __all__ = [
+  "create_session_v1",
   "get_rotkey_v1",
   "get_security_snapshot_v1",
+  "list_snapshots_v1",
+  "revoke_all_device_tokens_v1",
+  "revoke_device_token_v1",
+  "revoke_provider_tokens_v1",
+  "set_rotkey_v1",
+  "update_device_token_v1",
+  "update_session_v1",
 ]
+
+
+async def _get_auth_provider_recid(provider: str, *, cursor=None) -> int:
+  if cursor is not None:
+    await cursor.execute(
+      "SELECT recid FROM auth_providers WHERE element_name = ?;",
+      (provider,),
+    )
+    row = await cursor.fetchone()
+    if not row:
+      raise ValueError(f"Unknown auth provider: {provider}")
+    return row[0]
+  response = await run_json_one(
+    "SELECT recid FROM auth_providers WHERE element_name = ? FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;",
+    (provider,),
+  )
+  if not response.rows:
+    raise ValueError(f"Unknown auth provider: {provider}")
+  return response.rows[0]["recid"]
+
+
+async def create_session_v1(args: dict[str, Any]) -> DBResponse:
+  params = CreateSessionParams.model_validate(args)
+  access_token = params.access_token
+  expires = params.expires
+  fingerprint = params.fingerprint
+  user_agent = params.user_agent
+  ip_address = params.ip_address
+  rotkey = params.rotkey
+  rotkey_iat = params.rotkey_iat
+  rotkey_exp = params.rotkey_exp
+  user_guid = str(UUID(params.user_guid))
+  provider = params.provider
+
+  if not fingerprint:
+    raise ValueError("Missing device fingerprint")
+
+  async with transaction() as cur:
+    provider_recid = await _get_auth_provider_recid(provider, cursor=cur)
+
+    await cur.execute(
+      "SELECT element_guid FROM users_sessions WHERE users_guid = ?;",
+      (user_guid,),
+    )
+    row = await cur.fetchone()
+    if row:
+      session_guid = row[0]
+      await cur.execute(
+        "UPDATE users_sessions SET element_created_at = SYSDATETIMEOFFSET() WHERE users_guid = ?;",
+        (user_guid,),
+      )
+    else:
+      session_guid = str(uuid4())
+      await cur.execute(
+        """
+          INSERT INTO users_sessions (element_guid, users_guid, element_created_at)
+          VALUES (?, ?, SYSDATETIMEOFFSET());
+        """,
+        (session_guid, user_guid),
+      )
+
+    await cur.execute(
+      "SELECT element_guid FROM sessions_devices WHERE sessions_guid = ? AND element_device_fingerprint = ?;",
+      (session_guid, fingerprint),
+    )
+    row = await cur.fetchone()
+    if row:
+      device_guid = row[0]
+      await cur.execute(
+        """
+          UPDATE sessions_devices
+          SET element_token = ?, element_token_iat = SYSDATETIMEOFFSET(), element_token_exp = ?,
+              element_user_agent = ?, element_ip_last_seen = ?, element_revoked_at = NULL,
+              element_rotkey = ?, element_rotkey_iat = ?, element_rotkey_exp = ?
+          WHERE element_guid = ?;
+        """,
+        (access_token, expires, user_agent, ip_address, rotkey, rotkey_iat, rotkey_exp, device_guid),
+      )
+    else:
+      device_guid = str(uuid4())
+      await cur.execute(
+        """
+          INSERT INTO sessions_devices (
+            element_guid, sessions_guid, providers_recid, element_token, element_token_iat, element_token_exp,
+            element_device_fingerprint, element_user_agent, element_ip_last_seen,
+            element_rotkey, element_rotkey_iat, element_rotkey_exp
+          ) VALUES (?, ?, ?, ?, SYSDATETIMEOFFSET(), ?, ?, ?, ?, ?, ?, ?);
+        """,
+        (
+          device_guid,
+          session_guid,
+          provider_recid,
+          access_token,
+          expires,
+          fingerprint,
+          user_agent,
+          ip_address,
+          rotkey,
+          rotkey_iat,
+          rotkey_exp,
+        ),
+      )
+
+  return DBResponse(rows=[{"session_guid": session_guid, "device_guid": device_guid}], rowcount=1)
+
+
+async def update_session_v1(args: dict[str, Any]) -> DBResponse:
+  params = UpdateSessionParams.model_validate(args)
+  sql = """
+      UPDATE sessions_devices
+      SET element_ip_last_seen = ?, element_user_agent = ?
+      WHERE element_token = ?;
+    """
+  return await run_exec(sql, (params.ip_address, params.user_agent, params.access_token))
+
+
+async def update_device_token_v1(args: dict[str, Any]) -> DBResponse:
+  params = UpdateDeviceTokenParams.model_validate(args)
+  device_guid = str(UUID(params.device_guid))
+  sql = """
+    UPDATE sessions_devices
+    SET element_token = ?
+    WHERE element_guid = ?;
+  """
+  return await run_exec(sql, (params.access_token, device_guid))
+
+
+async def revoke_device_token_v1(args: dict[str, Any]) -> DBResponse:
+  params = RevokeDeviceTokenParams.model_validate(args)
+  sql = """
+    UPDATE sessions_devices
+    SET element_revoked_at = SYSDATETIMEOFFSET()
+    WHERE element_token = ?;
+  """
+  return await run_exec(sql, (params.access_token,))
+
+
+async def revoke_all_device_tokens_v1(args: dict[str, Any]) -> DBResponse:
+  params = GuidParams.model_validate(args)
+  guid = str(UUID(params.guid))
+  sql = """
+    UPDATE sd
+    SET element_revoked_at = SYSDATETIMEOFFSET()
+    FROM sessions_devices sd
+    JOIN users_sessions us ON us.element_guid = sd.sessions_guid
+    WHERE us.users_guid = ?;
+  """
+  return await run_exec(sql, (guid,))
+
+
+async def revoke_provider_tokens_v1(args: dict[str, Any]) -> DBResponse:
+  params = RevokeProviderTokensParams.model_validate(args)
+  guid = str(UUID(params.guid))
+  sql = """
+    UPDATE sd
+    SET element_revoked_at = SYSDATETIMEOFFSET()
+    FROM sessions_devices sd
+    JOIN users_sessions us ON us.element_guid = sd.sessions_guid
+    JOIN auth_providers ap ON ap.recid = sd.providers_recid
+    WHERE us.users_guid = ? AND ap.element_name = ?;
+  """
+  return await run_exec(sql, (guid, params.provider))
+
+
+async def set_rotkey_v1(args: dict[str, Any]) -> DBResponse:
+  params = SetRotkeyParams.model_validate(args)
+  guid = str(UUID(params.guid))
+  device_guid = str(UUID(params.device_guid)) if params.device_guid else None
+  sql = """
+    UPDATE sd
+    SET element_rotkey = ?, element_rotkey_iat = ?, element_rotkey_exp = ?
+    FROM sessions_devices sd
+    JOIN users_sessions us ON us.element_guid = sd.sessions_guid
+    WHERE us.users_guid = ?
+      AND (? IS NULL OR sd.element_guid = ?);
+  """
+  return await run_exec(sql, (params.rotkey, params.iat, params.exp, guid, device_guid, device_guid))
+
+
+async def list_snapshots_v1(args: dict[str, Any]) -> DBResponse:
+  params = GuidParams.model_validate(args)
+  guid = str(UUID(params.guid))
+  sql = """
+    SELECT
+      aus.user_guid,
+      aus.user_roles,
+      aus.user_created_on,
+      aus.user_modified_on,
+      aus.element_rotkey,
+      aus.element_rotkey_iat,
+      aus.element_rotkey_exp,
+      aus.element_device_rotkey,
+      aus.element_device_rotkey_iat,
+      aus.element_device_rotkey_exp,
+      aus.session_guid,
+      aus.session_created_on,
+      aus.session_modified_on,
+      aus.device_guid,
+      aus.device_created_on,
+      aus.device_modified_on,
+      aus.element_token,
+      aus.element_token_iat,
+      aus.element_token_exp,
+      aus.element_revoked_at,
+      aus.element_device_fingerprint,
+      aus.element_user_agent,
+      aus.element_ip_last_seen
+    FROM vw_user_session_security aus
+    WHERE aus.user_guid = ?
+    ORDER BY aus.session_created_on DESC, aus.device_created_on DESC
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql, (guid,))
 
 
 async def get_rotkey_v1(params: RotkeyRequestPayload) -> DBResponse:

--- a/queryregistry/identity/sessions/services.py
+++ b/queryregistry/identity/sessions/services.py
@@ -2,23 +2,178 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+from typing import Any
+
 from queryregistry.models import DBRequest, DBResponse
 
 from . import mssql
-from .models import RotkeyCallable, SecuritySnapshotCallable
+from .models import (
+  CreateSessionParams,
+  GuidParams,
+  ListSessionSnapshotsParams,
+  RevokeAllDeviceTokensParams,
+  RevokeDeviceTokenParams,
+  RevokeProviderTokensParams,
+  RotkeyLookupParams,
+  SetRotkeyParams,
+  UpdateDeviceTokenParams,
+  UpdateSessionParams,
+)
 
 __all__ = [
+  "create_session_v1",
   "get_rotkey_v1",
+  "list_snapshots_v1",
   "read_sessions_v1",
+  "revoke_all_device_tokens_v1",
+  "revoke_device_token_v1",
+  "revoke_provider_tokens_v1",
+  "set_rotkey_v1",
+  "update_device_token_v1",
+  "update_session_v1",
 ]
 
-_READ_DISPATCHERS: dict[str, SecuritySnapshotCallable] = {
+SessionOperationCallable = Callable[[dict[str, Any]], Awaitable[DBResponse]]
+
+_READ_DISPATCHERS: dict[str, SessionOperationCallable] = {
   "mssql": mssql.get_security_snapshot_v1,
 }
 
-_ROTKEY_DISPATCHERS: dict[str, RotkeyCallable] = {
+_ROTKEY_DISPATCHERS: dict[str, SessionOperationCallable] = {
   "mssql": mssql.get_rotkey_v1,
 }
+
+_CREATE_SESSION_DISPATCHERS: dict[str, SessionOperationCallable] = {
+  "mssql": mssql.create_session_v1,
+}
+
+_UPDATE_SESSION_DISPATCHERS: dict[str, SessionOperationCallable] = {
+  "mssql": mssql.update_session_v1,
+}
+
+_UPDATE_DEVICE_TOKEN_DISPATCHERS: dict[str, SessionOperationCallable] = {
+  "mssql": mssql.update_device_token_v1,
+}
+
+_REVOKE_DEVICE_TOKEN_DISPATCHERS: dict[str, SessionOperationCallable] = {
+  "mssql": mssql.revoke_device_token_v1,
+}
+
+_REVOKE_ALL_DEVICE_TOKENS_DISPATCHERS: dict[str, SessionOperationCallable] = {
+  "mssql": mssql.revoke_all_device_tokens_v1,
+}
+
+_REVOKE_PROVIDER_TOKENS_DISPATCHERS: dict[str, SessionOperationCallable] = {
+  "mssql": mssql.revoke_provider_tokens_v1,
+}
+
+_SET_ROTKEY_DISPATCHERS: dict[str, SessionOperationCallable] = {
+  "mssql": mssql.set_rotkey_v1,
+}
+
+_LIST_SNAPSHOTS_DISPATCHERS: dict[str, SessionOperationCallable] = {
+  "mssql": mssql.list_snapshots_v1,
+}
+
+
+def _resolve_dispatcher(
+  dispatchers: dict[str, SessionOperationCallable],
+  *,
+  provider: str,
+) -> SessionOperationCallable:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity sessions registry")
+  return dispatcher
+
+
+async def create_session_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_CREATE_SESSION_DISPATCHERS, provider=provider)
+  params = CreateSessionParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump(exclude_none=True))
+  return DBResponse(op=request.op, payload=result.payload, rows=result.rows, rowcount=result.rowcount)
+
+
+async def update_session_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_UPDATE_SESSION_DISPATCHERS, provider=provider)
+  params = UpdateSessionParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def update_device_token_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_UPDATE_DEVICE_TOKEN_DISPATCHERS, provider=provider)
+  params = UpdateDeviceTokenParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def revoke_device_token_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_REVOKE_DEVICE_TOKEN_DISPATCHERS, provider=provider)
+  params = RevokeDeviceTokenParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def revoke_all_device_tokens_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_REVOKE_ALL_DEVICE_TOKENS_DISPATCHERS, provider=provider)
+  params = RevokeAllDeviceTokensParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def revoke_provider_tokens_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_REVOKE_PROVIDER_TOKENS_DISPATCHERS, provider=provider)
+  params = RevokeProviderTokensParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def set_rotkey_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_SET_ROTKEY_DISPATCHERS, provider=provider)
+  params = SetRotkeyParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump(exclude_none=True))
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_snapshots_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_LIST_SNAPSHOTS_DISPATCHERS, provider=provider)
+  params = ListSessionSnapshotsParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
 
 
 async def get_rotkey_v1(
@@ -26,11 +181,10 @@ async def get_rotkey_v1(
   *,
   provider: str,
 ) -> DBResponse:
-  dispatcher = _ROTKEY_DISPATCHERS.get(provider)
-  if dispatcher is None:
-    raise KeyError(f"Unsupported provider '{provider}' for identity sessions registry")
-  result = await dispatcher(request.payload)
-  return DBResponse(op=request.op, payload=result.payload)
+  dispatcher = _resolve_dispatcher(_ROTKEY_DISPATCHERS, provider=provider)
+  params = RotkeyLookupParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump(exclude_none=True))
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
 
 
 async def read_sessions_v1(
@@ -38,8 +192,7 @@ async def read_sessions_v1(
   *,
   provider: str,
 ) -> DBResponse:
-  dispatcher = _READ_DISPATCHERS.get(provider)
-  if dispatcher is None:
-    raise KeyError(f"Unsupported provider '{provider}' for identity sessions registry")
-  result = await dispatcher(request.payload)
-  return DBResponse(op=request.op, payload=result.payload)
+  dispatcher = _resolve_dispatcher(_READ_DISPATCHERS, provider=provider)
+  params = GuidParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)


### PR DESCRIPTION
### Motivation

- Move legacy session lifecycle operations from the deprecated `server/registry/account/session` area into the canonical `queryregistry/identity/sessions` subdomain to centralize query registry behavior.
- Provide typed request/response contracts and provider implementations so higher-level code can call canonical `db:identity:sessions:{operation}:1` ops without touching legacy code.
- Preserve existing `read` (security snapshot) and `get_rotkey` behaviors while extending the subdomain to support the full session lifecycle.

### Description

- Added missing request/result types to `queryregistry/identity/sessions/models.py`, including `RevokeAllDeviceTokensParams`, `ListSessionSnapshotsParams`, `SessionCreationResult`, and `SessionSnapshotRecord` and exported request models used by new operations.
- Implemented MSSQL handlers in `queryregistry/identity/sessions/mssql.py` for `create_session`, `update_session`, `update_device_token`, `revoke_device_token`, `revoke_all_device_tokens`, `revoke_provider_tokens`, `set_rotkey`, and `list_snapshots`, including a local `_get_auth_provider_recid` helper, transactional `create_session` flow, and `uuid4()` usage for GUIDs.
- Added service-layer dispatchers in `queryregistry/identity/sessions/services.py` that apply `model_validate(...)` to incoming payloads and forward to provider dispatchers, returning canonical `DBResponse` values.
- Wired new operations into the handler dispatch map in `queryregistry/identity/sessions/handler.py` and added request builders in `queryregistry/identity/sessions/__init__.py` that emit `db:identity:sessions:{operation}:1` ops.

### Testing

- Compiled the updated package files with `python -m compileall queryregistry/identity/sessions`, which completed successfully.
- Ran the unified test harness via `python scripts/run_tests.py`, and the test run completed successfully with the test suite passing (66 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c56d07048325bded5863ffc0db2a)