### PR TITLE
Migrate system config queryregistry subdomain from stub to full implementation

### DIFF
--- a/queryregistry/system/config/__init__.py
+++ b/queryregistry/system/config/__init__.py
@@ -1,1 +1,30 @@
-"""System config query registry stubs."""
+"""System config query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import ConfigKeyParams, UpsertConfigParams
+
+__all__ = [
+  "delete_config_request",
+  "get_config_request",
+  "get_configs_request",
+  "upsert_config_request",
+]
+
+
+def get_config_request(params: ConfigKeyParams) -> DBRequest:
+  return DBRequest(op="db:system:config:get:1", payload=params.model_dump())
+
+
+def get_configs_request() -> DBRequest:
+  return DBRequest(op="db:system:config:list:1", payload={})
+
+
+def upsert_config_request(params: UpsertConfigParams) -> DBRequest:
+  return DBRequest(op="db:system:config:upsert:1", payload=params.model_dump())
+
+
+def delete_config_request(params: ConfigKeyParams) -> DBRequest:
+  return DBRequest(op="db:system:config:delete:1", payload=params.model_dump())

--- a/queryregistry/system/config/handler.py
+++ b/queryregistry/system/config/handler.py
@@ -6,11 +6,18 @@ from typing import Sequence
 
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
-from queryregistry.stubs import build_stub_dispatchers
+
+from .services import delete_config_v1, get_config_v1, get_configs_v1, upsert_config_v1
+from ..dispatch import SubdomainDispatcher
 
 __all__ = ["handle_config_request"]
 
-DISPATCHERS = build_stub_dispatchers("system.config")
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("get", "1"): get_config_v1,
+  ("list", "1"): get_configs_v1,
+  ("upsert", "1"): upsert_config_v1,
+  ("delete", "1"): delete_config_v1,
+}
 
 
 async def handle_config_request(

--- a/queryregistry/system/config/models.py
+++ b/queryregistry/system/config/models.py
@@ -21,14 +21,17 @@ class ConfigKeyParams(BaseModel):
   key: str
 
 
-class UpsertConfigParams(ConfigKeyParams):
+class UpsertConfigParams(BaseModel):
   """Parameters for inserting or updating a configuration value."""
 
+  model_config = ConfigDict(extra="forbid")
+
+  key: str
   value: str
 
 
-class ConfigRecord(TypedDict, total=False):
+class ConfigRecord(TypedDict):
   """Record representation returned by configuration queries."""
 
   key: str
-  value: str | None
+  value: str

--- a/queryregistry/system/config/mssql.py
+++ b/queryregistry/system/config/mssql.py
@@ -1,0 +1,60 @@
+"""MSSQL implementations for system config query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "delete_config_v1",
+  "get_config_v1",
+  "get_configs_v1",
+  "upsert_config_v1",
+]
+
+
+async def get_config_v1(args: Mapping[str, Any]) -> DBResponse:
+  key = args["key"]
+  sql = """
+    SELECT element_value AS value
+    FROM system_config
+    WHERE element_key = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return await run_json_one(sql, (key,))
+
+
+async def get_configs_v1(_: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT element_key AS [key], element_value AS value
+    FROM system_config
+    ORDER BY element_key
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql)
+
+
+async def upsert_config_v1(args: Mapping[str, Any]) -> DBResponse:
+  key = args["key"]
+  value = args["value"]
+  sql = """
+    MERGE system_config AS target
+    USING (SELECT ? AS element_key, ? AS element_value) AS src
+    ON target.element_key = src.element_key
+    WHEN MATCHED THEN
+      UPDATE SET element_value = src.element_value
+    WHEN NOT MATCHED THEN
+      INSERT (element_key, element_value)
+      VALUES (src.element_key, src.element_value);
+  """
+  return await run_exec(sql, (key, value))
+
+
+async def delete_config_v1(args: Mapping[str, Any]) -> DBResponse:
+  key = args["key"]
+  sql = "DELETE FROM system_config WHERE element_key = ?;"
+  return await run_exec(sql, (key,))

--- a/queryregistry/system/config/services.py
+++ b/queryregistry/system/config/services.py
@@ -1,0 +1,55 @@
+"""System config query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import ConfigKeyParams, UpsertConfigParams
+
+__all__ = [
+  "delete_config_v1",
+  "get_config_v1",
+  "get_configs_v1",
+  "upsert_config_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_GET_CONFIG_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_config_v1}
+_GET_CONFIGS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_configs_v1}
+_UPSERT_CONFIG_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_config_v1}
+_DELETE_CONFIG_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_config_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for system config registry")
+  return dispatcher
+
+
+async def get_config_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ConfigKeyParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_CONFIG_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_configs_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  result = await _select_dispatcher(provider, _GET_CONFIGS_DISPATCHERS)(request.payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def upsert_config_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpsertConfigParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPSERT_CONFIG_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_config_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ConfigKeyParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_CONFIG_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)


### PR DESCRIPTION
### Motivation

- Replace the previous stub in `queryregistry/system/config` with a full, canonical queryregistry implementation migrated from the legacy `server/registry` behavior to centralize system K/V config operations. 
- Expose the four canonical operations (`get`, `list`, `upsert`, `delete`) under the `db:system:config:*:1` naming scheme so callers use the canonical QueryRegistry boundary.

### Description

- Extended `queryregistry/system/config/models.py` by preserving `ConfigKeyParams`, adding `UpsertConfigParams` (with `extra="forbid"`) and a `ConfigRecord` typed record to represent K/V rows.
- Added `queryregistry/system/config/mssql.py` implementing provider SQL handlers: `get_config_v1` (select by key, `run_json_one`), `get_configs_v1` (select all, `run_json_many`), `upsert_config_v1` (`MERGE` using `run_exec`) and `delete_config_v1` (`DELETE` using `run_exec`).
- Added `queryregistry/system/config/services.py` service dispatchers which validate payloads with `model_validate`, select the provider dispatcher, and return canonical `DBResponse` objects.
- Replaced the stub handler with a concrete dispatcher map in `queryregistry/system/config/handler.py` and added request builders in `queryregistry/system/config/__init__.py` that produce `DBRequest` ops: `db:system:config:get:1`, `db:system:config:list:1`, `db:system:config:upsert:1`, and `db:system:config:delete:1`.

### Testing

- Ran the unified harness with `python scripts/run_tests.py`, which executed lint/type-check/test pipelines successfully and generated RPC/TS artifacts; frontend unit tests ran (`npm test`) and passed.
- Python test run completed successfully (pytest summary: tests passed) as part of the harness; final harness output included 66 pytest passes and frontend tests passing as reported by the run.
- One environment-specific warning occurred during the final build-version DB step due to missing ODBC driver (`ODBC Driver 18 for SQL Server`), which prevented connecting to a real SQL Server but did not affect unit/test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0cf216158832593277b4d521511fa)