### PR TITLE
Add finance credits subdomain to queryregistry (set credits v1)

### DIFF
--- a/queryregistry/finance/credits/__init__.py
+++ b/queryregistry/finance/credits/__init__.py
@@ -1,0 +1,13 @@
+"""Finance credits query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import SetCreditsParams
+
+__all__ = ["set_credits_request"]
+
+
+def set_credits_request(params: SetCreditsParams) -> DBRequest:
+  return DBRequest(op="db:finance:credits:set:1", payload=params.model_dump())

--- a/queryregistry/finance/credits/handler.py
+++ b/queryregistry/finance/credits/handler.py
@@ -1,0 +1,31 @@
+"""Finance credits subdomain handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import set_v1
+
+__all__ = ["handle_credits_request"]
+
+DISPATCHERS = {
+  ("set", "1"): set_v1,
+}
+
+
+async def handle_credits_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown finance credits operation",
+  )

--- a/queryregistry/finance/credits/models.py
+++ b/queryregistry/finance/credits/models.py
@@ -1,0 +1,14 @@
+"""Finance credits query registry models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = ["SetCreditsParams"]
+
+
+class SetCreditsParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str
+  credits: int

--- a/queryregistry/finance/credits/mssql.py
+++ b/queryregistry/finance/credits/mssql.py
@@ -1,0 +1,20 @@
+"""MSSQL implementations for finance credits query registry services."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec
+
+__all__ = ["set_v1"]
+
+
+async def set_v1(args: dict[str, Any]) -> DBResponse:
+  sql = """
+    UPDATE users_credits
+    SET element_credits = ?
+    WHERE users_guid = ?;
+  """
+  response = await run_exec(sql, (args["credits"], args["guid"]))
+  return DBResponse(payload=response.payload, rowcount=response.rowcount)

--- a/queryregistry/finance/credits/services.py
+++ b/queryregistry/finance/credits/services.py
@@ -1,0 +1,29 @@
+"""Finance credits query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import SetCreditsParams
+
+__all__ = ["set_v1"]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+_SET_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.set_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for finance credits registry")
+  return dispatcher
+
+
+async def set_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = SetCreditsParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _SET_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/queryregistry/finance/handler.py
+++ b/queryregistry/finance/handler.py
@@ -8,11 +8,13 @@ from fastapi import HTTPException
 
 from queryregistry.models import DBRequest, DBResponse
 
+from .credits.handler import handle_credits_request
 from .status.handler import handle_status_request
 
 __all__ = ["handle_finance_request"]
 
 HANDLERS = {
+  "credits": handle_credits_request,
   "status": handle_status_request,
 }
 


### PR DESCRIPTION
### Motivation
- Migrate the legacy finance credits registry operation into the canonical `queryregistry` layer and expose a typed, provider-dispatched update for user credits.
- Provide a single canonical operation `db:finance:credits:set:1` and avoid reintroducing legacy aliases.

### Description
- Added request builder `set_credits_request` in `queryregistry/finance/credits/__init__.py` that emits `db:finance:credits:set:1` using `SetCreditsParams`.
- Added `SetCreditsParams` Pydantic model in `queryregistry/finance/credits/models.py` with `guid: str` and `credits: int` and `extra="forbid"`.
- Implemented MSSQL adapter `set_v1` in `queryregistry/finance/credits/mssql.py` that runs `UPDATE users_credits SET element_credits = ? WHERE users_guid = ?` via `queryregistry.providers.mssql.run_exec` and returns `DBResponse`.
- Implemented service dispatcher `set_v1` in `queryregistry/finance/credits/services.py` which validates payload via `SetCreditsParams.model_validate`, selects the provider dispatcher, and returns a canonical `DBResponse`.
- Added credits subdomain handler `queryregistry/finance/credits/handler.py` with dispatch map `{("set","1"): set_v1}` and wired the subdomain into the finance domain handler by registering `"credits": handle_credits_request` in `queryregistry/finance/handler.py`.

### Testing
- Ran the unified harness `python scripts/run_tests.py`, which executed model/code generation, frontend lint/type-check/tests, and the backend `pytest` suite successfully.
- Automated test result: `pytest` completed with the test suite passing (66 tests passed) and the harness finished; a non-fatal database connection message was present but did not cause test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c83fe114832593c770b6de0f73a1)