### PR TITLE
Fix CLI bootstrap and rename reflection `schema` fields to avoid Pydantic shadowing

### DIFF
--- a/queryregistry/reflection/data/models.py
+++ b/queryregistry/reflection/data/models.py
@@ -34,7 +34,7 @@ class DumpTableParams(BaseModel):
 
   model_config = ConfigDict(extra="forbid")
 
-  schema: str
+  table_schema: str
   name: str
 
 

--- a/queryregistry/reflection/data/mssql.py
+++ b/queryregistry/reflection/data/mssql.py
@@ -38,7 +38,7 @@ async def update_version_v1(args: Mapping[str, Any]) -> DBResponse:
 
 
 async def dump_table_v1(args: Mapping[str, Any]) -> DBResponse:
-  schema_name = _quote_ident(args["schema"])
+  schema_name = _quote_ident(args["table_schema"])
   table_name = _quote_ident(args["name"])
   sql = f"SELECT * FROM {schema_name}.{table_name} FOR JSON PATH;"
   return await run_json_many(sql)

--- a/queryregistry/reflection/schema/models.py
+++ b/queryregistry/reflection/schema/models.py
@@ -24,7 +24,7 @@ class TableParams(BaseModel):
 
   model_config = ConfigDict(extra="forbid")
 
-  schema: str
+  table_schema: str
   name: str
 
 

--- a/queryregistry/reflection/schema/mssql.py
+++ b/queryregistry/reflection/schema/mssql.py
@@ -29,7 +29,7 @@ async def list_tables_v1(_: Mapping[str, Any]) -> DBResponse:
 
 
 async def list_columns_v1(args: Mapping[str, Any]) -> DBResponse:
-  schema_name = args["schema"]
+  schema_name = args["table_schema"]
   table_name = args["name"]
   sql = """
     SELECT c.tables_recid, c.element_name, c.element_nullable, c.element_default,
@@ -46,7 +46,7 @@ async def list_columns_v1(args: Mapping[str, Any]) -> DBResponse:
 
 
 async def list_indexes_v1(args: Mapping[str, Any]) -> DBResponse:
-  schema_name = args["schema"]
+  schema_name = args["table_schema"]
   table_name = args["name"]
   sql = """
     SELECT i.tables_recid, i.element_name, i.element_columns, i.element_is_unique
@@ -60,7 +60,7 @@ async def list_indexes_v1(args: Mapping[str, Any]) -> DBResponse:
 
 
 async def list_foreign_keys_v1(args: Mapping[str, Any]) -> DBResponse:
-  schema_name = args["schema"]
+  schema_name = args["table_schema"]
   table_name = args["name"]
   sql = """
     SELECT fk.tables_recid, fk.element_column_name, fk.referenced_tables_recid,

--- a/scripts/run_cli.py
+++ b/scripts/run_cli.py
@@ -1,5 +1,14 @@
 """Entry point for the database management CLI."""
 
+from __future__ import annotations
+
+import os
+import sys
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+  sys.path.insert(0, REPO_ROOT)
+
 from server.modules.database_cli.cli import run_repl
 
 if __name__ == "__main__":

--- a/server/modules/database_cli_module.py
+++ b/server/modules/database_cli_module.py
@@ -185,11 +185,11 @@ class DatabaseCliModule(BaseModule):
     table_rows = payload.get("tables", [])
     tables: dict[int, dict] = {}
     for row in table_rows:
-      parsed = TableParams(schema=row["element_schema"], name=row["element_name"])
+      parsed = TableParams(table_schema=row["element_schema"], name=row["element_name"])
       table_recid = int(row["recid"])
       tables[table_recid] = {
         "recid": table_recid,
-        "schema": parsed.schema,
+        "schema": parsed.table_schema,
         "name": parsed.name,
         "columns": [],
         "primary_key": None,
@@ -364,7 +364,7 @@ class DatabaseCliModule(BaseModule):
     for table in schema["tables"]:
       key = f"{table['schema']}.{table['name']}"
       res = await self.db.run(
-        dump_table_request(DumpTableParams(schema=table["schema"], name=table["name"]))
+        dump_table_request(DumpTableParams(table_schema=table["schema"], name=table["name"]))
       )
       table_rows = res.payload if isinstance(res.payload, list) else []
       data[key] = table_rows


### PR DESCRIPTION
### Motivation
- Running `scripts/run_cli.py` raised `ModuleNotFoundError: No module named 'server'` because the repo root was not on `sys.path`.  
- Pydantic emitted warnings because models used a field named `schema`, which shadows `BaseModel` internals.  
- Rename the offending fields and update consumers to remove warnings and make the CLI importable when run as a script.  

### Description
- Prepend the repository root to `sys.path` in `scripts/run_cli.py` using the same `REPO_ROOT` pattern as other scripts so `server.*` packages can be imported.  
- Rename the Pydantic fields `schema` -> `table_schema` in `TableParams` (`queryregistry/reflection/schema/models.py`) and `DumpTableParams` (`queryregistry/reflection/data/models.py`).  
- Update all downstream usages to the new name: MSSQL handlers now read `args['table_schema']` in `queryregistry/reflection/schema/mssql.py` and `queryregistry/reflection/data/mssql.py`, and `DatabaseCliModule` constructs/reads `TableParams(table_schema=...)` / `DumpTableParams(table_schema=...)` in `server/modules/database_cli_module.py`.  
- Changes are limited to the CLI bootstrap and reflection model/consumer updates; no behavior change to SQL logic was introduced.  

### Testing
- Ran `python -m py_compile scripts/run_cli.py` which succeeded.  
- Verified no remaining bare `"schema"` fields in reflection model files with `rg` (no matches).  
- Launched the CLI with `printf 'exit\n' | python scripts/run_cli.py` to validate import bootstrap, which no longer raises `ModuleNotFoundError` but aborts later due to the environment's missing DB provider (`MISSING_DATABASE_PROVIDER`), which is unrelated to these fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af595402f083258cf9b1ed6ce2ae3a)