### PR TITLE
refactor(oauth): switch oauth module to canonical queryregistry session/config imports

### DIFF
--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -15,7 +15,7 @@ from queryregistry.identity.profiles.models import (
   UpdateIfUneditedParams,
   UpdateProfileParams,
 )
-from server.registry.account.session.model import (
+from queryregistry.identity.sessions.models import (
   CreateSessionParams,
   RevokeProviderTokensParams,
   UpdateDeviceTokenParams,
@@ -42,12 +42,12 @@ from queryregistry.identity.providers import (
   unlink_last_provider_request,
   unlink_provider_request,
 )
-from server.modules.registry.helpers import (
+from queryregistry.identity.sessions import (
   create_session_request,
-  get_config_request,
   revoke_provider_tokens_request,
   update_device_token_request,
 )
+from queryregistry.system.config import get_config_request
 
 
 class OauthModule(BaseModule):


### PR DESCRIPTION
### Motivation
- Replace legacy session and bridge request-builder imports in the OAuth module with the canonical `queryregistry` builders and models to remove dependency on the deprecated registry bridge.

### Description
- Updated `server/modules/oauth_module.py` to import session parameter models from `queryregistry.identity.sessions.models` and session request builders from `queryregistry.identity.sessions`, and to import `get_config_request` from `queryregistry.system.config`, while preserving all other existing `queryregistry.*` imports and leaving call sites and logic unchanged.

### Testing
- Ran `python -m py_compile server/modules/oauth_module.py` which completed without errors.
- Verified legacy imports were removed with `rg` and manually inspected call sites to ensure model objects are still passed to `create_session_request`, `revoke_provider_tokens_request`, `update_device_token_request`, and `get_config_request` and that no signature changes were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace55a9f108325916bd54cdee96f06)