### PR TITLE
Add reflection queryregistry domain scaffolding

### DIFF
--- a/queryregistry/handler.py
+++ b/queryregistry/handler.py
@@ -9,6 +9,7 @@ from queryregistry.models import DBRequest, DBResponse
 from .content.handler import handle_content_request
 from .finance.handler import handle_finance_request
 from .identity.handler import handle_identity_request
+from .reflection.handler import handle_reflection_request
 from .system.handler import handle_system_request
 from .helpers import parse_query_request
 
@@ -17,6 +18,7 @@ HANDLERS: dict[str, DomainHandler] = {
   "content": handle_content_request,
   "finance": handle_finance_request,
   "identity": handle_identity_request,
+  "reflection": handle_reflection_request,
   "system": handle_system_request,
 }
 

--- a/queryregistry/reflection/__init__.py
+++ b/queryregistry/reflection/__init__.py
@@ -1,0 +1,1 @@
+"""Reflection query handler package."""

--- a/queryregistry/reflection/data/__init__.py
+++ b/queryregistry/reflection/data/__init__.py
@@ -1,0 +1,35 @@
+"""Reflection data query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import BatchParams, DumpTableParams, UpdateVersionParams
+
+__all__ = [
+  "apply_batch_request",
+  "dump_table_request",
+  "get_version_request",
+  "rebuild_indexes_request",
+  "update_version_request",
+]
+
+
+def get_version_request() -> DBRequest:
+  return DBRequest(op="db:reflection:data:get_version:1", payload={})
+
+
+def update_version_request(params: UpdateVersionParams) -> DBRequest:
+  return DBRequest(op="db:reflection:data:update_version:1", payload=params.model_dump())
+
+
+def dump_table_request(params: DumpTableParams) -> DBRequest:
+  return DBRequest(op="db:reflection:data:dump_table:1", payload=params.model_dump())
+
+
+def rebuild_indexes_request() -> DBRequest:
+  return DBRequest(op="db:reflection:data:rebuild_indexes:1", payload={})
+
+
+def apply_batch_request(params: BatchParams) -> DBRequest:
+  return DBRequest(op="db:reflection:data:apply_batch:1", payload=params.model_dump())

--- a/queryregistry/reflection/data/handler.py
+++ b/queryregistry/reflection/data/handler.py
@@ -1,0 +1,36 @@
+"""Reflection data handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import apply_batch_v1, dump_table_v1, get_version_v1, rebuild_indexes_v1, update_version_v1
+from ..dispatch import SubdomainDispatcher
+
+__all__ = ["handle_data_request"]
+
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("get_version", "1"): get_version_v1,
+  ("update_version", "1"): update_version_v1,
+  ("dump_table", "1"): dump_table_v1,
+  ("rebuild_indexes", "1"): rebuild_indexes_v1,
+  ("apply_batch", "1"): apply_batch_v1,
+}
+
+
+async def handle_data_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown reflection data operation",
+  )

--- a/queryregistry/reflection/data/models.py
+++ b/queryregistry/reflection/data/models.py
@@ -1,0 +1,53 @@
+"""Reflection data query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "BatchParams",
+  "DumpTableParams",
+  "UpdateVersionParams",
+  "VersionParams",
+  "VersionRecord",
+]
+
+
+class VersionParams(BaseModel):
+  """Payload for fetching current system version."""
+
+  model_config = ConfigDict(extra="forbid")
+
+
+class UpdateVersionParams(BaseModel):
+  """Payload for updating current system version."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  version: str
+
+
+class DumpTableParams(BaseModel):
+  """Payload for exporting table rows as JSON."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  schema: str
+  name: str
+
+
+class BatchParams(BaseModel):
+  """Payload for executing a SQL batch."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  sql: str
+
+
+class VersionRecord(TypedDict):
+  """Version record from system_config."""
+
+  element_key: str
+  element_value: str

