### PR TITLE
Migrate system personas subdomain into canonical queryregistry

### DIFF
--- a/queryregistry/system/personas/__init__.py
+++ b/queryregistry/system/personas/__init__.py
@@ -1,1 +1,30 @@
-"""System personas query registry stubs."""
+"""System personas query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import DeletePersonaParams, PersonaNameParams, UpsertPersonaParams
+
+__all__ = [
+  "delete_persona_request",
+  "get_persona_by_name_request",
+  "list_personas_request",
+  "upsert_persona_request",
+]
+
+
+def get_persona_by_name_request(params: PersonaNameParams) -> DBRequest:
+  return DBRequest(op="db:system:personas:get_by_name:1", payload=params.model_dump())
+
+
+def list_personas_request() -> DBRequest:
+  return DBRequest(op="db:system:personas:list:1", payload={})
+
+
+def upsert_persona_request(params: UpsertPersonaParams) -> DBRequest:
+  return DBRequest(op="db:system:personas:upsert:1", payload=params.model_dump())
+
+
+def delete_persona_request(params: DeletePersonaParams) -> DBRequest:
+  return DBRequest(op="db:system:personas:delete:1", payload=params.model_dump())

--- a/queryregistry/system/personas/handler.py
+++ b/queryregistry/system/personas/handler.py
@@ -6,11 +6,18 @@ from typing import Sequence
 
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
-from queryregistry.stubs import build_stub_dispatchers
+
+from .services import delete_persona_v1, get_by_name_v1, list_personas_v1, upsert_persona_v1
+from ..dispatch import SubdomainDispatcher
 
 __all__ = ["handle_personas_request"]
 
-DISPATCHERS = build_stub_dispatchers("system.personas")
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("get_by_name", "1"): get_by_name_v1,
+  ("list", "1"): list_personas_v1,
+  ("upsert", "1"): upsert_persona_v1,
+  ("delete", "1"): delete_persona_v1,
+}
 
 
 async def handle_personas_request(

--- a/queryregistry/system/personas/models.py
+++ b/queryregistry/system/personas/models.py
@@ -1,0 +1,56 @@
+"""System personas query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "DeletePersonaParams",
+  "PersonaNameParams",
+  "PersonaRecord",
+  "UpsertPersonaParams",
+]
+
+
+class PersonaNameParams(BaseModel):
+  """Payload targeting a single persona by name."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  name: str
+
+
+class UpsertPersonaParams(BaseModel):
+  """Parameters for inserting or updating a persona."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  name: str
+  prompt: str
+  tokens: int
+  models_recid: int
+  recid: int | None = None
+
+
+class DeletePersonaParams(BaseModel):
+  """Parameters for deleting a persona by recid or name."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int | None = None
+  name: str | None = None
+
+
+class PersonaRecord(TypedDict):
+  """Record representation returned by persona queries."""
+
+  recid: int
+  name: str
+  prompt: str
+  tokens: int
+  models_recid: int | None
+  model: str | None
+  element_created_on: str
+  element_modified_on: str

--- a/queryregistry/system/personas/mssql.py
+++ b/queryregistry/system/personas/mssql.py
@@ -1,0 +1,131 @@
+"""MSSQL implementations for system personas query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "delete_persona_v1",
+  "get_by_name_v1",
+  "list_personas_v1",
+  "upsert_persona_v1",
+]
+
+
+async def get_by_name_v1(args: Mapping[str, Any]) -> DBResponse:
+  name = args["name"]
+  sql = """
+    SELECT
+      ap.recid,
+      ap.models_recid,
+      vp.persona_name AS persona_name,
+      vp.persona_name AS name,
+      vp.system_role_prompt AS system_role_prompt,
+      vp.system_role_prompt AS prompt,
+      vp.system_role_prompt AS element_prompt,
+      vp.token_allowance AS token_allowance,
+      vp.token_allowance AS tokens,
+      vp.token_allowance AS element_tokens,
+      vp.model_name AS model_name,
+      vp.model_name AS model,
+      vp.model_name AS element_model,
+      vp.element_created_on,
+      vp.element_modified_on
+    FROM vw_content_personas vp
+    JOIN assistant_personas ap ON ap.element_name = vp.persona_name
+    WHERE vp.persona_name = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return await run_json_one(sql, (name,))
+
+
+async def list_personas_v1(_: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      ap.recid,
+      ap.models_recid,
+      vp.persona_name AS persona_name,
+      vp.persona_name AS name,
+      vp.system_role_prompt AS system_role_prompt,
+      vp.system_role_prompt AS prompt,
+      vp.system_role_prompt AS element_prompt,
+      vp.token_allowance AS token_allowance,
+      vp.token_allowance AS tokens,
+      vp.token_allowance AS element_tokens,
+      vp.model_name AS model_name,
+      vp.model_name AS model,
+      vp.model_name AS element_model,
+      vp.element_created_on,
+      vp.element_modified_on
+    FROM vw_content_personas vp
+    JOIN assistant_personas ap ON ap.element_name = vp.persona_name
+    ORDER BY vp.persona_name
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql)
+
+
+async def upsert_persona_v1(args: Mapping[str, Any]) -> DBResponse:
+  recid = args.get("recid")
+  name = args["name"]
+  prompt = args["prompt"]
+  tokens = int(args["tokens"])
+  models_recid = int(args["models_recid"])
+  if recid is not None:
+    rc = await run_exec(
+      """
+        UPDATE assistant_personas
+        SET element_name = ?,
+            element_prompt = ?,
+            element_tokens = ?,
+            models_recid = ?,
+            element_modified_on = SYSUTCDATETIME()
+        WHERE recid = ?;
+      """,
+      (name, prompt, tokens, models_recid, recid),
+    )
+    if rc.rowcount:
+      return rc
+  rc = await run_exec(
+    """
+      UPDATE assistant_personas
+      SET element_prompt = ?,
+          element_tokens = ?,
+          models_recid = ?,
+          element_modified_on = SYSUTCDATETIME()
+      WHERE element_name = ?;
+    """,
+    (prompt, tokens, models_recid, name),
+  )
+  if rc.rowcount:
+    return rc
+  return await run_exec(
+    """
+      INSERT INTO assistant_personas (
+        element_name,
+        element_prompt,
+        element_tokens,
+        models_recid
+      ) VALUES (?, ?, ?, ?);
+    """,
+    (name, prompt, tokens, models_recid),
+  )
+
+
+async def delete_persona_v1(args: Mapping[str, Any]) -> DBResponse:
+  recid = args.get("recid")
+  name = args.get("name")
+  if recid is not None:
+    sql = "DELETE FROM assistant_personas WHERE recid = ?;"
+    params = (recid,)
+  elif name is not None:
+    sql = "DELETE FROM assistant_personas WHERE element_name = ?;"
+    params = (name,)
+  else:
+    raise ValueError("Missing identifier for persona delete")
+  return await run_exec(sql, params)

--- a/queryregistry/system/personas/services.py
+++ b/queryregistry/system/personas/services.py
@@ -1,0 +1,62 @@
+"""System personas query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import DeletePersonaParams, PersonaNameParams, UpsertPersonaParams
+
+__all__ = [
+  "delete_persona_v1",
+  "get_by_name_v1",
+  "list_personas_v1",
+  "upsert_persona_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_GET_BY_NAME_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_by_name_v1}
+_LIST_PERSONAS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_personas_v1}
+_UPSERT_PERSONA_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_persona_v1}
+_DELETE_PERSONA_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_persona_v1}
+
+
+class _ListPersonasParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for system personas registry")
+  return dispatcher
+
+
+async def get_by_name_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = PersonaNameParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_BY_NAME_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_personas_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = _ListPersonasParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_PERSONAS_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def upsert_persona_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpsertPersonaParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPSERT_PERSONA_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_persona_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = DeletePersonaParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_PERSONA_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)


