### PR TITLE
Align system config responses to raw element_key/element_value columns

### DIFF
--- a/queryregistry/system/config/models.py
+++ b/queryregistry/system/config/models.py
@@ -33,5 +33,5 @@ class UpsertConfigParams(BaseModel):
 class ConfigRecord(TypedDict):
   """Record representation returned by configuration queries."""
 
-  key: str
-  value: str
+  element_key: str
+  element_value: str

--- a/queryregistry/system/config/mssql.py
+++ b/queryregistry/system/config/mssql.py
@@ -20,7 +20,7 @@ __all__ = [
 async def get_config_v1(args: Mapping[str, Any]) -> DBResponse:
   key = args["key"]
   sql = """
-    SELECT element_value AS value
+    SELECT element_value
     FROM system_config
     WHERE element_key = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
@@ -30,7 +30,7 @@ async def get_config_v1(args: Mapping[str, Any]) -> DBResponse:
 
 async def get_configs_v1(_: Mapping[str, Any]) -> DBResponse:
   sql = """
-    SELECT element_key AS [key], element_value AS value
+    SELECT element_key, element_value
     FROM system_config
     ORDER BY element_key
     FOR JSON PATH;

--- a/server/modules/bsky_module.py
+++ b/server/modules/bsky_module.py
@@ -48,7 +48,7 @@ class BskyModule(BaseModule):
     res = await self.db.run(get_config_request(ConfigKeyParams(key=key)))
     if not res.rows:
       return ""
-    return res.rows[0].get("value") or ""
+    return res.rows[0].get("element_value") or ""
 
   async def _ensure_credentials(self):
     if not self.db:

--- a/server/modules/db_module.py
+++ b/server/modules/db_module.py
@@ -130,7 +130,7 @@ class DbModule(BaseModule):
     assert self._provider
     await self._provider.startup()
     res = await self.run(get_config_request(ConfigKeyParams(key="LoggingLevel")))
-    val = res.rows[0]["value"] if res.rows else "0"
+    val = res.rows[0]["element_value"] if res.rows else "0"
     try:
       self.logging_level = int(val)
     except ValueError:
@@ -147,11 +147,11 @@ class DbModule(BaseModule):
     res = await self.run(get_config_request(ConfigKeyParams(key="MsApiId")))
     if not res.rows:
       raise ValueError("Missing config value for key: MsApiId")
-    return res.rows[0]["value"]
+    return res.rows[0]["element_value"]
 
   async def get_google_client_id(self) -> str:
     res = await self.run(get_config_request(ConfigKeyParams(key="GoogleClientId")))
-    value = res.rows[0]["value"] if res.rows else None
+    value = res.rows[0]["element_value"] if res.rows else None
     logging.debug("[DbModule] GoogleClientId=%s", value)
     if not value:
       raise ValueError("Missing config value for key: GoogleClientId")
@@ -168,7 +168,7 @@ class DbModule(BaseModule):
 
   async def get_discord_client_id(self) -> str:
     res = await self.run(get_config_request(ConfigKeyParams(key="DiscordClientId")))
-    value = res.rows[0]["value"] if res.rows else None
+    value = res.rows[0]["element_value"] if res.rows else None
     logging.debug("[DbModule] DiscordClientId=%s", value)
     if not value:
       raise ValueError("Missing config value for key: DiscordClientId")
@@ -176,14 +176,14 @@ class DbModule(BaseModule):
 
   async def get_auth_providers(self) -> list[str]:
     res = await self.run(get_config_request(ConfigKeyParams(key="AuthProviders")))
-    value = res.rows[0]["value"] if res.rows else None
+    value = res.rows[0]["element_value"] if res.rows else None
     if value is None:
       raise ValueError("Missing config value for key: AuthProviders")
     return [p.strip() for p in value.split(',') if p.strip()]
 
   async def get_jwks_cache_time(self) -> int:
     res = await self.run(get_config_request(ConfigKeyParams(key="JwksCacheTime")))
-    value = res.rows[0]["value"] if res.rows else None
+    value = res.rows[0]["element_value"] if res.rows else None
     if value is None:
       raise ValueError("Missing config value for key: JwksCacheTime")
     return int(value)

--- a/server/modules/discord_bot_module.py
+++ b/server/modules/discord_bot_module.py
@@ -80,7 +80,7 @@ class DiscordBotModule(BaseModule):
       res = await self.db.run(get_config_request(ConfigKeyParams(key="DiscordSyschan")))
       if not res.rows:
         raise ValueError("Missing config value for key: DiscordSyschan")
-      self.syschan = int(res.rows[0]["value"] or 0)
+      self.syschan = int(res.rows[0]["element_value"] or 0)
       try:
         await self.bot.login(self.secret)
         self._task = asyncio.create_task(self.bot.connect())

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -116,7 +116,7 @@ class OauthModule(BaseModule):
         status_code=500,
         detail=f"{self._provider_title(provider)} OAuth redirect URI not configured",
       )
