### PR TITLE
Add finance schema migration and QueryRegistry subdomains (accounts, numbers, dimensions, periods)

### DIFF
--- a/migrations/v0.8.3.0_finance_schema_evolution.sql
+++ b/migrations/v0.8.3.0_finance_schema_evolution.sql
@@ -1,0 +1,130 @@
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+-- ============================================================================
+-- v0.8.3.0 Finance Schema Evolution
+-- ============================================================================
+
+-- A1. finance_dimensions — multi-dimensional financial analysis
+CREATE TABLE [dbo].[finance_dimensions] (
+  [recid] BIGINT IDENTITY(1,1) NOT NULL,
+  [element_name] NVARCHAR(64) NOT NULL,
+  [element_value] NVARCHAR(128) NOT NULL,
+  [element_description] NVARCHAR(512) NULL,
+  [element_status] TINYINT NOT NULL DEFAULT ((1)),
+  [element_created_on] DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+  [element_modified_on] DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+  CONSTRAINT [PK_finance_dimensions] PRIMARY KEY ([recid])
+);
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX UQ_finance_dimensions_name_value
+  ON finance_dimensions (element_name, element_value);
+GO
+
+-- A2. finance_journals — journal type definitions
+CREATE TABLE [dbo].[finance_journals] (
+  [recid] BIGINT IDENTITY(1,1) NOT NULL,
+  [element_name] NVARCHAR(64) NOT NULL,
+  [element_description] NVARCHAR(512) NULL,
+  [numbers_recid] BIGINT NULL,
+  [element_status] TINYINT NOT NULL DEFAULT ((1)),
+  [element_created_on] DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+  [element_modified_on] DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+  CONSTRAINT [PK_finance_journals] PRIMARY KEY ([recid]),
+  CONSTRAINT [FK_finance_journals_numbers] FOREIGN KEY ([numbers_recid]) REFERENCES [finance_numbers]([recid])
+);
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX UQ_finance_journals_name
+  ON finance_journals (element_name);
+GO
+
+-- A3. finance_ledgers — ledger definitions
+CREATE TABLE [dbo].[finance_ledgers] (
+  [recid] BIGINT IDENTITY(1,1) NOT NULL,
+  [element_name] NVARCHAR(64) NOT NULL,
+  [element_description] NVARCHAR(512) NULL,
+  [element_chart_of_accounts_guid] UNIQUEIDENTIFIER NULL,
+  [element_fiscal_calendar_year] INT NULL,
+  [element_status] TINYINT NOT NULL DEFAULT ((1)),
+  [element_created_on] DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+  [element_modified_on] DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+  CONSTRAINT [PK_finance_ledgers] PRIMARY KEY ([recid]),
+  CONSTRAINT [FK_finance_ledgers_chart] FOREIGN KEY ([element_chart_of_accounts_guid]) REFERENCES [finance_accounts]([element_guid])
+);
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX UQ_finance_ledgers_name
+  ON finance_ledgers (element_name);
+GO
+
+-- ============================================================================
+-- REFLECTION TABLE UPDATES
+-- ============================================================================
+
+-- Register new tables
+INSERT INTO system_schema_tables (element_name, element_schema) VALUES
+  ('finance_dimensions', 'dbo'),
+  ('finance_journals', 'dbo'),
+  ('finance_ledgers', 'dbo');
+GO
+
+-- Columns for finance_dimensions (ordinals 1-7)
+INSERT INTO system_schema_columns (
+  tables_recid, edt_recid, element_name, element_ordinal, element_nullable,
+  element_default, element_max_length, element_is_primary_key, element_is_identity
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_dimensions' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64_IDENTITY'), 'recid', 1, 0, NULL, NULL, 1, 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_dimensions' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_name', 2, 0, NULL, 64, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_dimensions' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_value', 3, 0, NULL, 128, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_dimensions' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_description', 4, 1, NULL, 512, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_dimensions' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT8'), 'element_status', 5, 0, '((1))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_dimensions' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_created_on', 6, 0, '(sysutcdatetime())', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_dimensions' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_modified_on', 7, 0, '(sysutcdatetime())', NULL, 0, 0);
+GO
+
+-- Columns for finance_journals (ordinals 1-7)
+INSERT INTO system_schema_columns (
+  tables_recid, edt_recid, element_name, element_ordinal, element_nullable,
+  element_default, element_max_length, element_is_primary_key, element_is_identity
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64_IDENTITY'), 'recid', 1, 0, NULL, NULL, 1, 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_name', 2, 0, NULL, 64, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_description', 3, 1, NULL, 512, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'numbers_recid', 4, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT8'), 'element_status', 5, 0, '((1))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_created_on', 6, 0, '(sysutcdatetime())', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_modified_on', 7, 0, '(sysutcdatetime())', NULL, 0, 0);
+GO
+
+-- Columns for finance_ledgers (ordinals 1-8)
+INSERT INTO system_schema_columns (
+  tables_recid, edt_recid, element_name, element_ordinal, element_nullable,
+  element_default, element_max_length, element_is_primary_key, element_is_identity
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_ledgers' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64_IDENTITY'), 'recid', 1, 0, NULL, NULL, 1, 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_ledgers' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_name', 2, 0, NULL, 64, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_ledgers' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_description', 3, 1, NULL, 512, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_ledgers' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'UUID'), 'element_chart_of_accounts_guid', 4, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_ledgers' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT32'), 'element_fiscal_calendar_year', 5, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_ledgers' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT8'), 'element_status', 6, 0, '((1))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_ledgers' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_created_on', 7, 0, '(sysutcdatetime())', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_ledgers' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_modified_on', 8, 0, '(sysutcdatetime())', NULL, 0, 0);
+GO
+
+-- New indexes
+INSERT INTO system_schema_indexes (tables_recid, element_name, element_columns, element_is_unique) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_dimensions' AND element_schema = 'dbo'), 'UQ_finance_dimensions_name_value', 'element_name, element_value', 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), 'UQ_finance_journals_name', 'element_name', 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_ledgers' AND element_schema = 'dbo'), 'UQ_finance_ledgers_name', 'element_name', 1);
+GO
+
+-- New foreign keys
+INSERT INTO system_schema_foreign_keys (
+  tables_recid, element_column_name, referenced_tables_recid, element_referenced_column
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), 'numbers_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_numbers' AND element_schema = 'dbo'), 'recid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_ledgers' AND element_schema = 'dbo'), 'element_chart_of_accounts_guid', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_accounts' AND element_schema = 'dbo'), 'element_guid');
+GO

