### PR TITLE
Add Discord guilds sync RPC and UI action

### DIFF
--- a/frontend/src/pages/DiscordGuildsPage.tsx
+++ b/frontend/src/pages/DiscordGuildsPage.tsx
@@ -1,6 +1,8 @@
+import { Sync } from "@mui/icons-material";
 import { useEffect, useState } from "react";
 import {
         Box,
+        Button,
         Divider,
         Table,
         TableBody,
@@ -13,11 +15,12 @@ import PageTitle from "../components/PageTitle";
 import EditBox from "../components/EditBox";
 import ColumnHeader from "../components/ColumnHeader";
 import type { DiscordGuildsGuildItem1, DiscordGuildsList1 } from "../shared/RpcModels";
-import { fetchListGuilds, fetchUpdateCredits } from "../rpc/discord/guilds";
+import { fetchListGuilds, fetchSyncGuilds, fetchUpdateCredits } from "../rpc/discord/guilds";
 
 const DiscordGuildsPage = (): JSX.Element => {
         const [guilds, setGuilds] = useState<DiscordGuildsGuildItem1[]>([]);
         const [forbidden, setForbidden] = useState(false);
+        const [syncing, setSyncing] = useState(false);
 
         const loadGuilds = async (): Promise<void> => {
                 try {
@@ -45,6 +48,20 @@ const DiscordGuildsPage = (): JSX.Element => {
                 );
         }
 
+
+        const handleSync = async (): Promise<void> => {
+                setSyncing(true);
+                try {
+                        const res = await fetchSyncGuilds();
+                        setGuilds(res.guilds ?? []);
+                        setForbidden(false);
+                } catch (e: any) {
+                        console.error("Sync failed", e);
+                } finally {
+                        setSyncing(false);
+                }
+        };
+
         const updateCredits = async (index: number, credits: number): Promise<void> => {
                 const updated = [...guilds];
                 updated[index] = { ...updated[index], credits };
@@ -60,6 +77,19 @@ const DiscordGuildsPage = (): JSX.Element => {
                 <Box sx={{ p: 2 }}>
                         <PageTitle>Discord Guild Management</PageTitle>
                         <Divider sx={{ mb: 2 }} />
+                        <Box sx={{ mb: 2, display: "flex", alignItems: "center", gap: 2 }}>
+                                <Button
+                                        variant="outlined"
+                                        startIcon={<Sync />}
+                                        onClick={() => void handleSync()}
+                                        disabled={syncing}
+                                >
+                                        {syncing ? "Syncing..." : "Sync Guilds"}
+                                </Button>
+                                <Typography variant="body2" color="text.secondary">
+                                        {guilds.length} guild{guilds.length !== 1 ? "s" : ""} registered
+                                </Typography>
+                        </Box>
                         <Table size="small" sx={{ "& td, & th": { py: 0.5, verticalAlign: "top" } }}>
                                 <TableHead>
                                         <TableRow>

--- a/rpc/discord/guilds/__init__.py
+++ b/rpc/discord/guilds/__init__.py
@@ -1,6 +1,7 @@
 from .services import (
   discord_guilds_get_v1,
   discord_guilds_list_v1,
+  discord_guilds_sync_v1,
   discord_guilds_update_credits_v1,
 )
 
@@ -8,4 +9,5 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("list_guilds", "1"): discord_guilds_list_v1,
   ("get_guild", "1"): discord_guilds_get_v1,
   ("update_credits", "1"): discord_guilds_update_credits_v1,
+  ("sync_guilds", "1"): discord_guilds_sync_v1,
 }

--- a/rpc/discord/guilds/models.py
+++ b/rpc/discord/guilds/models.py
@@ -21,3 +21,8 @@ class DiscordGuildsList1(BaseModel):
 class DiscordGuildsUpdateCredits1(BaseModel):
   guild_id: str
   credits: int
+
+
+class DiscordGuildsSyncResult1(BaseModel):
+  synced: int
+  guilds: list[DiscordGuildsGuildItem1]

--- a/rpc/discord/guilds/services.py
+++ b/rpc/discord/guilds/services.py
@@ -1,13 +1,16 @@
 from fastapi import Request
+import logging
 
 from queryregistry.discord.guilds import (
   get_guild_request,
   list_guilds_request,
+  upsert_guild_request,
   update_credits_request,
 )
 from queryregistry.discord.guilds.models import (
   GuildIdParams,
   ListGuildsParams,
+  UpsertGuildParams,
   UpdateGuildCreditsParams,
 )
 from rpc.helpers import unbox_request
@@ -17,6 +20,7 @@ from server.modules.db_module import DbModule
 from .models import (
   DiscordGuildsGuildItem1,
   DiscordGuildsList1,
+  DiscordGuildsSyncResult1,
   DiscordGuildsUpdateCredits1,
 )
 
@@ -77,3 +81,65 @@ async def discord_guilds_update_credits_v1(request: Request):
     credits=payload.credits,
   )))
   return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def discord_guilds_sync_v1(request: Request):
+  """Sync live Discord bot guilds into the database.
+
+  Reads bot.guilds from the running Discord bot, upserts each guild
+  into the database, then returns the full updated guild list.
+  """
+  rpc_request, _, _ = await unbox_request(request)
+
+  discord_bot = getattr(request.app.state, "discord_bot", None)
+  if not discord_bot or not discord_bot.bot:
+    logging.warning("[discord_guilds_sync_v1] Discord bot not available")
+    return RPCResponse(
+      op=rpc_request.op,
+      payload=DiscordGuildsSyncResult1(synced=0, guilds=[]).model_dump(),
+      version=rpc_request.version,
+    )
+
+  bot = discord_bot.bot
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+
+  synced = 0
+  for guild in bot.guilds:
+    try:
+      await db.run(upsert_guild_request(UpsertGuildParams(
+        guild_id=str(guild.id),
+        name=guild.name,
+        member_count=guild.member_count,
+        owner_id=str(guild.owner_id) if guild.owner_id else None,
+      )))
+      synced += 1
+    except Exception:
+      logging.exception(
+        "[discord_guilds_sync_v1] failed to upsert guild",
+        extra={"guild_id": guild.id, "guild_name": guild.name},
+      )
+
+  res = await db.run(list_guilds_request(ListGuildsParams(include_inactive=True)))
+  guilds = []
+  for row in res.rows or []:
+    guilds.append(DiscordGuildsGuildItem1(
+      recid=row.get("recid", 0),
+      guild_id=row.get("element_guild_id", ""),
+      name=row.get("element_name", ""),
+      joined_on=row.get("element_joined_on"),
+      member_count=row.get("element_member_count"),
+      owner_id=row.get("element_owner_id"),
+      region=row.get("element_region"),
+      left_on=row.get("element_left_on"),
+      notes=row.get("element_notes"),
+      credits=int(row.get("element_credits", 0) or 0),
+    ))
+
+  logging.info("[discord_guilds_sync_v1] synced %d guilds", synced)
+  payload = DiscordGuildsSyncResult1(synced=synced, guilds=guilds)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
+    version=rpc_request.version,
+  )


