### PR TITLE
Fix service routes MSSQL query column names

### DIFF
--- a/queryregistry/system/routes/mssql.py
+++ b/queryregistry/system/routes/mssql.py
@@ -19,11 +19,11 @@ __all__ = [
 async def get_routes_v1(_: Mapping[str, Any]) -> DBResponse:
   sql = """
     SELECT
-      element_path AS path,
-      element_name AS name,
-      element_icon AS icon,
-      element_sequence AS sequence,
-      element_roles AS roles
+      element_path,
+      element_name,
+      element_icon,
+      element_sequence,
+      element_roles
     FROM frontend_routes
     ORDER BY element_sequence
     FOR JSON PATH;


### PR DESCRIPTION
### Motivation
- The service routes page returned blank fields because the SQL returned aliased keys (`path`, `name`, etc.) that did not match the module's expected `element_*` column names, so the query should emit raw column names to align with the module.

### Description
- Removed `AS` aliases in `get_routes_v1` within `queryregistry/system/routes/mssql.py` so the query now returns `element_path`, `element_name`, `element_icon`, `element_sequence`, and `element_roles` directly.

### Testing
- Ran `python -m py_compile queryregistry/system/routes/mssql.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1905479388325ab155fab07c09167)