### PR TITLE
Handle missing nullable reflection keys in database CLI schema dump

### DIFF
--- a/server/modules/database_cli_module.py
+++ b/server/modules/database_cli_module.py
@@ -208,11 +208,11 @@ class DatabaseCliModule(BaseModule):
         {
           "name": row["element_name"],
           "data_type": row["element_mssql_type"],
-          "max_length": row["element_max_length"],
+          "max_length": row.get("element_max_length"),
           "precision": None,
           "scale": None,
           "nullable": bool(row["element_nullable"]),
-          "default": row["element_default"],
+          "default": row.get("element_default"),
           "identity": bool(row["element_is_identity"]),
           "identity_seed": 1,
           "identity_increment": 1,
@@ -238,7 +238,7 @@ class DatabaseCliModule(BaseModule):
       table = tables.get(tables_recid)
       if not table:
         continue
-      key_columns = [_quote(col.strip()) for col in (row["element_columns"] or "").split(",") if col.strip()]
+      key_columns = [_quote(col.strip()) for col in (row.get("element_columns") or "").split(",") if col.strip()]
       table["indexes"].append(
         {
           "name": row["element_name"],
@@ -256,7 +256,7 @@ class DatabaseCliModule(BaseModule):
       {
         "schema": row["element_schema"],
         "name": row["element_name"],
-        "definition": row["element_definition"],
+        "definition": row.get("element_definition", ""),
       }
       for row in view_rows
     ]


### PR DESCRIPTION
### Motivation
- MSSQL `FOR JSON PATH` omits keys when column values are NULL which caused `KeyError` during schema dump, so nullable reflection fields must be read safely.

### Description
- Updated `DatabaseCliModule.get_schema_from_registry` to use `row.get(...)` for nullable fields (`element_max_length`, `element_default`, `element_definition`) and `row.get("element_columns") or ""` for index parsing to avoid missing-key errors while preserving direct access for required metadata.

### Testing
- Ran `python -m py_compile server/modules/database_cli_module.py` and performed `rg -n "row[\"element_max_length\"]"` and `rg -n "row[\"element_default\"]"` checks against the modified file, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af632dc1b48325a77c1857529d7ba4)