--- a/queryregistry/finance/accounts/__init__.py
+++ b/queryregistry/finance/accounts/__init__.py
@@ -1,0 +1,41 @@
+"""Finance accounts query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import (
+  DeleteAccountParams,
+  GetAccountParams,
+  ListAccountsParams,
+  ListChildrenParams,
+  UpsertAccountParams,
+)
+
+__all__ = [
+  "delete_account_request",
+  "get_account_request",
+  "list_account_children_request",
+  "list_accounts_request",
+  "upsert_account_request",
+]
+
+
+def list_accounts_request(params: ListAccountsParams) -> DBRequest:
+  return DBRequest(op="db:finance:accounts:list:1", payload=params.model_dump())
+
+
+def get_account_request(params: GetAccountParams) -> DBRequest:
+  return DBRequest(op="db:finance:accounts:get:1", payload=params.model_dump())
+
+
+def upsert_account_request(params: UpsertAccountParams) -> DBRequest:
+  return DBRequest(op="db:finance:accounts:upsert:1", payload=params.model_dump())
+
+
+def delete_account_request(params: DeleteAccountParams) -> DBRequest:
+  return DBRequest(op="db:finance:accounts:delete:1", payload=params.model_dump())
+
+
+def list_account_children_request(params: ListChildrenParams) -> DBRequest:
+  return DBRequest(op="db:finance:accounts:list_children:1", payload=params.model_dump())

--- a/queryregistry/finance/accounts/handler.py
+++ b/queryregistry/finance/accounts/handler.py
@@ -1,0 +1,35 @@
+"""Finance accounts subdomain handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import delete_v1, get_v1, list_children_v1, list_v1, upsert_v1
+
+__all__ = ["handle_accounts_request"]
+
+DISPATCHERS = {
+  ("list", "1"): list_v1,
+  ("get", "1"): get_v1,
+  ("upsert", "1"): upsert_v1,
+  ("delete", "1"): delete_v1,
+  ("list_children", "1"): list_children_v1,
+}
+
+
+async def handle_accounts_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown finance accounts operation",
+  )

--- a/queryregistry/finance/accounts/models.py
+++ b/queryregistry/finance/accounts/models.py
@@ -1,0 +1,62 @@
+"""Finance accounts query registry models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "AccountRecord",
+  "DeleteAccountParams",
+  "GetAccountParams",
+  "ListAccountsParams",
+  "ListChildrenParams",
+  "UpsertAccountParams",
+]
+
+
+class ListAccountsParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+
+class GetAccountParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str
+
+
+class UpsertAccountParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str | None = None
+  number: str
+  name: str
+  account_type: int
+  parent: str | None = None
+  is_posting: bool = True
+  status: int = 1
+
+
+class DeleteAccountParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str
+
+
+class ListChildrenParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  parent_guid: str
+
+
+class AccountRecord(TypedDict):
+  element_guid: str
+  element_number: str
+  element_name: str
+  element_type: int
+  element_parent: str | None
+  is_posting: bool
+  element_status: int
+  element_created_on: str
+  element_modified_on: str

--- a/queryregistry/finance/accounts/mssql.py
+++ b/queryregistry/finance/accounts/mssql.py
@@ -1,0 +1,157 @@
+"""MSSQL implementations for finance accounts query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
+
+__all__ = ["delete_v1", "get_v1", "list_children_v1", "list_v1", "upsert_v1"]
+
+
+async def list_v1(args: Mapping[str, Any]) -> DBResponse:
+  del args
+  sql = """
+    SELECT
+      account.element_guid,
+      account.element_number,
+      account.element_name,
+      account.element_type,
+      account.element_parent,
+      parent.element_number AS element_parent_number,
+      parent.element_name AS element_parent_name,
+      account.is_posting,
+      account.element_status,
+      account.element_created_on,
+      account.element_modified_on
+    FROM finance_accounts AS account
+    LEFT JOIN finance_accounts AS parent
+      ON parent.element_guid = account.element_parent
+    ORDER BY account.element_number
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql)
+
+
+async def get_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      account.element_guid,
+      account.element_number,
+      account.element_name,
+      account.element_type,
+      account.element_parent,
+      parent.element_number AS element_parent_number,
+      parent.element_name AS element_parent_name,
+      account.is_posting,
+      account.element_status,
+      account.element_created_on,
+      account.element_modified_on
+    FROM finance_accounts AS account
+    LEFT JOIN finance_accounts AS parent
+      ON parent.element_guid = account.element_parent
+    WHERE account.element_guid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (args["guid"],))
+
+
+async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    MERGE finance_accounts AS target
+    USING (
+      SELECT
+        COALESCE(TRY_CAST(? AS UNIQUEIDENTIFIER), NEWID()) AS element_guid,
+        ? AS element_number,
+        ? AS element_name,
+        ? AS element_type,
+        TRY_CAST(? AS UNIQUEIDENTIFIER) AS element_parent,
+        ? AS is_posting,
+        ? AS element_status
+    ) AS source
+    ON target.element_guid = source.element_guid
+    WHEN MATCHED THEN
+      UPDATE SET
+        target.element_number = source.element_number,
+        target.element_name = source.element_name,
+        target.element_type = source.element_type,
+        target.element_parent = source.element_parent,
+        target.is_posting = source.is_posting,
+        target.element_status = source.element_status,
+        target.element_modified_on = SYSUTCDATETIME()
+    WHEN NOT MATCHED THEN
+      INSERT (
+        element_guid,
+        element_number,
+        element_name,
+        element_type,
+        element_parent,
+        is_posting,
+        element_status,
+        element_created_on,
+        element_modified_on
+      )
+      VALUES (
+        source.element_guid,
+        source.element_number,
+        source.element_name,
+        source.element_type,
+        source.element_parent,
+        source.is_posting,
+        source.element_status,
+        SYSUTCDATETIME(),
+        SYSUTCDATETIME()
+      )
+    OUTPUT
+      inserted.element_guid,
+      inserted.element_number,
+      inserted.element_name,
+      inserted.element_type,
+      inserted.element_parent,
+      inserted.is_posting,
+      inserted.element_status,
+      inserted.element_created_on,
+      inserted.element_modified_on
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  params = (
+    args.get("guid"),
+    args["number"],
+    args["name"],
+    args["account_type"],
+    args.get("parent"),
+    args["is_posting"],
+    args["status"],
+  )
+  return await run_json_one(sql, params)
+
+
+async def delete_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SET NOCOUNT ON;
+    DELETE FROM finance_accounts
+    WHERE element_guid = ?;
+  """
+  return await run_exec(sql, (args["guid"],))
+
+
+async def list_children_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      element_guid,
+      element_number,
+      element_name,
+      element_type,
+      element_parent,
+      is_posting,
+      element_status,
+      element_created_on,
+      element_modified_on
+    FROM finance_accounts
+    WHERE element_parent = ?
+    ORDER BY element_number
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, (args["parent_guid"],))