### PR DESCRIPTION
### Motivation
- Ensure the Guilds admin page can refresh the database to match the bot's live guild list so new guilds appear and existing metadata is updated.
- Provide a one-click operation to upsert live `bot.guilds` into the `discord_guilds` table while preserving existing credits via the existing MERGE upsert.

### Description
- Added a new response model `DiscordGuildsSyncResult1` in `rpc/discord/guilds/models.py` to carry the sync count and refreshed guild list payload.
- Implemented `discord_guilds_sync_v1` in `rpc/discord/guilds/services.py` which reads `request.app.state.discord_bot.bot.guilds`, upserts each guild using `upsert_guild_request` / `UpsertGuildParams`, logs failures per-guild, and returns the updated DB-backed list.
- Registered the new dispatcher `("sync_guilds", "1")` in `rpc/discord/guilds/__init__.py` and regenerated frontend RPC bindings so `fetchSyncGuilds` is available.
- Added a `Sync Guilds` button and handler to `frontend/src/pages/DiscordGuildsPage.tsx` that calls `fetchSyncGuilds()`, shows a loading state, and replaces the table data with the returned guild list.

### Testing
- Ran `python scripts/generate_rpc_bindings.py` to regenerate TypeScript bindings and verified `fetchSyncGuilds` was emitted, succeeded.
- Performed `python -m py_compile rpc/discord/guilds/models.py rpc/discord/guilds/services.py rpc/discord/guilds/__init__.py` to validate Python syntax, succeeded.
- Executed frontend checks `npm run type-check` and `npm run lint` in `frontend/`, both commands completed without errors.
- Verified the updated page UI by starting the frontend and capturing a page screenshot to confirm the button renders (local dev server run successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a088ea388325b0895a376ed49743)