### PR TITLE
Add guilds and models icon mappings

### DIFF
--- a/frontend/src/icons.ts
+++ b/frontend/src/icons.ts
@@ -19,6 +19,8 @@ import {
     Money as MoneyIcon,
     AccountBalance as AccountantIcon,
     AccountBalanceWallet as ApproverIcon,
+    Hail as GuildsIcon,
+    Grain as ModelsIcon,
 } from '@mui/icons-material';
 
 export const iconMap: Record<string, ElementType> = {
@@ -43,6 +45,8 @@ export const iconMap: Record<string, ElementType> = {
     money: MoneyIcon,
     acct: AccountantIcon,
     appr: ApproverIcon,
+    typescriptguilds: GuildsIcon,
+    models: ModelsIcon,
 };
 
 export const defaultIcon = AdjustIcon;


### PR DESCRIPTION
### Motivation
- Provide icon support for new "guilds" and "models" UI elements by adding corresponding imports and map entries.

### Description
- Import `Hail as GuildsIcon` and `Grain as ModelsIcon` in `frontend/src/icons.ts` and add `typescriptguilds: GuildsIcon` and `models: ModelsIcon` to the `iconMap`.

### Testing
- No automated tests were run for this small mapping-only frontend change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e6532d848325aba1cad3fc3e25d1)