### PR TITLE
Add Discord guild management RPC subdomain and admin page; add persona `is_active` support

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ const ServiceRoutesPage = lazy(() => import("./pages/service/ServiceRoutesPage")
 const ServiceRolesPage = lazy(() => import("./pages/service/ServiceRolesPage"));
 const FileManager = lazy(() => import("./pages/FileManager"));
 const DiscordPersonasPage = lazy(() => import("./pages/DiscordPersonasPage"));
+const DiscordGuildsPage = lazy(() => import("./pages/DiscordGuildsPage"));
 const SystemConfigPage = lazy(() => import("./pages/system/SystemConfigPage"));
 const AccountRolesPage = lazy(() => import("./pages/AccountRolesPage"));
 const AccountUsersPage = lazy(() => import("./pages/AccountUsersPage"));
@@ -55,6 +56,7 @@ function App(): JSX.Element {
                                                                         path="/discord-personas"
                                                                         element={<DiscordPersonasPage />}
                                                                 />
+                                                                <Route path="/discord-guilds" element={<DiscordGuildsPage />} />
                                                                 <Route path="/privacy-policy" element={<PrivacyPolicy />} />
                                                                 <Route path="/terms-of-service" element={<TermsOfService />} />
                                                                 <Route path="/profile/:guid" element={<PublicProfile />} />

--- a/frontend/src/pages/DiscordGuildsPage.tsx
+++ b/frontend/src/pages/DiscordGuildsPage.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from "react";
+import {
+        Box,
+        Divider,
+        Table,
+        TableBody,
+        TableCell,
+        TableHead,
+        TableRow,
+        Typography,
+} from "@mui/material";
+import PageTitle from "../components/PageTitle";
+import EditBox from "../components/EditBox";
+import ColumnHeader from "../components/ColumnHeader";
+import type { DiscordGuildsGuildItem1, DiscordGuildsList1 } from "../shared/RpcModels";
+import { fetchListGuilds, fetchUpdateCredits } from "../rpc/discord/guilds";
+
+const DiscordGuildsPage = (): JSX.Element => {
+        const [guilds, setGuilds] = useState<DiscordGuildsGuildItem1[]>([]);
+        const [forbidden, setForbidden] = useState(false);
+
+        const loadGuilds = async (): Promise<void> => {
+                try {
+                        const res: DiscordGuildsList1 = await fetchListGuilds();
+                        setGuilds(res.guilds ?? []);
+                        setForbidden(false);
+                } catch (e: any) {
+                        if (e?.response?.status === 403) {
+                                setForbidden(true);
+                        } else {
+                                setGuilds([]);
+                        }
+                }
+        };
+
+        useEffect(() => {
+                void loadGuilds();
+        }, []);
+
+        if (forbidden) {
+                return (
+                        <Box sx={{ p: 2 }}>
+                                <Typography variant="h6">Forbidden</Typography>
+                        </Box>
+                );
+        }
+
+        const updateCredits = async (index: number, credits: number): Promise<void> => {
+                const updated = [...guilds];
+                updated[index] = { ...updated[index], credits };
+                setGuilds(updated);
+                await fetchUpdateCredits({
+                        guild_id: updated[index].guild_id,
+                        credits,
+                });
+                void loadGuilds();
+        };
+
+        return (
+                <Box sx={{ p: 2 }}>
+                        <PageTitle>Discord Guild Management</PageTitle>
+                        <Divider sx={{ mb: 2 }} />
+                        <Table size="small" sx={{ "& td, & th": { py: 0.5, verticalAlign: "top" } }}>
+                                <TableHead>
+                                        <TableRow>
+                                                <ColumnHeader>Name</ColumnHeader>
+                                                <ColumnHeader>Guild ID</ColumnHeader>
+                                                <ColumnHeader>Credits</ColumnHeader>
+                                                <ColumnHeader>Member Count</ColumnHeader>
+                                                <ColumnHeader>Joined</ColumnHeader>
+                                                <ColumnHeader>Region</ColumnHeader>
+                                                <ColumnHeader>Notes</ColumnHeader>
+                                        </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                        {guilds.map((guild, index) => (
+                                                <TableRow key={guild.recid}>
+                                                        <TableCell>{guild.name}</TableCell>
+                                                        <TableCell>{guild.guild_id}</TableCell>
+                                                        <TableCell>
+                                                                <EditBox
+                                                                        value={guild.credits}
+                                                                        onCommit={(value) => void updateCredits(index, Number(value))}
+                                                                        width="80px"
+                                                                />
+                                                        </TableCell>
+                                                        <TableCell>{guild.member_count ?? ""}</TableCell>
+                                                        <TableCell>{guild.joined_on ?? ""}</TableCell>
+                                                        <TableCell>{guild.region ?? ""}</TableCell>
+                                                        <TableCell>{guild.notes ?? ""}</TableCell>
+                                                </TableRow>
+                                        ))}
+                                </TableBody>
+                        </Table>
+                </Box>
+        );
+};
+
+export default DiscordGuildsPage;

--- a/frontend/src/pages/DiscordPersonasPage.tsx
+++ b/frontend/src/pages/DiscordPersonasPage.tsx
@@ -11,6 +11,7 @@ import {
         IconButton,
         TextField,
         MenuItem,
+        Checkbox,
 } from "@mui/material";
 import { Delete, Add } from "@mui/icons-material";
 import PageTitle from "../components/PageTitle";
@@ -39,6 +40,7 @@ const DiscordPersonasPage = (): JSX.Element => {
                 prompt: "",
                 tokens: 0,
                 models_recid: 0,
+                is_active: true,
         });
         const [forbidden, setForbidden] = useState(false);
 
@@ -99,6 +101,7 @@ const DiscordPersonasPage = (): JSX.Element => {
                         prompt: next.prompt,
                         tokens: next.tokens,
                         models_recid: next.models_recid,
+                        is_active: next.is_active,
                 });
                 void load();
         };
