### PR TITLE
Enhance database CLI with registry-backed schema/data operations, versioning, and raw SQL execution

### DIFF
--- a/server/modules/database_cli/cli.py
+++ b/server/modules/database_cli/cli.py
@@ -6,10 +6,28 @@ import asyncio
 import logging
 import os
 
+from .. import database_cli_module
 from . import mssql_cli
 
 
 DEFAULT_DATABASE_PLACEHOLDER = "database"
+
+
+HELP_TEXT = """\
+Available commands:
+  help
+  connect <database>
+  reconnect [database]
+  list tables
+  schema dump [name]
+  schema apply <file>
+  dump data [name]
+  update version major|minor|patch
+  index all
+  exit, quit
+
+Any unrecognized command is executed as raw SQL.
+"""
 
 
 def _get_dsn() -> str:
@@ -26,11 +44,7 @@ def _prompt(dbname: str | None) -> str:
 
 
 def _print_help():
-  print("Available commands:")
-  print("  help")
-  print("  connect <database>")
-  print("  reconnect [database]")
-  print("  list tables")
+  print(HELP_TEXT)
 
 
 def run_repl():
@@ -49,21 +63,23 @@ def run_repl():
       if not raw:
         continue
       parts = raw.split()
-      command = parts[0].lower()
-      if command == "help":
+
+      if parts == ["help"]:
         _print_help()
         continue
-      if command == "connect":
+      if parts in (["exit"], ["quit"]):
+        break
+
+      if parts[0].lower() == "connect":
         target_db = parts[1] if len(parts) > 1 else None
         try:
-          conn = loop.run_until_complete(
-            mssql_cli.connect(dsn=_get_dsn(), dbname=target_db)
-          )
+          conn = loop.run_until_complete(mssql_cli.connect(dsn=_get_dsn(), dbname=target_db))
           dbname = target_db
         except Exception:
           logging.exception("[DatabaseCli] Failed to connect")
         continue
-      if command == "reconnect":
+
+      if parts[0].lower() == "reconnect":
         target_db = parts[1] if len(parts) > 1 else dbname
         if not target_db:
           print("No database selected. Use: connect <database>.")
@@ -76,20 +92,97 @@ def run_repl():
         except Exception:
           logging.exception("[DatabaseCli] Failed to reconnect")
         continue
-      if command == "list" and len(parts) > 1 and parts[1].lower() == "tables":
+
+      if parts[:2] == ["list", "tables"]:
         if not conn:
           print("Not connected. Use: connect <database>.")
           continue
         try:
           tables = loop.run_until_complete(mssql_cli.list_tables(conn))
-          if tables:
-            print("\n".join(tables))
-          else:
-            print("No tables found.")
+          print("\n".join(tables) if tables else "No tables found.")
         except Exception:
           logging.exception("[DatabaseCli] Failed to list tables")
         continue
-      print(f"Unknown command: {raw}. Type 'help' for available commands.")
+
+      if parts[:2] == ["schema", "dump"]:
+        if not conn:
+          print("Not connected. Use: connect <database>.")
+          continue
+        prefix = parts[2] if len(parts) > 2 else "schema"
+        try:
+          loop.run_until_complete(database_cli_module.dump_schema_from_registry(conn, prefix))
+        except Exception:
+          logging.exception("[DatabaseCli] Failed to dump schema")
+        continue
+
+      if parts[:2] == ["schema", "apply"] and len(parts) > 2:
+        if not conn:
+          print("Not connected. Use: connect <database>.")
+          continue
+        try:
+          loop.run_until_complete(database_cli_module.apply_schema(conn, parts[2]))
+        except Exception:
+          logging.exception("[DatabaseCli] Failed to apply schema")
+        continue
+
+      if parts[:2] == ["dump", "data"]:
+        if not conn:
+          print("Not connected. Use: connect <database>.")
+          continue
+        prefix = parts[2] if len(parts) > 2 else "dump_data"
+        try:
+          loop.run_until_complete(database_cli_module.dump_data(conn, prefix))
+        except Exception:
+          logging.exception("[DatabaseCli] Failed to dump data")
+        continue
+
+      if parts[:2] == ["index", "all"]:
+        if not conn:
+          print("Not connected. Use: connect <database>.")
+          continue
+        try:
+          loop.run_until_complete(database_cli_module.rebuild_indexes(conn))
+        except Exception:
+          logging.exception("[DatabaseCli] Failed to rebuild indexes")
+        continue
+
+      if len(parts) == 3 and parts[:2] == ["update", "version"] and parts[2] in {
+        "major",
+        "minor",
+        "patch",
+      }:
+        if not conn:
+          print("Not connected. Use: connect <database>.")
+          continue
+        try:
+          new_version = loop.run_until_complete(database_cli_module.update_version(conn, parts[2]))
+          schema_file = loop.run_until_complete(
+            database_cli_module.dump_schema_from_registry(conn, new_version)
+          )
+          database_cli_module.commit_and_tag(new_version, schema_file)
+        except Exception:
+          logging.exception("[DatabaseCli] Failed to update version")
+        continue
+
+      if not conn:
+        print("Not connected. Use: connect <database>.")
+        continue
+
+      try:
+        async def _run_sql():
+          async with conn.cursor() as cur:
+            await cur.execute(raw)
+            try:
+              rows = await cur.fetchall()
+              cols = [desc[0] for desc in cur.description]
+              for row in rows:
+                print(dict(zip(cols, row)))
+            except Exception:
+              print(cur.rowcount)
+
+        loop.run_until_complete(_run_sql())
+      except Exception:
+        logging.exception("[DatabaseCli] Raw SQL failed")
   finally:
     if conn:
       try:

