### PR TITLE
Add system conversations admin RPC and management page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ const DiscordPersonasPage = lazy(() => import("./pages/DiscordPersonasPage"));
 const DiscordGuildsPage = lazy(() => import("./pages/DiscordGuildsPage"));
 const SystemConfigPage = lazy(() => import("./pages/system/SystemConfigPage"));
 const SystemModelsPage = lazy(() => import("./pages/system/SystemModelsPage"));
+const SystemConversationsPage = lazy(() => import("./pages/system/SystemConversationsPage"));
 const AccountRolesPage = lazy(() => import("./pages/AccountRolesPage"));
 const AccountUsersPage = lazy(() => import("./pages/AccountUsersPage"));
 const AccountUserPanel = lazy(() => import("./pages/AccountUserPanel"));
@@ -49,6 +50,7 @@ function App(): JSX.Element {
                                                                 <Route path="/service-routes" element={<ServiceRoutesPage />} />
                                                                 <Route path="/system-config" element={<SystemConfigPage />} />
                                                                 <Route path="/system-models" element={<SystemModelsPage />} />
+                                                                <Route path="/system-conversations" element={<SystemConversationsPage />} />
                                                                 <Route path="/service-roles" element={<ServiceRolesPage />} />
 								<Route path="/account-roles" element={<AccountRolesPage />} />
 								<Route path="/account-users" element={<AccountUsersPage />} />

--- a/frontend/src/pages/system/SystemConversationsPage.tsx
+++ b/frontend/src/pages/system/SystemConversationsPage.tsx
@@ -1,0 +1,297 @@
+import { useEffect, useState } from "react";
+import {
+    Box,
+    Button,
+    Divider,
+    MenuItem,
+    Paper,
+    Stack,
+    Tab,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableRow,
+    Tabs,
+    TextField,
+    Typography,
+} from "@mui/material";
+
+import PageTitle from "../../components/PageTitle";
+import {
+    fetchDeleteBefore,
+    fetchDeleteThread,
+    fetchStats,
+    fetchListConversations,
+    fetchViewThread,
+} from "../../rpc/system/conversations";
+import type {
+    SystemConversationsConversationItem1,
+    SystemConversationsStats1,
+    SystemConversationsThread1,
+} from "../../shared/RpcModels";
+
+interface TabPanelProps {
+    children?: React.ReactNode;
+    value: number;
+    index: number;
+}
+
+function TabPanel({ children, value, index }: TabPanelProps): JSX.Element {
+    if (value !== index) {
+        return <></>;
+    }
+    return <Box sx={{ pt: 2 }}>{children}</Box>;
+}
+
+const truncateThreadId = (threadId?: string | null): string => {
+    if (!threadId) return "";
+    if (threadId.length <= 18) return threadId;
+    return `${threadId.slice(0, 8)}...${threadId.slice(-6)}`;
+};
+
+const SystemConversationsPage = (): JSX.Element => {
+    const [tab, setTab] = useState(0);
+    const [forbidden, setForbidden] = useState(false);
+    const [stats, setStats] = useState<SystemConversationsStats1 | null>(null);
+    const [statsDeleted, setStatsDeleted] = useState<number | null>(null);
+    const [before, setBefore] = useState("");
+
+    const [limit, setLimit] = useState(50);
+    const [offset, setOffset] = useState(0);
+    const [rows, setRows] = useState<SystemConversationsConversationItem1[]>([]);
+
+    const [threadId, setThreadId] = useState("");
+    const [thread, setThread] = useState<SystemConversationsThread1 | null>(null);
+
+    const loadStats = async (): Promise<void> => {
+        try {
+            const res: SystemConversationsStats1 = await fetchStats({});
+            setStats(res);
+            setForbidden(false);
+        } catch (e: any) {
+            if (e?.response?.status === 403) {
+                setForbidden(true);
+            }
+        }
+    };
+
+    const loadBrowse = async (nextOffset: number = offset, nextLimit: number = limit): Promise<void> => {
+        try {
+            const res = await fetchListConversations({ limit: nextLimit, offset: nextOffset });
+            setRows(res.conversations || []);
+            setForbidden(false);
+        } catch (e: any) {
+            if (e?.response?.status === 403) {
+                setForbidden(true);
+            }
+        }
+    };
+
+    const loadThread = async (target: string = threadId): Promise<void> => {
+        if (!target.trim()) return;
+        try {
+            const res: SystemConversationsThread1 = await fetchViewThread({ thread_id: target.trim() });
+            setThread(res);
+            setForbidden(false);
+        } catch (e: any) {
+            if (e?.response?.status === 403) {
+                setForbidden(true);
+            }
+        }
+    };
+
+    useEffect(() => {
+        void loadStats();
+        void loadBrowse(0, limit);
+    }, []);
+
+    if (forbidden) {
+        return (
+            <Box sx={{ p: 2 }}>
+                <Typography variant="h6">Forbidden</Typography>
+            </Box>
+        );
+    }
+
+    return (
+        <Box sx={{ p: 2 }}>
+            <PageTitle>System Conversations</PageTitle>
+            <Tabs value={tab} onChange={(_e, v) => setTab(v)} aria-label="system conversations tabs">
+                <Tab label="Overview" />
+                <Tab label="Browse" />
+                <Tab label="Thread Viewer" />
+            </Tabs>
+            <Divider sx={{ my: 2 }} />
+
+            <TabPanel value={tab} index={0}>
+                <Stack spacing={2} sx={{ maxWidth: 800 }}>
+                    <Stack direction="row" spacing={2}>
+                        <Button variant="outlined" onClick={() => { void loadStats(); }}>Refresh</Button>
+                    </Stack>
+                    <Paper sx={{ p: 2 }}>
+                        <Typography>Total Rows: {stats?.total_rows ?? 0}</Typography>
+                        <Typography>Total Threads: {stats?.total_threads ?? 0}</Typography>
+                        <Typography>Oldest Entry: {stats?.oldest_entry ?? "-"}</Typography>
+                        <Typography>Newest Entry: {stats?.newest_entry ?? "-"}</Typography>
+                        <Typography>Total Tokens: {stats?.total_tokens ?? 0}</Typography>
+                    </Paper>
+                    <Stack direction="row" spacing={2} alignItems="center">
+                        <TextField
+                            label="Delete before (ISO datetime)"
+                            value={before}
+                            onChange={(e) => setBefore(e.target.value)}
+                            placeholder="2025-01-01T00:00:00Z"
+                            sx={{ minWidth: 320 }}
+                        />
+                        <Button
+                            color="error"
+                            variant="contained"
+                            onClick={async () => {
+                                if (!before.trim()) return;
+                                if (!window.confirm(`Delete all conversations before ${before}?`)) return;
+                                const res = await fetchDeleteBefore({ before: before.trim() });
+                                setStatsDeleted(res.deleted ?? 0);
+                                await loadStats();
+                                await loadBrowse(0, limit);
+                            }}
+                        >
+                            Delete
+                        </Button>
+                    </Stack>
+                    {statsDeleted !== null && <Typography>Deleted {statsDeleted} rows</Typography>}
+                </Stack>
+            </TabPanel>
+
+            <TabPanel value={tab} index={1}>
+                <Stack spacing={2}>
+                    <Stack direction="row" spacing={2} alignItems="center">
+                        <TextField
+                            select
+                            label="Limit"
+                            value={limit}
+                            onChange={async (e) => {
+                                const nextLimit = Number(e.target.value);
+                                setLimit(nextLimit);
+                                setOffset(0);
+                                await loadBrowse(0, nextLimit);
+                            }}
+                            sx={{ width: 120 }}
+                        >
+                            {[25, 50, 100].map((val) => (
+                                <MenuItem key={val} value={val}>{val}</MenuItem>
+                            ))}
+                        </TextField>
+                        <Button
+                            variant="outlined"
+                            disabled={offset === 0}
+                            onClick={async () => {
+                                const nextOffset = Math.max(0, offset - limit);
+                                setOffset(nextOffset);
+                                await loadBrowse(nextOffset, limit);
+                            }}
+                        >
+                            Previous
+                        </Button>
+                        <Button
+                            variant="outlined"
+                            disabled={rows.length < limit}
+                            onClick={async () => {
+                                const nextOffset = offset + limit;
+                                setOffset(nextOffset);
+                                await loadBrowse(nextOffset, limit);
+                            }}
+                        >
+                            Next
+                        </Button>
+                        <Typography>Offset: {offset}</Typography>
+                    </Stack>
+
+                    <Table size="small" sx={{ "& td, & th": { py: 0.75, verticalAlign: "top" } }}>
+                        <TableHead>
+                            <TableRow>
+                                <TableCell>Timestamp</TableCell>
+                                <TableCell>Persona</TableCell>
+                                <TableCell>Role</TableCell>
+                                <TableCell>Thread ID</TableCell>
+                                <TableCell>Preview</TableCell>
+                                <TableCell>Tokens</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {rows.map((row) => (
+                                <TableRow key={row.recid}>
+                                    <TableCell>{row.created_on || "-"}</TableCell>
+                                    <TableCell>{row.persona_name || row.personas_recid}</TableCell>
+                                    <TableCell>{row.role || "-"}</TableCell>
+                                    <TableCell>
+                                        {row.thread_id ? (
+                                            <Button
+                                                size="small"
+                                                onClick={async () => {
+                                                    const nextThreadId = row.thread_id || "";
+                                                    setThreadId(nextThreadId);
+                                                    setTab(2);
+                                                    await loadThread(nextThreadId);
+                                                }}
+                                            >
+                                                {truncateThreadId(row.thread_id)}
+                                            </Button>
+                                        ) : "-"}
+                                    </TableCell>
+                                    <TableCell>{row.preview || ""}</TableCell>
+                                    <TableCell>{row.tokens ?? "-"}</TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </Stack>
+            </TabPanel>
+
+            <TabPanel value={tab} index={2}>
+                <Stack spacing={2}>
+                    <Stack direction="row" spacing={2}>
+                        <TextField
+                            label="Thread ID"
+                            value={threadId}
+                            onChange={(e) => setThreadId(e.target.value)}
+                            sx={{ minWidth: 420 }}
+                        />
+                        <Button variant="outlined" onClick={() => { void loadThread(); }}>Load</Button>
+                    </Stack>
+
+                    <Stack spacing={1}>
+                        {(thread?.messages || []).map((message) => (
+                            <Paper key={message.recid} sx={{ p: 1.5 }}>
+                                <Typography variant="caption">
+                                    {(message.role || "unknown").toUpperCase()} — {message.created_on || "-"}
+                                </Typography>
+                                <Typography sx={{ whiteSpace: "pre-wrap" }}>{message.content || ""}</Typography>
+                            </Paper>
+                        ))}
+                    </Stack>
+
+                    <Box>
+                        <Button
+                            color="error"
+                            variant="contained"
+                            disabled={!threadId.trim()}
+                            onClick={async () => {
+                                if (!threadId.trim()) return;
+                                if (!window.confirm(`Delete thread ${threadId}?`)) return;
+                                await fetchDeleteThread({ thread_id: threadId.trim() });
+                                setThread(null);
+                                await loadStats();
+                                await loadBrowse(offset, limit);
+                            }}
+                        >
+                            Delete Thread
+                        </Button>
+                    </Box>
+                </Stack>
+            </TabPanel>
+        </Box>
+    );
+};
+
+export default SystemConversationsPage;

--- a/migrations/v0.8.2.2_system_conversations_route.sql
+++ b/migrations/v0.8.2.2_system_conversations_route.sql
@@ -1,0 +1,5 @@
+IF NOT EXISTS (SELECT 1 FROM frontend_routes WHERE element_path = '/system-conversations')
+  INSERT INTO frontend_routes (element_enablement, element_roles, element_sequence, element_path, element_name, element_icon)
+  SELECT '1', sr.element_mask, 16, '/system-conversations', 'Conversations', 'smartToy'
+  FROM system_roles sr WHERE sr.element_name = 'ROLE_SYSTEM_ADMIN';
+GO

--- a/queryregistry/system/conversations/__init__.py
+++ b/queryregistry/system/conversations/__init__.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 from queryregistry.models import DBRequest
 
 from .models import (
+  ConversationStatsParams,
+  DeleteByThreadParams,
+  DeleteByTimestampParams,
   FindRecentParams,
   InsertConversationParams,
   InsertMessageParams,
+  ListConversationSummaryParams,
   ListByTimeParams,
   ListChannelMessagesParams,
   ListThreadParams,
@@ -15,12 +19,16 @@ from .models import (
 )
 
 __all__ = [
+  "delete_before_timestamp_request",
+  "delete_by_thread_request",
   "find_recent_request",
+  "get_stats_request",
   "insert_conversation_request",
   "insert_message_request",
   "list_by_time_request",
   "list_channel_messages_request",
   "list_recent_request",
+  "list_summary_request",
   "list_thread_request",
   "update_output_request",
 ]
@@ -56,3 +64,19 @@ def list_thread_request(params: ListThreadParams) -> DBRequest:
 
 def list_channel_messages_request(params: ListChannelMessagesParams) -> DBRequest:
   return DBRequest(op="db:system:conversations:list_channel_messages:1", payload=params.model_dump())
+
+
+def list_summary_request(params: ListConversationSummaryParams) -> DBRequest:
+  return DBRequest(op="db:system:conversations:list_summary:1", payload=params.model_dump())
+
+
+def get_stats_request(params: ConversationStatsParams) -> DBRequest:
+  return DBRequest(op="db:system:conversations:get_stats:1", payload=params.model_dump())
+
+
+def delete_by_thread_request(params: DeleteByThreadParams) -> DBRequest:
+  return DBRequest(op="db:system:conversations:delete_by_thread:1", payload=params.model_dump())
+
+
+def delete_before_timestamp_request(params: DeleteByTimestampParams) -> DBRequest:
+  return DBRequest(op="db:system:conversations:delete_before_timestamp:1", payload=params.model_dump())

--- a/queryregistry/system/conversations/handler.py
+++ b/queryregistry/system/conversations/handler.py
@@ -8,12 +8,16 @@ from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
 
 from .services import (
+  delete_before_timestamp_v1,
+  delete_by_thread_v1,
   find_recent_v1,
+  get_stats_v1,
   insert_conversation_v1,
   insert_message_v1,
   list_by_time_v1,
   list_channel_messages_v1,
   list_recent_v1,
+  list_summary_v1,
   list_thread_v1,
   update_output_v1,
 )
@@ -30,6 +34,10 @@ DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
   ("list_thread", "1"): list_thread_v1,
   ("list_channel_messages", "1"): list_channel_messages_v1,
   ("list_recent", "1"): list_recent_v1,
+  ("list_summary", "1"): list_summary_v1,
+  ("get_stats", "1"): get_stats_v1,
+  ("delete_by_thread", "1"): delete_by_thread_v1,
+  ("delete_before_timestamp", "1"): delete_before_timestamp_v1,
 }
 
 

--- a/queryregistry/system/conversations/models.py
+++ b/queryregistry/system/conversations/models.py
@@ -7,10 +7,14 @@ from typing import TypedDict
 from pydantic import BaseModel, ConfigDict
 
 __all__ = [
+  "ConversationStatsParams",
   "ConversationRecord",
+  "DeleteByThreadParams",
+  "DeleteByTimestampParams",
   "FindRecentParams",
   "InsertConversationParams",
   "InsertMessageParams",
+  "ListConversationSummaryParams",
   "ListByTimeParams",
   "ListChannelMessagesParams",
   "ListThreadParams",
@@ -88,6 +92,29 @@ class ListByTimeParams(BaseModel):
   personas_recid: int
   start: str
   end: str
+
+
+class ListConversationSummaryParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  limit: int = 100
+  offset: int = 0
+
+
+class DeleteByThreadParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  thread_id: str
+
+
+class DeleteByTimestampParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  before: str
+
+
+class ConversationStatsParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
 
 
 class ConversationRecord(TypedDict):

--- a/queryregistry/system/conversations/mssql.py
+++ b/queryregistry/system/conversations/mssql.py
@@ -16,7 +16,11 @@ __all__ = [
   "list_by_time_v1",
   "list_channel_messages_v1",
   "list_recent_v1",
+  "list_summary_v1",
   "list_thread_v1",
+  "get_stats_v1",
+  "delete_by_thread_v1",
+  "delete_before_timestamp_v1",
   "update_output_v1",
 ]
 
@@ -177,6 +181,63 @@ async def list_by_time_v1(args: Mapping[str, Any]) -> DBResponse:
   """
   return await run_json_many(sql, (personas_recid, start, end))
 
+
+
+
+async def list_summary_v1(args: Mapping[str, Any]) -> DBResponse:
+  """List conversations with pagination, newest first, with persona name."""
+  limit = int(args.get("limit", 100))
+  offset = int(args.get("offset", 0))
+  sql = """
+    SELECT
+      c.recid,
+      c.personas_recid,
+      c.models_recid,
+      c.element_guild_id,
+      c.element_channel_id,
+      c.element_user_id,
+      c.element_role,
+      c.element_thread_id,
+      LEFT(COALESCE(c.element_content, c.element_input, ''), 120) AS element_preview,
+      c.element_tokens,
+      c.element_created_on,
+      ap.element_name AS persona_name
+    FROM assistant_conversations c
+    LEFT JOIN assistant_personas ap ON ap.recid = c.personas_recid
+    ORDER BY c.element_created_on DESC
+    OFFSET ? ROWS FETCH NEXT ? ROWS ONLY
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, (offset, limit))
+
+
+async def get_stats_v1(_: Mapping[str, Any]) -> DBResponse:
+  """Get conversation statistics."""
+  sql = """
+    SELECT
+      COUNT(*) AS total_rows,
+      COUNT(DISTINCT element_thread_id) AS total_threads,
+      MIN(element_created_on) AS oldest_entry,
+      MAX(element_created_on) AS newest_entry,
+      SUM(ISNULL(element_tokens, 0)) AS total_tokens
+    FROM assistant_conversations
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+  """
+  return await run_json_one(sql)
+
+
+async def delete_by_thread_v1(args: Mapping[str, Any]) -> DBResponse:
+  """Delete all messages in a thread."""
+  thread_id = args["thread_id"]
+  sql = "DELETE FROM assistant_conversations WHERE element_thread_id = ?;"
+  return await run_exec(sql, (thread_id,))
+
+
+async def delete_before_timestamp_v1(args: Mapping[str, Any]) -> DBResponse:
+  """Delete all conversations before a given timestamp."""
+  before = args["before"]
+  sql = "DELETE FROM assistant_conversations WHERE element_created_on < ?;"
+  return await run_exec(sql, (before,))
 
 async def list_recent_v1(_: Mapping[str, Any]) -> DBResponse:
   sql = """

--- a/queryregistry/system/conversations/services.py
+++ b/queryregistry/system/conversations/services.py
@@ -9,9 +9,13 @@ from queryregistry.models import DBRequest, DBResponse
 
 from . import mssql
 from .models import (
+  ConversationStatsParams,
+  DeleteByThreadParams,
+  DeleteByTimestampParams,
   FindRecentParams,
   InsertConversationParams,
   InsertMessageParams,
+  ListConversationSummaryParams,
   ListByTimeParams,
   ListChannelMessagesParams,
   ListThreadParams,
@@ -25,6 +29,10 @@ __all__ = [
   "list_by_time_v1",
   "list_channel_messages_v1",
   "list_recent_v1",
+  "list_summary_v1",
+  "get_stats_v1",
+  "delete_by_thread_v1",
+  "delete_before_timestamp_v1",
   "list_thread_v1",
   "update_output_v1",
 ]
@@ -39,6 +47,10 @@ _LIST_BY_TIME_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_by_time
 _LIST_THREAD_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_thread_v1}
 _LIST_CHANNEL_MESSAGES_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_channel_messages_v1}
 _LIST_RECENT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_recent_v1}
+_LIST_SUMMARY_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_summary_v1}
+_GET_STATS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_stats_v1}
+_DELETE_BY_THREAD_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_by_thread_v1}
+_DELETE_BEFORE_TIMESTAMP_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_before_timestamp_v1}
 
 
 def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
@@ -95,4 +107,28 @@ async def list_thread_v1(request: DBRequest, *, provider: str) -> DBResponse:
 async def list_channel_messages_v1(request: DBRequest, *, provider: str) -> DBResponse:
   params = ListChannelMessagesParams.model_validate(request.payload)
   result = await _select_dispatcher(provider, _LIST_CHANNEL_MESSAGES_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_summary_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListConversationSummaryParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_SUMMARY_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_stats_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ConversationStatsParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_STATS_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_by_thread_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = DeleteByThreadParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_BY_THREAD_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_before_timestamp_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = DeleteByTimestampParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_BEFORE_TIMESTAMP_DISPATCHERS)(params.model_dump())
   return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/rpc/system/__init__.py
+++ b/rpc/system/__init__.py
@@ -4,12 +4,14 @@ Requires ROLE_SYSTEM_ADMIN.
 """
 
 from .config.handler import handle_config_request
+from .conversations.handler import handle_conversations_request
 from .models.handler import handle_models_request
 from .roles.handler import handle_roles_request
 from .storage.handler import handle_storage_request
 
 HANDLERS: dict[str, callable] = {
   "config": handle_config_request,
+  "conversations": handle_conversations_request,
   "models": handle_models_request,
   "roles": handle_roles_request,
   "storage": handle_storage_request,

--- a/rpc/system/conversations/__init__.py
+++ b/rpc/system/conversations/__init__.py
@@ -1,0 +1,15 @@
+from .services import (
+  system_conversations_delete_before_v1,
+  system_conversations_delete_thread_v1,
+  system_conversations_list_v1,
+  system_conversations_stats_v1,
+  system_conversations_view_thread_v1,
+)
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list_conversations", "1"): system_conversations_list_v1,
+  ("get_stats", "1"): system_conversations_stats_v1,
+  ("view_thread", "1"): system_conversations_view_thread_v1,
+  ("delete_thread", "1"): system_conversations_delete_thread_v1,
+  ("delete_before", "1"): system_conversations_delete_before_v1,
+}

--- a/rpc/system/conversations/handler.py
+++ b/rpc/system/conversations/handler.py
@@ -1,0 +1,18 @@
+"""System conversations RPC handler.
+
+Dispatches conversation administration operations requiring ROLE_SYSTEM_ADMIN.
+"""
+
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_conversations_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/system/conversations/models.py
+++ b/rpc/system/conversations/models.py
@@ -1,0 +1,63 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class SystemConversationsConversationItem1(BaseModel):
+  recid: int
+  personas_recid: int = 0
+  models_recid: int = 0
+  guild_id: Optional[str] = None
+  channel_id: Optional[str] = None
+  user_id: Optional[str] = None
+  role: Optional[str] = None
+  thread_id: Optional[str] = None
+  preview: str = ""
+  tokens: Optional[int] = None
+  created_on: Optional[str] = None
+  persona_name: Optional[str] = None
+
+
+class SystemConversationsList1(BaseModel):
+  conversations: list[SystemConversationsConversationItem1]
+  total: int = 0
+  limit: int = 100
+  offset: int = 0
+
+
+class SystemConversationsStats1(BaseModel):
+  total_rows: int = 0
+  total_threads: int = 0
+  oldest_entry: Optional[str] = None
+  newest_entry: Optional[str] = None
+  total_tokens: int = 0
+
+
+class SystemConversationsThreadMessage1(BaseModel):
+  recid: int
+  role: Optional[str] = None
+  content: Optional[str] = None
+  user_id: Optional[str] = None
+  tokens: Optional[int] = None
+  created_on: Optional[str] = None
+
+
+class SystemConversationsThread1(BaseModel):
+  thread_id: str
+  messages: list[SystemConversationsThreadMessage1]
+
+
+class SystemConversationsViewThread1(BaseModel):
+  thread_id: str
+
+
+class SystemConversationsDeleteThread1(BaseModel):
+  thread_id: str
+
+
+class SystemConversationsDeleteBefore1(BaseModel):
+  before: str
+
+
+class SystemConversationsDeleteResult1(BaseModel):
+  deleted: int = 0

--- a/rpc/system/conversations/services.py
+++ b/rpc/system/conversations/services.py
@@ -1,0 +1,131 @@
+import logging
+
+from fastapi import Request
+
+from queryregistry.system.conversations import (
+  delete_before_timestamp_request,
+  delete_by_thread_request,
+  get_stats_request,
+  list_summary_request,
+  list_thread_request,
+)
+from queryregistry.system.conversations.models import (
+  ConversationStatsParams,
+  DeleteByThreadParams,
+  DeleteByTimestampParams,
+  ListConversationSummaryParams,
+  ListThreadParams,
+)
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.db_module import DbModule
+
+from .models import (
+  SystemConversationsConversationItem1,
+  SystemConversationsDeleteBefore1,
+  SystemConversationsDeleteResult1,
+  SystemConversationsDeleteThread1,
+  SystemConversationsList1,
+  SystemConversationsStats1,
+  SystemConversationsThread1,
+  SystemConversationsThreadMessage1,
+  SystemConversationsViewThread1,
+)
+
+
+async def system_conversations_list_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  payload = rpc_request.payload or {}
+  limit = int(payload.get("limit", 100))
+  offset = int(payload.get("offset", 0))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  res = await db.run(list_summary_request(ListConversationSummaryParams(limit=limit, offset=offset)))
+  conversations = []
+  for row in res.rows or []:
+    conversations.append(SystemConversationsConversationItem1(
+      recid=row.get("recid", 0),
+      personas_recid=row.get("personas_recid", 0),
+      models_recid=row.get("models_recid", 0),
+      guild_id=row.get("element_guild_id"),
+      channel_id=row.get("element_channel_id"),
+      user_id=row.get("element_user_id"),
+      role=row.get("element_role"),
+      thread_id=row.get("element_thread_id"),
+      preview=row.get("element_preview", ""),
+      tokens=row.get("element_tokens"),
+      created_on=row.get("element_created_on"),
+      persona_name=row.get("persona_name"),
+    ))
+  result = SystemConversationsList1(
+    conversations=conversations,
+    total=len(conversations),
+    limit=limit,
+    offset=offset,
+  )
+  return RPCResponse(op=rpc_request.op, payload=result.model_dump(), version=rpc_request.version)
+
+
+async def system_conversations_stats_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  res = await db.run(get_stats_request(ConversationStatsParams()))
+  row = res.rows[0] if res.rows else {}
+  stats = SystemConversationsStats1(
+    total_rows=int(row.get("total_rows", 0)),
+    total_threads=int(row.get("total_threads", 0)),
+    oldest_entry=row.get("oldest_entry"),
+    newest_entry=row.get("newest_entry"),
+    total_tokens=int(row.get("total_tokens", 0)),
+  )
+  return RPCResponse(op=rpc_request.op, payload=stats.model_dump(), version=rpc_request.version)
+
+
+async def system_conversations_view_thread_v1(request: Request):
+  rpc_request, _, _ = await unbox_request(request)
+  payload = SystemConversationsViewThread1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  res = await db.run(list_thread_request(ListThreadParams(thread_id=payload.thread_id)))
+  messages = []
+  for row in res.rows or []:
+    messages.append(SystemConversationsThreadMessage1(
+      recid=row.get("recid", 0),
+      role=row.get("element_role"),
+      content=row.get("element_content"),
+      user_id=row.get("element_user_id"),
+      tokens=row.get("element_tokens"),
+      created_on=row.get("element_created_on"),
+    ))
+  result = SystemConversationsThread1(thread_id=payload.thread_id, messages=messages)
+  return RPCResponse(op=rpc_request.op, payload=result.model_dump(), version=rpc_request.version)
+
+
+async def system_conversations_delete_thread_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  payload = SystemConversationsDeleteThread1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  res = await db.run(delete_by_thread_request(DeleteByThreadParams(thread_id=payload.thread_id)))
+  logging.info(
+    "[system_conversations_delete_thread_v1] deleted thread",
+    extra={"user_guid": auth_ctx.user_guid, "thread_id": payload.thread_id, "rowcount": res.rowcount},
+  )
+  result = SystemConversationsDeleteResult1(deleted=res.rowcount)
+  return RPCResponse(op=rpc_request.op, payload=result.model_dump(), version=rpc_request.version)
+
+
+async def system_conversations_delete_before_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  payload = SystemConversationsDeleteBefore1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  res = await db.run(delete_before_timestamp_request(DeleteByTimestampParams(before=payload.before)))
+  logging.info(
+    "[system_conversations_delete_before_v1] deleted conversations before %s",
+    payload.before,
+    extra={"user_guid": auth_ctx.user_guid, "before": payload.before, "rowcount": res.rowcount},
+  )
+  result = SystemConversationsDeleteResult1(deleted=res.rowcount)
+  return RPCResponse(op=rpc_request.op, payload=result.model_dump(), version=rpc_request.version)


### PR DESCRIPTION
### Motivation
- Provide administrators (ROLE_SYSTEM_ADMIN) with tools to review, audit, and trim conversation data stored in `assistant_conversations` via a single System UI page and matching RPC surface. 
- Expose safe, typed queryregistry operations for listing summaries, computing stats, and deleting by thread or timestamp range so the UI and RPC services can operate consistently.

### Description
- Added new queryregistry models and request builders for conversation admin operations (`ListConversationSummaryParams`, `ConversationStatsParams`, `DeleteByThreadParams`, `DeleteByTimestampParams`) and registered `list_summary`, `get_stats`, `delete_by_thread`, and `delete_before_timestamp` dispatchers in `queryregistry/system/conversations`.
- Implemented MSSQL providers for paginated conversation summary, aggregate stats, thread deletion, and timestamp-based deletion in `queryregistry/system/conversations/mssql.py` and wired them into the queryregistry service layer.
- Created a new RPC subdomain `rpc/system/conversations` with typed Pydantic RPC models, service handlers (list, stats, view thread, delete thread, delete before) and a dispatcher/handler that is registered under the `system` namespace so calls require `ROLE_SYSTEM_ADMIN`.
- Added a frontend admin page at `frontend/src/pages/system/SystemConversationsPage.tsx` and registered route `/system-conversations` in `frontend/src/App.tsx`; the page has three tabs (Overview, Browse, Thread Viewer) with confirmation for destructive actions.
- Added navigation migration `migrations/v0.8.2.2_system_conversations_route.sql` to insert the admin route for `ROLE_SYSTEM_ADMIN`.

### Testing
- Regenerated TypeScript RPC bindings with `python scripts/generate_rpc_bindings.py` and validated the new RPC signatures were discovered successfully.
- Performed Python compile checks with `python -m py_compile` on the modified backend/python modules and all compiled successfully.
- Ran frontend type checking with `npm run type-check` in `frontend/` and the type-check passed.
- Launched a local Vite server (`npx vite`) and captured a Playwright screenshot of `/system-conversations` to validate the UI renders; screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1ff1273008325a43c95123bf12b78)