--- a/queryregistry/reflection/data/mssql.py
+++ b/queryregistry/reflection/data/mssql.py
@@ -1,0 +1,36 @@
+"""MSSQL implementations for reflection data query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "apply_batch_v1",
+  "dump_table_v1",
+  "get_version_v1",
+  "rebuild_indexes_v1",
+  "update_version_v1",
+]
+
+
+async def get_version_v1(_: Mapping[str, Any]) -> DBResponse:
+  raise NotImplementedError("Not yet migrated from database_cli_module")
+
+
+async def update_version_v1(_: Mapping[str, Any]) -> DBResponse:
+  raise NotImplementedError("Not yet migrated from database_cli_module")
+
+
+async def dump_table_v1(_: Mapping[str, Any]) -> DBResponse:
+  raise NotImplementedError("Not yet migrated from database_cli_module")
+
+
+async def rebuild_indexes_v1(_: Mapping[str, Any]) -> DBResponse:
+  raise NotImplementedError("Not yet migrated from database_cli_module")
+
+
+async def apply_batch_v1(_: Mapping[str, Any]) -> DBResponse:
+  raise NotImplementedError("Not yet migrated from database_cli_module")

--- a/queryregistry/reflection/data/services.py
+++ b/queryregistry/reflection/data/services.py
@@ -1,0 +1,63 @@
+"""Reflection data query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import BatchParams, DumpTableParams, UpdateVersionParams, VersionParams
+
+__all__ = [
+  "apply_batch_v1",
+  "dump_table_v1",
+  "get_version_v1",
+  "rebuild_indexes_v1",
+  "update_version_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_GET_VERSION_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_version_v1}
+_UPDATE_VERSION_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.update_version_v1}
+_DUMP_TABLE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.dump_table_v1}
+_REBUILD_INDEXES_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.rebuild_indexes_v1}
+_APPLY_BATCH_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.apply_batch_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for reflection data registry")
+  return dispatcher
+
+
+async def get_version_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = VersionParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_VERSION_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def update_version_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpdateVersionParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPDATE_VERSION_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def dump_table_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = DumpTableParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DUMP_TABLE_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def rebuild_indexes_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  result = await _select_dispatcher(provider, _REBUILD_INDEXES_DISPATCHERS)(request.payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def apply_batch_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = BatchParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _APPLY_BATCH_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/queryregistry/reflection/dispatch.py
+++ b/queryregistry/reflection/dispatch.py
@@ -1,0 +1,13 @@
+"""Shared protocol helpers for reflection subdomain dispatchers."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from queryregistry.models import DBRequest, DBResponse
+
+__all__ = ["SubdomainDispatcher"]
+
+
+class SubdomainDispatcher(Protocol):
+  async def __call__(self, request: DBRequest, *, provider: str) -> DBResponse: ...

--- a/queryregistry/reflection/handler.py
+++ b/queryregistry/reflection/handler.py
@@ -1,0 +1,34 @@
+"""Reflection domain handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from fastapi import HTTPException
+
+from queryregistry.models import DBRequest, DBResponse
+
+from .data.handler import handle_data_request
+from .schema.handler import handle_schema_request
+
+__all__ = ["handle_reflection_request"]
+
+HANDLERS = {
+  "schema": handle_schema_request,
+  "data": handle_data_request,
+}
+
+
+async def handle_reflection_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  if not path:
+    raise HTTPException(status_code=404, detail="Unknown reflection registry operation")
+  subdomain = path[0]
+  handler = HANDLERS.get(subdomain)
+  if handler is None:
+    raise HTTPException(status_code=404, detail="Unknown reflection registry operation")
+  return await handler(path[1:], request, provider=provider)

--- a/queryregistry/reflection/models.py
+++ b/queryregistry/reflection/models.py
@@ -1,0 +1,14 @@
+"""Shared reflection domain models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+__all__ = ["SchemaObjectRef"]
+
+
+class SchemaObjectRef(TypedDict):
+  """Schema-qualified object reference."""
+
+  schema: str
+  name: str

--- a/queryregistry/reflection/schema/__init__.py
+++ b/queryregistry/reflection/schema/__init__.py
@@ -1,0 +1,41 @@
+"""Reflection schema query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import ColumnParams, TableParams
+
+__all__ = [
+  "get_full_schema_request",
+  "list_columns_request",
+  "list_foreign_keys_request",
+  "list_indexes_request",
+  "list_tables_request",
+  "list_views_request",
+]
+
+
+def list_tables_request() -> DBRequest:
+  return DBRequest(op="db:reflection:schema:list_tables:1", payload={})
+
+
+def list_columns_request(params: TableParams) -> DBRequest:
+  return DBRequest(op="db:reflection:schema:list_columns:1", payload=params.model_dump())
+
+
+def list_indexes_request(params: TableParams) -> DBRequest:
+  return DBRequest(op="db:reflection:schema:list_indexes:1", payload=params.model_dump())
+
+
+def list_foreign_keys_request(params: TableParams) -> DBRequest:
+  return DBRequest(op="db:reflection:schema:list_foreign_keys:1", payload=params.model_dump())
+
+
+def list_views_request() -> DBRequest:
+  return DBRequest(op="db:reflection:schema:list_views:1", payload={})
+
+
+def get_full_schema_request(params: ColumnParams | None = None) -> DBRequest:
+  payload = {} if params is None else params.model_dump()
+  return DBRequest(op="db:reflection:schema:get_full_schema:1", payload=payload)

--- a/queryregistry/reflection/schema/handler.py
+++ b/queryregistry/reflection/schema/handler.py
@@ -1,0 +1,44 @@
+"""Reflection schema handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import (
+  get_full_schema_v1,
+  list_columns_v1,
+  list_foreign_keys_v1,
+  list_indexes_v1,
+  list_tables_v1,
+  list_views_v1,
+)
+from ..dispatch import SubdomainDispatcher
+
+__all__ = ["handle_schema_request"]
+
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("list_tables", "1"): list_tables_v1,
+  ("list_columns", "1"): list_columns_v1,
+  ("list_indexes", "1"): list_indexes_v1,
+  ("list_foreign_keys", "1"): list_foreign_keys_v1,
+  ("list_views", "1"): list_views_v1,
+  ("get_full_schema", "1"): get_full_schema_v1,
+}
+
+
+async def handle_schema_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown reflection schema operation",
+  )

--- a/queryregistry/reflection/schema/models.py
+++ b/queryregistry/reflection/schema/models.py
@@ -1,0 +1,102 @@
+"""Reflection schema query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "ColumnParams",
+  "ColumnRecord",
+  "ForeignKeyRecord",
+  "FullSchemaRecord",
+  "IndexRecord",
+  "SchemaRecord",
+  "TableParams",
+  "TableRecord",
+  "ViewRecord",
+]
+
+
+class TableParams(BaseModel):
+  """Payload targeting a table in reflection metadata."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  schema: str
+  name: str
+
+
+class ColumnParams(BaseModel):
+  """Optional payload for schema-wide column introspection filters."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  schema: str | None = None
+  name: str | None = None
+
+
+class TableRecord(TypedDict):
+  """Table metadata record from system_schema_tables."""
+
+  recid: int
+  element_schema: str
+  element_name: str
+
+
+class ColumnRecord(TypedDict):
+  """Column metadata record resolved with EDT mappings."""
+
+  tables_recid: int
+  element_name: str
+  element_nullable: bool
+  element_default: str | None
+  element_max_length: int | None
+  element_is_primary_key: bool
+  element_is_identity: bool
+  element_ordinal: int
+  element_mssql_type: str
+
+
+class IndexRecord(TypedDict):
+  """Index metadata record from system_schema_indexes."""
+
+  tables_recid: int
+  element_name: str
+  element_columns: str
+  element_is_unique: bool
+
+
+class ForeignKeyRecord(TypedDict):
+  """Foreign key metadata record from system_schema_foreign_keys."""
+
+  tables_recid: int
+  element_column_name: str
+  referenced_tables_recid: int
+  element_referenced_column: str
+
+
+class ViewRecord(TypedDict):
+  """View metadata record from system_schema_views."""
+
+  element_schema: str
+  element_name: str
+  element_definition: str
+
+
+class SchemaRecord(TypedDict):
+  """Logical schema record matching composed table metadata."""
+
+  tables: list[TableRecord]
+  columns: list[ColumnRecord]
+  indexes: list[IndexRecord]
+  foreign_keys: list[ForeignKeyRecord]
+  views: list[ViewRecord]
+
+
+class FullSchemaRecord(TypedDict):
+  """Composite schema response payload."""
+
+  tables: list[dict]
+  views: list[dict]

