### PR TITLE
Add System Models management: RPC endpoints, DB migration, registry, and frontend UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ const FileManager = lazy(() => import("./pages/FileManager"));
 const DiscordPersonasPage = lazy(() => import("./pages/DiscordPersonasPage"));
 const DiscordGuildsPage = lazy(() => import("./pages/DiscordGuildsPage"));
 const SystemConfigPage = lazy(() => import("./pages/system/SystemConfigPage"));
+const SystemModelsPage = lazy(() => import("./pages/system/SystemModelsPage"));
 const AccountRolesPage = lazy(() => import("./pages/AccountRolesPage"));
 const AccountUsersPage = lazy(() => import("./pages/AccountUsersPage"));
 const AccountUserPanel = lazy(() => import("./pages/AccountUserPanel"));
@@ -47,6 +48,7 @@ function App(): JSX.Element {
 								<Route path="/userpage" element={<UserPage />} />
                                                                 <Route path="/service-routes" element={<ServiceRoutesPage />} />
                                                                 <Route path="/system-config" element={<SystemConfigPage />} />
+                                                                <Route path="/system-models" element={<SystemModelsPage />} />
                                                                 <Route path="/service-roles" element={<ServiceRolesPage />} />
 								<Route path="/account-roles" element={<AccountRolesPage />} />
 								<Route path="/account-users" element={<AccountUsersPage />} />

--- a/frontend/src/pages/system/SystemModelsPage.tsx
+++ b/frontend/src/pages/system/SystemModelsPage.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useState } from "react";
+import {
+        Box,
+        Checkbox,
+        Divider,
+        IconButton,
+        MenuItem,
+        Table,
+        TableBody,
+        TableCell,
+        TableHead,
+        TableRow,
+        TextField,
+        Typography,
+} from "@mui/material";
+import { Add, Delete } from "@mui/icons-material";
+
+import ColumnHeader from "../../components/ColumnHeader";
+import EditBox from "../../components/EditBox";
+import PageTitle from "../../components/PageTitle";
+import {
+        fetchDeleteModel,
+        fetchModels,
+        fetchUpsertModel,
+} from "../../rpc/system/models";
+import type {
+        SystemModelsList1,
+        SystemModelsModelItem1,
+        SystemModelsUpsertModel1,
+} from "../../shared/RpcModels";
+
+const SystemModelsPage = (): JSX.Element => {
+        const [models, setModels] = useState<SystemModelsModelItem1[]>([]);
+        const [apiProviders, setApiProviders] = useState<string[]>(["openai", "lumalabs"]);
+        const [newModel, setNewModel] = useState<SystemModelsUpsertModel1>({
+                recid: null,
+                name: "",
+                api_provider: "openai",
+                is_active: true,
+        });
+        const [forbidden, setForbidden] = useState(false);
+
+        const load = async (): Promise<void> => {
+                try {
+                        const res: SystemModelsList1 = await fetchModels();
+                        const sorted = [...(res.models ?? [])].sort((a, b) => a.name.localeCompare(b.name));
+                        setModels(sorted);
+                        setApiProviders(res.api_providers?.length ? res.api_providers : ["openai", "lumalabs"]);
+                        setNewModel((prev) => ({
+                                ...prev,
+                                recid: null,
+                                api_provider: prev.api_provider || "openai",
+                        }));
+                        setForbidden(false);
+                } catch (e: any) {
+                        if (e?.response?.status === 403) {
+                                setForbidden(true);
+                        } else {
+                                setModels([]);
+                        }
+                }
+        };
+
+        useEffect(() => {
+                void load();
+        }, []);
+
+        if (forbidden) {
+                return (
+                        <Box sx={{ p: 2 }}>
+                                <Typography variant="h6">Forbidden</Typography>
+                        </Box>
+                );
+        }
+
+        const updateModel = async (
+                index: number,
+                changes: Partial<SystemModelsModelItem1>,
+        ): Promise<void> => {
+                const updated = [...models];
+                const next = { ...updated[index], ...changes };
+                updated[index] = next;
+                setModels(updated);
+                await fetchUpsertModel({
+                        recid: next.recid ?? null,
+                        name: next.name,
+                        api_provider: next.api_provider,
+                        is_active: next.is_active,
+                });
+                void load();
+        };
+
+        const handleDelete = async (item: SystemModelsModelItem1): Promise<void> => {
+                await fetchDeleteModel({
+                        recid: item.recid ?? null,
+                        name: item.name,
+                });
+                void load();
+        };
+
+        const handleAdd = async (): Promise<void> => {
+                if (!newModel.name.trim()) return;
+                await fetchUpsertModel({
+                        recid: null,
+                        name: newModel.name.trim(),
+                        api_provider: newModel.api_provider,
+                        is_active: Boolean(newModel.is_active),
+                });
+                setNewModel({
+                        recid: null,
+                        name: "",
+                        api_provider: apiProviders.length ? apiProviders[0] : "openai",
+                        is_active: true,
+                });
+                void load();
+        };
+
+        return (
+                <Box sx={{ p: 2 }}>
+                        <PageTitle>System Models</PageTitle>
+                        <Divider sx={{ mb: 2 }} />
+                        <Table size="small" sx={{ "& td, & th": { py: 0.5, verticalAlign: "top" } }}>
+                                <TableHead>
+                                        <TableRow>
+                                                <ColumnHeader sx={{ width: "45%" }}>Model Name</ColumnHeader>
+                                                <ColumnHeader sx={{ width: "30%" }}>API Provider</ColumnHeader>
+                                                <ColumnHeader sx={{ width: "15%" }}>Active</ColumnHeader>
+                                                <ColumnHeader sx={{ width: "10%" }}>Actions</ColumnHeader>
+                                        </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                        {models.map((model, index) => (
+                                                <TableRow key={model.recid}>
+                                                        <TableCell sx={{ width: "45%" }}>
+                                                                <EditBox
+                                                                        value={model.name}
+                                                                        onCommit={(value) =>
+                                                                                void updateModel(index, { name: String(value) })
+                                                                        }
+                                                                />
+                                                        </TableCell>
+                                                        <TableCell sx={{ width: "30%" }}>
+                                                                <TextField
+                                                                        select
+                                                                        sx={{ width: "95%" }}
+                                                                        value={model.api_provider}
+                                                                        onChange={(e) =>
+                                                                                void updateModel(index, {
+                                                                                        api_provider: e.target.value,
+                                                                                })
+                                                                        }
+                                                                >
+                                                                        {apiProviders.map((provider) => (
+                                                                                <MenuItem key={provider} value={provider}>
+                                                                                        {provider}
+                                                                                </MenuItem>
+                                                                        ))}
+                                                                </TextField>
+                                                        </TableCell>
+                                                        <TableCell sx={{ width: "15%" }}>
+                                                                <Checkbox
+                                                                        checked={Boolean(model.is_active)}
+                                                                        onChange={(e) =>
+                                                                                void updateModel(index, {
+                                                                                        is_active: e.target.checked,
+                                                                                })
+                                                                        }
+                                                                />
+                                                        </TableCell>
+                                                        <TableCell sx={{ width: "10%" }}>
+                                                                <IconButton onClick={() => void handleDelete(model)}>
+                                                                        <Delete />
+                                                                </IconButton>
+                                                        </TableCell>
+                                                </TableRow>
+                                        ))}
+                                        <TableRow>
+                                                <TableCell sx={{ width: "45%" }}>
+                                                        <TextField
+                                                                sx={{ width: "95%" }}
+                                                                value={newModel.name}
+                                                                placeholder="Model Name"
+                                                                onChange={(e) =>
+                                                                        setNewModel({
+                                                                                ...newModel,
+                                                                                name: e.target.value,
+                                                                        })
+                                                                }
+                                                        />
+                                                </TableCell>
+                                                <TableCell sx={{ width: "30%" }}>
+                                                        <TextField
+                                                                select
+                                                                sx={{ width: "95%" }}
+                                                                value={newModel.api_provider}
+                                                                onChange={(e) =>
+                                                                        setNewModel({
+                                                                                ...newModel,
+                                                                                api_provider: e.target.value,
+                                                                        })
+                                                                }
+                                                        >
+                                                                {apiProviders.map((provider) => (
+                                                                        <MenuItem key={provider} value={provider}>
+                                                                                {provider}
+                                                                        </MenuItem>
+                                                                ))}
+                                                        </TextField>
+                                                </TableCell>
+                                                <TableCell sx={{ width: "15%" }}>
+                                                        <Checkbox
+                                                                checked={Boolean(newModel.is_active)}
+                                                                onChange={(e) =>
+                                                                        setNewModel({
+                                                                                ...newModel,
+                                                                                is_active: e.target.checked,
+                                                                        })
+                                                                }
+                                                        />
+                                                </TableCell>
+                                                <TableCell sx={{ width: "10%" }}>
+                                                        <IconButton onClick={() => void handleAdd()}>
+                                                                <Add />
+                                                        </IconButton>
+                                                </TableCell>
+                                        </TableRow>
+                                </TableBody>
+                        </Table>
+                </Box>
+        );
+};
+
+export default SystemModelsPage;

