### PR TITLE
Wire Discord persona pipeline to message-based conversation context

### DIFF
--- a/server/modules/discord_chat_module.py
+++ b/server/modules/discord_chat_module.py
@@ -1,12 +1,15 @@
 """Discord chat utilities module."""
 
 import logging, time, discord, uuid
+from queryregistry.discord.channels import bump_activity_request
+from queryregistry.discord.channels.models import BumpChannelActivityParams
 from datetime import datetime, timedelta, timezone
 from fastapi import FastAPI
 from typing import Any, Dict, List
 
 from . import BaseModule
 from .discord_bot_module import DiscordBotModule
+from .db_module import DbModule
 
 
 class DiscordChatModule(BaseModule):
@@ -24,6 +27,34 @@ class DiscordChatModule(BaseModule):
 
   async def shutdown(self):
     logging.info("[DiscordChatModule] shutdown")
+
+  def _generate_thread_id(self, guild_id: int | None, channel_id: int | None) -> str:
+    """Generate a thread ID for a persona conversation session.
+
+    Format: discord:{guild_id}:{channel_id}:{session_uuid}
+    Each command invocation starts a new thread to group the
+    user message and assistant response together.
+    """
+    g = str(guild_id) if guild_id is not None else "0"
+    c = str(channel_id) if channel_id is not None else "0"
+    return f"discord:{g}:{c}:{uuid.uuid4().hex[:12]}"
+
+  async def _bump_channel_activity(self, metadata: dict) -> None:
+    if not metadata.get("channel_id"):
+      return
+    try:
+      db: DbModule = getattr(self.app.state, "db", None)
+      if db:
+        await db.run(
+          bump_activity_request(BumpChannelActivityParams(
+            channel_id=str(metadata["channel_id"]),
+          ))
+        )
+    except Exception:
+      logging.debug(
+        "[DiscordChatModule] channel activity bump failed (channel may not be registered)",
+        extra={"channel_id": metadata.get("channel_id")},
+      )
 
   async def fetch_channel_history_backwards(self, guild_id: int, channel_id: int, hours: int, max_messages: int = 5000) -> dict:
     assert self.discord and self.discord.bot
@@ -564,6 +595,7 @@ class DiscordChatModule(BaseModule):
     persona_details: Dict[str, Any] | None = None,
     conversation_history: List[Dict[str, Any]] | None = None,
     channel_history: List[Dict[str, Any]] | None = None,
+    stored_context: List[Dict[str, Any]] | None = None,
     model: str | None = None,
     max_tokens: int | None = None,
     conversation_reference: int | None = None,
@@ -647,6 +679,17 @@ class DiscordChatModule(BaseModule):
     channel_text = _format_channel(channel_history)
     if channel_text:
       context_sections.append("Recent channel activity:\n" + channel_text)
+    stored_context = stored_context or []
+    if stored_context:
+      stored_parts: List[str] = []
+      for msg in stored_context[-15:]:
+        r = msg.get("role") or "user"
+        c = msg.get("content") or ""
+        if c:
+          stored_parts.append(f"{r}: {c}")
+      stored_text = "\n".join(stored_parts)
+      if stored_text:
+        context_sections.append("Recent stored conversation context:\n" + stored_text)
     prompt_context = "\n\n".join(context_sections)
 
     system_prompt = persona_details.get("prompt") or ""
@@ -793,23 +836,30 @@ class DiscordChatModule(BaseModule):
     }
     context = await self._persona_parse_and_dispatch(command_text, metadata)
     if not context.get("success", True):
+      await self._bump_channel_activity(metadata)
       return self._finalize_persona_context(context, success=False)
     context = await self._persona_fetch_persona(context, metadata)
     if not context.get("success", True):
+      await self._bump_channel_activity(metadata)
       return self._finalize_persona_context(context, success=False)
     context = await self._persona_fetch_conversation(context, metadata)
     if not context.get("success", True):
+      await self._bump_channel_activity(metadata)
       return self._finalize_persona_context(context, success=False)
     context = await self._persona_fetch_channel_history(context, metadata)
     if not context.get("success", True):
+      await self._bump_channel_activity(metadata)
       return self._finalize_persona_context(context, success=False)
     context = await self._persona_insert_conversation_input(context, metadata)
     if not context.get("success", True):
+      await self._bump_channel_activity(metadata)
       return self._finalize_persona_context(context, success=False)
     context = await self._persona_generate_response(context, metadata)
     if not context.get("success", True):
+      await self._bump_channel_activity(metadata)
       return self._finalize_persona_context(context, success=False)
     context = await self._persona_deliver_response(context, metadata)
+    await self._bump_channel_activity(metadata)
     return self._finalize_persona_context(context, success=context.get("success", True))
 
   async def _persona_parse_and_dispatch(self, command_text: str, metadata: dict) -> dict:
