### PR TITLE
Fix Discord handler and personas service test expectations

### DIFF
--- a/tests/test_discord_handler.py
+++ b/tests/test_discord_handler.py
@@ -37,12 +37,12 @@ sys.modules['server.modules.auth_module'] = auth_module_pkg
 from rpc.discord import handler as discord_handler
 
 async def _stub_unbox_request(request):
-  return RPCRequest(op='urn:discord:command:get_roles:1'), AuthContext(user_guid='u1'), []
+  return RPCRequest(op='urn:discord:chat:get_roles:1'), AuthContext(user_guid='u1'), []
 
 discord_handler.unbox_request = _stub_unbox_request
 
 async def dummy_handler(parts, request):
-  return RPCResponse(op='urn:discord:command:get_roles:1', payload={'roles': ['ROLE_A']}, version=1)
+  return RPCResponse(op='urn:discord:chat:get_roles:1', payload={'roles': ['ROLE_A']}, version=1)
 
 class DummyAuth:
   def __init__(self, allowed: bool):
@@ -55,17 +55,17 @@ class DummyAuth:
 def _get_client(allowed: bool):
   app = FastAPI()
   app.state.auth = DummyAuth(allowed)
-  discord_handler.HANDLERS = {'command': dummy_handler}
+  discord_handler.HANDLERS = {'chat': dummy_handler}
 
   @app.post('/rpc')
   async def rpc_endpoint(request: Request):
-    return await discord_handler.handle_discord_request(['command'], request)
+    return await discord_handler.handle_discord_request(['chat'], request)
 
   return TestClient(app)
 
 def test_discord_handler_rejects_missing_role():
   client = _get_client(False)
-  resp = client.post('/rpc', json={'op': 'urn:discord:command:get_roles:1'})
+  resp = client.post('/rpc', json={'op': 'urn:discord:chat:get_roles:1'})
   assert resp.status_code == 403
   data = resp.json()
   assert (
@@ -75,7 +75,21 @@ def test_discord_handler_rejects_missing_role():
 
 def test_discord_handler_allows_role():
   client = _get_client(True)
-  resp = client.post('/rpc', json={'op': 'urn:discord:command:get_roles:1'})
+  resp = client.post('/rpc', json={'op': 'urn:discord:chat:get_roles:1'})
   assert resp.status_code == 200
   data = resp.json()
   assert data['payload'] == {'roles': ['ROLE_A']}
+
+
+def test_discord_handler_allows_command_without_role():
+  app = FastAPI()
+  app.state.auth = DummyAuth(False)
+  discord_handler.HANDLERS = {'command': dummy_handler}
+
+  @app.post('/rpc')
+  async def rpc_endpoint(request: Request):
+    return await discord_handler.handle_discord_request(['command'], request)
+
+  client = TestClient(app)
+  resp = client.post('/rpc', json={'op': 'urn:discord:command:get_roles:1'})
+  assert resp.status_code == 200

--- a/tests/test_discord_personas_services.py
+++ b/tests/test_discord_personas_services.py
@@ -138,6 +138,7 @@ def test_get_personas_service():
         'tokens': 512,
         'models_recid': 2,
         'model': 'gpt-4',
+        'is_active': True,
       }
     ]
   }
@@ -164,6 +165,7 @@ def test_upsert_and_delete_persona_service():
     'prompt': 'updated prompt',
     'tokens': 1024,
     'models_recid': 2,
+    'is_active': True,
   }
   resp = client.post(
     '/rpc',


### PR DESCRIPTION
### Motivation
- Tests broke after changing `REQUIRED_ROLES['command']` to open (no role required) and adding an `is_active: bool = True` default to persona models, so assertions no longer matched runtime behavior.
- The goal is to update test expectations to reflect the new routing security model and persona defaults without changing application code.

### Description
- Updated `tests/test_discord_handler.py` to exercise the `chat` subdomain (which remains role-protected) for the rejection/allow assertions and adjusted op strings and handler wiring accordingly.
- Added `test_discord_handler_allows_command_without_role` which verifies that the `command` subdomain is intentionally open and returns `200` even when the role check would otherwise fail.
- Updated `tests/test_discord_personas_services.py` to include `'is_active': True` in the expected `get_personas` payload and to include `'is_active': True` in the `upsert_payload` so the `db.upserts` assertion matches the model default.

### Testing
- Ran the unified test harness via `python scripts/run_tests.py` and observed `67 passed, 1 warning` with no test failures.
- Focused edits were validated by running the relevant test modules during iteration and ensuring the final harness succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1998219608325ac9ee355327ae74f)