### PR TITLE
Remove legacy persona conversation dual-write path

### DIFF
--- a/server/modules/discord_chat_module.py
+++ b/server/modules/discord_chat_module.py
@@ -555,34 +555,9 @@ class DiscordChatModule(BaseModule):
         "reason": "persona_not_configured",
         "ack_message": "Persona chat is currently unavailable.",
       }
-    try:
-      recid = await openai.log_persona_conversation_input(
-        personas_recid,
-        models_recid,
-        guild_id,
-        channel_id,
-        user_id,
-        message_text,
-        None,
-      )
-    except Exception:
-      logging.exception(
-        "[DiscordChatModule] failed to insert persona conversation input",
-        extra={
-          "persona": persona_name,
-          "guild_id": guild_id,
-          "channel_id": channel_id,
-          "user_id": user_id,
-        },
-      )
-      return {
-        "success": False,
-        "reason": "conversation_log_failed",
-        "ack_message": "Persona chat is currently unavailable.",
-      }
     return {
       "success": True,
-      "conversation_reference": recid,
+      "conversation_reference": None,
       "personas_recid": personas_recid,
       "models_recid": models_recid,
     }
@@ -737,28 +712,6 @@ class DiscordChatModule(BaseModule):
     total_tokens = None
     if isinstance(usage, dict):
       total_tokens = usage.get("total_tokens")