--- a/queryregistry/finance/accounts/services.py
+++ b/queryregistry/finance/accounts/services.py
@@ -1,0 +1,64 @@
+"""Finance accounts query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  DeleteAccountParams,
+  GetAccountParams,
+  ListAccountsParams,
+  ListChildrenParams,
+  UpsertAccountParams,
+)
+
+__all__ = ["delete_v1", "get_v1", "list_children_v1", "list_v1", "upsert_v1"]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_v1}
+_GET_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_v1}
+_UPSERT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_v1}
+_DELETE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_v1}
+_LIST_CHILDREN_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_children_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for finance accounts registry")
+  return dispatcher
+
+
+async def list_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListAccountsParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = GetAccountParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def upsert_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpsertAccountParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPSERT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = DeleteAccountParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_children_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListChildrenParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_CHILDREN_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/queryregistry/finance/dimensions/__init__.py
+++ b/queryregistry/finance/dimensions/__init__.py
@@ -1,0 +1,41 @@
+"""Finance dimensions query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import (
+  DeleteDimensionParams,
+  GetDimensionParams,
+  ListDimensionsByNameParams,
+  ListDimensionsParams,
+  UpsertDimensionParams,
+)
+
+__all__ = [
+  "delete_dimension_request",
+  "get_dimension_request",
+  "list_dimensions_by_name_request",
+  "list_dimensions_request",
+  "upsert_dimension_request",
+]
+
+
+def list_dimensions_request(params: ListDimensionsParams) -> DBRequest:
+  return DBRequest(op="db:finance:dimensions:list:1", payload=params.model_dump())
+
+
+def list_dimensions_by_name_request(params: ListDimensionsByNameParams) -> DBRequest:
+  return DBRequest(op="db:finance:dimensions:list_by_name:1", payload=params.model_dump())
+
+
+def get_dimension_request(params: GetDimensionParams) -> DBRequest:
+  return DBRequest(op="db:finance:dimensions:get:1", payload=params.model_dump())
+
+
+def upsert_dimension_request(params: UpsertDimensionParams) -> DBRequest:
+  return DBRequest(op="db:finance:dimensions:upsert:1", payload=params.model_dump())
+
+
+def delete_dimension_request(params: DeleteDimensionParams) -> DBRequest:
+  return DBRequest(op="db:finance:dimensions:delete:1", payload=params.model_dump())

--- a/queryregistry/finance/dimensions/handler.py
+++ b/queryregistry/finance/dimensions/handler.py
@@ -1,0 +1,35 @@
+"""Finance dimensions subdomain handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import delete_v1, get_v1, list_by_name_v1, list_v1, upsert_v1
+
+__all__ = ["handle_dimensions_request"]
+
+DISPATCHERS = {
+  ("list", "1"): list_v1,
+  ("list_by_name", "1"): list_by_name_v1,
+  ("get", "1"): get_v1,
+  ("upsert", "1"): upsert_v1,
+  ("delete", "1"): delete_v1,
+}
+
+
+async def handle_dimensions_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown finance dimensions operation",
+  )

--- a/queryregistry/finance/dimensions/models.py
+++ b/queryregistry/finance/dimensions/models.py
@@ -1,0 +1,58 @@
+"""Finance dimensions query registry models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "DeleteDimensionParams",
+  "DimensionRecord",
+  "GetDimensionParams",
+  "ListDimensionsByNameParams",
+  "ListDimensionsParams",
+  "UpsertDimensionParams",
+]
+
+
+class ListDimensionsParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+
+class ListDimensionsByNameParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  name: str
+
+
+class GetDimensionParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+
+
+class UpsertDimensionParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int | None = None
+  name: str
+  value: str
+  description: str | None = None
+  status: int = 1
+
+
+class DeleteDimensionParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+
+
+class DimensionRecord(TypedDict):
+  recid: int
+  element_name: str
+  element_value: str
+  element_description: str | None
+  element_status: int
+  element_created_on: str
+  element_modified_on: str

