### PR TITLE
Add discord_id field to RPCRequest model

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -41,6 +41,10 @@ class RPCRequest(BaseModel):
     default=0,
     description="Bitmask representing user roles",
   )
+  discord_id: Optional[str] = Field(
+    default=None,
+    description="Discord snowflake ID stashed for unregistered user flows",
+  )
 
 
 """


### PR DESCRIPTION
### Motivation
- Pydantic v2 rejects assignment to undeclared attributes and the RPC handler sets `rpc_request.discord_id` for Discord unregistered-user flows, causing a runtime `ValueError`, so the model must declare `discord_id`.

### Description
- Add `discord_id: Optional[str] = Field(default=None, description="Discord snowflake ID stashed for unregistered user flows")` to the `RPCRequest` Pydantic model immediately after `role_mask` in `server/models.py` and do not modify any other files.

### Testing
- Ran `python -m py_compile server/models.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21903dbe48325968a2587fe28aa3b)