@@ -120,6 +123,7 @@ const DiscordPersonasPage = (): JSX.Element => {
                         prompt: newPersona.prompt,
                         tokens: newPersona.tokens,
                         models_recid: newPersona.models_recid,
+                        is_active: newPersona.is_active,
                 });
                 setNewPersona({
                         recid: null,
@@ -127,6 +131,7 @@ const DiscordPersonasPage = (): JSX.Element => {
                         prompt: "",
                         tokens: 0,
                         models_recid: models.length ? models[0].recid : 0,
+                        is_active: true,
                 });
                 void load();
         };
@@ -139,33 +144,37 @@ const DiscordPersonasPage = (): JSX.Element => {
                                 <TableHead>
                                         <TableRow>
                                                 <ColumnHeader sx={{ width: "15%" }}>Persona</ColumnHeader>
-                                                <ColumnHeader sx={{ width: "15%" }}>Model</ColumnHeader>
+                                                <ColumnHeader sx={{ width: "8%" }}>Active</ColumnHeader>
+                                                <ColumnHeader sx={{ width: "12%" }}>Model</ColumnHeader>
                                                 <ColumnHeader sx={{ width: "10%" }}>Tokens</ColumnHeader>
-                                                <ColumnHeader sx={{ width: "55%" }}>Prompt</ColumnHeader>
+                                                <ColumnHeader sx={{ width: "50%" }}>Prompt</ColumnHeader>
                                                 <ColumnHeader sx={{ width: "5%" }} />
                                         </TableRow>
                                 </TableHead>
                                 <TableBody>
-                                        {personas.map((persona, idx) => (
-                                                <TableRow key={`${persona.name}-${persona.recid ?? idx}`}>
-                                                        <TableCell sx={{ width: "15%" }}>
-                                                                <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                                                                        {persona.name}
-                                                                </Typography>
+                                        {personas.map((persona, index) => (
+                                                <TableRow key={persona.recid ?? `persona-${index}`}>
+                                                        <TableCell sx={{ width: "15%" }}>{persona.name}</TableCell>
+                                                        <TableCell sx={{ width: "8%" }}>
+                                                                <Checkbox
+                                                                        checked={Boolean(persona.is_active)}
+                                                                        onChange={(e) =>
+                                                                                void updatePersona(index, {
+                                                                                        is_active: e.target.checked,
+                                                                                })
+                                                                        }
+                                                                />
                                                         </TableCell>
-                                                        <TableCell sx={{ width: "15%" }}>
+                                                        <TableCell sx={{ width: "12%" }}>
                                                                 <TextField
                                                                         select
                                                                         sx={{ width: "95%" }}
                                                                         value={persona.models_recid}
-                                                                        onChange={(e) => {
-                                                                                const value = Number(e.target.value);
-                                                                                const modelName = models.find((m) => m.recid === value)?.name ?? persona.model;
-                                                                                void updatePersona(idx, {
-                                                                                        models_recid: value,
-                                                                                        model: modelName,
-                                                                                });
-                                                                        }}
+                                                                        onChange={(e) =>
+                                                                                void updatePersona(index, {
+                                                                                        models_recid: Number(e.target.value),
+                                                                                })
+                                                                        }
                                                                 >
                                                                         {models.map((model) => (
                                                                                 <MenuItem key={model.recid} value={model.recid}>
@@ -177,14 +186,18 @@ const DiscordPersonasPage = (): JSX.Element => {
                                                         <TableCell sx={{ width: "10%" }}>
                                                                 <EditBox
                                                                         value={persona.tokens}
-                                                                        onCommit={(val) => updatePersona(idx, { tokens: Number(val) })}
+                                                                        onCommit={(value) =>
+                                                                                void updatePersona(index, { tokens: Number(value) })
+                                                                        }
                                                                         width="80px"
                                                                 />
                                                         </TableCell>
-                                                        <TableCell sx={{ width: "55%" }}>
+                                                        <TableCell sx={{ width: "50%" }}>
                                                                 <EditBox
                                                                         value={persona.prompt}
-                                                                        onCommit={(val) => updatePersona(idx, { prompt: String(val) })}
+                                                                        onCommit={(value) =>
+                                                                                void updatePersona(index, { prompt: String(value) })
+                                                                        }
                                                                         width="100%"
                                                                 />
                                                         </TableCell>
@@ -209,7 +222,18 @@ const DiscordPersonasPage = (): JSX.Element => {
                                                                 }
                                                         />
                                                 </TableCell>
-                                                <TableCell sx={{ width: "15%" }}>
+                                                <TableCell sx={{ width: "8%" }}>
+                                                        <Checkbox
+                                                                checked={Boolean(newPersona.is_active)}
+                                                                onChange={(e) =>
+                                                                        setNewPersona({
+                                                                                ...newPersona,
+                                                                                is_active: e.target.checked,
+                                                                        })
+                                                                }
+                                                        />
+                                                </TableCell>
+                                                <TableCell sx={{ width: "12%" }}>
                                                         <TextField
                                                                 select
                                                                 sx={{ width: "95%" }}
@@ -241,7 +265,7 @@ const DiscordPersonasPage = (): JSX.Element => {
                                                                 }
                                                         />
                                                 </TableCell>
-                                                <TableCell sx={{ width: "55%" }}>
+                                                <TableCell sx={{ width: "50%" }}>
                                                         <TextField
                                                                 sx={{ width: "100%" }}
                                                                 value={newPersona.prompt}

--- a/migrations/v0.8.1.1_discord_guilds_route.sql
+++ b/migrations/v0.8.1.1_discord_guilds_route.sql
@@ -1,0 +1,7 @@
+-- Add guild management route to frontend navigation
+-- The element_roles value should match ROLE_DISCORD_ADMIN's mask
+-- Check the system_roles table for the correct mask value
+INSERT INTO frontend_routes (element_enablement, element_roles, element_sequence, element_path, element_name, element_icon)
+SELECT '1', sr.element_mask, 82, '/discord-guilds', 'Discord Guilds', 'Groups'
+FROM system_roles sr WHERE sr.element_name = 'ROLE_DISCORD_ADMIN';
+GO

--- a/queryregistry/system/personas/models.py
+++ b/queryregistry/system/personas/models.py
@@ -31,6 +31,7 @@ class UpsertPersonaParams(BaseModel):
   prompt: str
   tokens: int
   models_recid: int
+  is_active: bool = True
   recid: int | None = None
 
 

--- a/queryregistry/system/personas/mssql.py
+++ b/queryregistry/system/personas/mssql.py
@@ -34,6 +34,7 @@ async def get_by_name_v1(args: Mapping[str, Any]) -> DBResponse:
       vp.model_name AS model_name,
       vp.model_name AS model,
       vp.model_name AS element_model,
+      ap.element_is_active AS is_active,
       vp.element_created_on,
       vp.element_modified_on
     FROM vw_content_personas vp
@@ -60,6 +61,7 @@ async def list_personas_v1(_: Mapping[str, Any]) -> DBResponse:
       vp.model_name AS model_name,
       vp.model_name AS model,
       vp.model_name AS element_model,
+      ap.element_is_active AS is_active,
       vp.element_created_on,
       vp.element_modified_on
     FROM vw_content_personas vp
@@ -76,6 +78,7 @@ async def upsert_persona_v1(args: Mapping[str, Any]) -> DBResponse:
   prompt = args["prompt"]
   tokens = int(args["tokens"])
   models_recid = int(args["models_recid"])
+  is_active = bool(args.get("is_active", True))
   if recid is not None:
     rc = await run_exec(
       """
@@ -84,10 +87,11 @@ async def upsert_persona_v1(args: Mapping[str, Any]) -> DBResponse:
             element_prompt = ?,
             element_tokens = ?,
             models_recid = ?,
+            element_is_active = ?,
             element_modified_on = SYSUTCDATETIME()
         WHERE recid = ?;
       """,
-      (name, prompt, tokens, models_recid, recid),
+      (name, prompt, tokens, models_recid, is_active, recid),
     )
     if rc.rowcount:
       return rc
@@ -97,10 +101,11 @@ async def upsert_persona_v1(args: Mapping[str, Any]) -> DBResponse:
       SET element_prompt = ?,
           element_tokens = ?,
           models_recid = ?,
+          element_is_active = ?,
           element_modified_on = SYSUTCDATETIME()
       WHERE element_name = ?;
     """,
-    (prompt, tokens, models_recid, name),
+    (prompt, tokens, models_recid, is_active, name),
   )
   if rc.rowcount:
     return rc
@@ -110,10 +115,11 @@ async def upsert_persona_v1(args: Mapping[str, Any]) -> DBResponse:
         element_name,
         element_prompt,
         element_tokens,
-        models_recid
-      ) VALUES (?, ?, ?, ?);
+        models_recid,
+        element_is_active
+      ) VALUES (?, ?, ?, ?, ?);
     """,
-    (name, prompt, tokens, models_recid),
+    (name, prompt, tokens, models_recid, is_active),
   )
 
 

--- a/rpc/discord/__init__.py
+++ b/rpc/discord/__init__.py
@@ -7,12 +7,14 @@ administration flows (``ROLE_DISCORD_ADMIN``).
 from .bsky.handler import handle_bsky_request
 from .chat.handler import handle_chat_request
 from .command.handler import handle_command_request
+from .guilds.handler import handle_guilds_request
 from .personas.handler import handle_personas_request
 
 HANDLERS: dict[str, callable] = {
   "bsky": handle_bsky_request,
   "chat": handle_chat_request,
   "command": handle_command_request,
+  "guilds": handle_guilds_request,
   "personas": handle_personas_request,
 }
 
@@ -21,6 +23,7 @@ REQUIRED_ROLES: dict[str, str | None] = {
   "bsky": "ROLE_DISCORD_BOT",
   "chat": "ROLE_DISCORD_BOT",
   "command": None,
+  "guilds": "ROLE_DISCORD_ADMIN",
   "personas": "ROLE_DISCORD_ADMIN",
 }
 
@@ -29,5 +32,6 @@ FORBIDDEN_DETAILS: dict[str, str] = {
   "bsky": 'You must have the Discord bot role assigned to use this bot.',
   "chat": 'You must have the Discord bot role assigned to use this bot.',
   "command": 'You must have the Discord bot role assigned to use this bot.',
+  "guilds": 'Forbidden',
   "personas": 'Forbidden',
 }

--- a/rpc/discord/guilds/__init__.py
+++ b/rpc/discord/guilds/__init__.py
@@ -1,0 +1,11 @@
+from .services import (
+  discord_guilds_get_v1,
+  discord_guilds_list_v1,
+  discord_guilds_update_credits_v1,
+)
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list_guilds", "1"): discord_guilds_list_v1,
+  ("get_guild", "1"): discord_guilds_get_v1,
+  ("update_credits", "1"): discord_guilds_update_credits_v1,
+}

--- a/rpc/discord/guilds/handler.py
+++ b/rpc/discord/guilds/handler.py
@@ -1,0 +1,19 @@
+"""Discord guilds RPC handler.
+
+Dispatches guild administration operations once ``ROLE_DISCORD_ADMIN`` access
+has been verified by the domain handler.
+"""
+
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_guilds_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/discord/guilds/models.py
+++ b/rpc/discord/guilds/models.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+
+
+class DiscordGuildsGuildItem1(BaseModel):
+  recid: int
+  guild_id: str
+  name: str
+  joined_on: str | None = None
+  member_count: int | None = None
+  owner_id: str | None = None
+  region: str | None = None
+  left_on: str | None = None
+  notes: str | None = None
+  credits: int = 0
+
+
+class DiscordGuildsList1(BaseModel):
+  guilds: list[DiscordGuildsGuildItem1]
+
+
+class DiscordGuildsUpdateCredits1(BaseModel):
+  guild_id: str
+  credits: int

--- a/rpc/discord/guilds/services.py
+++ b/rpc/discord/guilds/services.py
@@ -1,0 +1,79 @@
+from fastapi import Request
+
+from queryregistry.discord.guilds import (
+  get_guild_request,
+  list_guilds_request,
+  update_credits_request,
+)
+from queryregistry.discord.guilds.models import (
+  GuildIdParams,
+  ListGuildsParams,
+  UpdateGuildCreditsParams,
+)
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.db_module import DbModule
+
+from .models import (
+  DiscordGuildsGuildItem1,
+  DiscordGuildsList1,
+  DiscordGuildsUpdateCredits1,
+)
+
+
+async def discord_guilds_list_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  res = await db.run(list_guilds_request(ListGuildsParams(include_inactive=True)))
+  guilds = []
+  for row in res.rows or []:
+    guilds.append(DiscordGuildsGuildItem1(
+      recid=row.get("recid", 0),
+      guild_id=row.get("element_guild_id", ""),
+      name=row.get("element_name", ""),
+      joined_on=row.get("element_joined_on"),
+      member_count=row.get("element_member_count"),
+      owner_id=row.get("element_owner_id"),
+      region=row.get("element_region"),
+      left_on=row.get("element_left_on"),
+      notes=row.get("element_notes"),
+      credits=int(row.get("element_credits", 0) or 0),
+    ))
+  payload = DiscordGuildsList1(guilds=guilds)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def discord_guilds_get_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  payload_dict = rpc_request.payload or {}
+  guild_id = payload_dict.get("guild_id", "")
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  res = await db.run(get_guild_request(GuildIdParams(guild_id=guild_id)))
+  row = res.rows[0] if res.rows else {}
+  guild = DiscordGuildsGuildItem1(
+    recid=row.get("recid", 0),
+    guild_id=row.get("element_guild_id", guild_id),
+    name=row.get("element_name", ""),
+    joined_on=row.get("element_joined_on"),
+    member_count=row.get("element_member_count"),
+    owner_id=row.get("element_owner_id"),
+    region=row.get("element_region"),
+    left_on=row.get("element_left_on"),
+    notes=row.get("element_notes"),
+    credits=int(row.get("element_credits", 0) or 0),
+  )
+  return RPCResponse(op=rpc_request.op, payload=guild.model_dump(), version=rpc_request.version)
+
+
+async def discord_guilds_update_credits_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  payload = DiscordGuildsUpdateCredits1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  await db.run(update_credits_request(UpdateGuildCreditsParams(
+    guild_id=payload.guild_id,
+    credits=payload.credits,
+  )))
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)

--- a/rpc/discord/personas/models.py
+++ b/rpc/discord/personas/models.py
@@ -19,6 +19,7 @@ class DiscordPersonasPersonaItem1(BaseModel):
   tokens: int
   models_recid: int
   model: Optional[str] = None
+  is_active: bool = True
 
 
 class DiscordPersonasList1(BaseModel):
@@ -31,6 +32,7 @@ class DiscordPersonasUpsertPersona1(BaseModel):
   prompt: str
   tokens: int
   models_recid: int
+  is_active: bool = True
 
 
 class DiscordPersonasDeletePersona1(BaseModel):

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -177,6 +177,7 @@ class OpenaiModule(BaseModule):
           int(row.get("models_recid")) if row.get("models_recid") is not None else None
         ),
         "model": row.get("model"),
+        "is_active": bool(row.get("is_active", row.get("element_is_active", True))),
       })
     return personas
 
@@ -191,6 +192,7 @@ class OpenaiModule(BaseModule):
       "prompt": persona.get("prompt", ""),
       "tokens": int(persona.get("tokens", 0) or 0),
       "models_recid": int(model_recid),
+      "is_active": bool(persona.get("is_active", True)),
     }
     if not payload["name"]:
       raise ValueError("name required")
@@ -201,6 +203,7 @@ class OpenaiModule(BaseModule):
         prompt=payload["prompt"],
         tokens=payload["tokens"],
         models_recid=payload["models_recid"],
+        is_active=payload["is_active"],
       ))
     )
 


### PR DESCRIPTION
### Motivation
- Expose guild data and credits management to the frontend so admins can view guilds and update credits. 
- Provide a simple admin UI for guild management following existing MUI/table patterns. 
- Add `is_active` support to personas so persona records can be enabled/disabled and the UI can surface that state.

### Description
- Added a new RPC subdomain `rpc/discord/guilds` with `list_guilds`, `get_guild`, and `update_credits` dispatchers, handler, Pydantic models, and service implementations that call the queryregistry DB requests. 
- Registered the `guilds` handler in `rpc/discord/__init__.py` and enforced `ROLE_DISCORD_ADMIN` with the same forbidden messaging pattern as other admin subdomains. 
- Implemented `frontend/src/pages/DiscordGuildsPage.tsx` which lists guilds, shows Name/Guild ID/Credits/Member Count/Joined/Region/Notes, supports inline credits editing via `EditBox`, and renders a `Forbidden` fallback on 403. 
- Updated routes by adding `DiscordGuildsPage` to `frontend/src/App.tsx` and added `migrations/v0.8.1.1_discord_guilds_route.sql` to insert the `/discord-guilds` nav route for `ROLE_DISCORD_ADMIN`. 
- Plumbed `is_active` end-to-end for personas by adding the field to `queryregistry/system/personas/models.py`, updating `queryregistry/system/personas/mssql.py` (selects + upsert/insert to persist `element_is_active`), adding `is_active` to RPC persona models in `rpc/discord/personas/models.py`, and wiring `server/modules/openai_module.py` to include `is_active` in `list_personas` and `upsert_persona` payloads. 
- Ran the RPC binding generator to regenerate frontend shared models and RPC clients; validated generated command bindings include `fetchRegister`, `fetchCredits`, and `fetchGuildCredits` and that persona interfaces now include `is_active`. 

### Testing
- Ran `python scripts/generate_rpc_bindings.py` to regenerate TypeScript interfaces and client bindings and confirmed generation succeeded. (passed)
- Ran `npm run type-check` in `frontend/` (`tsc --noEmit`) and observed no type errors. (passed)
- Ran `npm run lint` in `frontend/` (`eslint ./src`) and observed no lint failures. (passed)
- Ran `python -m py_compile` on modified/new backend Python files to verify syntax correctness. (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b17a59c0d8832594f52b1afdfc474c)