--- a/server/modules/database_cli/mssql_cli.py
+++ b/server/modules/database_cli/mssql_cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Iterable
 
 
 def _rewrite_dsn_database(dsn: str, dbname: str) -> str:
@@ -55,11 +54,9 @@ async def reconnect(conn, *, dsn: str | None, dbname: str):
 
 async def list_tables(conn) -> list[str]:
   query = (
-    "SELECT TABLE_SCHEMA, TABLE_NAME "
-    "FROM INFORMATION_SCHEMA.TABLES "
-    "WHERE TABLE_TYPE='BASE TABLE' "
-    "AND TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA', 'sys') "
-    "ORDER BY TABLE_SCHEMA, TABLE_NAME"
+    "SELECT element_schema, element_name "
+    "FROM system_schema_tables "
+    "ORDER BY element_schema, element_name"
   )
   async with conn.cursor() as cur:
     await cur.execute(query)

--- a/server/modules/database_cli_module.py
+++ b/server/modules/database_cli_module.py
@@ -1,12 +1,351 @@
 """Database CLI module exposing management helpers."""
 
 import ast
-from pathlib import Path
-from fastapi import FastAPI
+import json
 import logging
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import FastAPI
+
 from . import BaseModule
-from .env_module import EnvModule
 from .database_cli import mssql_cli
