### PR TITLE
Rewire public vars/links modules to canonical queryregistry requests

### DIFF
--- a/queryregistry/system/links/__init__.py
+++ b/queryregistry/system/links/__init__.py
@@ -1,1 +1,20 @@
 """System links query handler package."""
+
+from queryregistry.models import DBRequest
+
+
+def get_home_links_request() -> DBRequest:
+  return DBRequest(op="db:system:links:get_home_links:1", payload={})
+
+
+def get_navbar_routes_request(role_mask: int | None = None) -> DBRequest:
+  payload: dict[str, object] = {}
+  if role_mask is not None:
+    payload["role_mask"] = role_mask
+  return DBRequest(op="db:system:links:get_navbar_routes:1", payload=payload)
+
+
+__all__ = [
+  "get_home_links_request",
+  "get_navbar_routes_request",
+]

--- a/queryregistry/system/public_vars/__init__.py
+++ b/queryregistry/system/public_vars/__init__.py
@@ -1,1 +1,22 @@
 """System public_vars query handler package."""
+
+from queryregistry.models import DBRequest
+
+
+def get_version_request() -> DBRequest:
+  return DBRequest(op="db:system:public_vars:get_version:1", payload={})
+
+
+def get_hostname_request() -> DBRequest:
+  return DBRequest(op="db:system:public_vars:get_hostname:1", payload={})
+
+
+def get_repo_request() -> DBRequest:
+  return DBRequest(op="db:system:public_vars:get_repo:1", payload={})
+
+
+__all__ = [
+  "get_hostname_request",
+  "get_repo_request",
+  "get_version_request",
+]

--- a/server/modules/public_links_module.py
+++ b/server/modules/public_links_module.py
@@ -6,8 +6,8 @@ from fastapi import FastAPI
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
-from server.modules.registry.helpers import (
-  dispatch_query_request_with_fallback,
+from queryregistry.handler import dispatch_query_request
+from queryregistry.system.links import (
   get_home_links_request,
   get_navbar_routes_request,
 )
@@ -42,7 +42,7 @@ class PublicLinksModule(BaseModule):
 
   async def get_home_links(self):
     assert self.db
-    res = await dispatch_query_request_with_fallback(
+    res = await dispatch_query_request(
       get_home_links_request(),
       provider=self.db.provider,
     )
@@ -50,7 +50,7 @@ class PublicLinksModule(BaseModule):
 
   async def get_navbar_routes(self, role_mask: int):
     assert self.db
-    res = await dispatch_query_request_with_fallback(
+    res = await dispatch_query_request(
       get_navbar_routes_request(role_mask),
       provider=self.db.provider,
     )

--- a/server/modules/public_vars_module.py
+++ b/server/modules/public_vars_module.py
@@ -5,7 +5,7 @@ from . import BaseModule
 from .db_module import DbModule
 from .auth_module import AuthModule
 from .discord_bot_module import DiscordBotModule
-from .registry.helpers import (
+from queryregistry.system.public_vars import (
   get_hostname_request,
   get_repo_request,
   get_version_request,


### PR DESCRIPTION
### Motivation

- Replace legacy registry bridge imports with direct canonical `queryregistry` request builders so modules call the canonical data-access layer.
- Add missing request-builder exports to the `queryregistry` subpackages so modules can import the builders directly.

### Description

- Added parameterless request builders to `queryregistry.system.public_vars` for `get_version`, `get_hostname`, and `get_repo` returning `DBRequest` with empty payloads.
- Added request builders to `queryregistry.system.links` for `get_home_links_request()` and `get_navbar_routes_request(role_mask: int | None = None)`, with `role_mask` included in the payload when provided.
- Updated `server/modules/public_vars_module.py` to import public vars builders from `queryregistry.system.public_vars` instead of the legacy bridge.
- Updated `server/modules/public_links_module.py` to import `dispatch_query_request` from `queryregistry.handler`, import links builders from `queryregistry.system.links`, and replace `dispatch_query_request_with_fallback` calls with `dispatch_query_request` at both call sites.

### Testing

- Ran the unified harness `python scripts/run_tests.py`, which executed backend `pytest` and frontend checks, and completed successfully.
- Backend tests: `pytest` suite passed (`66 passed`, `1 warning`).
- Frontend tests: `npm`/Jest checks passed (`2 passed`).
- The test run completed end-to-end and the modified modules exercised canonical dispatch paths during the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac89495d5883259186dad7d831822b)