--- a/migrations/v0.8.2.0_models_schema_evolution.sql
+++ b/migrations/v0.8.2.0_models_schema_evolution.sql
@@ -1,0 +1,97 @@
+-- ============================================================
+-- v0.8.2.0 — Expand assistant_models table
+-- Adds element_api_provider and element_is_active columns
+-- ============================================================
+
+-- Add api_provider column (defaults to 'openai' for existing rows)
+IF NOT EXISTS (
+  SELECT 1 FROM sys.columns
+  WHERE object_id = OBJECT_ID('dbo.assistant_models')
+  AND name = 'element_api_provider'
+)
+BEGIN
+  ALTER TABLE assistant_models ADD element_api_provider NVARCHAR(64) NOT NULL DEFAULT 'openai';
+END
+GO
+
+-- Add is_active column (defaults to 1 for existing rows)
+IF NOT EXISTS (
+  SELECT 1 FROM sys.columns
+  WHERE object_id = OBJECT_ID('dbo.assistant_models')
+  AND name = 'element_is_active'
+)
+BEGIN
+  ALTER TABLE assistant_models ADD element_is_active BIT NOT NULL DEFAULT 1;
+END
+GO
+
+-- Add timestamps if they don't exist
+IF NOT EXISTS (
+  SELECT 1 FROM sys.columns
+  WHERE object_id = OBJECT_ID('dbo.assistant_models')
+  AND name = 'element_created_on'
+)
+BEGIN
+  ALTER TABLE assistant_models ADD element_created_on DATETIMEOFFSET(7) NOT NULL DEFAULT SYSUTCDATETIME();
+END
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.columns
+  WHERE object_id = OBJECT_ID('dbo.assistant_models')
+  AND name = 'element_modified_on'
+)
+BEGIN
+  ALTER TABLE assistant_models ADD element_modified_on DATETIMEOFFSET(7) NOT NULL DEFAULT SYSUTCDATETIME();
+END
+GO
+
+-- Reflection table updates
+-- system_schema_columns for new columns on assistant_models
+INSERT INTO system_schema_columns (tables_recid, edt_recid, element_name, element_ordinal, element_nullable, element_default, element_max_length, element_is_primary_key, element_is_identity)
+SELECT
+  (SELECT recid FROM system_schema_tables WHERE element_name = 'assistant_models' AND element_schema = 'dbo'),
+  (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'),
+  'element_api_provider', 3, 0, '(''openai'')', 64, 0, 0
+WHERE NOT EXISTS (
+  SELECT 1 FROM system_schema_columns c
+  JOIN system_schema_tables t ON t.recid = c.tables_recid
+  WHERE t.element_name = 'assistant_models' AND c.element_name = 'element_api_provider'
+);
+GO
+
+INSERT INTO system_schema_columns (tables_recid, edt_recid, element_name, element_ordinal, element_nullable, element_default, element_max_length, element_is_primary_key, element_is_identity)
+SELECT
+  (SELECT recid FROM system_schema_tables WHERE element_name = 'assistant_models' AND element_schema = 'dbo'),
+  (SELECT recid FROM system_edt_mappings WHERE element_name = 'BOOLEAN'),
+  'element_is_active', 4, 0, '((1))', NULL, 0, 0
+WHERE NOT EXISTS (
+  SELECT 1 FROM system_schema_columns c
+  JOIN system_schema_tables t ON t.recid = c.tables_recid
+  WHERE t.element_name = 'assistant_models' AND c.element_name = 'element_is_active'
+);
+GO
+
+INSERT INTO system_schema_columns (tables_recid, edt_recid, element_name, element_ordinal, element_nullable, element_default, element_max_length, element_is_primary_key, element_is_identity)
+SELECT
+  (SELECT recid FROM system_schema_tables WHERE element_name = 'assistant_models' AND element_schema = 'dbo'),
+  (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'),
+  'element_created_on', 5, 0, '(sysutcdatetime())', NULL, 0, 0
+WHERE NOT EXISTS (
+  SELECT 1 FROM system_schema_columns c
+  JOIN system_schema_tables t ON t.recid = c.tables_recid
+  WHERE t.element_name = 'assistant_models' AND c.element_name = 'element_created_on'
+);
+GO
+
+INSERT INTO system_schema_columns (tables_recid, edt_recid, element_name, element_ordinal, element_nullable, element_default, element_max_length, element_is_primary_key, element_is_identity)
+SELECT
+  (SELECT recid FROM system_schema_tables WHERE element_name = 'assistant_models' AND element_schema = 'dbo'),
+  (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'),
+  'element_modified_on', 6, 0, '(sysutcdatetime())', NULL, 0, 0
+WHERE NOT EXISTS (
+  SELECT 1 FROM system_schema_columns c
+  JOIN system_schema_tables t ON t.recid = c.tables_recid
+  WHERE t.element_name = 'assistant_models' AND c.element_name = 'element_modified_on'
+);
+GO

--- a/migrations/v0.8.2.1_system_models_route.sql
+++ b/migrations/v0.8.2.1_system_models_route.sql
@@ -1,0 +1,4 @@
+INSERT INTO frontend_routes (element_enablement, element_roles, element_sequence, element_path, element_name, element_icon)
+SELECT '1', sr.element_mask, 15, '/system-models', 'System Models', 'Settings'
+FROM system_roles sr WHERE sr.element_name = 'ROLE_SYSTEM_ADMIN';
+GO

--- a/queryregistry/system/models_registry/__init__.py
+++ b/queryregistry/system/models_registry/__init__.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from queryregistry.models import DBRequest
 
-from .models import ModelNameParams
+from .models import DeleteModelParams, ModelNameParams, UpsertModelParams
 
 __all__ = [
+  "delete_model_request",
   "get_model_by_name_request",
   "list_models_request",
+  "upsert_model_request",
 ]
 
 
@@ -25,3 +27,11 @@ def list_models_request() -> DBRequest:
 
 def get_model_by_name_request(params: ModelNameParams) -> DBRequest:
   return DBRequest(op=_op("get_by_name"), payload=params.model_dump())
+
+
+def upsert_model_request(params: UpsertModelParams) -> DBRequest:
+  return DBRequest(op=_op("upsert"), payload=params.model_dump())
+
+
+def delete_model_request(params: DeleteModelParams) -> DBRequest:
+  return DBRequest(op=_op("delete"), payload=params.model_dump())

--- a/queryregistry/system/models_registry/handler.py
+++ b/queryregistry/system/models_registry/handler.py
@@ -7,7 +7,7 @@ from typing import Sequence
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
 
-from .services import get_by_name_v1, list_v1
+from .services import delete_v1, get_by_name_v1, list_v1, upsert_v1
 from ..dispatch import SubdomainDispatcher
 
 __all__ = ["handle_models_request"]
@@ -15,6 +15,8 @@ __all__ = ["handle_models_request"]
 DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
   ("list", "1"): list_v1,
   ("get_by_name", "1"): get_by_name_v1,
+  ("upsert", "1"): upsert_v1,
+  ("delete", "1"): delete_v1,
 }
 
 

--- a/queryregistry/system/models_registry/models.py
+++ b/queryregistry/system/models_registry/models.py
@@ -7,8 +7,10 @@ from typing import TypedDict
 from pydantic import BaseModel, ConfigDict
 
 __all__ = [
+  "DeleteModelParams",
   "ModelNameParams",
   "ModelRecord",
+  "UpsertModelParams",
 ]
 
 
@@ -20,8 +22,26 @@ class ModelNameParams(BaseModel):
   name: str
 
 
+class UpsertModelParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int | None = None
+  name: str
+  api_provider: str = "openai"
+  is_active: bool = True
+
+
+class DeleteModelParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int | None = None
+  name: str | None = None
+
+
 class ModelRecord(TypedDict):
   """Record representation returned by model queries."""
 
   recid: int
   name: str
+  api_provider: str
+  is_active: bool

--- a/queryregistry/system/models_registry/mssql.py
+++ b/queryregistry/system/models_registry/mssql.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from queryregistry.providers.mssql import run_json_many, run_json_one
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
 
 from queryregistry.models import DBResponse
 
 __all__ = [
+  "delete_v1",
   "get_by_name_v1",
   "list_v1",
+  "upsert_v1",
 ]
 
 
@@ -19,7 +21,9 @@ async def list_v1(_: Mapping[str, Any]) -> DBResponse:
   sql = """
     SELECT
       recid,
-      element_name AS name
+      element_name,
+      element_api_provider,
+      element_is_active
     FROM assistant_models
     ORDER BY element_name
     FOR JSON PATH;
@@ -36,3 +40,57 @@ async def get_by_name_v1(args: Mapping[str, Any]) -> DBResponse:
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
   """
   return await run_json_one(sql, (name,))
+
+
+async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
+  recid = args.get("recid")
+  name = args["name"]
+  api_provider = args.get("api_provider", "openai")
+  is_active = bool(args.get("is_active", True))
+
+  if recid is not None:
+    rc = await run_exec(
+      """
+        UPDATE assistant_models
+        SET element_name = ?,
+            element_api_provider = ?,
+            element_is_active = ?,
+            element_modified_on = SYSUTCDATETIME()
+        WHERE recid = ?;
+      """,
+      (name, api_provider, is_active, recid),
+    )
+    if rc.rowcount:
+      return rc
+
+  rc = await run_exec(
+    """
+      UPDATE assistant_models
+      SET element_api_provider = ?,
+          element_is_active = ?,
+          element_modified_on = SYSUTCDATETIME()
+      WHERE element_name = ?;
+    """,
+    (api_provider, is_active, name),
+  )
+  if rc.rowcount:
+    return rc
+
+  return await run_exec(
+    """
+      INSERT INTO assistant_models (
+        element_name, element_api_provider, element_is_active
+      ) VALUES (?, ?, ?);
+    """,
+    (name, api_provider, is_active),
+  )
+
+
+async def delete_v1(args: Mapping[str, Any]) -> DBResponse:
+  recid = args.get("recid")
+  name = args.get("name")
+  if recid is not None:
+    return await run_exec("DELETE FROM assistant_models WHERE recid = ?;", (recid,))
+  if name is not None:
+    return await run_exec("DELETE FROM assistant_models WHERE element_name = ?;", (name,))
+  raise ValueError("Missing identifier for model delete")

--- a/queryregistry/system/models_registry/services.py
+++ b/queryregistry/system/models_registry/services.py
@@ -8,17 +8,21 @@ from typing import Any
 from queryregistry.models import DBRequest, DBResponse
 
 from . import mssql
-from .models import ModelNameParams
+from .models import DeleteModelParams, ModelNameParams, UpsertModelParams
 
 __all__ = [
+  "delete_v1",
   "get_by_name_v1",
   "list_v1",
+  "upsert_v1",
 ]
 
 _Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
 
 _LIST_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_v1}
 _GET_BY_NAME_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_by_name_v1}