+from .env_module import EnvModule
+
+
+def _quote(name: str) -> str:
+  return "[" + name.replace("]", "]]" ) + "]"
+
+
+def _qualify(schema: str, name: str) -> str:
+  return f"{_quote(schema)}.{_quote(name)}"
+
+
+def _normalize_length(length: int | None) -> int | None:
+  if length is None:
+    return None
+  if length in {-1, 0}:
+    return -1
+  return int(length)
+
+
+def _format_data_type(col: dict) -> str:
+  dtype = (col.get("data_type") or "").strip()
+  if not dtype:
+    return ""
+  upper = dtype.upper()
+  length = _normalize_length(col.get("max_length"))
+
+  if "(" in dtype:
+    return dtype
+  if upper in {"NVARCHAR", "NCHAR"}:
+    if length == -1:
+      return f"{upper}(MAX)"
+    if length is not None:
+      return f"{upper}({length})"
+  if upper in {"VARCHAR", "CHAR", "VARBINARY", "BINARY"}:
+    if length == -1:
+      return f"{upper}(MAX)"
+    if length is not None:
+      return f"{upper}({length})"
+  return upper
+
+
+def _format_column(col: dict) -> str:
+  parts = [_quote(col["name"]), _format_data_type(col)]
+  if col.get("identity"):
+    parts.append("IDENTITY(1, 1)")
+  parts.append("NULL" if col.get("nullable", True) else "NOT NULL")
+  if col.get("default"):
+    parts.append(f"DEFAULT {col['default']}")
+  return " ".join(parts)
+
+
+def _build_create_sql(table: dict) -> str:
+  table_name = _qualify(table["schema"], table["name"])
+  column_lines = [_format_column(col) for col in table["columns"]]
+  constraints: list[str] = []
+  pk = table.get("primary_key")
+  if pk and pk.get("columns"):
+    clause = f"CONSTRAINT {_quote(pk['name'])} PRIMARY KEY ({', '.join(pk['columns'])})"
+    constraints.append(clause)
+  body = ",\n  ".join(column_lines + constraints)
+  return f"CREATE TABLE {table_name} (\n  {body}\n);"
+
+
+def _build_index_sql(table: dict, index: dict) -> str:
+  table_name = _qualify(table["schema"], table["name"])
+  parts = ["CREATE"]
+  if index.get("is_unique"):
+    parts.append("UNIQUE")
+  parts.extend(["INDEX", _quote(index["name"]), "ON", table_name, f"({', '.join(index['key_columns'])})"])
+  return " ".join(parts) + ";"
+
+
+def _build_foreign_key_sql(table: dict, fk: dict) -> list[str]:
+  table_name = _qualify(table["schema"], table["name"])
+  ref_table = _qualify(fk["ref_schema"], fk["ref_table"])
+  statement = (
+    f"ALTER TABLE {table_name} ADD CONSTRAINT {_quote(fk['name'])} FOREIGN KEY "
+    f"({', '.join(fk['columns'])}) REFERENCES {ref_table} ({', '.join(fk['ref_columns'])});"
+  )
+  return [statement]
+
+
+async def get_schema_from_registry(conn) -> dict[str, list[dict]]:
+  async with conn.cursor() as cur:
+    await cur.execute(
+      "SELECT recid, element_schema, element_name "
+      "FROM system_schema_tables "
+      "ORDER BY element_schema, element_name"
+    )
+    table_rows = await cur.fetchall()
+
+  tables: dict[int, dict] = {}
+  for row in table_rows:
+    table_recid, schema_name, table_name = row
+    tables[int(table_recid)] = {
+      "recid": int(table_recid),
+      "schema": schema_name,
+      "name": table_name,
+      "columns": [],
+      "primary_key": None,
+      "unique_constraints": [],
+      "check_constraints": [],
+      "foreign_keys": [],
+      "indexes": [],
+    }
+
+  async with conn.cursor() as cur:
+    await cur.execute(
+      "SELECT c.tables_recid, c.element_name, c.element_nullable, c.element_default, "
+      "c.element_max_length, c.element_is_primary_key, c.element_is_identity, c.element_ordinal, "
+      "m.element_mssql_type "
+      "FROM system_schema_columns c "
+      "JOIN system_edt_mappings m ON c.edt_recid = m.recid "
+      "ORDER BY c.tables_recid, c.element_ordinal"
+    )
+    for row in await cur.fetchall():
+      (
+        tables_recid,
+        col_name,
+        nullable,
+        default_value,
+        max_length,
+        is_primary,
+        is_identity,
+        _ordinal,
+        mssql_type,
+      ) = row
+      table = tables.get(int(tables_recid))
+      if not table:
+        continue
+      table["columns"].append(
+        {
+          "name": col_name,
+          "data_type": mssql_type,
+          "max_length": max_length,
+          "precision": None,
+          "scale": None,
+          "nullable": bool(nullable),
+          "default": default_value,
+          "identity": bool(is_identity),
+          "identity_seed": 1,
+          "identity_increment": 1,
+          "rowguidcol": False,
+          "computed": None,
+          "computed_persisted": False,
+          "collation": None,
+          "is_primary_key": bool(is_primary),
+        }
+      )
+
+  for table in tables.values():
+    pk_columns = [_quote(col["name"]) for col in table["columns"] if col["is_primary_key"]]
+    if pk_columns:
+      table["primary_key"] = {
+        "name": f"PK_{table['name']}",
+        "type_desc": "CLUSTERED",
+        "columns": pk_columns,
+      }
+
+  async with conn.cursor() as cur:
+    await cur.execute(
+      "SELECT i.tables_recid, i.element_name, i.element_columns, i.element_is_unique "
+      "FROM system_schema_indexes i "
+      "ORDER BY i.tables_recid, i.element_name"
+    )
+    for row in await cur.fetchall():
+      tables_recid, idx_name, idx_columns, is_unique = row
+      table = tables.get(int(tables_recid))
+      if not table:
+        continue
+      key_columns = [_quote(col.strip()) for col in (idx_columns or "").split(",") if col.strip()]
+      table["indexes"].append(
+        {
+          "name": idx_name,
+          "is_unique": bool(is_unique),
+          "type_desc": "",
+          "has_filter": False,
+          "filter_definition": None,
+          "key_columns": key_columns,
+          "included_columns": [],
+        }
+      )
+
+  async with conn.cursor() as cur:
+    await cur.execute(
+      "SELECT fk.tables_recid, fk.element_column_name, fk.referenced_tables_recid, fk.element_referenced_column "
+      "FROM system_schema_foreign_keys fk "
+      "ORDER BY fk.tables_recid, fk.element_column_name"
+    )
+    fk_rows = await cur.fetchall()
+
+  for row in fk_rows:
+    tables_recid, source_column, ref_tables_recid, ref_column = row
+    table = tables.get(int(tables_recid))
+    ref_table = tables.get(int(ref_tables_recid))
+    if not table or not ref_table:
+      continue
+    table["foreign_keys"].append(
+      {
+        "name": f"FK_{table['name']}_{source_column}_{ref_table['name']}",
+        "columns": [_quote(source_column)],
+        "ref_columns": [_quote(ref_column)],
+        "ref_schema": ref_table["schema"],
+        "ref_table": ref_table["name"],
+      }
+    )
+
+  ordered_tables = sorted(tables.values(), key=lambda item: (item["schema"], item["name"]))
+  return {"tables": ordered_tables, "views": []}
+
+
+async def dump_schema_from_registry(conn, prefix: str = "schema") -> str:
+  schema = await get_schema_from_registry(conn)
+  ts = datetime.now(timezone.utc).strftime("%Y%m%d")
+  filename = f"{prefix}_{ts}.sql"
+
+  table_stmts: list[str] = []
+  index_stmts: list[str] = []
+  fk_stmts: list[str] = []
+
+  for table in schema["tables"]:
+    table_stmts.append(_build_create_sql(table))
+    for index in table["indexes"]:
+      index_stmts.append(_build_index_sql(table, index))
+    for fk in table["foreign_keys"]:
+      fk_stmts.extend(_build_foreign_key_sql(table, fk))
+
+  lines: list[str] = ["SET ANSI_NULLS ON;", "SET QUOTED_IDENTIFIER ON;", ""]
+  for section in (table_stmts, index_stmts, fk_stmts):
+    if not section:
+      continue
+    lines.extend(section)
+    lines.append("")
+
+  Path(filename).write_text("\n".join(lines).strip() + "\n", encoding="utf-8")
+  print(f"Schema dumped to {filename}")
+  return filename
+
+
+def parse_version(ver: str) -> tuple[int, int, int, int]:
+  ver = ver.lstrip("v")
+  major, minor, patch, build = [int(part) for part in ver.split(".")]
+  return major, minor, patch, build
+
+
+def bump_version(version: str, part: str) -> str:
+  major, minor, patch, build = parse_version(version)
+  match part:
+    case "major":
+      major += 1
+      minor = 0
+      patch = 0
+      build = 0
+    case "minor":
+      minor += 1
+      patch = 0
+      build = 0
+    case "patch":
+      patch += 1
+    case "build":
+      build += 1
+    case _:
+      raise ValueError(f"Unknown part: {part}")
+  return f"v{major}.{minor}.{patch}.{build}"
+
+
+async def update_version(conn, part: str) -> str:
+  async with conn.cursor() as cur:
+    await cur.execute("SELECT element_value FROM system_config WHERE element_key='Version'")
+    row = await cur.fetchone()
+    if not row:
+      raise RuntimeError("Version entry not found in system_config")
+    current_version = row[0]
+
+    next_version = bump_version(current_version, part)
+    await cur.execute(
+      "UPDATE system_config SET element_value=? WHERE element_key='Version'",
+      (next_version,),
+    )
+  print(f"Updated Version: {current_version} -> {next_version}")
+  return next_version
+
+
+def commit_and_tag(version: str, schema_file: str):
+  subprocess.check_call(f"git add {schema_file}", shell=True)
+  subprocess.check_call(f'git commit -m "Exported DB schema for {version}"', shell=True)
+  subprocess.check_call(f"git tag {version}", shell=True)
+  current_branch = subprocess.check_output(
+    "git rev-parse --abbrev-ref HEAD", shell=True, text=True
+  ).strip()
+  subprocess.check_call(f"git push origin {current_branch}", shell=True)
+  subprocess.check_call("git push origin --tags", shell=True)
+
+
+_GO_PATTERN = re.compile(r"^\s*GO\s*$", flags=re.IGNORECASE | re.MULTILINE)
+
+
+def _iter_batches(sql: str) -> list[str]:
+  return [batch for batch in _GO_PATTERN.split(sql) if batch.strip()]
+
+
+async def apply_schema(conn, path: str):
+  sql = Path(path).read_text(encoding="utf-8")
+  batches = _iter_batches(sql)
+  async with conn.cursor() as cur:
+    for batch in batches:
+      await cur.execute(batch)
+  print("Schema applied.")
+
+
+async def dump_data(conn, prefix: str = "dump_data") -> str:
+  schema = await get_schema_from_registry(conn)
+  data: dict[str, list[dict]] = {}
+  for table in schema["tables"]:
+    table_name = _qualify(table["schema"], table["name"])
+    key = f"{table['schema']}.{table['name']}"
+    async with conn.cursor() as cur:
+      await cur.execute(f"SELECT * FROM {table_name} FOR JSON PATH")
+      row = await cur.fetchone()
+      data[key] = json.loads(row[0]) if row and row[0] else []
+  ts = datetime.now(timezone.utc).strftime("%Y%m%d_BACKUP")
+  filename = f"{prefix}_{ts}.json"
+  Path(filename).write_text(
+    json.dumps({"schema": schema, "data": data}, indent=2, default=str),
+    encoding="utf-8",
+  )
+  print(f"Data dumped to {filename}")
+  return filename
+
+
+async def rebuild_indexes(conn):
+  async with conn.cursor() as cur:
+    await cur.execute("EXEC sp_MSforeachtable 'ALTER INDEX ALL ON ? REBUILD'")
+  print("Reindex complete.")
 
 
 class DatabaseCliModule(BaseModule):
