### PR TITLE
Fix discord personas model mapping for raw model rows

### DIFF
--- a/rpc/discord/personas/services.py
+++ b/rpc/discord/personas/services.py
@@ -49,7 +49,13 @@ async def discord_personas_get_models_v1(request: Request):
   module: OpenaiModule = request.app.state.openai
   await module.on_ready()
   rows = await module.list_models()
-  models = [DiscordPersonasModelItem1(**row) for row in rows]
+  models = [
+    DiscordPersonasModelItem1(
+      recid=row.get("recid", 0),
+      name=row.get("element_name", row.get("name", "")),
+    )
+    for row in rows
+  ]
   payload = DiscordPersonasModels1(models=models)
   logging.debug(
     "[discord_personas_get_models_v1] returning %d models",


### PR DESCRIPTION
### Motivation
- The `list_models()` query now returns raw columns (`element_name`, `element_api_provider`, `element_is_active`) while the `DiscordPersonasModelItem1` model expects `recid` and `name`, so the RPC service must normalize rows before constructing the Pydantic model. 

### Description
- Replace the direct unpacking `DiscordPersonasModelItem1(**row)` with an explicit mapping that sets `recid=row.get("recid", 0)` and `name=row.get("element_name", row.get("name", ""))` to support both new raw columns and legacy rows. 

### Testing
- Ran `python -m py_compile rpc/discord/personas/services.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1edbe71a8832596a2e83562f05b60)