### PR TITLE
Implement MSSQL reflection providers and add FullSchemaParams

### DIFF
--- a/queryregistry/reflection/data/mssql.py
+++ b/queryregistry/reflection/data/mssql.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
 
 __all__ = [
   "apply_batch_v1",
@@ -16,21 +17,38 @@ __all__ = [
 ]
 
 
+def _quote_ident(identifier: str) -> str:
+  return "[" + identifier.replace("]", "]]" ) + "]"
+
+
 async def get_version_v1(_: Mapping[str, Any]) -> DBResponse:
-  raise NotImplementedError("Not yet migrated from database_cli_module")
+  sql = """
+    SELECT element_value
+    FROM system_config
+    WHERE element_key='Version'
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return await run_json_one(sql)
 
 
-async def update_version_v1(_: Mapping[str, Any]) -> DBResponse:
-  raise NotImplementedError("Not yet migrated from database_cli_module")
+async def update_version_v1(args: Mapping[str, Any]) -> DBResponse:
+  version = args["version"]
+  sql = "UPDATE system_config SET element_value=? WHERE element_key='Version';"
+  return await run_exec(sql, (version,))
 
 
-async def dump_table_v1(_: Mapping[str, Any]) -> DBResponse:
-  raise NotImplementedError("Not yet migrated from database_cli_module")
+async def dump_table_v1(args: Mapping[str, Any]) -> DBResponse:
+  schema_name = _quote_ident(args["schema"])
+  table_name = _quote_ident(args["name"])
+  sql = f"SELECT * FROM {schema_name}.{table_name} FOR JSON PATH;"
+  return await run_json_many(sql)
 
 
 async def rebuild_indexes_v1(_: Mapping[str, Any]) -> DBResponse:
-  raise NotImplementedError("Not yet migrated from database_cli_module")
+  sql = "EXEC sp_MSforeachtable 'ALTER INDEX ALL ON ? REBUILD'"
+  return await run_exec(sql)
 
 
-async def apply_batch_v1(_: Mapping[str, Any]) -> DBResponse:
-  raise NotImplementedError("Not yet migrated from database_cli_module")
+async def apply_batch_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = args["sql"]
+  return await run_exec(sql)

--- a/queryregistry/reflection/schema/__init__.py
+++ b/queryregistry/reflection/schema/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from queryregistry.models import DBRequest
 
-from .models import ColumnParams, TableParams
+from .models import TableParams
 
 __all__ = [
   "get_full_schema_request",
@@ -36,6 +36,5 @@ def list_views_request() -> DBRequest:
   return DBRequest(op="db:reflection:schema:list_views:1", payload={})
 
 
-def get_full_schema_request(params: ColumnParams | None = None) -> DBRequest:
-  payload = {} if params is None else params.model_dump()
-  return DBRequest(op="db:reflection:schema:get_full_schema:1", payload=payload)
+def get_full_schema_request() -> DBRequest:
+  return DBRequest(op="db:reflection:schema:get_full_schema:1", payload={})

--- a/queryregistry/reflection/schema/models.py
+++ b/queryregistry/reflection/schema/models.py
@@ -7,9 +7,9 @@ from typing import TypedDict
 from pydantic import BaseModel, ConfigDict
 
 __all__ = [
-  "ColumnParams",
   "ColumnRecord",
   "ForeignKeyRecord",
+  "FullSchemaParams",
   "FullSchemaRecord",
   "IndexRecord",
   "SchemaRecord",
@@ -28,13 +28,10 @@ class TableParams(BaseModel):
   name: str
 
 
-class ColumnParams(BaseModel):
-  """Optional payload for schema-wide column introspection filters."""
+class FullSchemaParams(BaseModel):
+  """Empty payload for full schema introspection."""
 
   model_config = ConfigDict(extra="forbid")
-
-  schema: str | None = None
-  name: str | None = None
 
 
 class TableRecord(TypedDict):
@@ -98,5 +95,8 @@ class SchemaRecord(TypedDict):
 class FullSchemaRecord(TypedDict):
   """Composite schema response payload."""
 
-  tables: list[dict]
-  views: list[dict]
+  tables: list[TableRecord]
+  columns: list[ColumnRecord]
+  indexes: list[IndexRecord]
+  foreign_keys: list[ForeignKeyRecord]
+  views: list[ViewRecord]

--- a/queryregistry/reflection/schema/mssql.py
+++ b/queryregistry/reflection/schema/mssql.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_json_many
 
 __all__ = [
   "get_full_schema_v1",
@@ -18,24 +19,121 @@ __all__ = [
 
 
 async def list_tables_v1(_: Mapping[str, Any]) -> DBResponse:
-  raise NotImplementedError("Not yet migrated from database_cli_module")
+  sql = """
+    SELECT recid, element_schema, element_name
+    FROM system_schema_tables
+    ORDER BY element_schema, element_name
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql)
 
 
-async def list_columns_v1(_: Mapping[str, Any]) -> DBResponse:
-  raise NotImplementedError("Not yet migrated from database_cli_module")
+async def list_columns_v1(args: Mapping[str, Any]) -> DBResponse:
+  schema_name = args["schema"]
+  table_name = args["name"]
+  sql = """
+    SELECT c.tables_recid, c.element_name, c.element_nullable, c.element_default,
+           c.element_max_length, c.element_is_primary_key, c.element_is_identity,
+           c.element_ordinal, m.element_mssql_type
+    FROM system_schema_columns c
+    JOIN system_edt_mappings m ON c.edt_recid = m.recid
+    JOIN system_schema_tables t ON c.tables_recid = t.recid
+    WHERE t.element_schema = ? AND t.element_name = ?
+    ORDER BY c.element_ordinal
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql, (schema_name, table_name))
 
 
-async def list_indexes_v1(_: Mapping[str, Any]) -> DBResponse:
-  raise NotImplementedError("Not yet migrated from database_cli_module")
+async def list_indexes_v1(args: Mapping[str, Any]) -> DBResponse:
+  schema_name = args["schema"]
+  table_name = args["name"]
+  sql = """
+    SELECT i.tables_recid, i.element_name, i.element_columns, i.element_is_unique
+    FROM system_schema_indexes i
+    JOIN system_schema_tables t ON i.tables_recid = t.recid
+    WHERE t.element_schema = ? AND t.element_name = ?
+    ORDER BY i.element_name
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql, (schema_name, table_name))
 
 
-async def list_foreign_keys_v1(_: Mapping[str, Any]) -> DBResponse:
-  raise NotImplementedError("Not yet migrated from database_cli_module")
+async def list_foreign_keys_v1(args: Mapping[str, Any]) -> DBResponse:
+  schema_name = args["schema"]
+  table_name = args["name"]
+  sql = """
+    SELECT fk.tables_recid, fk.element_column_name, fk.referenced_tables_recid,
+           fk.element_referenced_column
+    FROM system_schema_foreign_keys fk
+    JOIN system_schema_tables t ON fk.tables_recid = t.recid
+    WHERE t.element_schema = ? AND t.element_name = ?
+    ORDER BY fk.element_column_name
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql, (schema_name, table_name))
 
 
 async def list_views_v1(_: Mapping[str, Any]) -> DBResponse:
-  raise NotImplementedError("Not yet migrated from database_cli_module")
+  sql = """
+    SELECT element_schema, element_name, element_definition
+    FROM system_schema_views
+    ORDER BY element_schema, element_name
+    FOR JSON PATH;
+  """
+  return await run_json_many(sql)
 
 
 async def get_full_schema_v1(_: Mapping[str, Any]) -> DBResponse:
-  raise NotImplementedError("Not yet migrated from database_cli_module")
+  tables = await run_json_many(
+    """
+    SELECT recid, element_schema, element_name
+    FROM system_schema_tables
+    ORDER BY element_schema, element_name
+    FOR JSON PATH;
+    """
+  )
+  columns = await run_json_many(
+    """
+    SELECT c.tables_recid, c.element_name, c.element_nullable, c.element_default,
+           c.element_max_length, c.element_is_primary_key, c.element_is_identity,
+           c.element_ordinal, m.element_mssql_type
+    FROM system_schema_columns c
+    JOIN system_edt_mappings m ON c.edt_recid = m.recid
+    ORDER BY c.tables_recid, c.element_ordinal
+    FOR JSON PATH;
+    """
+  )
+  indexes = await run_json_many(
+    """
+    SELECT i.tables_recid, i.element_name, i.element_columns, i.element_is_unique
+    FROM system_schema_indexes i
+    ORDER BY i.tables_recid, i.element_name
+    FOR JSON PATH;
+    """
+  )
+  foreign_keys = await run_json_many(
+    """
+    SELECT fk.tables_recid, fk.element_column_name, fk.referenced_tables_recid,
+           fk.element_referenced_column
+    FROM system_schema_foreign_keys fk
+    ORDER BY fk.tables_recid, fk.element_column_name
+    FOR JSON PATH;
+    """
+  )
+  views = await run_json_many(
+    """
+    SELECT element_schema, element_name, element_definition
+    FROM system_schema_views
+    ORDER BY element_schema, element_name
+    FOR JSON PATH;
+    """
+  )
+  payload = {
+    "tables": tables.payload,
+    "columns": columns.payload,
+    "indexes": indexes.payload,
+    "foreign_keys": foreign_keys.payload,
+    "views": views.payload,
+  }
+  return DBResponse(payload=payload, rowcount=len(payload["tables"]))

--- a/queryregistry/reflection/schema/services.py
+++ b/queryregistry/reflection/schema/services.py
@@ -8,7 +8,7 @@ from typing import Any
 from queryregistry.models import DBRequest, DBResponse
 
 from . import mssql
-from .models import ColumnParams, TableParams
+from .models import FullSchemaParams, TableParams
 
 __all__ = [
   "get_full_schema_v1",
@@ -37,7 +37,8 @@ def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _D
 
 
 async def list_tables_v1(request: DBRequest, *, provider: str) -> DBResponse:
-  result = await _select_dispatcher(provider, _LIST_TABLES_DISPATCHERS)(request.payload)
+  params = FullSchemaParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_TABLES_DISPATCHERS)(params.model_dump())
   return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
 
 
@@ -60,11 +61,12 @@ async def list_foreign_keys_v1(request: DBRequest, *, provider: str) -> DBRespon
 
 
 async def list_views_v1(request: DBRequest, *, provider: str) -> DBResponse:
-  result = await _select_dispatcher(provider, _LIST_VIEWS_DISPATCHERS)(request.payload)
+  params = FullSchemaParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_VIEWS_DISPATCHERS)(params.model_dump())
   return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
 
 
 async def get_full_schema_v1(request: DBRequest, *, provider: str) -> DBResponse:
-  params = ColumnParams.model_validate(request.payload)
+  params = FullSchemaParams.model_validate(request.payload)
   result = await _select_dispatcher(provider, _GET_FULL_SCHEMA_DISPATCHERS)(params.model_dump())
   return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)


### PR DESCRIPTION
### Motivation

- Replace the misleading `ColumnParams` stand-in with a dedicated empty-payload model for full-schema operations to make intent explicit and forbid extra fields.
- Move raw SQL used for schema and data introspection out of the CLI module and into the queryregistry reflection MSSQL providers to centralize data-access logic in the queryregistry layer.
- Provide working MSSQL handlers for the reflection domain so modules can call typed queryregistry operations instead of running ad-hoc SQL in the CLI.

### Description

- Added `FullSchemaParams` and removed `ColumnParams`, and expanded `FullSchemaRecord` to include `tables`, `columns`, `indexes`, `foreign_keys`, and `views` in `queryregistry/reflection/schema/models.py`.
- Updated services to validate empty-payload operations with `FullSchemaParams` for `list_tables_v1`, `list_views_v1`, and `get_full_schema_v1` in `queryregistry/reflection/schema/services.py`.
- Changed the request builder `get_full_schema_request()` to accept no params and always emit an empty payload in `queryregistry/reflection/schema/__init__.py`.
- Implemented MSSQL handlers in `queryregistry/reflection/schema/mssql.py` by migrating SQL patterns from `server/modules/database_cli_module.py` for `list_tables_v1`, `list_columns_v1` (with EDT join), `list_indexes_v1`, `list_foreign_keys_v1`, `list_views_v1`, and the composite `get_full_schema_v1` that returns raw tables/columns/indexes/foreign_keys/views payloads.
- Implemented MSSQL handlers in `queryregistry/reflection/data/mssql.py` for `get_version_v1`, `update_version_v1`, `dump_table_v1` (uses `FOR JSON PATH` and provider JSON helpers), `rebuild_indexes_v1`, and `apply_batch_v1`, using provider helpers `run_json_many`, `run_json_one`, and `run_exec` where appropriate.

### Testing

- Ran `python -m py_compile` against `queryregistry/reflection/schema/mssql.py`, `queryregistry/reflection/schema/services.py`, `queryregistry/reflection/schema/models.py`, `queryregistry/reflection/schema/__init__.py`, `queryregistry/reflection/data/mssql.py`, and `queryregistry/reflection/data/services.py`, and all compiled successfully.
- Verified there are no remaining stubs with `rg -n "NotImplementedError" queryregistry/reflection/` and no remaining uses of the removed model with `rg -n "ColumnParams" queryregistry/reflection/schema/`, both returning no matches.
- Changes were committed locally after validation (branch-ready for PR review).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af3c014e6c832594981684d0f6abdc)