--- a/queryregistry/finance/dimensions/mssql.py
+++ b/queryregistry/finance/dimensions/mssql.py
@@ -1,0 +1,133 @@
+"""MSSQL implementations for finance dimensions query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
+
+__all__ = ["delete_v1", "get_v1", "list_by_name_v1", "list_v1", "upsert_v1"]
+
+
+async def list_v1(args: Mapping[str, Any]) -> DBResponse:
+  del args
+  sql = """
+    SELECT
+      recid,
+      element_name,
+      element_value,
+      element_description,
+      element_status,
+      element_created_on,
+      element_modified_on
+    FROM finance_dimensions
+    ORDER BY element_name, element_value
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql)
+
+
+async def list_by_name_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      recid,
+      element_name,
+      element_value,
+      element_description,
+      element_status,
+      element_created_on,
+      element_modified_on
+    FROM finance_dimensions
+    WHERE element_name = ?
+    ORDER BY element_value
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, (args["name"],))
+
+
+async def get_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      recid,
+      element_name,
+      element_value,
+      element_description,
+      element_status,
+      element_created_on,
+      element_modified_on
+    FROM finance_dimensions
+    WHERE recid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (args["recid"],))
+
+
+async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    MERGE finance_dimensions AS target
+    USING (
+      SELECT
+        ? AS recid,
+        ? AS element_name,
+        ? AS element_value,
+        ? AS element_description,
+        ? AS element_status
+    ) AS source
+    ON (
+      (source.recid IS NOT NULL AND target.recid = source.recid)
+      OR (source.recid IS NULL AND target.element_name = source.element_name
+          AND target.element_value = source.element_value)
+    )
+    WHEN MATCHED THEN
+      UPDATE SET
+        target.element_name = source.element_name,
+        target.element_value = source.element_value,
+        target.element_description = source.element_description,
+        target.element_status = source.element_status,
+        target.element_modified_on = SYSUTCDATETIME()
+    WHEN NOT MATCHED THEN
+      INSERT (
+        element_name,
+        element_value,
+        element_description,
+        element_status,
+        element_created_on,
+        element_modified_on
+      )
+      VALUES (
+        source.element_name,
+        source.element_value,
+        source.element_description,
+        source.element_status,
+        SYSUTCDATETIME(),
+        SYSUTCDATETIME()
+      )
+    OUTPUT
+      inserted.recid,
+      inserted.element_name,
+      inserted.element_value,
+      inserted.element_description,
+      inserted.element_status,
+      inserted.element_created_on,
+      inserted.element_modified_on
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  params = (
+    args.get("recid"),
+    args["name"],
+    args["value"],
+    args.get("description"),
+    args["status"],
+  )
+  return await run_json_one(sql, params)
+
+
+async def delete_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SET NOCOUNT ON;
+    DELETE FROM finance_dimensions
+    WHERE recid = ?;
+  """
+  return await run_exec(sql, (args["recid"],))

--- a/queryregistry/finance/dimensions/services.py
+++ b/queryregistry/finance/dimensions/services.py
@@ -1,0 +1,64 @@
+"""Finance dimensions query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  DeleteDimensionParams,
+  GetDimensionParams,
+  ListDimensionsByNameParams,
+  ListDimensionsParams,
+  UpsertDimensionParams,
+)
+
+__all__ = ["delete_v1", "get_v1", "list_by_name_v1", "list_v1", "upsert_v1"]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_v1}
+_LIST_BY_NAME_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_by_name_v1}
+_GET_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_v1}
+_UPSERT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_v1}
+_DELETE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for finance dimensions registry")
+  return dispatcher
+
+
+async def list_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListDimensionsParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_by_name_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListDimensionsByNameParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_BY_NAME_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = GetDimensionParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def upsert_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpsertDimensionParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPSERT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = DeleteDimensionParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/queryregistry/finance/handler.py
+++ b/queryregistry/finance/handler.py
@@ -8,13 +8,21 @@ from fastapi import HTTPException
 
 from queryregistry.models import DBRequest, DBResponse
 
+from .accounts.handler import handle_accounts_request
 from .credits.handler import handle_credits_request
+from .dimensions.handler import handle_dimensions_request
+from .numbers.handler import handle_numbers_request
+from .periods.handler import handle_periods_request
 from .status.handler import handle_status_request
 
 __all__ = ["handle_finance_request"]
 
 HANDLERS = {
+  "accounts": handle_accounts_request,
   "credits": handle_credits_request,
+  "dimensions": handle_dimensions_request,
+  "numbers": handle_numbers_request,
+  "periods": handle_periods_request,
   "status": handle_status_request,
 }
 