@@ -46,6 +385,37 @@ class DatabaseCliModule(BaseModule):
   async def list_tables(self, conn):
     await self.on_ready()
     return await mssql_cli.list_tables(conn)
+
+  async def get_schema_from_registry(self, conn):
+    await self.on_ready()
+    return await get_schema_from_registry(conn)
+
+  async def dump_schema_from_registry(self, conn, prefix: str = "schema"):
+    await self.on_ready()
+    return await dump_schema_from_registry(conn, prefix)
+
+  async def dump_schema(self, conn, prefix: str):
+    await self.on_ready()
+    return await dump_schema_from_registry(conn, prefix)
+
+  async def apply_schema(self, conn, path: str):
+    await self.on_ready()
+    return await apply_schema(conn, path)
+
+  async def dump_data(self, conn, prefix: str):
+    await self.on_ready()
+    return await dump_data(conn, prefix)
+
+  async def update_version(self, conn, part: str):
+    await self.on_ready()
+    return await update_version(conn, part)
+
+  def commit_and_tag(self, version: str, schema_file: str):
+    commit_and_tag(version, schema_file)
+
+  async def rebuild_indexes(self, conn):
+    await self.on_ready()
+    return await rebuild_indexes(conn)
 
   async def get_database_rpc_namespace(self) -> dict[str, object]:
     operations = self._discover_queryregistry_operations()


