### PR TITLE
Fix seed dump EDT subqueries to use canonical EDT names

### DIFF
--- a/server/modules/database_cli_module.py
+++ b/server/modules/database_cli_module.py
@@ -373,6 +373,11 @@ class DatabaseCliModule(BaseModule):
     )
     edt_rows = edt_res.payload if isinstance(edt_res.payload, list) else []
     view_rows = views_res.payload if isinstance(views_res.payload, list) else []
+    edt_name_by_mssql_type = {
+      str(row.get("element_mssql_type") or ""): str(row.get("element_name") or "")
+      for row in edt_rows
+      if row.get("element_mssql_type") and row.get("element_name")
+    }
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%d")
     filename = f"{prefix}_{ts}.sql"
@@ -393,7 +398,9 @@ class DatabaseCliModule(BaseModule):
       columns = sorted(table.get("columns", []), key=lambda row: int(row.get("ordinal", 0)))
       for ordinal, column in enumerate(columns, start=1):
         data_type = str(column.get("data_type") or "")
-        edt_name = data_type.split("(", 1)[0].strip().upper()
+        edt_name = edt_name_by_mssql_type.get(data_type)
+        if not edt_name:
+          edt_name = data_type.split("(", 1)[0].strip().upper()
         table_recid_sql = (
           "(SELECT recid FROM system_schema_tables "
           f"WHERE element_name = {_sql_literal(table['name'])} "


### PR DESCRIPTION
### Motivation
- The seed dump generated EDT lookup subqueries using provider MSSQL type strings (e.g. `BIGINT IDENTITY`, `NVARCHAR`) which do not match `system_edt_mappings.element_name` that stores canonical EDT names (e.g. `INT64_IDENTITY`, `STRING`), causing incorrect or missing EDT recid resolution.

### Description
- Built a reverse mapping from the already-fetched `system_edt_mappings` rows with `edt_name_by_mssql_type = { row["element_mssql_type"]: row["element_name"] }` in `dump_seed_from_registry` within `server/modules/database_cli_module.py`.
- Resolved `edt_name` from that mapping when generating the column `edt_recid` subquery so the `(SELECT recid FROM system_edt_mappings WHERE element_name = ...)` uses the canonical EDT name.
- Preserved a fallback to the original normalization (`data_type.split("(", 1)[0].strip().upper()`) when no mapping entry exists.

### Testing
- Ran `python -m py_compile server/modules/database_cli_module.py` which succeeded without syntax errors.
- Attempted to validate runtime behavior with `printf 'seed dump test\nexit\n' | python scripts/run_cli.py`, but the CLI bootstrap failed due to an absent database provider configuration (`Unsupported provider: MISSING_DATABASE_PROVIDER`), so runtime seed output could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af6b0530c48325813fe1eaa4c4e315)