### PR TITLE
Migrate system routes into queryregistry (get/upsert/delete v1)

### DIFF
--- a/queryregistry/system/routes/__init__.py
+++ b/queryregistry/system/routes/__init__.py
@@ -1,1 +1,25 @@
-"""System routes query registry stubs."""
+"""System routes query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import RoutePathParams, UpsertRouteParams
+
+__all__ = [
+  "delete_route_request",
+  "get_routes_request",
+  "upsert_route_request",
+]
+
+
+def get_routes_request() -> DBRequest:
+  return DBRequest(op="db:system:routes:get_routes:1", payload={})
+
+
+def upsert_route_request(params: UpsertRouteParams) -> DBRequest:
+  return DBRequest(op="db:system:routes:upsert_route:1", payload=params.model_dump())
+
+
+def delete_route_request(params: RoutePathParams) -> DBRequest:
+  return DBRequest(op="db:system:routes:delete_route:1", payload=params.model_dump())

--- a/queryregistry/system/routes/handler.py
+++ b/queryregistry/system/routes/handler.py
@@ -6,11 +6,16 @@ from typing import Sequence
 
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
-from queryregistry.stubs import build_stub_dispatchers
+
+from .services import delete_route_v1, get_routes_v1, upsert_route_v1
 
 __all__ = ["handle_routes_request"]
 
-DISPATCHERS = build_stub_dispatchers("system.routes")
+DISPATCHERS = {
+  ("get_routes", "1"): get_routes_v1,
+  ("upsert_route", "1"): upsert_route_v1,
+  ("delete_route", "1"): delete_route_v1,
+}
 
 
 async def handle_routes_request(

--- a/queryregistry/system/routes/models.py
+++ b/queryregistry/system/routes/models.py
@@ -1,0 +1,37 @@
+"""System routes query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "RoutePathParams",
+  "RouteRecord",
+  "UpsertRouteParams",
+]
+
+
+class RoutePathParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  path: str
+
+
+class UpsertRouteParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  path: str
+  name: str
+  icon: str | None = None
+  sequence: int
+  roles: int
+
+
+class RouteRecord(TypedDict):
+  path: str
+  name: str
+  icon: str | None
+  sequence: int
+  roles: int

--- a/queryregistry/system/routes/mssql.py
+++ b/queryregistry/system/routes/mssql.py
@@ -1,0 +1,55 @@
+"""MSSQL implementations for system routes query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.providers.mssql import run_exec, run_json_many
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "delete_route_v1",
+  "get_routes_v1",
+  "upsert_route_v1",
+]
+
+
+async def get_routes_v1(_: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      element_path AS path,
+      element_name AS name,
+      element_icon AS icon,
+      element_sequence AS sequence,
+      element_roles AS roles
+    FROM frontend_routes
+    ORDER BY element_sequence
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql)
+
+
+async def upsert_route_v1(args: Mapping[str, Any]) -> DBResponse:
+  path = args["path"]
+  name = args["name"]
+  icon = args.get("icon")
+  sequence = int(args["sequence"])
+  roles = int(args["roles"])
+  response = await run_exec(
+    "UPDATE frontend_routes SET element_name = ?, element_icon = ?, element_sequence = ?, element_roles = ? WHERE element_path = ?;",
+    (name, icon, sequence, roles, path),
+  )
+  if response.rowcount == 0:
+    response = await run_exec(
+      "INSERT INTO frontend_routes (element_path, element_name, element_icon, element_sequence, element_roles) VALUES (?, ?, ?, ?, ?);",
+      (path, name, icon, sequence, roles),
+    )
+  return response
+
+
+async def delete_route_v1(args: Mapping[str, Any]) -> DBResponse:
+  path = args["path"]
+  sql = "DELETE FROM frontend_routes WHERE element_path = ?;"
+  return await run_exec(sql, (path,))

--- a/queryregistry/system/routes/services.py
+++ b/queryregistry/system/routes/services.py
@@ -1,0 +1,47 @@
+"""System routes query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import RoutePathParams, UpsertRouteParams
+
+__all__ = [
+  "delete_route_v1",
+  "get_routes_v1",
+  "upsert_route_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_GET_ROUTES_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_routes_v1}
+_UPSERT_ROUTE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_route_v1}
+_DELETE_ROUTE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_route_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for system routes registry")
+  return dispatcher
+
+
+async def get_routes_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  result = await _select_dispatcher(provider, _GET_ROUTES_DISPATCHERS)(request.payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def upsert_route_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpsertRouteParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPSERT_ROUTE_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_route_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = RoutePathParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_ROUTE_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)


### PR DESCRIPTION
### Motivation

- Move legacy system routes operations from the deprecated `server/registry` area into the canonical `queryregistry` layer.  
- Replace the existing stub with a full implementation that provides typed contracts and provider-specific SQL adapters.  
- Preserve the existing data-access behavior (including update-then-insert fallback) and follow the canonical `handler → services → mssql` pattern.

### Description

- Added `queryregistry/system/routes/models.py` containing `RoutePathParams`, `UpsertRouteParams` (both `BaseModel` with `extra="forbid"`), and `RouteRecord` (`TypedDict`).
- Added `queryregistry/system/routes/mssql.py` implementing `get_routes_v1`, `upsert_route_v1`, and `delete_route_v1` using `run_json_many`/`run_exec` from `queryregistry.providers.mssql`, and preserved the UPDATE-then-INSERT fallback for upserts.
- Added `queryregistry/system/routes/services.py` which validates incoming payloads with `model_validate`, selects a provider dispatcher, and returns canonical `DBResponse` values for each operation.
- Replaced the stub handler in `queryregistry/system/routes/handler.py` with a concrete `DISPATCHERS` map for `("get_routes","1")`, `("upsert_route","1")`, and `("delete_route","1")` wired to the service dispatchers.
- Replaced the stub request-builders in `queryregistry/system/routes/__init__.py` with canonical builders producing `db:system:routes:get_routes:1`, `db:system:routes:upsert_route:1`, and `db:system:routes:delete_route:1`.

### Testing

- Ran the unified harness: `python scripts/run_tests.py`, which completed with `66 passed, 1 warning` and a non-fatal ODBC driver connection warning related to an environment DB connection attempt.  
- Compiled the new package files: `python -m compileall queryregistry/system/routes`, which completed successfully.  
- No additional failing automated tests were observed during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab7d8defa88325b0100ae5de4861c2)