-    self._redirect_uri = res.rows[0]["value"]
+    self._redirect_uri = res.rows[0]["element_value"]
     return self._redirect_uri
 
   def _get_provider_client_id(self, provider: str) -> str:

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -116,7 +116,7 @@ class OpenaiModule(BaseModule):
     assert self.db
     res = await self.db.run(get_config_request(ConfigKeyParams(key="OpenAIApiKey")))
     if res.rows:
-      return res.rows[0].get("value", "")
+      return res.rows[0].get("element_value", "")
     return ""
 
   async def init_openai_client(self) -> AsyncOpenAI | None:

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -83,7 +83,7 @@ class StorageModule(BaseModule):
 
     try:
       res = await self.db.run(get_config_request(ConfigKeyParams(key="StorageCacheTime")))
-      value = res.rows[0]["value"] if res.rows else "15m"
+      value = res.rows[0]["element_value"] if res.rows else "15m"
       try:
         self.reindex_interval = self._parse_duration(value)
       except Exception:
@@ -128,7 +128,7 @@ class StorageModule(BaseModule):
       logging.error("[StorageModule] Database module unavailable")
       return None
     res = await self.db.run(get_config_request(ConfigKeyParams(key="AzureBlobContainerName")))
-    container_name = res.rows[0]["value"] if res.rows else None
+    container_name = res.rows[0]["element_value"] if res.rows else None
     if not container_name:
       logging.error("[StorageModule] AzureBlobContainerName missing")
     return container_name


### PR DESCRIPTION
### Motivation

- The System Configuration frontend showed empty values due to a mismatch between SQL column aliases and the module code that expects raw DB column names `element_key`/`element_value`.
- The database is the source of truth and queries should return the raw column names rather than aliases so downstream modules can consume results consistently.

### Description

- Updated `queryregistry/system/config/mssql.py` to remove aliases in `get_config_v1` and `get_configs_v1` so queries return `element_value` and `element_key, element_value` respectively.
- Updated the system-config query model `ConfigRecord` to reflect `element_key`/`element_value` in `queryregistry/system/config/models.py`.
- Updated downstream consumers to read the raw column name `element_value` instead of the old `value` in modules that call `get_config_request(...)`: `server/modules/db_module.py`, `server/modules/openai_module.py`, `server/modules/bsky_module.py`, `server/modules/discord_bot_module.py`, `server/modules/oauth_module.py`, and `server/modules/storage_module.py`.
- Confirmed `server/modules/system_config_module.py` already reads `element_key`/`element_value` and required no changes.

### Testing

- Compiled modified files successfully using `python -m py_compile queryregistry/system/config/mssql.py` and `python -m py_compile server/modules/system_config_module.py` (succeeded).
- Compiled the updated modules and models using `python -m py_compile queryregistry/system/config/models.py server/modules/db_module.py server/modules/openai_module.py server/modules/bsky_module.py server/modules/discord_bot_module.py server/modules/oauth_module.py server/modules/storage_module.py rpc/system/config/services.py queryregistry/system/config/services.py` (succeeded).
- Verified no remaining SQL alias matches with `rg -n "AS value|AS \[key\]" queryregistry/system/config/mssql.py` (no matches) and that modules no longer reference `value` by regex checks (no matches).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae365d50e88325a8be63d3025787b5)