### PR TITLE
Implement system.models registry: list and get_by_name (v1)

### DIFF
--- a/queryregistry/system/models_registry/__init__.py
+++ b/queryregistry/system/models_registry/__init__.py
@@ -1,1 +1,27 @@
-"""System models query registry stubs."""
+"""System models query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import ModelNameParams
+
+__all__ = [
+  "get_model_by_name_request",
+  "list_models_request",
+]
+
+
+_OP_PREFIX = "db:system:models"
+
+
+def _op(name: str) -> str:
+  return f"{_OP_PREFIX}:{name}:1"
+
+
+def list_models_request() -> DBRequest:
+  return DBRequest(op=_op("list"), payload={})
+
+
+def get_model_by_name_request(params: ModelNameParams) -> DBRequest:
+  return DBRequest(op=_op("get_by_name"), payload=params.model_dump())

--- a/queryregistry/system/models_registry/handler.py
+++ b/queryregistry/system/models_registry/handler.py
@@ -6,11 +6,16 @@ from typing import Sequence
 
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
-from queryregistry.stubs import build_stub_dispatchers
+
+from .services import get_by_name_v1, list_v1
+from ..dispatch import SubdomainDispatcher
 
 __all__ = ["handle_models_request"]
 
-DISPATCHERS = build_stub_dispatchers("system.models")
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("list", "1"): list_v1,
+  ("get_by_name", "1"): get_by_name_v1,
+}
 
 
 async def handle_models_request(

--- a/queryregistry/system/models_registry/models.py
+++ b/queryregistry/system/models_registry/models.py
@@ -1,0 +1,27 @@
+"""System models query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "ModelNameParams",
+  "ModelRecord",
+]
+
+
+class ModelNameParams(BaseModel):
+  """Payload targeting a single assistant model by name."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  name: str
+
+
+class ModelRecord(TypedDict):
+  """Record representation returned by model queries."""
+
+  recid: int
+  name: str

--- a/queryregistry/system/models_registry/mssql.py
+++ b/queryregistry/system/models_registry/mssql.py
@@ -1,0 +1,38 @@
+"""MSSQL implementations for system models query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.providers.mssql import run_json_many, run_json_one
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "get_by_name_v1",
+  "list_v1",
+]
+
+
+async def list_v1(_: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      recid,
+      element_name AS name
+    FROM assistant_models
+    ORDER BY element_name
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql)
+
+
+async def get_by_name_v1(args: Mapping[str, Any]) -> DBResponse:
+  name = args["name"]
+  sql = """
+    SELECT recid
+    FROM assistant_models
+    WHERE element_name = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return await run_json_one(sql, (name,))

--- a/queryregistry/system/models_registry/services.py
+++ b/queryregistry/system/models_registry/services.py
@@ -1,0 +1,39 @@
+"""System models query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import ModelNameParams
+
+__all__ = [
+  "get_by_name_v1",
+  "list_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_v1}
+_GET_BY_NAME_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_by_name_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for system models registry")
+  return dispatcher
+
+
+async def list_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  result = await _select_dispatcher(provider, _LIST_DISPATCHERS)(request.payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_by_name_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ModelNameParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_BY_NAME_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)


### PR DESCRIPTION
### Motivation
- Migrate legacy assistant model registry operations into the canonical `queryregistry` layer by replacing the stub for `system.models` with working request builders and dispatch paths for the `list` and `get_by_name` operations.
- Provide typed request/response contracts and provider-specific MSSQL implementations to align with the existing `queryregistry` dispatch pattern and remove reliance on legacy `server/registry` helpers.

### Description
- Added `queryregistry/system/models_registry/models.py` with `ModelNameParams` (`BaseModel` with `extra="forbid"`) and `ModelRecord` (`TypedDict`).
- Added `queryregistry/system/models_registry/mssql.py` implementing `list_v1` and `get_by_name_v1` using `run_json_many` and `run_json_one` with the migrated SQL queries against `assistant_models`.
- Added `queryregistry/system/models_registry/services.py` which selects provider dispatchers, validates payloads via `ModelNameParams.model_validate` for `get_by_name_v1`, and wraps results into `DBResponse` for both operations.
- Replaced the handler stub in `queryregistry/system/models_registry/handler.py` with a real `DISPATCHERS` map for `("list","1")` and `("get_by_name","1")` and wired to `dispatch_subdomain_request`.
- Replaced request-builder stub in `queryregistry/system/models_registry/__init__.py` with canonical builders `list_models_request()` and `get_model_by_name_request(params: ModelNameParams)` producing ops `db:system:models:list:1` and `db:system:models:get_by_name:1`.

### Testing
- Ran the unified test harness with `python scripts/run_tests.py`, which completed successfully with `66 passed, 1 warning`.
- The harness emitted an environment warning about missing ODBC driver during a build-version update step, but it did not cause test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab81d5ceac8325b1e057d78a095ea9)