### PR TITLE
Add DB CLI reconnect command and MSSQL pool connection info

### DIFF
--- a/server/modules/database_cli/cli.py
+++ b/server/modules/database_cli/cli.py
@@ -18,6 +18,7 @@ from . import mssql_cli
 HELP_TEXT = """\
 Available commands:
   help
+  reconnect
   list tables
   schema dump [name]
   schema apply <file>
@@ -110,6 +111,23 @@ def run_repl():
         continue
       if parts in (["exit"], ["quit"]):
         break
+
+      if parts == ["reconnect"]:
+        try:
+          if app:
+            loop.run_until_complete(_shutdown(app))
+          if raw_conn:
+            try:
+              loop.run_until_complete(raw_conn.close())
+            except Exception:
+              pass
+            raw_conn = None
+          app, cli_mod = loop.run_until_complete(_bootstrap())
+          print("Reconnected.")
+        except Exception as e:
+          print(f"Reconnect failed: {e}")
+          logging.exception("[DatabaseCli] Reconnect failed")
+        continue
 
       if parts[:2] == ["list", "tables"]:
         try:

--- a/server/modules/providers/database/mssql_provider/logic.py
+++ b/server/modules/providers/database/mssql_provider/logic.py
@@ -5,13 +5,41 @@ from typing import Callable, Optional
 
 _pool: aioodbc.pool.Pool | None = None
 
+
+def _parse_dsn_info(dsn: str) -> dict[str, str]:
+  """Extract server and database from a DSN connection string."""
+  info: dict[str, str] = {}
+  for part in dsn.split(";"):
+    part = part.strip()
+    if not part or "=" not in part:
+      continue
+    key, _, value = part.partition("=")
+    key_upper = key.strip().upper()
+    if key_upper == "SERVER":
+      info["server"] = value.strip()
+    elif key_upper in ("DATABASE", "INITIAL CATALOG"):
+      info["database"] = value.strip()
+    elif key_upper == "DRIVER":
+      info["driver"] = value.strip()
+  return info
+
+
 async def init_pool(*, dsn: str | None = None, **cfg):
-    global _pool
-    if not dsn:
-        # allow explicit pieces if you pass them later
-        raise RuntimeError("MSSQL DSN is required")
-    _pool = await aioodbc.create_pool(dsn=dsn, autocommit=True)
-    logging.info("MSSQL ODBC Connection Pool Created")
+  global _pool
+  if not dsn:
+    raise RuntimeError("MSSQL DSN is required")
+  info = _parse_dsn_info(dsn)
+  server = info.get("server", "unknown")
+  database = info.get("database", "unknown")
+  driver = info.get("driver", "unknown")
+  _pool = await aioodbc.create_pool(dsn=dsn, autocommit=True)
+  logging.info(
+    "MSSQL ODBC Connection Pool Created: server=%s database=%s driver=%s",
+    server,
+    database,
+    driver,
+  )
+  print(f"Connected to {database} on {server} ({driver})")
 
 async def close_pool():
   global _pool


### PR DESCRIPTION
### Motivation

- Make CLI behavior clearer by showing which MSSQL server/database/driver the pool connected to without exposing DSN credentials.
- Allow operators to tear down and re-establish the app and raw SQL connection from the REPL without restarting the process.

### Description

- Added a defensive DSN parser `_parse_dsn_info` in `server/modules/providers/database/mssql_provider/logic.py` that extracts `server`, `database`, and `driver` from a DSN string.
- Updated `init_pool` to validate presence of `dsn`, call `_parse_dsn_info`, log structured connection metadata (server/database/driver) at `INFO` level, and `print` a user-facing `Connected to ...` message after pool creation.
- Extended CLI help in `server/modules/database_cli/cli.py` to include a `reconnect` command and implemented a `reconnect` handler in the REPL that calls `await _shutdown(app)`, closes and resets the raw SQL connection, reboots modules via `_bootstrap()`, and reports success or failure while logging exceptions.

### Testing

- Ran `python -m py_compile server/modules/providers/database/mssql_provider/logic.py server/modules/database_cli/cli.py` and the files compiled with no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a5d35db483259a247811bd7348ae)