@@ -865,6 +915,18 @@ class DiscordChatModule(BaseModule):
     context["reason"] = response.get("reason", context.get("reason"))
     if response.get("ack_message"):
       context["ack_message"] = response.get("ack_message")
+    openai = getattr(self.app.state, "openai", None)
+    if openai and metadata.get("guild_id") and metadata.get("channel_id"):
+      try:
+        stored_context = await openai.get_channel_context(
+          metadata["guild_id"],
+          metadata["channel_id"],
+          limit=20,
+        )
+        if stored_context:
+          context["stored_channel_context"] = stored_context
+      except Exception:
+        logging.exception("[DiscordChatModule] failed to fetch stored channel context")
     return context
 
   async def _persona_fetch_channel_history(self, context: dict, metadata: dict) -> dict:
@@ -900,6 +962,24 @@ class DiscordChatModule(BaseModule):
     context["reason"] = response.get("reason", context.get("reason"))
     if response.get("ack_message"):
       context["ack_message"] = response.get("ack_message")
+    thread_id = self._generate_thread_id(
+      metadata.get("guild_id"),
+      metadata.get("channel_id"),
+    )
+    context["thread_id"] = thread_id
+
+    openai = getattr(self.app.state, "openai", None)
+    if openai and context.get("personas_recid") and context.get("models_recid"):
+      await openai.log_message(
+        personas_recid=context["personas_recid"],
+        models_recid=context["models_recid"],
+        role="user",
+        content=context.get("message", ""),
+        guild_id=metadata.get("guild_id"),
+        channel_id=metadata.get("channel_id"),
+        user_id=metadata.get("user_id"),
+        thread_id=thread_id,
+      )
     return context
 
   async def _persona_generate_response(self, context: dict, metadata: dict) -> dict:
@@ -909,6 +989,7 @@ class DiscordChatModule(BaseModule):
       persona_details=context.get("persona_details"),
       conversation_history=context.get("conversation_history", []),
       channel_history=context.get("channel_history", []),
+      stored_context=context.get("stored_channel_context", []),
       model=context.get("model"),
       max_tokens=context.get("max_tokens"),
       conversation_reference=context.get("conversation_reference"),
@@ -924,6 +1005,26 @@ class DiscordChatModule(BaseModule):
     context["reason"] = response.get("reason", context.get("reason"))
     if response.get("ack_message"):
       context["ack_message"] = response.get("ack_message")
+
+    openai = getattr(self.app.state, "openai", None)
+    if context.get("success") and context.get("thread_id"):
+      response_text = ""
+      resp = context.get("response")
+      if isinstance(resp, dict):
+        response_text = resp.get("text") or resp.get("content") or ""
+      elif isinstance(resp, str):
+        response_text = resp
+      if response_text and openai:
+        await openai.log_message(
+          personas_recid=context.get("personas_recid", 0),
+          models_recid=context.get("models_recid", 0),
+          role="assistant",
+          content=response_text,
+          guild_id=metadata.get("guild_id"),
+          channel_id=metadata.get("channel_id"),
+          user_id=metadata.get("user_id"),
+          thread_id=context["thread_id"],
+        )
     return context
 
   async def _persona_deliver_response(self, context: dict, metadata: dict) -> dict:

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -14,13 +14,19 @@ from queryregistry.system.config.models import ConfigKeyParams
 from queryregistry.system.conversations import (
   find_recent_request,
   insert_conversation_request,
+  insert_message_request,
   list_by_time_request,
+  list_channel_messages_request,
+  list_thread_request,
   update_output_request,
 )
 from queryregistry.system.conversations.models import (
   FindRecentParams,
   InsertConversationParams,
+  InsertMessageParams,
   ListByTimeParams,
+  ListChannelMessagesParams,
+  ListThreadParams,
   UpdateOutputParams,
 )
 from queryregistry.system.models_registry import list_models_request
@@ -275,6 +281,102 @@ class OpenaiModule(BaseModule):
         )
     except Exception:
       logging.exception("[OpenaiModule] update conversation failed")