--- a/queryregistry/finance/numbers/__init__.py
+++ b/queryregistry/finance/numbers/__init__.py
@@ -1,0 +1,41 @@
+"""Finance numbers query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import (
+  DeleteNumberParams,
+  GetNumberParams,
+  ListNumbersParams,
+  NextNumberParams,
+  UpsertNumberParams,
+)
+
+__all__ = [
+  "delete_number_request",
+  "get_number_request",
+  "list_numbers_request",
+  "next_number_request",
+  "upsert_number_request",
+]
+
+
+def list_numbers_request(params: ListNumbersParams) -> DBRequest:
+  return DBRequest(op="db:finance:numbers:list:1", payload=params.model_dump())
+
+
+def get_number_request(params: GetNumberParams) -> DBRequest:
+  return DBRequest(op="db:finance:numbers:get:1", payload=params.model_dump())
+
+
+def upsert_number_request(params: UpsertNumberParams) -> DBRequest:
+  return DBRequest(op="db:finance:numbers:upsert:1", payload=params.model_dump())
+
+
+def delete_number_request(params: DeleteNumberParams) -> DBRequest:
+  return DBRequest(op="db:finance:numbers:delete:1", payload=params.model_dump())
+
+
+def next_number_request(params: NextNumberParams) -> DBRequest:
+  return DBRequest(op="db:finance:numbers:next_number:1", payload=params.model_dump())

--- a/queryregistry/finance/numbers/handler.py
+++ b/queryregistry/finance/numbers/handler.py
@@ -1,0 +1,35 @@
+"""Finance numbers subdomain handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import delete_v1, get_v1, list_v1, next_number_v1, upsert_v1
+
+__all__ = ["handle_numbers_request"]
+
+DISPATCHERS = {
+  ("list", "1"): list_v1,
+  ("get", "1"): get_v1,
+  ("upsert", "1"): upsert_v1,
+  ("delete", "1"): delete_v1,
+  ("next_number", "1"): next_number_v1,
+}
+
+
+async def handle_numbers_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown finance numbers operation",
+  )

--- a/queryregistry/finance/numbers/models.py
+++ b/queryregistry/finance/numbers/models.py
@@ -1,0 +1,63 @@
+"""Finance numbers query registry models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "DeleteNumberParams",
+  "GetNumberParams",
+  "ListNumbersParams",
+  "NextNumberParams",
+  "NumberRecord",
+  "UpsertNumberParams",
+]
+
+
+class ListNumbersParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+
+class GetNumberParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+
+
+class UpsertNumberParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int | None = None
+  accounts_guid: str
+  prefix: str | None = None
+  account_number: str
+  last_number: int = 1000
+  allocation_size: int = 10
+  reset_policy: str = "Never"
+
+
+class DeleteNumberParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+
+
+class NextNumberParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+
+
+class NumberRecord(TypedDict):
+  recid: int
+  accounts_guid: str
+  element_prefix: str | None
+  element_account_number: str
+  element_last_number: int
+  element_allocation_size: int
+  element_reset_policy: str
+  element_created_on: str
+  element_modified_on: str
+  account_name: str | None

--- a/queryregistry/finance/numbers/mssql.py
+++ b/queryregistry/finance/numbers/mssql.py
@@ -1,0 +1,158 @@
+"""MSSQL implementations for finance numbers query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
+
+__all__ = ["delete_v1", "get_v1", "list_v1", "next_number_v1", "upsert_v1"]
+
+
+async def list_v1(args: Mapping[str, Any]) -> DBResponse:
+  del args
+  sql = """
+    SELECT
+      number.recid,
+      number.accounts_guid,
+      number.element_prefix,
+      number.element_account_number,
+      number.element_last_number,
+      number.element_allocation_size,
+      number.element_reset_policy,
+      number.element_created_on,
+      number.element_modified_on,
+      account.element_name AS account_name
+    FROM finance_numbers AS number
+    LEFT JOIN finance_accounts AS account
+      ON account.element_guid = number.accounts_guid
+    ORDER BY number.recid
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql)
+
+
+async def get_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      number.recid,
+      number.accounts_guid,
+      number.element_prefix,
+      number.element_account_number,
+      number.element_last_number,
+      number.element_allocation_size,
+      number.element_reset_policy,
+      number.element_created_on,
+      number.element_modified_on,
+      account.element_name AS account_name
+    FROM finance_numbers AS number
+    LEFT JOIN finance_accounts AS account
+      ON account.element_guid = number.accounts_guid
+    WHERE number.recid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (args["recid"],))
+
+
+async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    MERGE finance_numbers AS target
+    USING (
+      SELECT
+        ? AS recid,
+        TRY_CAST(? AS UNIQUEIDENTIFIER) AS accounts_guid,
+        ? AS element_prefix,
+        ? AS element_account_number,
+        ? AS element_last_number,
+        ? AS element_allocation_size,
+        ? AS element_reset_policy
+    ) AS source
+    ON (
+      (source.recid IS NOT NULL AND target.recid = source.recid)
+      OR (source.recid IS NULL AND target.accounts_guid = source.accounts_guid)
+    )
+    WHEN MATCHED THEN
+      UPDATE SET
+        target.accounts_guid = source.accounts_guid,
+        target.element_prefix = source.element_prefix,
+        target.element_account_number = source.element_account_number,
+        target.element_last_number = source.element_last_number,
+        target.element_allocation_size = source.element_allocation_size,
+        target.element_reset_policy = source.element_reset_policy,
+        target.element_modified_on = SYSUTCDATETIME()
+    WHEN NOT MATCHED THEN
+      INSERT (
+        accounts_guid,
+        element_prefix,
+        element_account_number,
+        element_last_number,
+        element_allocation_size,
+        element_reset_policy,
+        element_created_on,
+        element_modified_on
+      )
+      VALUES (
+        source.accounts_guid,
+        source.element_prefix,
+        source.element_account_number,
+        source.element_last_number,
+        source.element_allocation_size,
+        source.element_reset_policy,
+        SYSUTCDATETIME(),
+        SYSUTCDATETIME()
+      )
+    OUTPUT
+      inserted.recid,
+      inserted.accounts_guid,
+      inserted.element_prefix,
+      inserted.element_account_number,
+      inserted.element_last_number,
+      inserted.element_allocation_size,
+      inserted.element_reset_policy,
+      inserted.element_created_on,
+      inserted.element_modified_on
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  params = (
+    args.get("recid"),
+    args["accounts_guid"],
+    args.get("prefix"),
+    args["account_number"],
+    args["last_number"],
+    args["allocation_size"],
+    args["reset_policy"],
+  )
+  return await run_json_one(sql, params)
+
+
+async def delete_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SET NOCOUNT ON;
+    DELETE FROM finance_numbers
+    WHERE recid = ?;
+  """
+  return await run_exec(sql, (args["recid"],))
+
+
+async def next_number_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    UPDATE finance_numbers
+    SET element_last_number = element_last_number + element_allocation_size,
+        element_modified_on = SYSUTCDATETIME()
+    OUTPUT
+      inserted.recid,
+      inserted.accounts_guid,
+      inserted.element_prefix,
+      inserted.element_account_number,
+      (inserted.element_last_number - inserted.element_allocation_size + 1) AS element_block_start,
+      inserted.element_last_number AS element_block_end,
+      inserted.element_allocation_size,
+      inserted.element_reset_policy,
+      inserted.element_created_on,
+      inserted.element_modified_on
+    WHERE recid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (args["recid"],))

