### PR TITLE
Refactor database CLI to module-only lifecycle and route ops through DbModule

### DIFF
--- a/server/modules/database_cli/cli.py
+++ b/server/modules/database_cli/cli.py
@@ -6,18 +6,18 @@ import asyncio
 import logging
 import os
 
+from fastapi import FastAPI
+
 from .. import database_cli_module
+from ..db_module import DbModule
+from ..env_module import EnvModule
 from . import mssql_cli
 
-
-DEFAULT_DATABASE_PLACEHOLDER = "database"
 
 
 HELP_TEXT = """\
 Available commands:
   help
-  connect <database>
-  reconnect [database]
   list tables
   schema dump [name]
   schema apply <file>
@@ -38,24 +38,59 @@ def _get_dsn() -> str:
   return dsn
 
 
-def _prompt(dbname: str | None) -> str:
-  label = dbname or DEFAULT_DATABASE_PLACEHOLDER
-  return f"{label}> "
+def _prompt() -> str:
+  return "cli> "
 
 
 def _print_help():
   print(HELP_TEXT)
 
 
+async def _bootstrap() -> tuple[FastAPI, database_cli_module.DatabaseCliModule]:
+  app = FastAPI()
+
+  env_mod = EnvModule(app)
+  setattr(app.state, "env", env_mod)
+  await env_mod.startup()
+
+  db_mod = DbModule(app)
+  setattr(app.state, "db", db_mod)
+  await db_mod.startup()
+
+  cli_mod = database_cli_module.DatabaseCliModule(app)
+  setattr(app.state, "database_cli", cli_mod)
+  await cli_mod.startup()
+
+  return app, cli_mod
+
+
+async def _shutdown(app: FastAPI):
+  cli_mod = getattr(app.state, "database_cli", None)
+  db_mod = getattr(app.state, "db", None)
+  env_mod = getattr(app.state, "env", None)
+
+  if cli_mod:
+    await cli_mod.shutdown()
+    setattr(app.state, "database_cli", None)
+  if db_mod:
+    await db_mod.shutdown()
+    setattr(app.state, "db", None)
+  if env_mod:
+    await env_mod.shutdown()
+    setattr(app.state, "env", None)
+
+
 def run_repl():
   loop = asyncio.new_event_loop()
   asyncio.set_event_loop(loop)
-  conn = None
-  dbname: str | None = None
+  raw_conn = None
+  app = None
+  cli_mod = None
   try:
+    app, cli_mod = loop.run_until_complete(_bootstrap())
     while True:
       try:
-        raw = input(_prompt(dbname))
+        raw = input(_prompt())
       except (EOFError, KeyboardInterrupt):
         print()
         break
@@ -70,78 +105,40 @@ def run_repl():
       if parts in (["exit"], ["quit"]):
         break
 
-      if parts[0].lower() == "connect":
-        target_db = parts[1] if len(parts) > 1 else None
-        try:
-          conn = loop.run_until_complete(mssql_cli.connect(dsn=_get_dsn(), dbname=target_db))
-          dbname = target_db
-        except Exception:
-          logging.exception("[DatabaseCli] Failed to connect")
-        continue
-
-      if parts[0].lower() == "reconnect":
-        target_db = parts[1] if len(parts) > 1 else dbname
-        if not target_db:
-          print("No database selected. Use: connect <database>.")
-          continue
-        try:
-          conn = loop.run_until_complete(
-            mssql_cli.reconnect(conn, dsn=_get_dsn(), dbname=target_db)
-          )
-          dbname = target_db
-        except Exception:
-          logging.exception("[DatabaseCli] Failed to reconnect")
-        continue
-
       if parts[:2] == ["list", "tables"]:
-        if not conn:
-          print("Not connected. Use: connect <database>.")
-          continue
         try:
-          tables = loop.run_until_complete(mssql_cli.list_tables(conn))
+          tables = loop.run_until_complete(cli_mod.list_tables())
           print("\n".join(tables) if tables else "No tables found.")
         except Exception:
           logging.exception("[DatabaseCli] Failed to list tables")
         continue
 
       if parts[:2] == ["schema", "dump"]:
-        if not conn:
-          print("Not connected. Use: connect <database>.")
-          continue
         prefix = parts[2] if len(parts) > 2 else "schema"
         try:
-          loop.run_until_complete(database_cli_module.dump_schema_from_registry(conn, prefix))
+          loop.run_until_complete(cli_mod.dump_schema_from_registry(prefix))
         except Exception:
           logging.exception("[DatabaseCli] Failed to dump schema")
         continue
 
       if parts[:2] == ["schema", "apply"] and len(parts) > 2:
-        if not conn:
-          print("Not connected. Use: connect <database>.")
-          continue
         try:
-          loop.run_until_complete(database_cli_module.apply_schema(conn, parts[2]))
+          loop.run_until_complete(cli_mod.apply_schema(parts[2]))
         except Exception:
           logging.exception("[DatabaseCli] Failed to apply schema")
         continue
 
       if parts[:2] == ["dump", "data"]:
-        if not conn:
-          print("Not connected. Use: connect <database>.")
-          continue
         prefix = parts[2] if len(parts) > 2 else "dump_data"
         try:
-          loop.run_until_complete(database_cli_module.dump_data(conn, prefix))
+          loop.run_until_complete(cli_mod.dump_data(prefix))
         except Exception:
           logging.exception("[DatabaseCli] Failed to dump data")
         continue
 
       if parts[:2] == ["index", "all"]:
-        if not conn:
-          print("Not connected. Use: connect <database>.")
-          continue
         try:
-          loop.run_until_complete(database_cli_module.rebuild_indexes(conn))
+          loop.run_until_complete(cli_mod.rebuild_indexes())
         except Exception:
           logging.exception("[DatabaseCli] Failed to rebuild indexes")
         continue
@@ -151,26 +148,20 @@ def run_repl():
         "minor",
         "patch",
       }:
-        if not conn:
-          print("Not connected. Use: connect <database>.")
-          continue
         try:
-          new_version = loop.run_until_complete(database_cli_module.update_version(conn, parts[2]))
-          schema_file = loop.run_until_complete(
-            database_cli_module.dump_schema_from_registry(conn, new_version)
-          )
-          database_cli_module.commit_and_tag(new_version, schema_file)
+          new_version = loop.run_until_complete(cli_mod.update_version(parts[2]))
+          schema_file = loop.run_until_complete(cli_mod.dump_schema_from_registry(new_version))
+          cli_mod.commit_and_tag(new_version, schema_file)
         except Exception:
           logging.exception("[DatabaseCli] Failed to update version")
         continue
 
-      if not conn:
-        print("Not connected. Use: connect <database>.")
-        continue
-
       try:
         async def _run_sql():
-          async with conn.cursor() as cur:
+          nonlocal raw_conn
+          if not raw_conn:
+            raw_conn = await mssql_cli.connect(dsn=_get_dsn())
+          async with raw_conn.cursor() as cur:
             await cur.execute(raw)
             try:
               rows = await cur.fetchall()
@@ -184,11 +175,16 @@ def run_repl():
       except Exception:
         logging.exception("[DatabaseCli] Raw SQL failed")
   finally:
-    if conn:
+    if raw_conn:
       try:
-        loop.run_until_complete(conn.close())
+        loop.run_until_complete(raw_conn.close())
       except Exception:
         logging.exception("[DatabaseCli] Failed to close connection")
       else:
         logging.info("[DatabaseCli] Connection closed")
+    if app:
+      try:
+        loop.run_until_complete(_shutdown(app))
+      except Exception:
+        logging.exception("[DatabaseCli] Failed to shutdown modules")
     loop.close()

--- a/server/modules/database_cli_module.py
+++ b/server/modules/database_cli_module.py
@@ -17,11 +17,10 @@ from queryregistry.reflection.data import (
   update_version_request,
 )
 from queryregistry.reflection.data.models import BatchParams, DumpTableParams, UpdateVersionParams
-from queryregistry.reflection.schema import get_full_schema_request, list_tables_request, list_views_request
+from queryregistry.reflection.schema import get_full_schema_request, list_tables_request
 from queryregistry.reflection.schema.models import TableParams
 
 from . import BaseModule
-from .database_cli import mssql_cli
 from .db_module import DbModule
 from .env_module import EnvModule
 
@@ -106,215 +105,6 @@ def _build_foreign_key_sql(table: dict, fk: dict) -> list[str]:
   return [statement]
 
 
-async def get_schema_from_registry(conn) -> dict[str, list[dict]]:
-  async with conn.cursor() as cur:
-    await cur.execute(
-      "SELECT recid, element_schema, element_name "
-      "FROM system_schema_tables "
-      "ORDER BY element_schema, element_name"
-    )
-    table_rows = await cur.fetchall()
-
-  tables: dict[int, dict] = {}
-  for row in table_rows:
-    table_recid, schema_name, table_name = row
-    tables[int(table_recid)] = {
-      "recid": int(table_recid),
-      "schema": schema_name,
-      "name": table_name,
-      "columns": [],
-      "primary_key": None,
-      "unique_constraints": [],
-      "check_constraints": [],
-      "foreign_keys": [],
-      "indexes": [],
-    }
-
-  async with conn.cursor() as cur:
-    await cur.execute(
-      "SELECT c.tables_recid, c.element_name, c.element_nullable, c.element_default, "
-      "c.element_max_length, c.element_is_primary_key, c.element_is_identity, c.element_ordinal, "
-      "m.element_mssql_type "
-      "FROM system_schema_columns c "
-      "JOIN system_edt_mappings m ON c.edt_recid = m.recid "
-      "ORDER BY c.tables_recid, c.element_ordinal"
-    )
-    for row in await cur.fetchall():
-      (
-        tables_recid,
-        col_name,
-        nullable,
-        default_value,
-        max_length,
-        is_primary,
-        is_identity,
-        _ordinal,
-        mssql_type,
-      ) = row
-      table = tables.get(int(tables_recid))
-      if not table:
-        continue
-      table["columns"].append(
-        {
-          "name": col_name,
-          "data_type": mssql_type,
-          "max_length": max_length,
-          "precision": None,
-          "scale": None,
-          "nullable": bool(nullable),
-          "default": default_value,
-          "identity": bool(is_identity),
-          "identity_seed": 1,
-          "identity_increment": 1,
-          "rowguidcol": False,
-          "computed": None,
-          "computed_persisted": False,
-          "collation": None,
-          "is_primary_key": bool(is_primary),
-        }
-      )
-
-  for table in tables.values():
-    pk_columns = [_quote(col["name"]) for col in table["columns"] if col["is_primary_key"]]
-    if pk_columns:
-      table["primary_key"] = {
-        "name": f"PK_{table['name']}",
-        "type_desc": "CLUSTERED",
-        "columns": pk_columns,
-      }
-
-  async with conn.cursor() as cur:
-    await cur.execute(
-      "SELECT i.tables_recid, i.element_name, i.element_columns, i.element_is_unique "
-      "FROM system_schema_indexes i "
-      "ORDER BY i.tables_recid, i.element_name"
-    )
-    for row in await cur.fetchall():
-      tables_recid, idx_name, idx_columns, is_unique = row
-      table = tables.get(int(tables_recid))
-      if not table:
-        continue
-      key_columns = [_quote(col.strip()) for col in (idx_columns or "").split(",") if col.strip()]
-      table["indexes"].append(
-        {
-          "name": idx_name,
-          "is_unique": bool(is_unique),
-          "type_desc": "",
-          "has_filter": False,
-          "filter_definition": None,
-          "key_columns": key_columns,
-          "included_columns": [],
-        }
-      )
-
-  async with conn.cursor() as cur:
-    await cur.execute(
-      "SELECT fk.tables_recid, fk.element_column_name, fk.referenced_tables_recid, fk.element_referenced_column "
-      "FROM system_schema_foreign_keys fk "
-      "ORDER BY fk.tables_recid, fk.element_column_name"
-    )
-    fk_rows = await cur.fetchall()
-
-  async with conn.cursor() as cur:
-    await cur.execute(
-      "SELECT element_schema, element_name, element_definition "
-      "FROM system_schema_views "
-      "ORDER BY element_schema, element_name"
-    )
-    view_rows = await cur.fetchall()
-
-  views = [
-    {
-      "schema": row[0],
-      "name": row[1],
-      "definition": row[2],
-    }
-    for row in view_rows
-  ]
-
-  for row in fk_rows:
-    tables_recid, source_column, ref_tables_recid, ref_column = row
-    table = tables.get(int(tables_recid))
-    ref_table = tables.get(int(ref_tables_recid))
-    if not table or not ref_table:
-      continue
-    table["foreign_keys"].append(
-      {
-        "name": f"FK_{table['name']}_{source_column}_{ref_table['name']}",
-        "columns": [_quote(source_column)],
-        "ref_columns": [_quote(ref_column)],
-        "ref_schema": ref_table["schema"],
-        "ref_table": ref_table["name"],
-      }
-    )
-
-  schema_name_to_recid: dict[tuple[str, str], int] = {
-    (table["schema"], table["name"]): recid for recid, table in tables.items()
-  }
-
-  deps: dict[int, set[int]] = {}
-  for recid, table in tables.items():
-    fk_targets: set[int] = set()
-    for fk in table["foreign_keys"]:
-      target_recid = schema_name_to_recid.get((fk["ref_schema"], fk["ref_table"]))
-      if target_recid is None or target_recid == recid:
-        continue
-      fk_targets.add(target_recid)
-    deps[recid] = fk_targets
-
-  ordered: list[int] = []
-  visited: set[int] = set()
-
-  def _visit(recid: int) -> None:
-    if recid in visited:
-      return
-    visited.add(recid)
-    for dep in deps.get(recid, set()):
-      if dep in tables:
-        _visit(dep)
-    ordered.append(recid)
-
-  for recid in tables:
-    _visit(recid)
-
-  return {"tables": [tables[recid] for recid in ordered], "views": views}
-
-
-async def dump_schema_from_registry(conn, prefix: str = "schema") -> str:
-  schema = await get_schema_from_registry(conn)
-  ts = datetime.now(timezone.utc).strftime("%Y%m%d")
-  filename = f"{prefix}_{ts}.sql"
-
-  table_stmts: list[str] = []
-  index_stmts: list[str] = []
-  fk_stmts: list[str] = []
-  view_stmts: list[str] = []
-
-  for table in schema["tables"]:
-    table_stmts.append(_build_create_sql(table))
-    for index in table["indexes"]:
-      index_stmts.append(_build_index_sql(table, index))
-    for fk in table["foreign_keys"]:
-      fk_stmts.extend(_build_foreign_key_sql(table, fk))
-
-  for view in schema.get("views", []):
-    definition = view["definition"].strip()
-    if not definition.endswith(";"):
-      definition += ";"
-    view_stmts.append(definition)
-
-  lines: list[str] = ["SET ANSI_NULLS ON;", "SET QUOTED_IDENTIFIER ON;", ""]
-  for section in (table_stmts, index_stmts, fk_stmts, view_stmts):
-    if not section:
-      continue
-    lines.extend(section)
-    lines.append("")
-
-  Path(filename).write_text("\n".join(lines).strip() + "\n", encoding="utf-8")
-  print(f"Schema dumped to {filename}")
-  return filename
-
-
 def parse_version(ver: str) -> tuple[int, int, int, int]:
   ver = ver.lstrip("v")
   major, minor, patch, build = [int(part) for part in ver.split(".")]
@@ -342,23 +132,6 @@ def bump_version(version: str, part: str) -> str:
   return f"v{major}.{minor}.{patch}.{build}"
 
 
-async def update_version(conn, part: str) -> str:
-  async with conn.cursor() as cur:
-    await cur.execute("SELECT element_value FROM system_config WHERE element_key='Version'")
-    row = await cur.fetchone()
-    if not row:
-      raise RuntimeError("Version entry not found in system_config")
-    current_version = row[0]
-
-    next_version = bump_version(current_version, part)
-    await cur.execute(
-      "UPDATE system_config SET element_value=? WHERE element_key='Version'",
-      (next_version,),
-    )
-  print(f"Updated Version: {current_version} -> {next_version}")
-  return next_version
-
-
 def commit_and_tag(version: str, schema_file: str):
   subprocess.check_call(f"git add {schema_file}", shell=True)
   subprocess.check_call(f'git commit -m "Exported DB schema for {version}"', shell=True)
@@ -377,51 +150,10 @@ def _iter_batches(sql: str) -> list[str]:
   return [batch for batch in _GO_PATTERN.split(sql) if batch.strip()]
 
 
-async def apply_schema(conn, path: str):
-  sql = Path(path).read_text(encoding="utf-8")
-  batches = _iter_batches(sql)
-  async with conn.cursor() as cur:
-    for batch in batches:
-      await cur.execute(batch)
-  print("Schema applied.")
-
-
-async def dump_data(conn, prefix: str = "dump_data") -> str:
-  schema = await get_schema_from_registry(conn)
-  data: dict[str, list[dict]] = {}
-  for table in schema["tables"]:
-    table_name = _qualify(table["schema"], table["name"])
-    key = f"{table['schema']}.{table['name']}"
-    async with conn.cursor() as cur:
-      await cur.execute(f"SELECT * FROM {table_name} FOR JSON PATH")
-      parts: list[str] = []
-      while True:
-        row = await cur.fetchone()
-        if not row or not row[0]:
-          break
-        parts.append(row[0])
-      data[key] = json.loads("".join(parts)) if parts else []
-  ts = datetime.now(timezone.utc).strftime("%Y%m%d_BACKUP")
-  filename = f"{prefix}_{ts}.json"
-  Path(filename).write_text(
-    json.dumps({"schema": schema, "data": data}, indent=2, default=str),
-    encoding="utf-8",
-  )
-  print(f"Data dumped to {filename}")
-  return filename
-
-
-async def rebuild_indexes(conn):
-  async with conn.cursor() as cur:
-    await cur.execute("EXEC sp_MSforeachtable 'ALTER INDEX ALL ON ? REBUILD'")
-  print("Reindex complete.")
-
-
 class DatabaseCliModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.db: DbModule | None = None
-    self._dsn: str | None = None
     self._queryregistry_root = Path(__file__).resolve().parents[2] / "queryregistry"
 
   async def startup(self):
@@ -429,45 +161,24 @@ class DatabaseCliModule(BaseModule):
     await self.db.on_ready()
     env: EnvModule = self.app.state.env
     await env.on_ready()
-    self._dsn = env.get("AZURE_SQL_CONNECTION_STRING")
-    if not self._dsn:
-      logging.warning(
-        "[DatabaseCli] Missing AZURE_SQL_CONNECTION_STRING; metadata-only APIs remain available"
-      )
     logging.info("[DatabaseCli] module ready")
     self.mark_ready()
 
   async def shutdown(self):
     self.db = None
-    self._dsn = None
 
-  async def connect(self, dbname: str | None = None):
-    await self.on_ready()
-    if not self._dsn:
-      logging.error("[DatabaseCli] connect requested without AZURE_SQL_CONNECTION_STRING")
-      raise RuntimeError("AZURE_SQL_CONNECTION_STRING not configured")
-    return await mssql_cli.connect(dsn=self._dsn, dbname=dbname)
-
-  async def reconnect(self, conn, dbname: str):
-    await self.on_ready()
-    if not self._dsn:
-      logging.error("[DatabaseCli] reconnect requested without AZURE_SQL_CONNECTION_STRING")
-      raise RuntimeError("AZURE_SQL_CONNECTION_STRING not configured")
-    return await mssql_cli.reconnect(conn, dsn=self._dsn, dbname=dbname)
-
-  async def list_tables(self, conn):
-    await self.on_ready()
-    return await mssql_cli.list_tables(conn)
-
-  async def get_schema_from_registry(self, conn=None):
+  async def list_tables(self):
     await self.on_ready()
     if not self.db:
       raise RuntimeError("DatabaseCliModule missing DbModule dependency")
-    logging.debug(
-      "[DatabaseCli] reflection schema requests available: %s, %s",
-      list_tables_request().op,
-      list_views_request().op,
-    )
+    res = await self.db.run(list_tables_request())
+    rows = res.payload if isinstance(res.payload, list) else []
+    return [f"{row['element_schema']}.{row['element_name']}" for row in rows]
+
+  async def get_schema_from_registry(self):
+    await self.on_ready()
+    if not self.db:
+      raise RuntimeError("DatabaseCliModule missing DbModule dependency")
     res = await self.db.run(get_full_schema_request())
     payload = res.payload if isinstance(res.payload, dict) else {}
 
@@ -599,7 +310,7 @@ class DatabaseCliModule(BaseModule):
 
     return {"tables": [tables[recid] for recid in ordered], "views": views}
 
-  async def dump_schema_from_registry(self, conn=None, prefix: str = "schema"):
+  async def dump_schema_from_registry(self, prefix: str = "schema"):
     await self.on_ready()
     schema = await self.get_schema_from_registry()
     ts = datetime.now(timezone.utc).strftime("%Y%m%d")
@@ -634,11 +345,7 @@ class DatabaseCliModule(BaseModule):
     print(f"Schema dumped to {filename}")
     return filename
 
-  async def dump_schema(self, conn, prefix: str):
-    await self.on_ready()
-    return await dump_schema_from_registry(conn, prefix)
-
-  async def apply_schema(self, conn=None, path: str = ""):
+  async def apply_schema(self, path: str = ""):
     await self.on_ready()
     if not self.db:
       raise RuntimeError("DatabaseCliModule missing DbModule dependency")
@@ -648,7 +355,7 @@ class DatabaseCliModule(BaseModule):
       await self.db.run(apply_batch_request(BatchParams(sql=batch)))
     print("Schema applied.")
 
-  async def dump_data(self, conn=None, prefix: str = "dump_data"):
+  async def dump_data(self, prefix: str = "dump_data"):
     await self.on_ready()
     if not self.db:
       raise RuntimeError("DatabaseCliModule missing DbModule dependency")
@@ -670,7 +377,7 @@ class DatabaseCliModule(BaseModule):
     print(f"Data dumped to {filename}")
     return filename
 
-  async def update_version(self, conn=None, part: str = ""):
+  async def update_version(self, part: str = ""):
     await self.on_ready()
     if not self.db:
       raise RuntimeError("DatabaseCliModule missing DbModule dependency")
@@ -688,7 +395,7 @@ class DatabaseCliModule(BaseModule):
   def commit_and_tag(self, version: str, schema_file: str):
     commit_and_tag(version, schema_file)
 
-  async def rebuild_indexes(self, conn=None):
+  async def rebuild_indexes(self):
     await self.on_ready()
     if not self.db:
       raise RuntimeError("DatabaseCliModule missing DbModule dependency")


### PR DESCRIPTION
### Motivation

- Remove the dual-path architecture where standalone module-level DB functions duplicated `DatabaseCliModule` logic and instead centralize all DB access through the `DbModule` reflection path. 
- Make the REPL follow the application module lifecycle so metadata operations use `queryregistry` dispatching and the same initialization order used by the server. 

### Description

- Deleted standalone module-level DB helpers and kept only shared utilities (quoting/SQL builders, `_GO_PATTERN`, `_iter_batches`, `parse_version`, `bump_version`, `commit_and_tag`).
- Converted `DatabaseCliModule` methods to no-`conn` signatures, removed `_dsn`, `connect`, `reconnect`, and the `dump_schema` alias, and routed operations through `self.db.run(...)` (e.g. `list_tables` now dispatches `list_tables_request()`).
- Removed debug logging that constructed throwaway `DBRequest` objects and cleaned imports (removed `mssql_cli` usage from the module class scope and `list_views_request` import).
- Rewrote the REPL in `server/modules/database_cli/cli.py` to bootstrap a minimal FastAPI app and lifecycle (`EnvModule` → `DbModule` → `DatabaseCliModule`), shut down modules in reverse order, call `cli_mod` class methods for operations, remove `connect`/`reconnect` commands, and keep a lazy `mssql_cli` raw connection only for raw SQL result display; prompt changed to a static `cli>`.

### Testing

- Compiled updated modules with `python -m py_compile server/modules/database_cli_module.py` and `python -m py_compile server/modules/database_cli/cli.py` which succeeded. 
- Ran repository checks used by the task to validate the refactor: `rg -n "async def get_schema_from_registry" server/modules/database_cli_module.py` returned the single class method, `rg -n "self.db.run" server/modules/database_cli_module.py` shows the dispatch call sites, and `rg -n "self._dsn" server/modules/database_cli_module.py` / `rg -n "conn=None" server/modules/database_cli_module.py` returned no matches as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4b773cf48325b4d63959df6b3728)