### PR TITLE
Add canonical system conversations subdomain to queryregistry

### DIFF
--- a/queryregistry/system/conversations/__init__.py
+++ b/queryregistry/system/conversations/__init__.py
@@ -1,0 +1,35 @@
+"""System conversations query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import FindRecentParams, InsertConversationParams, ListByTimeParams, UpdateOutputParams
+
+__all__ = [
+  "find_recent_request",
+  "insert_conversation_request",
+  "list_by_time_request",
+  "list_recent_request",
+  "update_output_request",
+]
+
+
+def insert_conversation_request(params: InsertConversationParams) -> DBRequest:
+  return DBRequest(op="db:system:conversations:insert:1", payload=params.model_dump())
+
+
+def find_recent_request(params: FindRecentParams) -> DBRequest:
+  return DBRequest(op="db:system:conversations:find_recent:1", payload=params.model_dump())
+
+
+def update_output_request(params: UpdateOutputParams) -> DBRequest:
+  return DBRequest(op="db:system:conversations:update_output:1", payload=params.model_dump())
+
+
+def list_by_time_request(params: ListByTimeParams) -> DBRequest:
+  return DBRequest(op="db:system:conversations:list_by_time:1", payload=params.model_dump())
+
+
+def list_recent_request() -> DBRequest:
+  return DBRequest(op="db:system:conversations:list_recent:1", payload={})

--- a/queryregistry/system/conversations/handler.py
+++ b/queryregistry/system/conversations/handler.py
@@ -1,0 +1,42 @@
+"""System conversations handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import (
+  find_recent_v1,
+  insert_conversation_v1,
+  list_by_time_v1,
+  list_recent_v1,
+  update_output_v1,
+)
+from ..dispatch import SubdomainDispatcher
+
+__all__ = ["handle_conversations_request"]
+
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("insert", "1"): insert_conversation_v1,
+  ("find_recent", "1"): find_recent_v1,
+  ("update_output", "1"): update_output_v1,
+  ("list_by_time", "1"): list_by_time_v1,
+  ("list_recent", "1"): list_recent_v1,
+}
+
+
+async def handle_conversations_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown system conversations operation",
+  )

--- a/queryregistry/system/conversations/models.py
+++ b/queryregistry/system/conversations/models.py
@@ -1,0 +1,69 @@
+"""System conversations query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "ConversationRecord",
+  "FindRecentParams",
+  "InsertConversationParams",
+  "ListByTimeParams",
+  "UpdateOutputParams",
+]
+
+
+class InsertConversationParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  personas_recid: int
+  models_recid: int
+  input_data: str
+  guild_id: str | None = None
+  channel_id: str | None = None
+  user_id: str | None = None
+  output_data: str | None = None
+  tokens: int | None = None
+
+
+class FindRecentParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  personas_recid: int
+  models_recid: int
+  input_data: str
+  guild_id: str | None = None
+  channel_id: str | None = None
+  user_id: str | None = None
+  window_seconds: int = 300
+
+
+class UpdateOutputParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+  output_data: str | None = None
+  tokens: int | None = None
+
+
+class ListByTimeParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  personas_recid: int
+  start: str
+  end: str
+
+
+class ConversationRecord(TypedDict):
+  recid: int
+  personas_recid: int
+  models_recid: int
+  element_guild_id: str | None
+  element_channel_id: str | None
+  element_user_id: str | None
+  element_input: str
+  element_output: str | None
+  element_tokens: int | None
+  element_created_on: str

--- a/queryregistry/system/conversations/mssql.py
+++ b/queryregistry/system/conversations/mssql.py
@@ -1,0 +1,157 @@
+"""MSSQL implementations for system conversations query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "find_recent_v1",
+  "insert_conversation_v1",
+  "list_by_time_v1",
+  "list_recent_v1",
+  "update_output_v1",
+]
+
+
+async def insert_conversation_v1(args: Mapping[str, Any]) -> DBResponse:
+  personas_recid = args["personas_recid"]
+  models_recid = args["models_recid"]
+  guild_id = args.get("guild_id")
+  channel_id = args.get("channel_id")
+  user_id = args.get("user_id")
+  input_data = args.get("input_data")
+  output_data = args.get("output_data")
+  tokens = args.get("tokens")
+  sql = """
+    INSERT INTO assistant_conversations (
+      personas_recid,
+      models_recid,
+      element_guild_id,
+      element_channel_id,
+      element_user_id,
+      element_input,
+      element_output,
+      element_tokens
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+    SELECT SCOPE_IDENTITY() AS recid
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return await run_json_one(
+    sql,
+    (
+      personas_recid,
+      models_recid,
+      guild_id,
+      channel_id,
+      user_id,
+      input_data,
+      output_data,
+      tokens,
+    ),
+  )
+
+
+async def find_recent_v1(args: Mapping[str, Any]) -> DBResponse:
+  personas_recid = args["personas_recid"]
+  models_recid = args["models_recid"]
+  guild_id = args.get("guild_id")
+  channel_id = args.get("channel_id")
+  user_id = args.get("user_id")
+  input_data = args["input_data"]
+  window_seconds = args.get("window_seconds", 300)
+
+  def _norm(value: Any) -> str | None:
+    return str(value) if value is not None else None
+
+  guild_id = _norm(guild_id)
+  channel_id = _norm(channel_id)
+  user_id = _norm(user_id)
+
+  sql = """
+    SELECT TOP 1 recid
+    FROM assistant_conversations
+    WHERE personas_recid = ?
+      AND models_recid = ?
+      AND element_input = ?
+      AND ((element_guild_id = ?) OR (element_guild_id IS NULL AND ? IS NULL))
+      AND ((element_channel_id = ?) OR (element_channel_id IS NULL AND ? IS NULL))
+      AND ((element_user_id = ?) OR (element_user_id IS NULL AND ? IS NULL))
+      AND element_created_on >= DATEADD(second, -?, SYSDATETIMEOFFSET())
+    ORDER BY element_created_on DESC
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return await run_json_one(
+    sql,
+    (
+      personas_recid,
+      models_recid,
+      input_data,
+      guild_id,
+      guild_id,
+      channel_id,
+      channel_id,
+      user_id,
+      user_id,
+      window_seconds,
+    ),
+  )
+
+
+async def update_output_v1(args: Mapping[str, Any]) -> DBResponse:
+  recid = args["recid"]
+  output_data = args.get("output_data")
+  tokens = args.get("tokens")
+  sql = """
+    UPDATE assistant_conversations
+    SET element_output = ?,
+        element_tokens = ?
+    WHERE recid = ?;
+  """
+  return await run_exec(sql, (output_data, tokens, recid))
+
+
+async def list_by_time_v1(args: Mapping[str, Any]) -> DBResponse:
+  personas_recid = args["personas_recid"]
+  start = args["start"]
+  end = args["end"]
+  sql = """
+    SELECT recid,
+           element_guild_id,
+           element_channel_id,
+           element_user_id,
+           element_input,
+           element_output,
+           element_tokens,
+           element_created_on,
+           element_modified_on,
+           models_recid
+    FROM assistant_conversations
+    WHERE personas_recid = ? AND element_created_on BETWEEN ? AND ?
+    ORDER BY element_created_on
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, (personas_recid, start, end))
+
+
+async def list_recent_v1(_: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT TOP (2)
+           recid,
+           personas_recid,
+           element_guild_id,
+           element_channel_id,
+           element_user_id,
+           element_output,
+           element_tokens,
+           element_created_on
+    FROM assistant_conversations
+    WHERE element_output IS NOT NULL AND LTRIM(RTRIM(element_output)) <> ''
+    ORDER BY element_created_on DESC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql)

--- a/queryregistry/system/conversations/services.py
+++ b/queryregistry/system/conversations/services.py
@@ -1,0 +1,65 @@
+"""System conversations query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import FindRecentParams, InsertConversationParams, ListByTimeParams, UpdateOutputParams
+
+__all__ = [
+  "find_recent_v1",
+  "insert_conversation_v1",
+  "list_by_time_v1",
+  "list_recent_v1",
+  "update_output_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_INSERT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.insert_conversation_v1}
+_FIND_RECENT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.find_recent_v1}
+_UPDATE_OUTPUT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.update_output_v1}
+_LIST_BY_TIME_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_by_time_v1}
+_LIST_RECENT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_recent_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(
+      f"Unsupported provider '{provider}' for system conversations registry"
+    )
+  return dispatcher
+
+
+async def insert_conversation_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = InsertConversationParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _INSERT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def find_recent_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = FindRecentParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _FIND_RECENT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def update_output_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpdateOutputParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPDATE_OUTPUT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_by_time_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListByTimeParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_BY_TIME_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_recent_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  result = await _select_dispatcher(provider, _LIST_RECENT_DISPATCHERS)({})
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/queryregistry/system/handler.py
+++ b/queryregistry/system/handler.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 from queryregistry.models import DBRequest, DBResponse
 
 from .config.handler import handle_config_request