--- a/queryregistry/finance/numbers/services.py
+++ b/queryregistry/finance/numbers/services.py
@@ -1,0 +1,64 @@
+"""Finance numbers query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  DeleteNumberParams,
+  GetNumberParams,
+  ListNumbersParams,
+  NextNumberParams,
+  UpsertNumberParams,
+)
+
+__all__ = ["delete_v1", "get_v1", "list_v1", "next_number_v1", "upsert_v1"]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_v1}
+_GET_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_v1}
+_UPSERT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_v1}
+_DELETE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_v1}
+_NEXT_NUMBER_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.next_number_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for finance numbers registry")
+  return dispatcher
+
+
+async def list_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListNumbersParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = GetNumberParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def upsert_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpsertNumberParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPSERT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = DeleteNumberParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def next_number_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = NextNumberParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _NEXT_NUMBER_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/queryregistry/finance/periods/__init__.py
+++ b/queryregistry/finance/periods/__init__.py
@@ -1,0 +1,47 @@
+"""Finance periods query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import (
+  DeletePeriodParams,
+  GenerateCalendarParams,
+  GetPeriodParams,
+  ListPeriodsByYearParams,
+  ListPeriodsParams,
+  UpsertPeriodParams,
+)
+
+__all__ = [
+  "delete_period_request",
+  "generate_calendar_request",
+  "get_period_request",
+  "list_periods_by_year_request",
+  "list_periods_request",
+  "upsert_period_request",
+]
+
+
+def list_periods_request(params: ListPeriodsParams) -> DBRequest:
+  return DBRequest(op="db:finance:periods:list:1", payload=params.model_dump())
+
+
+def list_periods_by_year_request(params: ListPeriodsByYearParams) -> DBRequest:
+  return DBRequest(op="db:finance:periods:list_by_year:1", payload=params.model_dump())
+
+
+def get_period_request(params: GetPeriodParams) -> DBRequest:
+  return DBRequest(op="db:finance:periods:get:1", payload=params.model_dump())
+
+
+def upsert_period_request(params: UpsertPeriodParams) -> DBRequest:
+  return DBRequest(op="db:finance:periods:upsert:1", payload=params.model_dump())
+
+
+def delete_period_request(params: DeletePeriodParams) -> DBRequest:
+  return DBRequest(op="db:finance:periods:delete:1", payload=params.model_dump())
+
+
+def generate_calendar_request(params: GenerateCalendarParams) -> DBRequest:
+  return DBRequest(op="db:finance:periods:generate_calendar:1", payload=params.model_dump())

--- a/queryregistry/finance/periods/handler.py
+++ b/queryregistry/finance/periods/handler.py
@@ -1,0 +1,36 @@
+"""Finance periods subdomain handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import delete_v1, generate_calendar_v1, get_v1, list_by_year_v1, list_v1, upsert_v1
+
+__all__ = ["handle_periods_request"]
+
+DISPATCHERS = {
+  ("list", "1"): list_v1,
+  ("list_by_year", "1"): list_by_year_v1,
+  ("get", "1"): get_v1,
+  ("upsert", "1"): upsert_v1,
+  ("delete", "1"): delete_v1,
+  ("generate_calendar", "1"): generate_calendar_v1,
+}
+
+
+async def handle_periods_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown finance periods operation",
+  )

--- a/queryregistry/finance/periods/models.py
+++ b/queryregistry/finance/periods/models.py
@@ -1,0 +1,82 @@
+"""Finance periods query registry models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "DeletePeriodParams",
+  "GenerateCalendarParams",
+  "GetPeriodParams",
+  "ListPeriodsByYearParams",
+  "ListPeriodsParams",
+  "PeriodRecord",
+  "UpsertPeriodParams",
+]
+
+
+class ListPeriodsParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+
+class ListPeriodsByYearParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  year: int
+
+
+class GetPeriodParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str
+
+
+class UpsertPeriodParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str | None = None
+  year: int
+  period_number: int
+  period_name: str
+  start_date: str
+  end_date: str
+  days_in_period: int
+  quarter_number: int
+  has_closing_week: bool = False
+  is_leap_adjustment: bool = False
+  anchor_event: str | None = None
+  close_type: int = 0
+  status: int = 1
+
+
+class DeletePeriodParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  guid: str
+
+
+class GenerateCalendarParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  fiscal_year: int
+  start_date: str
+
+
+class PeriodRecord(TypedDict):
+  element_guid: str
+  element_year: int
+  element_period_number: int
+  element_period_name: str
+  element_start_date: str
+  element_end_date: str
+  element_days_in_period: int
+  element_quarter_number: int
+  element_has_closing_week: bool
+  element_is_leap_adjustment: bool
+  element_anchor_event: str | None
+  element_close_type: int
+  element_status: int
+  element_created_on: str
+  element_modified_on: str