-
-    conversation_ref = conversation_reference
-    if conversation_ref is not None:
-      try:
-        conversation_id = int(conversation_ref)
-      except (TypeError, ValueError):
-        logging.warning(
-          "[DiscordChatModule] invalid conversation reference",
-          extra={"conversation_reference": conversation_ref},
-        )
-      else:
-        try:
-          await openai.finalize_persona_conversation(
-            conversation_id,
-            content or "",
-            total_tokens,
-          )
-        except Exception:
-          logging.exception(
-            "[DiscordChatModule] failed to update persona conversation output",
-            extra={"conversation_reference": conversation_ref},
-          )
 
     return {
       "success": True,

--- a/server/modules/openai_module.py
+++ b/server/modules/openai_module.py
@@ -12,22 +12,16 @@ from .discord_bot_module import DiscordBotModule
 from queryregistry.system.config import get_config_request
 from queryregistry.system.config.models import ConfigKeyParams
 from queryregistry.system.conversations import (
-  find_recent_request,
-  insert_conversation_request,
   insert_message_request,
   list_by_time_request,
   list_channel_messages_request,
   list_thread_request,
-  update_output_request,
 )
 from queryregistry.system.conversations.models import (
-  FindRecentParams,
-  InsertConversationParams,
   InsertMessageParams,
   ListByTimeParams,
   ListChannelMessagesParams,
   ListThreadParams,
-  UpdateOutputParams,
 )
 from queryregistry.system.models_registry import list_models_request
 from queryregistry.system.personas import (
@@ -217,71 +211,6 @@ class OpenaiModule(BaseModule):
     assert self.db
     await self.db.run(delete_persona_request(DeletePersonaParams(recid=recid, name=name)))
 
-  async def log_persona_conversation_input(
-    self,
-    personas_recid: int | None,
-    models_recid: int | None,
-    guild_id: int | None,
-    channel_id: int | None,
-    user_id: int | None,
-    input_data: str,
-    tokens: int | None,
-  ) -> int | None:
-    if not self.db or personas_recid is None or models_recid is None:
-      return None
-    try:
-      existing = await self.db.run(
-        find_recent_request(FindRecentParams(
-          personas_recid=personas_recid,
-          models_recid=models_recid,
-          guild_id=str(guild_id) if guild_id is not None else None,
-          channel_id=str(channel_id) if channel_id is not None else None,
-          user_id=str(user_id) if user_id is not None else None,
-          input_data=input_data,
-        ))
-      )
-      if existing.rows:
-        recid = existing.rows[0].get("recid")
-        if recid is not None:
-          return recid
-      res = await self.db.run(
-        insert_conversation_request(InsertConversationParams(
-          personas_recid=personas_recid,
-          models_recid=models_recid,
-          guild_id=str(guild_id) if guild_id is not None else None,
-          channel_id=str(channel_id) if channel_id is not None else None,
-          user_id=str(user_id) if user_id is not None else None,
-          input_data=input_data,
-          output_data="",
-          tokens=tokens,
-        ))
-      )
-      if res.rows:
-        return res.rows[0].get("recid")
-    except Exception:
-      logging.exception("[OpenaiModule] insert conversation failed")
-    return None
-
-  async def finalize_persona_conversation(
-    self,
-    recid: int,
-    output_data: str,
-    tokens: int | None,
-  ):
-    if not self.db:
-      return
-    try:
-      res = await self.db.run(
-        update_output_request(UpdateOutputParams(recid=recid, output_data=output_data, tokens=tokens))
-      )
-      if res.rowcount == 0:
-        logging.warning(
-          "[OpenaiModule] conversation update affected 0 rows (recid=%s)",
-          recid,
-        )
-    except Exception:
-      logging.exception("[OpenaiModule] update conversation failed")
-
   async def log_message(
     self,
     *,
@@ -454,9 +383,6 @@ class OpenaiModule(BaseModule):
       logging.warning("[OpenaiModule] client not initialized")
       return {"content": ""}
 
-    conv_id = None
-    personas_recid = None
-    models_recid = None
     resolved_model = (model or "").strip() or "gpt-4o-mini"
     resolved_tokens = max_tokens
     resolved_prompt = system_prompt or ""
@@ -473,8 +399,6 @@ class OpenaiModule(BaseModule):
           )
           resolved_persona_details = None
       if resolved_persona_details:
-        personas_recid = resolved_persona_details.get("recid")
-        models_recid = resolved_persona_details.get("models_recid")
         persona_model = resolved_persona_details.get("model")
         if persona_model:
           resolved_model = persona_model
@@ -487,17 +411,6 @@ class OpenaiModule(BaseModule):
 
     if resolved_tokens is None:
       resolved_tokens = 64
-
-    if persona and personas_recid is not None and models_recid is not None:
-      conv_id = await self.log_persona_conversation_input(
-        personas_recid,
-        models_recid,
-        guild_id,
-        channel_id,
-        user_id,
-        input_log or (user_prompt or ""),
-        token_count,
-      )
 
     messages: List[Dict[str, str]] = []
     if resolved_prompt:
@@ -534,8 +447,6 @@ class OpenaiModule(BaseModule):
         "completion_tokens": getattr(usage, "completion_tokens", None),
         "total_tokens": total_tokens,
       }
-    if conv_id:
-      await self.finalize_persona_conversation(conv_id, content, total_tokens)
     return result
 
   async def persona_response(


### PR DESCRIPTION
### Motivation
- Stop maintaining the legacy conversation dual-write that used `element_input/element_output` rows and fully rely on the new message-per-row schema (`element_role/element_content/element_thread_id`).
- Simplify persona logging flow by removing unused legacy APIs and eliminating redundant writes to the old conversation table.

### Description
- Removed legacy conversation query imports and legacy models from `server/modules/openai_module.py` while preserving the new message-per-row imports (`insert_message_request`, `list_by_time_request`, `list_channel_messages_request`, `list_thread_request`) and their models.
- Deleted the legacy `log_persona_conversation_input` and `finalize_persona_conversation` methods from `OpenaiModule` and removed their usages inside `generate_chat` so legacy `element_input/element_output` writes no longer occur.
- Updated `DiscordChatModule.insert_conversation_input` to stop calling the removed legacy logger and return `conversation_reference: None` while still resolving and returning `personas_recid` and `models_recid` for downstream flows.
- Removed the finalize block in `DiscordChatModule.generate_persona_response` that attempted to update legacy conversation output rows; retained the new message-per-row behavior and thread/channel history helpers.

### Testing
- Ran the unified pipeline with `python scripts/run_tests.py` which completed lint, type-check and test steps successfully.
- All Python unit tests passed in the test run (test suite completed without failures).
- The test run emitted an environment warning about a missing SQL Server ODBC driver (`ODBC Driver 18 for SQL Server`) but that did not prevent the pipeline from completing successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b20cfc31f88325b47e675ee7ba1e25)