### PR TITLE
Rewire module registry imports to canonical queryregistry domains

### DIFF
--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -19,7 +19,7 @@ from server.modules.discord_bot_module import DiscordBotModule
 from queryregistry.handler import dispatch_query_request
 from queryregistry.identity.sessions import get_rotkey_request
 from queryregistry.identity.sessions.models import RotkeyLookupParams
-from server.registry.types import DBRequest, DBResponse
+from queryregistry.models import DBRequest, DBResponse
 
 DEFAULT_SESSION_TOKEN_EXPIRY = 15 # minutes
 DEFAULT_ROTATION_TOKEN_EXPIRY = 90 # days

--- a/server/modules/bsky_module.py
+++ b/server/modules/bsky_module.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from atproto import AsyncClient as AsyncBskyClient, client_utils
 from fastapi import FastAPI
 
-from server.registry.system.config.model import ConfigKeyParams
-from server.modules.registry.helpers import get_config_request
+from queryregistry.system.config.models import ConfigKeyParams
+from queryregistry.system.config import get_config_request
 from . import BaseModule
 from .db_module import DbModule
 

--- a/server/modules/discord_bot_module.py
+++ b/server/modules/discord_bot_module.py
@@ -18,8 +18,8 @@ except ImportError:  # pragma: no cover - non-Windows platforms
 from . import BaseModule
 from .env_module import EnvModule
 from .db_module import DbModule
-from server.registry.system.config.model import ConfigKeyParams
-from server.modules.registry.helpers import get_config_request
+from queryregistry.system.config.models import ConfigKeyParams
+from queryregistry.system.config import get_config_request
 
 from server.helpers.logging import configure_discord_logging, remove_discord_logging, update_logging_level
 from server.routers.discord_events import register_discord_event_handlers

--- a/server/modules/user_admin_module.py
+++ b/server/modules/user_admin_module.py
@@ -5,8 +5,8 @@ from server.modules.discord_bot_module import DiscordBotModule
 from queryregistry.handler import dispatch_query_request
 from queryregistry.identity.profiles import get_profile_request, update_profile_request
 from queryregistry.identity.profiles.models import GuidParams, UpdateProfileParams
-from server.registry.finance.credits.model import SetCreditsParams
-from server.modules.registry.helpers import set_credits_request
+from queryregistry.finance.credits.models import SetCreditsParams
+from queryregistry.finance.credits import set_credits_request
 
 
 class UserAdminModule(BaseModule):


### PR DESCRIPTION
### Motivation
- Remove usage of the legacy `server.registry` bridge and `server.modules.registry.helpers` shim so data-access flows use the canonical `queryregistry` domains.
- Keep module behavior unchanged while aligning import paths with the domain-based queryregistry layout (identity, content, system, finance).

### Description
- In `server/modules/auth_module.py` replace `DBRequest`/`DBResponse` import from `server.registry.types` with `queryregistry.models`.
- In `server/modules/bsky_module.py` replace system config imports from legacy registry paths with `queryregistry.system.config.models.ConfigKeyParams` and `queryregistry.system.config.get_config_request`.
- In `server/modules/discord_bot_module.py` replace system config imports from legacy registry paths with `queryregistry.system.config.models.ConfigKeyParams` and `queryregistry.system.config.get_config_request`.
- In `server/modules/user_admin_module.py` replace finance credits imports from legacy registry paths with `queryregistry.finance.credits.models.SetCreditsParams` and `queryregistry.finance.credits.set_credits_request`.

### Testing
- Compiled the modified files with `python -m py_compile server/modules/auth_module.py server/modules/bsky_module.py server/modules/discord_bot_module.py server/modules/user_admin_module.py`, which completed without errors.
- Verified removal of legacy import usages with `rg -n "server\.registry\.|server\.modules\.registry\.helpers" server/modules/auth_module.py server/modules/bsky_module.py server/modules/discord_bot_module.py server/modules/user_admin_module.py`, which returned no matches.
- No behavioral or op-string changes were made; this change is limited to import-path rewiring only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae1e406dc08325963982da6946864c)