### PR TITLE
Refactor Tier 2 modules to use canonical queryregistry request builders

### DIFF
--- a/queryregistry/identity/accounts/__init__.py
+++ b/queryregistry/identity/accounts/__init__.py
@@ -1,1 +1,13 @@
-"""Identity accounts query registry stubs."""
+"""Identity accounts query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import AccountExistsRequestPayload
+
+__all__ = ["account_exists_request"]
+
+
+def account_exists_request(params: AccountExistsRequestPayload) -> DBRequest:
+  return DBRequest(op="db:identity:accounts:exists:1", payload=dict(params))

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -12,23 +12,23 @@ from queryregistry.system.config.models import ConfigKeyParams
 from . import BaseModule
 from .env_module import EnvModule
 from .providers import DbProviderBase
-from server.registry.types import DBRequest, DBResponse
-from server.registry.account.cache.model import (
+from queryregistry.models import DBRequest, DBResponse
+from queryregistry.content.cache.models import (
   CacheItemKey,
   DeleteCacheFolderParams,
   ListCacheParams,
   ReplaceUserCacheParams,
   UpsertCacheItemParams,
 )
-from server.modules.registry.helpers import (
+from queryregistry.content.cache import (
   delete_cache_folder_request,
   delete_cache_item_request,
-  get_config_request,
-  identity_account_exists_request,
   list_cache_request,
   replace_user_cache_request,
   upsert_cache_item_request,
 )
+from queryregistry.system.config import get_config_request
+from queryregistry.identity.accounts import account_exists_request
 from server.helpers.logging import update_logging_level
 from server.registry import get_handler_info, parse_db_op
 
@@ -264,7 +264,7 @@ class DbModule(BaseModule):
 
   async def user_exists(self, user_guid: str) -> bool:
     params: AccountExistsRequestPayload = {"user_guid": user_guid}
-    request = identity_account_exists_request(params)
+    request = account_exists_request(params)
     provider_name = self.provider or "mssql"
     try:
       res = await dispatch_query_request(request, provider=provider_name)

--- a/server/modules/public_gallery_module.py
+++ b/server/modules/public_gallery_module.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
-from server.modules.registry.helpers import get_public_files_request
+from queryregistry.content.cache import list_public_request
 
 class PublicGalleryModule(BaseModule):
   def __init__(self, app: FastAPI):
@@ -23,4 +23,4 @@ class PublicGalleryModule(BaseModule):
 
   async def list_public_files(self):
     assert self.db
-    return (await self.db.run(get_public_files_request())).rows
+    return (await self.db.run(list_public_request())).rows

--- a/server/modules/public_users_module.py
+++ b/server/modules/public_users_module.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 from fastapi import FastAPI
-from server.modules.registry.helpers import (
-  get_public_user_profile_request,
-  get_published_files_request,
-)
+from queryregistry.identity.profiles import get_public_profile_request
+from queryregistry.identity.profiles.models import GetPublicProfileParams
+from queryregistry.content.cache import get_published_files_request
+from queryregistry.content.cache.models import GetPublishedFilesParams
 from . import BaseModule
 from .db_module import DbModule
 from .discord_bot_module import DiscordBotModule
@@ -27,10 +27,10 @@ class PublicUsersModule(BaseModule):
 
   async def get_profile(self, guid: str):
     assert self.db
-    res = await self.db.run(get_public_user_profile_request(guid=guid))
+    res = await self.db.run(get_public_profile_request(GetPublicProfileParams(guid=guid)))
     return res.rows[0] if res.rows else None
 
   async def get_published_files(self, guid: str):
     assert self.db
-    res = await self.db.run(get_published_files_request(guid=guid))
+    res = await self.db.run(get_published_files_request(GetPublishedFilesParams(guid=guid)))
     return res.rows

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -5,15 +5,16 @@ from typing import Any
 from datetime import datetime, timezone
 from uuid import UUID
 from fastapi import FastAPI
-from server.registry.system.config.model import ConfigKeyParams
-from server.modules.registry.helpers import (
+from queryregistry.system.config.models import ConfigKeyParams
+from queryregistry.system.config import get_config_request
+from queryregistry.content.cache import (
   count_rows_request,
-  get_config_request,
   list_public_request,
   list_reported_request,
   set_gallery_request,
   set_reported_request,
 )
+from queryregistry.content.cache.models import SetGalleryParams, SetReportedParams
 from . import BaseModule
 from .env_module import EnvModule
 from .db_module import DbModule
@@ -518,12 +519,12 @@ class StorageModule(BaseModule):
 
   async def set_gallery(self, user_guid: str, name: str, gallery: bool):
     assert self.db
-    await self.db.run(set_gallery_request(user_guid, name, gallery))
+    await self.db.run(set_gallery_request(SetGalleryParams(user_guid=user_guid, name=name, gallery=gallery)))
 
   async def report_file(self, user_guid: str, name: str):
     assert self.db
     path, filename = name.rsplit("/", 1) if "/" in name else ("", name)
-    await self.db.run(set_reported_request(user_guid, path=path, filename=filename, reported=True))
+    await self.db.run(set_reported_request(SetReportedParams(user_guid=user_guid, path=path, filename=filename, reported=True)))
 
   async def create_folder(self, user_guid: str, path: str):
     if not self.db:


### PR DESCRIPTION
### Motivation
- Remove usage of legacy `server.modules.registry.helpers` and `server.registry` types in favor of the canonical `queryregistry` request builders and models for identity, content, and system config interactions.
- Align module call-site signatures with typed `queryregistry` request models so modules send canonical `DBRequest` payloads and avoid legacy naming/aliases.

### Description
- Added `account_exists_request` builder in `queryregistry/identity/accounts/__init__.py` to construct `DBRequest(op="db:identity:accounts:exists:1", ...)` from `AccountExistsRequestPayload`.
- Replaced legacy imports in `server/modules/db_module.py` to use `queryregistry.models.DBRequest/DBResponse`, `queryregistry.content.cache.models` types, cache request builders from `queryregistry.content.cache`, plus `get_config_request` from `queryregistry.system.config` and `account_exists_request` from `queryregistry.identity.accounts`, and updated `DbModule.user_exists` to call `account_exists_request(...)`; preserved `from server.registry import get_handler_info, parse_db_op` as the dispatch mechanism.
- Updated `server/modules/storage_module.py` to import `ConfigKeyParams` from `queryregistry.system.config.models`, cache builders and models from `queryregistry.content.cache` and `queryregistry.content.cache.models`, and adjusted call sites to use `SetGalleryParams` and `SetReportedParams` when calling `set_gallery_request` and `set_reported_request`.
- Rewrote `server/modules/public_gallery_module.py` to use `list_public_request()` from `queryregistry.content.cache` in place of the legacy alias.
- Rewrote `server/modules/public_users_module.py` to call `get_public_profile_request(GetPublicProfileParams(...))` and `get_published_files_request(GetPublishedFilesParams(...))` using typed param models from `queryregistry.identity.profiles.models` and `queryregistry.content.cache.models` respectively.

### Testing
- Ran `python -m py_compile queryregistry/identity/accounts/__init__.py server/modules/db_module.py server/modules/storage_module.py server/modules/public_gallery_module.py server/modules/public_users_module.py` and compilation succeeded.
- Verified there are no remaining references to `server.modules.registry.helpers` or the legacy `server.registry.account/finance/system.config.model` imports in the modified modules using ripgrep, and the check returned no matches.
- Confirmed `queryregistry/identity/accounts/__init__.py` is no longer a stub and contains the new `account_exists_request` builder and that `db_module` still imports `get_handler_info` and `parse_db_op` for dispatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae253305d08325b74e5a9b5b71b246)