### PR TITLE
Fix MSSQL conversation inserts returning no JSON results

### DIFF
--- a/queryregistry/system/conversations/mssql.py
+++ b/queryregistry/system/conversations/mssql.py
@@ -31,6 +31,7 @@ async def insert_conversation_v1(args: Mapping[str, Any]) -> DBResponse:
   output_data = args.get("output_data")
   tokens = args.get("tokens")
   sql = """
+    SET NOCOUNT ON;
     INSERT INTO assistant_conversations (
       personas_recid,
       models_recid,
@@ -63,6 +64,7 @@ async def insert_conversation_v1(args: Mapping[str, Any]) -> DBResponse:
 
 async def insert_message_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
+    SET NOCOUNT ON;
     INSERT INTO assistant_conversations (
       personas_recid,
       models_recid,


### PR DESCRIPTION
### Motivation
- The `INSERT` statements in `insert_conversation_v1` and `insert_message_v1` produced a row-count result that prevented `run_json_one` from reading the subsequent `SELECT ... FOR JSON PATH` output, causing "No results. Previous SQL was not a query." errors.

### Description
- Add `SET NOCOUNT ON;` at the start of the SQL batch in `queryregistry/system/conversations/mssql.py` for both `insert_conversation_v1` and `insert_message_v1` so the `INSERT` does not emit a row-count result.

### Testing
- Ran `python -m py_compile queryregistry/system/conversations/mssql.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1f4f82eb08325b678d89b0d76f6c4)