### PR TITLE
Rewire ServiceRoutesModule to canonical system routes queryregistry

### DIFF
--- a/server/modules/service_routes_module.py
+++ b/server/modules/service_routes_module.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import logging
 from fastapi import FastAPI
 
-from server.modules.registry.helpers import (
+from queryregistry.system.routes import (
   delete_route_request,
   get_routes_request,
   upsert_route_request,
 )
+from queryregistry.system.routes.models import RoutePathParams, UpsertRouteParams
 
 from . import BaseModule
 from .auth_module import AuthModule
@@ -83,13 +84,13 @@ class ServiceRoutesModule(BaseModule):
       raise RuntimeError("ServiceRoutesModule not ready")
     mask = self.auth.names_to_mask(route.required_roles)
     await self.db.run(
-      upsert_route_request(
+      upsert_route_request(UpsertRouteParams(
         path=route.path,
         name=route.name,
         icon=route.icon,
         sequence=route.sequence,
         roles=mask,
-      )
+      ))
     )
     logging.debug(
       "[service_routes_upsert_route_v1] upserted route %s",
@@ -111,7 +112,7 @@ class ServiceRoutesModule(BaseModule):
     )
     if not self.db:
       raise RuntimeError("ServiceRoutesModule not ready")
-    await self.db.run(delete_route_request(path))
+    await self.db.run(delete_route_request(RoutePathParams(path=path)))
     logging.debug(
       "[service_routes_delete_route_v1] deleted route %s",
       path,


### PR DESCRIPTION
### Motivation
- Migrate module data-access calls to the canonical `queryregistry.system.routes` builders so the module uses the new queryregistry layer directly.
- Update call sites to the new builders which require Pydantic param models instead of legacy keyword/positional arguments.

### Description
- Replaced legacy imports from `server.modules.registry.helpers` with imports from `queryregistry.system.routes` and added `RoutePathParams` and `UpsertRouteParams` imports from `queryregistry.system.routes.models` in `server/modules/service_routes_module.py`.
- Updated `upsert_route` to build and pass an `UpsertRouteParams` instance to `upsert_route_request` instead of using keyword arguments to the request builder.
- Updated `delete_route` to build and pass a `RoutePathParams` instance to `delete_route_request` instead of passing a raw string path.
- Preserved all logging, error handling, return values, and the `get_routes_request()` usage which required no changes.

### Testing
- Ran `python -m compileall server/modules/service_routes_module.py` to validate the modified module compiles successfully, and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac6a9038088325be3816bf8f87e54c)