--- a/queryregistry/reflection/schema/mssql.py
+++ b/queryregistry/reflection/schema/mssql.py
@@ -1,0 +1,41 @@
+"""MSSQL implementations for reflection schema query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+
+__all__ = [
+  "get_full_schema_v1",
+  "list_columns_v1",
+  "list_foreign_keys_v1",
+  "list_indexes_v1",
+  "list_tables_v1",
+  "list_views_v1",
+]
+
+
+async def list_tables_v1(_: Mapping[str, Any]) -> DBResponse:
+  raise NotImplementedError("Not yet migrated from database_cli_module")
+
+
+async def list_columns_v1(_: Mapping[str, Any]) -> DBResponse:
+  raise NotImplementedError("Not yet migrated from database_cli_module")
+
+
+async def list_indexes_v1(_: Mapping[str, Any]) -> DBResponse:
+  raise NotImplementedError("Not yet migrated from database_cli_module")
+
+
+async def list_foreign_keys_v1(_: Mapping[str, Any]) -> DBResponse:
+  raise NotImplementedError("Not yet migrated from database_cli_module")
+
+
+async def list_views_v1(_: Mapping[str, Any]) -> DBResponse:
+  raise NotImplementedError("Not yet migrated from database_cli_module")
+
+
+async def get_full_schema_v1(_: Mapping[str, Any]) -> DBResponse:
+  raise NotImplementedError("Not yet migrated from database_cli_module")

--- a/queryregistry/reflection/schema/services.py
+++ b/queryregistry/reflection/schema/services.py
@@ -1,0 +1,70 @@
+"""Reflection schema query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import ColumnParams, TableParams
+
+__all__ = [
+  "get_full_schema_v1",
+  "list_columns_v1",
+  "list_foreign_keys_v1",
+  "list_indexes_v1",
+  "list_tables_v1",
+  "list_views_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_TABLES_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_tables_v1}
+_LIST_COLUMNS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_columns_v1}
+_LIST_INDEXES_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_indexes_v1}
+_LIST_FOREIGN_KEYS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_foreign_keys_v1}
+_LIST_VIEWS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_views_v1}
+_GET_FULL_SCHEMA_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_full_schema_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for reflection schema registry")
+  return dispatcher
+
+
+async def list_tables_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  result = await _select_dispatcher(provider, _LIST_TABLES_DISPATCHERS)(request.payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_columns_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = TableParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_COLUMNS_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_indexes_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = TableParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_INDEXES_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_foreign_keys_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = TableParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_FOREIGN_KEYS_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_views_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  result = await _select_dispatcher(provider, _LIST_VIEWS_DISPATCHERS)(request.payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_full_schema_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ColumnParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_FULL_SCHEMA_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)


### PR DESCRIPTION
### Motivation
- Prepare a new `reflection` queryregistry domain to host schema introspection and data operations currently embedded as raw SQL in the `database_cli_module`. 
- Introduce the domain structure first so SQL and provider implementations can be migrated in a follow-up change. 
- Conform to existing `queryregistry` patterns (domain/subdomain dispatch, typed models, provider dispatch) to keep the layer strictly data-access only.

### Description
- Add `queryregistry/reflection` package and register `handle_reflection_request` in the top-level `HANDLERS` map so the domain is routable via `dispatch_query_request`. 
- Implement `schema` and `data` subdomains with request builders (`__init__.py`), subdomain `handler.py` dispatch maps, typed `models.py`, and service wrappers in `services.py` that select provider dispatchers. 
- Add MSSQL provider stubs in `schema/mssql.py` and `data/mssql.py` as async functions that raise `NotImplementedError("Not yet migrated from database_cli_module")` to mark work remaining. 
- Add shared reflection helpers in `queryregistry/reflection/dispatch.py` and shared domain types in `queryregistry/reflection/models.py` to match existing domain conventions.

### Testing
- Ran syntax checks with `python -m py_compile` for the new files and top-level handler and all checks passed. 
- Verified the new domain is referenced in `queryregistry/handler.py` with `rg -n "reflection" queryregistry/handler.py` which returned the import and `HANDLERS` entry. 
- No functional provider SQL was added in this change, so runtime behavior for reflection operations remains gated by the `NotImplementedError` stubs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af381766b483258872690450c00460)