+
+  async def log_message(
+    self,
+    *,
+    personas_recid: int,
+    models_recid: int,
+    role: str,
+    content: str,
+    guild_id: int | str | None = None,
+    channel_id: int | str | None = None,
+    user_id: int | str | None = None,
+    users_guid: str | None = None,
+    thread_id: str | None = None,
+    tokens: int | None = None,
+  ) -> int | None:
+    """Insert a single message row using the new message-per-row schema."""
+    if not self.db:
+      return None
+    try:
+      res = await self.db.run(
+        insert_message_request(InsertMessageParams(
+          personas_recid=personas_recid,
+          models_recid=models_recid,
+          role=role,
+          content=content,
+          guild_id=str(guild_id) if guild_id is not None else None,
+          channel_id=str(channel_id) if channel_id is not None else None,
+          user_id=str(user_id) if user_id is not None else None,
+          users_guid=users_guid,
+          thread_id=thread_id,
+          tokens=tokens,
+        ))
+      )
+      if res.rows:
+        return res.rows[0].get("recid")
+    except Exception:
+      logging.exception("[OpenaiModule] insert message failed")
+    return None
+
+  async def get_thread_history(
+    self,
+    thread_id: str,
+    *,
+    limit: int = 20,
+  ) -> List[Dict[str, str]]:
+    """Retrieve message history for a thread, formatted for OpenAI messages."""
+    if not self.db or not thread_id:
+      return []
+    try:
+      res = await self.db.run(
+        list_thread_request(ListThreadParams(thread_id=thread_id))
+      )
+    except Exception:
+      logging.exception("[OpenaiModule] failed to load thread history")
+      return []
+    rows = list(res.rows or [])
+    if limit and limit > 0:
+      rows = rows[-limit:]
+    messages: List[Dict[str, str]] = []
+    for row in rows:
+      role = (row.get("element_role") or "user").strip()
+      content = (row.get("element_content") or "").strip()
+      if content:
+        messages.append({"role": role, "content": content})
+    return messages
+
+  async def get_channel_context(
+    self,
+    guild_id: int | str,
+    channel_id: int | str,
+    *,
+    limit: int = 30,
+  ) -> List[Dict[str, str]]:
+    """Retrieve recent stored messages from a guild+channel for context."""
+    if not self.db:
+      return []
+    try:
+      res = await self.db.run(
+        list_channel_messages_request(ListChannelMessagesParams(
+          guild_id=str(guild_id),
+          channel_id=str(channel_id),
+          limit=limit,
+        ))
+      )
+    except Exception:
+      logging.exception("[OpenaiModule] failed to load channel context")
+      return []
+    rows = list(res.rows or [])
+    rows.reverse()
+    messages: List[Dict[str, str]] = []
+    for row in rows:
+      role = (row.get("element_role") or "user").strip()
+      content = (row.get("element_content") or "").strip()
+      if content:
+        messages.append({"role": role, "content": content})
+    return messages
 
   async def get_recent_persona_conversation_history(
     self,

--- a/server/modules/providers/social/discord_input_provider.py
+++ b/server/modules/providers/social/discord_input_provider.py
@@ -182,6 +182,20 @@ class DiscordInputProvider(SocialInputProvider):
       if not data.get("success"):
         message = data.get("ack_message") or "Failed to send summary. Please try again later."
         await self._queue_channel_notice(ctx, message, reason=data.get("reason") or "delivery_failed")
+
+      try:
+        from queryregistry.discord.channels import bump_activity_request
+        from queryregistry.discord.channels.models import BumpChannelActivityParams
+        db = getattr(self.discord.app.state, "db", None)
+        if db:
+          await db.run(
+            bump_activity_request(
+              BumpChannelActivityParams(channel_id=str(getattr(ctx.channel, "id", 0)))
+            )
+          )
+      except Exception:
+        pass
+
       elapsed = time.perf_counter() - start
       logging.info(
         "[DiscordInputProvider] summarize",


### PR DESCRIPTION
### Motivation
- Move persona conversation logging from the legacy flat row format into the new message-per-row schema so each user message and assistant response are stored as individual rows.
- Group persona interactions by a generated `thread_id` so user+assistant exchanges can be retrieved coherently for context.
- Surface stored channel context alongside recent Discord history and bump channel activity metrics on persona and summarize commands to improve context-aware responses and activity tracking.

### Description
- Expanded `OpenaiModule` imports to include the new conversation request builders and models and added additive helpers `log_message`, `get_thread_history`, and `get_channel_context` to write and read the message-per-row records.
- Updated `DiscordChatModule` to generate per-invocation thread ids via `_generate_thread_id`, log the user input and assistant output with `openai.log_message`, fetch stored channel messages via `openai.get_channel_context`, pass stored context into `generate_persona_response`, and centrally bump channel activity using a `_bump_channel_activity` helper; failures to bump are logged at debug level.
- Added `stored_context` parameter handling in persona response assembly so stored messages are included in `prompt_context` when building the chat prompt.
- Updated `DiscordInputProvider` summarize handler to bump channel activity after successful summarize RPC completion.
- Preserved existing legacy conversation logging methods so the `!summarize` flow remains unchanged.

### Testing
- Ran `python -m py_compile server/modules/openai_module.py server/modules/discord_chat_module.py server/modules/providers/social/discord_input_provider.py` and compilation completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18985088c832584809a8198b07d14)