### PR TITLE
Rewire role admin to canonical queryregistry request builders

### DIFF
--- a/queryregistry/identity/role_memberships/__init__.py
+++ b/queryregistry/identity/role_memberships/__init__.py
@@ -1,1 +1,42 @@
-"""Identity role_memberships query registry stubs."""
+"""Identity role_memberships request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import ModifyRoleMemberPayload, RoleScopePayload
+
+__all__ = [
+  "create_role_membership_request",
+  "delete_role_membership_request",
+  "list_role_memberships_request",
+  "list_role_non_memberships_request",
+]
+
+
+def list_role_memberships_request(params: RoleScopePayload) -> DBRequest:
+  return DBRequest(
+    op="db:identity:role_memberships:list:1",
+    payload=dict(params),
+  )
+
+
+def list_role_non_memberships_request(params: RoleScopePayload) -> DBRequest:
+  return DBRequest(
+    op="db:identity:role_memberships:list_non_members:1",
+    payload=dict(params),
+  )
+
+
+def create_role_membership_request(params: ModifyRoleMemberPayload) -> DBRequest:
+  return DBRequest(
+    op="db:identity:role_memberships:create:1",
+    payload=dict(params),
+  )
+
+
+def delete_role_membership_request(params: ModifyRoleMemberPayload) -> DBRequest:
+  return DBRequest(
+    op="db:identity:role_memberships:delete:1",
+    payload=dict(params),
+  )

--- a/queryregistry/system/roles/__init__.py
+++ b/queryregistry/system/roles/__init__.py
@@ -1,1 +1,39 @@
-"""System roles query registry stubs."""
+"""System roles request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import DeleteRolePayload, UpsertRolePayload
+
+__all__ = [
+  "create_system_role_request",
+  "delete_system_role_request",
+  "list_system_roles_request",
+  "update_system_role_request",
+]
+
+
+def list_system_roles_request() -> DBRequest:
+  return DBRequest(op="db:system:roles:list:1", payload={})
+
+
+def create_system_role_request(params: UpsertRolePayload) -> DBRequest:
+  return DBRequest(
+    op="db:system:roles:create:1",
+    payload=dict(params),
+  )
+
+
+def update_system_role_request(params: UpsertRolePayload) -> DBRequest:
+  return DBRequest(
+    op="db:system:roles:update:1",
+    payload=dict(params),
+  )
+
+
+def delete_system_role_request(params: DeleteRolePayload) -> DBRequest:
+  return DBRequest(
+    op="db:system:roles:delete:1",
+    payload=dict(params),
+  )

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -3,21 +3,21 @@ from typing import Any
 
 from fastapi import FastAPI, HTTPException
 from queryregistry.handler import dispatch_query_request
-from queryregistry.identity.role_memberships.models import (
-  ModifyRoleMemberPayload,
-  RoleScopePayload,
-)
-from server.modules import BaseModule
-from server.modules.db_module import DbModule
-from server.modules.auth_module import AuthModule
-from server.modules.discord_bot_module import DiscordBotModule
-from server.modules.registry.helpers import (
+from queryregistry.identity.role_memberships import (
   create_role_membership_request,
   delete_role_membership_request,
   list_role_memberships_request,
   list_role_non_memberships_request,
-  list_system_roles_request,
 )
+from queryregistry.identity.role_memberships.models import (
+  ModifyRoleMemberPayload,
+  RoleScopePayload,
+)
+from queryregistry.system.roles import list_system_roles_request
+from server.modules import BaseModule
+from server.modules.db_module import DbModule
+from server.modules.auth_module import AuthModule
+from server.modules.discord_bot_module import DiscordBotModule
 
 
 def _normalize_payload(payload: Any | None) -> list[dict[str, Any]]:


### PR DESCRIPTION
### Motivation

- Move role-related request builders out of the legacy bridge and into the canonical `queryregistry` packages so modules can import directly from `queryregistry/` without relying on `server.modules.registry.helpers`.
- Provide request-builder functions for the `system/roles` and `identity/role_memberships` subdomains because their `__init__.py` files were empty stubs.

### Description

- Added request builders to `queryregistry/system/roles/__init__.py` for `list`, `create`, `update`, and `delete` operations using `DBRequest` and converting typed payloads with `dict(params)`.
- Added request builders to `queryregistry/identity/role_memberships/__init__.py` for `list`, `list_non_members`, `create`, and `delete` operations using `DBRequest` and converting typed payloads with `dict(params)`.
- Updated `server/modules/role_admin_module.py` to import builders from `queryregistry.identity.role_memberships` and `queryregistry.system.roles` and removed the legacy `server.modules.registry.helpers` imports.
- Preserved `__all__` exports and kept builder signatures identical to the previous bridge behavior (payloads remain `dict(params)`).

### Testing

- Ran `python -m compileall queryregistry/system/roles/__init__.py queryregistry/identity/role_memberships/__init__.py server/modules/role_admin_module.py` and compilation completed successfully.
- Static inspection ensured the builder signatures match the existing call sites in `server/modules/role_admin_module.py` and no other files were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8c53a8b8832587b0f31e8567ddd9)