--- a/queryregistry/finance/periods/mssql.py
+++ b/queryregistry/finance/periods/mssql.py
@@ -1,0 +1,202 @@
+"""MSSQL implementations for finance periods query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
+
+__all__ = ["delete_v1", "get_v1", "list_by_year_v1", "list_v1", "upsert_v1"]
+
+
+async def list_v1(args: Mapping[str, Any]) -> DBResponse:
+  del args
+  sql = """
+    SELECT
+      element_guid,
+      element_year,
+      element_period_number,
+      element_period_name,
+      element_start_date,
+      element_end_date,
+      element_days_in_period,
+      element_quarter_number,
+      element_has_closing_week,
+      element_is_leap_adjustment,
+      element_anchor_event,
+      element_close_type,
+      element_status,
+      element_created_on,
+      element_modified_on
+    FROM finance_periods
+    ORDER BY element_year DESC, element_period_number ASC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql)
+
+
+async def list_by_year_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      element_guid,
+      element_year,
+      element_period_number,
+      element_period_name,
+      element_start_date,
+      element_end_date,
+      element_days_in_period,
+      element_quarter_number,
+      element_has_closing_week,
+      element_is_leap_adjustment,
+      element_anchor_event,
+      element_close_type,
+      element_status,
+      element_created_on,
+      element_modified_on
+    FROM finance_periods
+    WHERE element_year = ?
+    ORDER BY element_period_number ASC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, (args["year"],))
+
+
+async def get_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      element_guid,
+      element_year,
+      element_period_number,
+      element_period_name,
+      element_start_date,
+      element_end_date,
+      element_days_in_period,
+      element_quarter_number,
+      element_has_closing_week,
+      element_is_leap_adjustment,
+      element_anchor_event,
+      element_close_type,
+      element_status,
+      element_created_on,
+      element_modified_on
+    FROM finance_periods
+    WHERE element_guid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (args["guid"],))
+
+
+async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    MERGE finance_periods AS target
+    USING (
+      SELECT
+        COALESCE(TRY_CAST(? AS UNIQUEIDENTIFIER), NEWID()) AS element_guid,
+        ? AS element_year,
+        ? AS element_period_number,
+        ? AS element_period_name,
+        TRY_CAST(? AS DATE) AS element_start_date,
+        TRY_CAST(? AS DATE) AS element_end_date,
+        ? AS element_days_in_period,
+        ? AS element_quarter_number,
+        ? AS element_has_closing_week,
+        ? AS element_is_leap_adjustment,
+        ? AS element_anchor_event,
+        ? AS element_close_type,
+        ? AS element_status
+    ) AS source
+    ON target.element_year = source.element_year
+      AND target.element_period_number = source.element_period_number
+    WHEN MATCHED THEN
+      UPDATE SET
+        target.element_period_name = source.element_period_name,
+        target.element_start_date = source.element_start_date,
+        target.element_end_date = source.element_end_date,
+        target.element_days_in_period = source.element_days_in_period,
+        target.element_quarter_number = source.element_quarter_number,
+        target.element_has_closing_week = source.element_has_closing_week,
+        target.element_is_leap_adjustment = source.element_is_leap_adjustment,
+        target.element_anchor_event = source.element_anchor_event,
+        target.element_close_type = source.element_close_type,
+        target.element_status = source.element_status,
+        target.element_modified_on = SYSUTCDATETIME()
+    WHEN NOT MATCHED THEN
+      INSERT (
+        element_guid,
+        element_year,
+        element_period_number,
+        element_period_name,
+        element_start_date,
+        element_end_date,
+        element_days_in_period,
+        element_quarter_number,
+        element_has_closing_week,
+        element_is_leap_adjustment,
+        element_anchor_event,
+        element_close_type,
+        element_status,
+        element_created_on,
+        element_modified_on
+      )
+      VALUES (
+        source.element_guid,
+        source.element_year,
+        source.element_period_number,
+        source.element_period_name,
+        source.element_start_date,
+        source.element_end_date,
+        source.element_days_in_period,
+        source.element_quarter_number,
+        source.element_has_closing_week,
+        source.element_is_leap_adjustment,
+        source.element_anchor_event,
+        source.element_close_type,
+        source.element_status,
+        SYSUTCDATETIME(),
+        SYSUTCDATETIME()
+      )
+    OUTPUT
+      inserted.element_guid,
+      inserted.element_year,
+      inserted.element_period_number,
+      inserted.element_period_name,
+      inserted.element_start_date,
+      inserted.element_end_date,
+      inserted.element_days_in_period,
+      inserted.element_quarter_number,
+      inserted.element_has_closing_week,
+      inserted.element_is_leap_adjustment,
+      inserted.element_anchor_event,
+      inserted.element_close_type,
+      inserted.element_status,
+      inserted.element_created_on,
+      inserted.element_modified_on
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  params = (
+    args.get("guid"),
+    args["year"],
+    args["period_number"],
+    args["period_name"],
+    args["start_date"],
+    args["end_date"],
+    args["days_in_period"],
+    args["quarter_number"],
+    args["has_closing_week"],
+    args["is_leap_adjustment"],
+    args.get("anchor_event"),
+    args["close_type"],
+    args["status"],
+  )
+  return await run_json_one(sql, params)
+
+
+async def delete_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SET NOCOUNT ON;
+    DELETE FROM finance_periods
+    WHERE element_guid = ?;
+  """
+  return await run_exec(sql, (args["guid"],))

--- a/queryregistry/finance/periods/services.py
+++ b/queryregistry/finance/periods/services.py
@@ -1,0 +1,151 @@
+"""Finance periods query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from datetime import date, timedelta
+from typing import Any
+import uuid
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  DeletePeriodParams,
+  GenerateCalendarParams,
+  GetPeriodParams,
+  ListPeriodsByYearParams,
+  ListPeriodsParams,
+  UpsertPeriodParams,
+)
+
+__all__ = [
+  "delete_v1",
+  "generate_calendar_v1",
+  "get_v1",
+  "list_by_year_v1",
+  "list_v1",
+  "upsert_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_v1}
+_LIST_BY_YEAR_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_by_year_v1}
+_GET_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_v1}
+_UPSERT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_v1}
+_DELETE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for finance periods registry")
+  return dispatcher
+
+
+def _fiscal_year_has_feb_29(fy_start: date) -> bool:
+  fy_end = fy_start + timedelta(days=364)
+  for year in {fy_start.year, fy_end.year}:
+    try:
+      feb29 = date(year, 2, 29)
+    except ValueError:
+      continue
+    if fy_start <= feb29 <= fy_end:
+      return True
+  return False
+
+
+async def list_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListPeriodsParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_by_year_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListPeriodsByYearParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_BY_YEAR_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = GetPeriodParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def upsert_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpsertPeriodParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPSERT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = DeletePeriodParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def generate_calendar_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = GenerateCalendarParams.model_validate(request.payload)
+  fy_start = date.fromisoformat(params.start_date)
+  if fy_start.weekday() != 6:
+    raise ValueError("Fiscal year start_date must be a Sunday")
+
+  is_leap = _fiscal_year_has_feb_29(fy_start)
+  periods: list[dict[str, Any]] = []
+  cursor = fy_start
+
+  for quarter in range(1, 5):
+    for month in range(1, 5):
+      days = 28 if month <= 3 else 7
+      if is_leap and quarter == 1 and month == 4:
+        days = 8
+      period_start = cursor
+      period_end = cursor + timedelta(days=days - 1)
+
+      periods.append(
+        {
+          "guid": str(uuid.uuid4()),
+          "year": params.fiscal_year,
+          "period_number": (quarter - 1) * 5 + month,
+          "period_name": f"Q{quarter}M{month}",
+          "start_date": period_start.isoformat(),
+          "end_date": period_end.isoformat(),
+          "days_in_period": days,
+          "quarter_number": quarter,
+          "has_closing_week": False,
+          "is_leap_adjustment": is_leap and quarter == 1 and month == 4,
+          "anchor_event": None,
+          "close_type": 0,
+          "status": 1,
+        }
+      )
+      cursor = period_end + timedelta(days=1)
+
+    periods.append(
+      {
+        "guid": str(uuid.uuid4()),
+        "year": params.fiscal_year,
+        "period_number": (quarter - 1) * 5 + 5,
+        "period_name": f"Q{quarter}MC",
+        "start_date": (cursor - timedelta(days=7)).isoformat(),
+        "end_date": (cursor - timedelta(days=1)).isoformat(),
+        "days_in_period": 0,
+        "quarter_number": quarter,
+        "has_closing_week": True,
+        "is_leap_adjustment": False,
+        "anchor_event": "period_close",
+        "close_type": 0,
+        "status": 1,
+      }
+    )
+
+  upsert_dispatcher = _select_dispatcher(provider, _UPSERT_DISPATCHERS)
+  for period in periods:
+    await upsert_dispatcher(period)
+
+  result = await _select_dispatcher(provider, _LIST_BY_YEAR_DISPATCHERS)(
+    {"year": params.fiscal_year}
+  )
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)