+_UPSERT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_v1}
+_DELETE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_v1}
 
 
 def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
@@ -36,4 +40,16 @@ async def list_v1(request: DBRequest, *, provider: str) -> DBResponse:
 async def get_by_name_v1(request: DBRequest, *, provider: str) -> DBResponse:
   params = ModelNameParams.model_validate(request.payload)
   result = await _select_dispatcher(provider, _GET_BY_NAME_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def upsert_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpsertModelParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPSERT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = DeleteModelParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_DISPATCHERS)(params.model_dump())
   return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/rpc/system/__init__.py
+++ b/rpc/system/__init__.py
@@ -4,11 +4,13 @@ Requires ROLE_SYSTEM_ADMIN.
 """
 
 from .config.handler import handle_config_request
+from .models.handler import handle_models_request
 from .roles.handler import handle_roles_request
 from .storage.handler import handle_storage_request
 
 HANDLERS: dict[str, callable] = {
   "config": handle_config_request,
+  "models": handle_models_request,
   "roles": handle_roles_request,
   "storage": handle_storage_request,
 }

--- a/rpc/system/models/__init__.py
+++ b/rpc/system/models/__init__.py
@@ -1,0 +1,11 @@
+from .services import (
+  system_models_delete_model_v1,
+  system_models_get_models_v1,
+  system_models_upsert_model_v1,
+)
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("get_models", "1"): system_models_get_models_v1,
+  ("upsert_model", "1"): system_models_upsert_model_v1,
+  ("delete_model", "1"): system_models_delete_model_v1,
+}

--- a/rpc/system/models/handler.py
+++ b/rpc/system/models/handler.py
@@ -1,0 +1,18 @@
+"""System models RPC handler.
+
+Dispatches model operations requiring ROLE_SYSTEM_ADMIN.
+"""
+
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_models_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/system/models/models.py
+++ b/rpc/system/models/models.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+# Static list of supported API providers — hardcoded for now
+API_PROVIDERS = ["openai", "lumalabs"]
+
+
+class SystemModelsModelItem1(BaseModel):
+  recid: int
+  name: str
+  api_provider: str = "openai"
+  is_active: bool = True
+
+
+class SystemModelsList1(BaseModel):
+  models: list[SystemModelsModelItem1]
+  api_providers: list[str] = API_PROVIDERS
+
+
+class SystemModelsUpsertModel1(BaseModel):
+  recid: Optional[int] = None
+  name: str
+  api_provider: str = "openai"
+  is_active: bool = True
+
+
+class SystemModelsDeleteModel1(BaseModel):
+  recid: Optional[int] = None
+  name: Optional[str] = None

--- a/rpc/system/models/services.py
+++ b/rpc/system/models/services.py
@@ -1,0 +1,62 @@
+from fastapi import Request
+
+from queryregistry.system.models_registry import (
+  delete_model_request,
+  list_models_request,
+  upsert_model_request,
+)
+from queryregistry.system.models_registry.models import DeleteModelParams, UpsertModelParams
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.db_module import DbModule
+
+from .models import (
+  API_PROVIDERS,
+  SystemModelsDeleteModel1,
+  SystemModelsList1,
+  SystemModelsModelItem1,
+  SystemModelsUpsertModel1,
+)
+
+
+async def system_models_get_models_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  res = await db.run(list_models_request())
+  models = []
+  for row in res.rows or []:
+    models.append(SystemModelsModelItem1(
+      recid=row.get("recid", 0),
+      name=row.get("element_name", ""),
+      api_provider=row.get("element_api_provider", "openai"),
+      is_active=bool(row.get("element_is_active", True)),
+    ))
+  payload = SystemModelsList1(models=models, api_providers=API_PROVIDERS)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def system_models_upsert_model_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  rpc_payload = SystemModelsUpsertModel1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  await db.run(upsert_model_request(UpsertModelParams(
+    recid=rpc_payload.recid,
+    name=rpc_payload.name,
+    api_provider=rpc_payload.api_provider,
+    is_active=rpc_payload.is_active,
+  )))
+  return RPCResponse(op=rpc_request.op, payload=rpc_payload.model_dump(), version=rpc_request.version)
+
+
+async def system_models_delete_model_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  rpc_payload = SystemModelsDeleteModel1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  await db.run(delete_model_request(DeleteModelParams(
+    recid=rpc_payload.recid,
+    name=rpc_payload.name,
+  )))
+  return RPCResponse(op=rpc_request.op, payload=rpc_payload.model_dump(), version=rpc_request.version)


### PR DESCRIPTION
### Motivation
- Provide CRUD management for assistant models including API provider and active flag so admins can configure available system models.
- Expose server-side RPCs and query registry operations to persist model metadata to the database and reflect schema changes.
- Add a frontend admin page and route to allow system administrators to view, add, update, and delete models.

### Description
- Added a new frontend page `SystemModelsPage` and registered route `/system-models` in `App.tsx` to manage models with a table UI and forms for upsert/delete operations. 
- Introduced RPC layer handlers under `rpc/system/models` with `system_models_get_models_v1`, `system_models_upsert_model_v1`, and `system_models_delete_model_v1` and wired the handler into `rpc/system/__init__.py`. 
- Extended the query registry `queryregistry/system/models_registry` with new request builders, dispatchers, service models, and MSSQL implementations for `list`, `upsert`, and `delete` operations, including `upsert_v1` and `delete_v1` SQL logic. 
- Added database schema evolution migration `migrations/v0.8.2.0_models_schema_evolution.sql` to add `element_api_provider`, `element_is_active`, and timestamp columns to `assistant_models` plus reflection table updates, and `migrations/v0.8.2.1_system_models_route.sql` to register the frontend route for `ROLE_SYSTEM_ADMIN`.

### Testing
- Ran the backend automated test suite via `pytest` against the modified code and the run completed with no failures. 
- Built the frontend with `npm run build` to verify the new page compiles and the bundle completes successfully. 
- No new automated unit tests were added for the new models handlers or frontend page in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d2dea714832585d45edbe308ead8)