### PR TITLE
Upgrade Docker runtime to Python 3.12-bookworm and Node 20; bump pyodbc to 5.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # ────────────────────────────────────────────────────────────────────────────────
 # Frontend build
 # ────────────────────────────────────────────────────────────────────────────────
-FROM node:18 AS builder
+FROM node:20 AS builder
 
 # Download and install Node 18
 RUN apt-get update && apt-get install -y curl python3 python3-pip python3-venv
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && apt-get install -y nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs
 WORKDIR /app
 
 COPY requirements.txt ./
@@ -35,7 +35,7 @@ RUN npm run build
 # ────────────────────────────────────────────────────────────────────────────────
 # Python build
 # ────────────────────────────────────────────────────────────────────────────────
-FROM python:3.11
+FROM python:3.12-bookworm
 
 # RUN apt-get update && apt-get install -y ffmpeg libodbc2 unixodbc
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ azure-containerregistry
 aiofiles
 aiohttp
 aioodbc==0.5.0
-pyodbc==5.1.0
+pyodbc==5.3.0
 python-dotenv
 asyncpg
 python-jose


### PR DESCRIPTION
### Motivation
- Move the image stack to supported LTS versions (Node 20 and Python 3.12) and use pyodbc wheels for Python 3.12 to avoid local ODBC compilation.

### Description
- Updated the builder base image from `node:18` to `node:20` and adjusted the NodeSource setup script from `setup_18.x` to `setup_20.x` in the Dockerfile.
- Updated the runtime base image from `python:3.11` to `python:3.12-bookworm` in the Dockerfile while leaving the ODBC registration/installation and all other blocks unchanged.
- Bumped `pyodbc` from `5.1.0` to `5.3.0` in `requirements.txt` and did not change any other package pins.

### Testing
- Ran the unified harness with `python scripts/run_tests.py`, which executed the lint, type-check, frontend, and backend tests and completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b1f3b7b08325ad4850bde8c09690)