### PR DESCRIPTION
### Motivation

- Provide schema support for additional finance concepts by adding `finance_dimensions`, `finance_journals`, and `finance_ledgers` tables and registering them in the reflection metadata. 
- Expose canonical QueryRegistry operations for finance domains that were missing in v0.8.0 (accounts, numbers, dimensions, periods). 
- Implement a deterministic, provider-agnostic fiscal calendar generator for periods so callers can create complete FY period sets via the registry. 

### Description

- Added migration `migrations/v0.8.3.0_finance_schema_evolution.sql` which creates `finance_dimensions`, `finance_journals`, and `finance_ledgers` with PKs, unique indexes, foreign keys, and reflection inserts for `system_schema_tables`, `system_schema_columns`, `system_schema_indexes`, and `system_schema_foreign_keys`. 
- Implemented four new QueryRegistry subdomains under `queryregistry/finance/`: `accounts`, `numbers`, `dimensions`, and `periods`, each following the canonical structure (`__init__.py` request builders, `handler.py`, `services.py`, `mssql.py`, `models.py`). 
- Implemented `periods:generate_calendar:1` in `queryregistry/finance/periods/services.py` to compute a 20-period fiscal calendar (4 quarters × (M1–M4 + MC)), validating FY start is a Sunday and applying the Q1 leap-day adjustment (Q1M4 = 8 days) and producing bulk upserts via the provider dispatch. 
- Registered the new subdomain handlers in `queryregistry/finance/handler.py` so the finance domain dispatch includes `accounts`, `numbers`, `dimensions`, and `periods`. 

### Testing

- Ran `python -m py_compile` on the new/modified QueryRegistry Python files and the compilation succeeded. 
- Ran the unified harness `python scripts/run_tests.py`; the pipeline completed and automated test suites passed (unit/test generation steps and frontend test runs completed), with `67` Python tests passing in the environment run. 
- Note: the test run reported an environment warning when attempting a DB-version update step due to a missing local ODBC driver (`ODBC Driver 18 for SQL Server`), which prevented a live DB connection during that final step but did not affect the unit/test pipeline outcome.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b22dd4e2348325b5efd6827b17bb04)