### PR TITLE
Remove dead MSSQL CLI reconnect/table-list helpers

### DIFF
--- a/server/modules/database_cli/mssql_cli.py
+++ b/server/modules/database_cli/mssql_cli.py
@@ -39,30 +39,3 @@ async def connect(*, dsn: str | None, dbname: str | None = None):
   conn = await aioodbc.connect(dsn=dsn, autocommit=True)
   logging.info("[DatabaseCli] Connected to database")
   return conn
-
-
-async def reconnect(conn, *, dsn: str | None, dbname: str):
-  if conn:
-    try:
-      await conn.close()
-      logging.info("[DatabaseCli] Closed existing connection")
-    except Exception:
-      logging.exception("[DatabaseCli] Failed to close existing connection")
-      raise
-  return await connect(dsn=dsn, dbname=dbname)
-
-
-async def list_tables(conn) -> list[str]:
-  query = (
-    "SELECT element_schema, element_name "
-    "FROM system_schema_tables "
-    "ORDER BY element_schema, element_name"
-  )
-  async with conn.cursor() as cur:
-    await cur.execute(query)
-    rows = await cur.fetchall()
-  return [f"{row[0]}.{row[1]}" for row in rows]
-
-
-async def list_table_names(conn) -> list[str]:
-  return await list_tables(conn)


### PR DESCRIPTION
### Motivation
- Clean up dead module-level helpers that are no longer used because the REPL bootstraps a lifecycle and uses `DatabaseCliModule` class methods instead.

### Description
- Deleted unused functions `reconnect`, `list_tables`, and `list_table_names` from `server/modules/database_cli/mssql_cli.py` and left `connect`, `_rewrite_dsn_database`, and `_warn_if_missing_odbc18` intact.
- No changes were required to `server/modules/database_cli_module.py` because class-based implementations such as `get_schema_from_registry` and `rebuild_indexes` are already present.

### Testing
- Compiled affected files with `python -m py_compile server/modules/database_cli_module.py`, `python -m py_compile server/modules/database_cli/mssql_cli.py`, and `python -m py_compile server/modules/database_cli/cli.py`, all of which succeeded.
- Verified with ripgrep that `async def get_schema_from_registry` and `async def rebuild_indexes` appear in `server/modules/database_cli_module.py` and that `def reconnect` and `def list_tables` no longer exist in `server/modules/database_cli/mssql_cli.py` (no matches).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4e2d867c8325a902bce13407f9d1)