### PR TITLE
Replace legacy persona history fetch with stored context and add context assembly logging

### DIFF
--- a/server/modules/discord_chat_module.py
+++ b/server/modules/discord_chat_module.py
@@ -666,6 +666,19 @@ class DiscordChatModule(BaseModule):
       if stored_text:
         context_sections.append("Recent stored conversation context:\n" + stored_text)
     prompt_context = "\n\n".join(context_sections)
+    logging.info(
+      "[DiscordChatModule] context assembled for persona response",
+      extra={
+        "persona": persona_name,
+        "guild_id": guild_id,
+        "channel_id": channel_id,
+        "conversation_history_count": len(conversation_history),
+        "channel_history_count": len(channel_history),
+        "stored_context_count": len(stored_context),
+        "context_sections_count": len(context_sections),
+        "prompt_context_length": len(prompt_context),
+      },
+    )
 
     system_prompt = persona_details.get("prompt") or ""
 
@@ -852,22 +865,7 @@ class DiscordChatModule(BaseModule):
     return context
 
   async def _persona_fetch_conversation(self, context: dict, metadata: dict) -> dict:
-    response = await self.get_conversation_history(
-      context.get("persona"),
-      guild_id=metadata.get("guild_id"),
-      channel_id=metadata.get("channel_id"),
-      user_id=metadata.get("user_id"),
-      limit=20,
-    )
-    context["conversation_history"] = response.get("conversation_history") or []
-    if response.get("personas_recid") is not None:
-      context["personas_recid"] = response.get("personas_recid")
-    if response.get("models_recid") is not None:
-      context["models_recid"] = response.get("models_recid")
-    context["success"] = response.get("success", True)
-    context["reason"] = response.get("reason", context.get("reason"))
-    if response.get("ack_message"):
-      context["ack_message"] = response.get("ack_message")
+    context["conversation_history"] = []
     openai = getattr(self.app.state, "openai", None)
     if openai and metadata.get("guild_id") and metadata.get("channel_id"):
       try:


### PR DESCRIPTION
### Motivation
- Legacy persona conversation history relied on `get_recent_persona_conversation_history` which used deprecated `element_input/element_output` columns and is no longer populated.
- The codebase now stores richer thread context via `get_channel_context`, and live Discord channel history already provides other user messages, so the legacy fetch is redundant and brittle.

### Description
- Removed the call to the legacy conversation history fetch and set `context["conversation_history"] = []` in `_persona_fetch_conversation`, relying on `get_channel_context` for stored assistant memory. 
- Continued to populate `context["stored_channel_context"]` via `openai.get_channel_context` when available. 
- Added an INFO log in `generate_persona_response` immediately after `prompt_context = "\n\n".join(context_sections)` which records `persona`, `guild_id`, `channel_id`, counts for `conversation_history`, `channel_history`, and `stored_context`, the number of `context_sections`, and `prompt_context` length.
- Changes are limited to `server/modules/discord_chat_module.py` and do not alter other modules or generated files.

### Testing
- Ran `python -m py_compile server/modules/discord_chat_module.py` to validate Python syntax, which succeeded. 
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b216ed0d948325b5e215d4010d57f7)