### PR DESCRIPTION
### Motivation
- Extend the interactive database CLI to support schema and data management, version bumping and tagging, and index rebuilds backed by a registry of schema metadata.
- Provide convenient commands and improved raw SQL execution for ad-hoc operations in the REPL.
- Adapt MSSQL helpers to a new internal system schema layout used by the registry.

### Description
- Add `server/modules/database_cli_module.py` which implements registry-driven schema introspection (`get_schema_from_registry`), schema dump (`dump_schema_from_registry`), schema apply (`apply_schema`), data dump (`dump_data`), version bumping (`update_version` / `bump_version` / `commit_and_tag`), and `rebuild_indexes` utilities, plus SQL formatting helpers and batching by `GO`.
- Update the interactive REPL in `server/modules/database_cli/cli.py` to print an expanded `HELP_TEXT`, parse and handle new commands (`schema dump`, `schema apply`, `dump data`, `update version`, `index all`, `reconnect`, `connect`, `list tables`, `exit/quit`) and to execute raw SQL when an unrecognized command is provided.
- Wire the REPL to call the new module functions via `database_cli_module` and added module adapter methods in `DatabaseCliModule` to expose the new helpers (e.g. `dump_schema_from_registry`, `apply_schema`, `dump_data`, `update_version`, `rebuild_indexes`, `commit_and_tag`).
- Adjust `server/modules/database_cli/mssql_cli.py` to target the new registry tables by changing the `list_tables` query and keep connection helpers intact, plus minor internal refactors.

### Testing
- No automated tests were added for the new schema/data/versioning features in this rollout.
- Existing automated test suite was not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aefd38b1b08325b72b5e114b1fcc97)