+from .conversations.handler import handle_conversations_request
 from .configuration.handler import handle_configuration_request
 from .integrations.handler import handle_integrations_request
 from .links.handler import handle_links_request
@@ -24,6 +25,7 @@ __all__ = ["handle_system_request"]
 HANDLERS = {
   "configuration": handle_configuration_request,
   "config": handle_config_request,
+  "conversations": handle_conversations_request,
   "integrations": handle_integrations_request,
   "links": handle_links_request,
   "models": handle_models_request,


### PR DESCRIPTION
### Motivation
- Migrate legacy assistant conversation registry operations from `server/registry/system/conversations/` into the canonical `queryregistry` layer to centralize data access and follow the queryregistry dispatch pattern. 
- Provide typed service contracts and provider-specific MSSQL implementations for conversation operations so callers can use canonical `db:system:conversations:*:1` operations.

### Description
- Added a new subdomain package `queryregistry/system/conversations/` containing request builders in `__init__.py` that emit `db:system:conversations:*:1` ops. 
- Introduced strict Pydantic models in `models.py` (`InsertConversationParams`, `FindRecentParams`, `UpdateOutputParams`, `ListByTimeParams`) and `ConversationRecord` typed contract, all with `extra="forbid"` configuration. 
- Ported MSSQL provider implementations to `mssql.py`, including `insert_conversation_v1` (INSERT + `SCOPE_IDENTITY()`), `find_recent_v1` (preserving the nullable double-parameter equality/IS NULL pattern), `update_output_v1`, `list_by_time_v1`, and `list_recent_v1`, using `run_json_one`, `run_json_many`, and `run_exec` from `queryregistry.providers.mssql`. 
- Implemented service dispatchers in `services.py` that use `model_validate` and provider selection before calling provider dispatchers, and added the subdomain handler in `handler.py` with a `DISPATCHERS` map for each operation/version. 
- Registered the new subdomain in the system domain handler by importing and adding `"conversations": handle_conversations_request` to `queryregistry/system/handler.py`.

### Testing
- Ran the unified pipeline via `python scripts/run_tests.py` (lint, type-check, frontend tasks, and backend `pytest`) which completed successfully and reported all tests passing. 
- Backend test summary: `66` tests passed and the test run finished without failures. 
- The test run printed a post-test environment warning about a missing ODBC driver (`ODBC Driver 18 for SQL Server`) during an attempted DB version update, but this did not cause test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab87ae44988325a2ae6ff3d497bacb)