### PR TITLE
Fix PublicVarsModule config getters to read DBResponse rows

### DIFF
--- a/server/modules/public_vars_module.py
+++ b/server/modules/public_vars_module.py
@@ -47,20 +47,23 @@ class PublicVarsModule(BaseModule):
   async def get_version(self) -> str:
     assert self.db
     res = await self.db.run(get_version_request())
-    payload = res.payload if isinstance(res.payload, dict) else {}
-    return payload.get("version", "")
+    if res.rows:
+      return res.rows[0].get("version", "")
+    return ""
 
   async def get_hostname(self) -> str:
     assert self.db
     res = await self.db.run(get_hostname_request())
-    payload = res.payload if isinstance(res.payload, dict) else {}
-    return payload.get("hostname", "")
+    if res.rows:
+      return res.rows[0].get("hostname", "")
+    return ""
 
   async def get_repo(self) -> str:
     assert self.db
     res = await self.db.run(get_repo_request())
-    payload = res.payload if isinstance(res.payload, dict) else {}
-    return payload.get("repo", "")
+    if res.rows:
+      return res.rows[0].get("repo", "")
+    return ""
 
   async def get_ffmpeg_version(self) -> str:
     try:


### PR DESCRIPTION
### Motivation
- `PublicVarsModule.get_version`, `get_hostname`, and `get_repo` were checking `res.payload` as a `dict`, but `DBResponse` constructed from DB rows exposes data as a list via `payload`/`rows`, causing those getters to return empty strings despite data existing in `system_config`.

### Description
- Update `get_version` to return the first row value with `res.rows[0].get("version", "")` when rows exist and `""` otherwise.
- Update `get_hostname` to return the first row value with `res.rows[0].get("hostname", "")` when rows exist and `""` otherwise.
- Update `get_repo` to return the first row value with `res.rows[0].get("repo", "")` when rows exist and `""` otherwise.
- Only the three methods in `server/modules/public_vars_module.py` were modified and no imports, class structure, or other methods were changed.

### Testing
- Ran `python -m py_compile server/modules/public_vars_module.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace034f5208325a5366409ca17a9c0)