### PR DESCRIPTION
### Motivation

- Move legacy assistant persona registry logic from the deprecated server registry into the canonical `queryregistry` data-access layer to follow the repository's canonical pattern.
- Provide typed payload contracts and request builders so callers use the canonical `DBRequest`/`DBResponse` shapes and payload validation.
- Preserve existing MSSQL semantics and compatibility (dual-alias SELECT columns and the three-step upsert fallback) to avoid behavioral regressions.

### Description

- Added typed models in `queryregistry/system/personas/models.py` including `PersonaNameParams`, `UpsertPersonaParams`, `DeletePersonaParams`, and `PersonaRecord` with `extra="forbid"` validation.
- Implemented MSSQL provider adapters in `queryregistry/system/personas/mssql.py` with `get_by_name_v1`, `list_personas_v1`, `upsert_persona_v1` (update-by-recid → update-by-name → insert), and `delete_persona_v1` (delete by recid or name with validation) using `run_exec`, `run_json_many`, and `run_json_one`.
- Added service dispatchers in `queryregistry/system/personas/services.py` that perform `model_validate` on payloads, select the provider dispatcher, and return canonical `DBResponse` objects.
- Replaced the stub handler and request builders by updating `queryregistry/system/personas/handler.py` to use a real `DISPATCHERS` map and `queryregistry/system/personas/__init__.py` to expose canonical request builders for `get_by_name`, `list`, `upsert`, and `delete`.

### Testing

- Ran the unified harness via `python scripts/run_tests.py`, which completed successfully (including frontend TS generation and tests) with no failures.
- Compiled the new package files with `python -m compileall queryregistry/system/personas` to validate importability and the result succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab8559ddb08325b9a1a2097dab696f)