### PR TITLE
Use canonical queryregistry imports in SystemConfigModule

### DIFF
--- a/server/modules/system_config_module.py
+++ b/server/modules/system_config_module.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 import logging
 from fastapi import FastAPI
-from server.registry.system.config.model import ConfigKeyParams, UpsertConfigParams
-from server.modules.registry.helpers import (
+from queryregistry.system.config.models import ConfigKeyParams, UpsertConfigParams
+from queryregistry.system.config import (
   delete_config_request,
   get_configs_request,
   upsert_config_request,


### PR DESCRIPTION
### Motivation
- Move system config request builders and models to the canonical `queryregistry` layer as part of the migration away from legacy registry bridges.

### Description
- Updated `server/modules/system_config_module.py` to import `ConfigKeyParams` and `UpsertConfigParams` from `queryregistry.system.config.models` and to import `delete_config_request`, `get_configs_request`, and `upsert_config_request` from `queryregistry.system.config` without changing any function signatures or module logic.

### Testing
- Ran `python -m py_compile server/modules/system_config_module.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab8b5dc41c832598db780054479050)