### PR TITLE
refactor(session): rewire session_module imports to canonical queryregistry sessions

### DIFF
--- a/server/modules/session_module.py
+++ b/server/modules/session_module.py
@@ -16,23 +16,23 @@ from server.modules.discord_bot_module import DiscordBotModule
 from queryregistry.identity.profiles import update_profile_request
 from queryregistry.identity.profiles.models import UpdateProfileParams
 from queryregistry.handler import dispatch_query_request
-from queryregistry.identity.sessions import get_rotkey_request
-from queryregistry.identity.sessions.models import RotkeyLookupParams
-from server.registry.account.session.model import (
-  CreateSessionParams,
-  RevokeDeviceTokenParams,
-  SetRotkeyParams,
-  UpdateDeviceTokenParams,
-  UpdateSessionParams,
-)
-from server.registry.types import DBRequest
-from server.modules.registry.helpers import (
+from queryregistry.identity.sessions import (
   create_session_request,
+  get_rotkey_request,
   revoke_device_token_request,
   set_rotkey_request,
   update_device_token_request,
   update_session_request,
 )
+from queryregistry.identity.sessions.models import (
+  CreateSessionParams,
+  RotkeyLookupParams,
+  RevokeDeviceTokenParams,
+  SetRotkeyParams,
+  UpdateDeviceTokenParams,
+  UpdateSessionParams,
+)
+from queryregistry.models import DBRequest
 
 
 class SessionModule(BaseModule):


### PR DESCRIPTION
### Motivation
- Replace legacy bridge imports with canonical `queryregistry` session request builders and models so the module uses the authoritative data-access translation layer while preserving existing behavior.

### Description
- Updated `server/modules/session_module.py` to import session request builders from `queryregistry.identity.sessions` (`create_session_request`, `get_rotkey_request`, `revoke_device_token_request`, `set_rotkey_request`, `update_device_token_request`, `update_session_request`).
- Switched session parameter model imports to `queryregistry.identity.sessions.models` (`CreateSessionParams`, `RotkeyLookupParams`, `RevokeDeviceTokenParams`, `SetRotkeyParams`, `UpdateDeviceTokenParams`, `UpdateSessionParams`).
- Replaced legacy `DBRequest` import with `queryregistry.models.DBRequest` because `DBRequest(...)` is used directly in this file, and made no changes to method signatures, business logic, or error handling.

### Testing
- Ran `python -m py_compile server/modules/session_module.py` and the file compiled successfully. 
- No other automated tests were modified or required for this import-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace43a762483258a4575852cfc418e)