### PR TITLE
Add Finance admin UI, RPC endpoints, module, and DB migrations

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ const DiscordGuildsPage = lazy(() => import("./pages/DiscordGuildsPage"));
 const SystemConfigPage = lazy(() => import("./pages/system/SystemConfigPage"));
 const SystemModelsPage = lazy(() => import("./pages/system/SystemModelsPage"));
 const SystemConversationsPage = lazy(() => import("./pages/system/SystemConversationsPage"));
+const FinanceAdminPage = lazy(() => import("./pages/finance/FinanceAdminPage"));
 const AccountRolesPage = lazy(() => import("./pages/AccountRolesPage"));
 const AccountUsersPage = lazy(() => import("./pages/AccountUsersPage"));
 const AccountUserPanel = lazy(() => import("./pages/AccountUserPanel"));
@@ -51,6 +52,7 @@ function App(): JSX.Element {
                                                                 <Route path="/system-config" element={<SystemConfigPage />} />
                                                                 <Route path="/system-models" element={<SystemModelsPage />} />
                                                                 <Route path="/system-conversations" element={<SystemConversationsPage />} />
+                                                                <Route path="/finance-admin" element={<FinanceAdminPage />} />
                                                                 <Route path="/service-roles" element={<ServiceRolesPage />} />
 								<Route path="/account-roles" element={<AccountRolesPage />} />
 								<Route path="/account-users" element={<AccountUsersPage />} />

--- a/frontend/src/pages/finance/FinanceAdminPage.tsx
+++ b/frontend/src/pages/finance/FinanceAdminPage.tsx
@@ -1,0 +1,387 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+	Box,
+	Button,
+	Checkbox,
+	Divider,
+	FormControlLabel,
+	MenuItem,
+	Paper,
+	Stack,
+	Tab,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableRow,
+	Tabs,
+	TextField,
+	Typography,
+} from "@mui/material";
+import PageTitle from "../../components/PageTitle";
+import { rpcCall } from "../../shared/RpcModels";
+
+type FinancePeriod = {
+	guid?: string | null;
+	year: number;
+	period_number: number;
+	period_name: string;
+	start_date: string;
+	end_date: string;
+	days_in_period: number;
+	quarter_number: number;
+	has_closing_week: boolean;
+	status: number;
+	is_leap_adjustment: boolean;
+};
+
+type FinanceAccount = {
+	guid?: string | null;
+	number: string;
+	name: string;
+	account_type: number;
+	parent?: string | null;
+	is_posting: boolean;
+	status: number;
+};
+
+type FinanceNumber = {
+	recid?: number | null;
+	accounts_guid: string;
+	prefix?: string | null;
+	account_number: string;
+	last_number: number;
+	allocation_size: number;
+	reset_policy: string;
+	account_name?: string | null;
+};
+
+type FinanceDimension = {
+	recid?: number | null;
+	name: string;
+	value: string;
+	description?: string | null;
+	status: number;
+};
+
+const ACCOUNT_TYPES: { value: number; label: string }[] = [
+	{ value: 0, label: "Asset" },
+	{ value: 1, label: "Liability" },
+	{ value: 2, label: "Equity" },
+	{ value: 3, label: "Revenue" },
+	{ value: 4, label: "Expense" },
+];
+
+const FinanceAdminPage = (): JSX.Element => {
+	const [tab, setTab] = useState(0);
+	const [forbidden, setForbidden] = useState(false);
+
+	const [periods, setPeriods] = useState<FinancePeriod[]>([]);
+	const [fiscalYear, setFiscalYear] = useState<number>(new Date().getFullYear());
+	const [fiscalStartDate, setFiscalStartDate] = useState<string>("");
+
+	const [accounts, setAccounts] = useState<FinanceAccount[]>([]);
+	const [newAccount, setNewAccount] = useState<FinanceAccount>({
+		number: "",
+		name: "",
+		account_type: 0,
+		parent: null,
+		is_posting: true,
+		status: 1,
+	});
+
+	const [numbers, setNumbers] = useState<FinanceNumber[]>([]);
+	const [numberForm, setNumberForm] = useState<FinanceNumber>({
+		recid: null,
+		accounts_guid: "",
+		prefix: "",
+		account_number: "",
+		last_number: 1000,
+		allocation_size: 10,
+		reset_policy: "Never",
+	});
+
+	const [dimensions, setDimensions] = useState<FinanceDimension[]>([]);
+	const [dimensionForm, setDimensionForm] = useState<FinanceDimension>({
+		recid: null,
+		name: "",
+		value: "",
+		description: "",
+		status: 1,
+	});
+
+	const loadPeriods = useCallback(async (): Promise<void> => {
+		const res = await rpcCall<{ periods: FinancePeriod[] }>("urn:finance:periods:list:1");
+		setPeriods(res.periods || []);
+	}, []);
+
+	const loadAccounts = useCallback(async (): Promise<void> => {
+		const res = await rpcCall<{ accounts: FinanceAccount[] }>("urn:finance:accounts:list:1");
+		setAccounts(res.accounts || []);
+	}, []);
+
+	const loadNumbers = useCallback(async (): Promise<void> => {
+		const res = await rpcCall<{ numbers: FinanceNumber[] }>("urn:finance:numbers:list:1");
+		setNumbers(res.numbers || []);
+	}, []);
+
+	const loadDimensions = useCallback(async (): Promise<void> => {
+		const res = await rpcCall<{ dimensions: FinanceDimension[] }>("urn:finance:dimensions:list:1");
+		setDimensions(res.dimensions || []);
+	}, []);
+
+	const loadAll = useCallback(async (): Promise<void> => {
+		try {
+			await Promise.all([loadPeriods(), loadAccounts(), loadNumbers(), loadDimensions()]);
+			setForbidden(false);
+		} catch (e: any) {
+			if (e?.response?.status === 403) {
+				setForbidden(true);
+				return;
+			}
+			throw e;
+		}
+	}, [loadPeriods, loadAccounts, loadNumbers, loadDimensions]);
+
+	useEffect(() => {
+		void loadAll();
+	}, [loadAll]);
+
+	if (forbidden) {
+		return (
+			<Box sx={{ p: 2 }}>
+				<Typography variant="h6">Forbidden</Typography>
+			</Box>
+		);
+	}
+
+	return (
+		<Box sx={{ p: 2 }}>
+			<PageTitle>Finance Admin</PageTitle>
+			<Divider sx={{ mb: 2 }} />
+			<Tabs value={tab} onChange={(_, next) => setTab(next)}>
+				<Tab label="Fiscal Periods" />
+				<Tab label="Chart of Accounts" />
+				<Tab label="Number Sequences" />
+				<Tab label="Financial Dimensions" />
+			</Tabs>
+
+			{tab === 0 && (
+				<Stack spacing={2} sx={{ mt: 2 }}>
+					<Paper sx={{ p: 2 }}>
+						<Stack direction="row" spacing={1} alignItems="center">
+							<TextField
+								type="number"
+								label="Fiscal Year"
+								value={fiscalYear}
+								onChange={(e) => setFiscalYear(Number(e.target.value))}
+							/>
+							<TextField
+								label="Start Date (YYYY-MM-DD)"
+								value={fiscalStartDate}
+								onChange={(e) => setFiscalStartDate(e.target.value)}
+							/>
+							<Button
+								variant="contained"
+								onClick={async () => {
+									await rpcCall("urn:finance:periods:generate_calendar:1", {
+										fiscal_year: fiscalYear,
+										start_date: fiscalStartDate,
+									});
+									await loadPeriods();
+								}}
+							>
+								Generate
+							</Button>
+						</Stack>
+					</Paper>
+					<Table size="small">
+						<TableHead>
+							<TableRow>
+								<TableCell>Period Name</TableCell>
+								<TableCell>Quarter</TableCell>
+								<TableCell>Start</TableCell>
+								<TableCell>End</TableCell>
+								<TableCell>Days</TableCell>
+								<TableCell>Close</TableCell>
+								<TableCell>Status</TableCell>
+								<TableCell>Leap</TableCell>
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							{periods.map((item) => (
+								<TableRow key={item.guid || `${item.year}-${item.period_number}`}>
+									<TableCell>{item.period_name}</TableCell>
+									<TableCell>{item.quarter_number}</TableCell>
+									<TableCell>{item.start_date}</TableCell>
+									<TableCell>{item.end_date}</TableCell>
+									<TableCell>{item.days_in_period}</TableCell>
+									<TableCell>{item.has_closing_week ? "Yes" : "No"}</TableCell>
+									<TableCell>{item.status}</TableCell>
+									<TableCell>{item.is_leap_adjustment ? "Yes" : "No"}</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</Stack>
+			)}
+
+			{tab === 1 && (
+				<Stack spacing={2} sx={{ mt: 2 }}>
+					<Paper sx={{ p: 2 }}>
+						<Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+							<TextField
+								label="Number"
+								value={newAccount.number}
+								onChange={(e) => setNewAccount((prev) => ({ ...prev, number: e.target.value }))}
+							/>
+							<TextField
+								label="Name"
+								value={newAccount.name}
+								onChange={(e) => setNewAccount((prev) => ({ ...prev, name: e.target.value }))}
+							/>
+							<TextField
+								select
+								label="Type"
+								value={newAccount.account_type}
+								onChange={(e) => setNewAccount((prev) => ({ ...prev, account_type: Number(e.target.value) }))}
+							>
+								{ACCOUNT_TYPES.map((option) => (
+									<MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+								))}
+							</TextField>
+							<TextField
+								select
+								label="Parent"
+								value={newAccount.parent || ""}
+								onChange={(e) => setNewAccount((prev) => ({ ...prev, parent: e.target.value || null }))}
+							>
+								<MenuItem value="">None</MenuItem>
+								{accounts.map((account) => (
+									<MenuItem key={account.guid} value={account.guid || ""}>{account.number} - {account.name}</MenuItem>
+								))}
+							</TextField>
+							<FormControlLabel
+								label="Posting"
+								control={
+									<Checkbox
+										checked={newAccount.is_posting}
+										onChange={(e) => setNewAccount((prev) => ({ ...prev, is_posting: e.target.checked }))}
+									/>
+								}
+							/>
+							<Button
+								variant="contained"
+								onClick={async () => {
+									await rpcCall("urn:finance:accounts:upsert:1", newAccount);
+									setNewAccount({ number: "", name: "", account_type: 0, parent: null, is_posting: true, status: 1 });
+									await loadAccounts();
+								}}
+							>
+								Add
+							</Button>
+						</Stack>
+					</Paper>
+					<Table size="small">
+						<TableHead><TableRow><TableCell>Number</TableCell><TableCell>Name</TableCell><TableCell>Type</TableCell><TableCell>Parent</TableCell><TableCell>Posting</TableCell><TableCell>Status</TableCell><TableCell /></TableRow></TableHead>
+						<TableBody>
+							{accounts.map((item) => (
+								<TableRow key={item.guid || item.number}>
+									<TableCell>{item.number}</TableCell>
+									<TableCell>{item.name}</TableCell>
+									<TableCell>{ACCOUNT_TYPES.find((a) => a.value === item.account_type)?.label || item.account_type}</TableCell>
+									<TableCell>{item.parent || "-"}</TableCell>
+									<TableCell>{item.is_posting ? "Yes" : "No"}</TableCell>
+									<TableCell>{item.status}</TableCell>
+									<TableCell>
+										<Button color="error" onClick={async () => {
+											if (!item.guid) return;
+											await rpcCall("urn:finance:accounts:delete:1", { guid: item.guid });
+											await loadAccounts();
+										}}>Delete</Button>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</Stack>
+			)}
+
+			{tab === 2 && (
+				<Stack spacing={2} sx={{ mt: 2 }}>
+					<Paper sx={{ p: 2 }}>
+						<Stack direction="row" spacing={1} flexWrap="wrap">
+							<TextField label="Prefix" value={numberForm.prefix || ""} onChange={(e) => setNumberForm((prev) => ({ ...prev, prefix: e.target.value }))} />
+							<TextField label="Account GUID" value={numberForm.accounts_guid} onChange={(e) => setNumberForm((prev) => ({ ...prev, accounts_guid: e.target.value }))} />
+							<TextField label="Account Number" value={numberForm.account_number} onChange={(e) => setNumberForm((prev) => ({ ...prev, account_number: e.target.value }))} />
+							<TextField type="number" label="Last Number" value={numberForm.last_number} onChange={(e) => setNumberForm((prev) => ({ ...prev, last_number: Number(e.target.value) }))} />
+							<TextField type="number" label="Allocation Size" value={numberForm.allocation_size} onChange={(e) => setNumberForm((prev) => ({ ...prev, allocation_size: Number(e.target.value) }))} />
+							<TextField label="Reset Policy" value={numberForm.reset_policy} onChange={(e) => setNumberForm((prev) => ({ ...prev, reset_policy: e.target.value }))} />
+							<Button variant="contained" onClick={async () => {
+								await rpcCall("urn:finance:numbers:upsert:1", numberForm);
+								setNumberForm({ recid: null, accounts_guid: "", prefix: "", account_number: "", last_number: 1000, allocation_size: 10, reset_policy: "Never" });
+								await loadNumbers();
+							}}>Save</Button>
+						</Stack>
+					</Paper>
+					<Table size="small">
+						<TableHead><TableRow><TableCell>Prefix</TableCell><TableCell>Account Number</TableCell><TableCell>Last Number</TableCell><TableCell>Allocation Size</TableCell><TableCell>Reset Policy</TableCell><TableCell /></TableRow></TableHead>
+						<TableBody>
+							{numbers.map((item) => (
+								<TableRow key={item.recid || `${item.accounts_guid}-${item.account_number}`}>
+									<TableCell>{item.prefix || ""}</TableCell>
+									<TableCell>{item.account_number}</TableCell>
+									<TableCell>{item.last_number}</TableCell>
+									<TableCell>{item.allocation_size}</TableCell>
+									<TableCell>{item.reset_policy}</TableCell>
+									<TableCell>
+										<Button onClick={() => setNumberForm(item)}>Edit</Button>
+										<Button onClick={async () => { if (!item.recid) return; await rpcCall("urn:finance:numbers:next_number:1", { recid: item.recid }); await loadNumbers(); }}>Get Next</Button>
+										<Button color="error" onClick={async () => { if (!item.recid) return; await rpcCall("urn:finance:numbers:delete:1", { recid: item.recid }); await loadNumbers(); }}>Delete</Button>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</Stack>
+			)}
+
+			{tab === 3 && (
+				<Stack spacing={2} sx={{ mt: 2 }}>
+					<Paper sx={{ p: 2 }}>
+						<Stack direction="row" spacing={1} flexWrap="wrap">
+							<TextField label="Name" value={dimensionForm.name} onChange={(e) => setDimensionForm((prev) => ({ ...prev, name: e.target.value }))} />
+							<TextField label="Value" value={dimensionForm.value} onChange={(e) => setDimensionForm((prev) => ({ ...prev, value: e.target.value }))} />
+							<TextField label="Description" value={dimensionForm.description || ""} onChange={(e) => setDimensionForm((prev) => ({ ...prev, description: e.target.value }))} />
+							<TextField type="number" label="Status" value={dimensionForm.status} onChange={(e) => setDimensionForm((prev) => ({ ...prev, status: Number(e.target.value) }))} />
+							<Button variant="contained" onClick={async () => {
+								await rpcCall("urn:finance:dimensions:upsert:1", dimensionForm);
+								setDimensionForm({ recid: null, name: "", value: "", description: "", status: 1 });
+								await loadDimensions();
+							}}>Save</Button>
+						</Stack>
+					</Paper>
+					<Table size="small">
+						<TableHead><TableRow><TableCell>Name</TableCell><TableCell>Value</TableCell><TableCell>Description</TableCell><TableCell>Status</TableCell><TableCell /></TableRow></TableHead>
+						<TableBody>
+							{dimensions.map((item) => (
+								<TableRow key={item.recid || `${item.name}:${item.value}`}>
+									<TableCell>{item.name}</TableCell>
+									<TableCell>{item.value}</TableCell>
+									<TableCell>{item.description || ""}</TableCell>
+									<TableCell>{item.status}</TableCell>
+									<TableCell>
+										<Button onClick={() => setDimensionForm(item)}>Edit</Button>
+										<Button color="error" onClick={async () => { if (!item.recid) return; await rpcCall("urn:finance:dimensions:delete:1", { recid: item.recid }); await loadDimensions(); }}>Delete</Button>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</Stack>
+			)}
+		</Box>
+	);
+};
+
+export default FinanceAdminPage;

--- a/migrations/v0.8.3.1_finance_admin_route.sql
+++ b/migrations/v0.8.3.1_finance_admin_route.sql
@@ -1,0 +1,13 @@
+IF EXISTS (SELECT 1 FROM system_roles WHERE element_name = 'ROLE_FINANCE_ADMIN')
+BEGIN
+  INSERT INTO frontend_routes (element_enablement, element_roles, element_sequence, element_path, element_name, element_icon)
+  SELECT '1', sr.element_mask, 90, '/finance-admin', 'Finance Admin', 'money'
+  FROM system_roles sr WHERE sr.element_name = 'ROLE_FINANCE_ADMIN';
+END
+ELSE
+BEGIN
+  INSERT INTO frontend_routes (element_enablement, element_roles, element_sequence, element_path, element_name, element_icon)
+  SELECT '1', COALESCE(sr.element_mask, 0), 90, '/finance-admin', 'Finance Admin', 'money'
+  FROM system_roles sr WHERE sr.element_name = 'ROLE_SERVICE_ADMIN';
+END
+GO

--- a/migrations/v0.8.3.2_number_sequence_formats.sql
+++ b/migrations/v0.8.3.2_number_sequence_formats.sql
@@ -1,0 +1,48 @@
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+-- ============================================================================
+-- v0.8.3.2 Number Sequence Format Fields + Periods FK
+-- ============================================================================
+
+-- A1. Add format fields to finance_numbers
+ALTER TABLE finance_numbers ADD element_pattern NVARCHAR(256) NULL;
+GO
+ALTER TABLE finance_numbers ADD element_display_format NVARCHAR(256) NULL;
+GO
+
+-- A2. Add numbers_recid FK to finance_periods
+ALTER TABLE finance_periods ADD numbers_recid BIGINT NULL;
+GO
+ALTER TABLE finance_periods ADD CONSTRAINT FK_finance_periods_numbers
+  FOREIGN KEY (numbers_recid) REFERENCES finance_numbers(recid);
+GO
+
+-- ============================================================================
+-- REFLECTION TABLE UPDATES
+-- ============================================================================
+
+-- New columns on finance_numbers (ordinals 10-11, after existing 9 columns)
+INSERT INTO system_schema_columns (
+  tables_recid, edt_recid, element_name, element_ordinal, element_nullable,
+  element_default, element_max_length, element_is_primary_key, element_is_identity
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_numbers' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_pattern', 10, 1, NULL, 256, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_numbers' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_display_format', 11, 1, NULL, 256, 0, 0);
+GO
+
+-- New column on finance_periods (ordinal 16, after existing 15 columns)
+INSERT INTO system_schema_columns (
+  tables_recid, edt_recid, element_name, element_ordinal, element_nullable,
+  element_default, element_max_length, element_is_primary_key, element_is_identity
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_periods' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'numbers_recid', 16, 1, NULL, NULL, 0, 0);
+GO
+
+-- New foreign key
+INSERT INTO system_schema_foreign_keys (
+  tables_recid, element_column_name, referenced_tables_recid, element_referenced_column
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_periods' AND element_schema = 'dbo'), 'numbers_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_numbers' AND element_schema = 'dbo'), 'recid');
+GO

--- a/queryregistry/finance/numbers/models.py
+++ b/queryregistry/finance/numbers/models.py
@@ -36,6 +36,8 @@ class UpsertNumberParams(BaseModel):
   last_number: int = 1000
   allocation_size: int = 10
   reset_policy: str = "Never"
+  pattern: str | None = None
+  display_format: str | None = None
 
 
 class DeleteNumberParams(BaseModel):
@@ -58,6 +60,8 @@ class NumberRecord(TypedDict):
   element_last_number: int
   element_allocation_size: int
   element_reset_policy: str
+  element_pattern: str | None
+  element_display_format: str | None
   element_created_on: str
   element_modified_on: str
   account_name: str | None

--- a/queryregistry/finance/numbers/mssql.py
+++ b/queryregistry/finance/numbers/mssql.py
@@ -22,6 +22,8 @@ async def list_v1(args: Mapping[str, Any]) -> DBResponse:
       number.element_last_number,
       number.element_allocation_size,
       number.element_reset_policy,
+      number.element_pattern,
+      number.element_display_format,
       number.element_created_on,
       number.element_modified_on,
       account.element_name AS account_name
@@ -44,6 +46,8 @@ async def get_v1(args: Mapping[str, Any]) -> DBResponse:
       number.element_last_number,
       number.element_allocation_size,
       number.element_reset_policy,
+      number.element_pattern,
+      number.element_display_format,
       number.element_created_on,
       number.element_modified_on,
       account.element_name AS account_name
@@ -67,7 +71,9 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
         ? AS element_account_number,
         ? AS element_last_number,
         ? AS element_allocation_size,
-        ? AS element_reset_policy
+        ? AS element_reset_policy,
+        ? AS element_pattern,
+        ? AS element_display_format
     ) AS source
     ON (
       (source.recid IS NOT NULL AND target.recid = source.recid)
@@ -81,6 +87,8 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
         target.element_last_number = source.element_last_number,
         target.element_allocation_size = source.element_allocation_size,
         target.element_reset_policy = source.element_reset_policy,
+        target.element_pattern = source.element_pattern,
+        target.element_display_format = source.element_display_format,
         target.element_modified_on = SYSUTCDATETIME()
     WHEN NOT MATCHED THEN
       INSERT (
@@ -90,6 +98,8 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
         element_last_number,
         element_allocation_size,
         element_reset_policy,
+        element_pattern,
+        element_display_format,
         element_created_on,
         element_modified_on
       )
@@ -100,6 +110,8 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
         source.element_last_number,
         source.element_allocation_size,
         source.element_reset_policy,
+        source.element_pattern,
+        source.element_display_format,
         SYSUTCDATETIME(),
         SYSUTCDATETIME()
       )
@@ -111,6 +123,8 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
       inserted.element_last_number,
       inserted.element_allocation_size,
       inserted.element_reset_policy,
+      inserted.element_pattern,
+      inserted.element_display_format,
       inserted.element_created_on,
       inserted.element_modified_on
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
@@ -123,6 +137,8 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
     args["last_number"],
     args["allocation_size"],
     args["reset_policy"],
+    args.get("pattern"),
+    args.get("display_format"),
   )
   return await run_json_one(sql, params)
 

--- a/queryregistry/finance/periods/models.py
+++ b/queryregistry/finance/periods/models.py
@@ -49,6 +49,7 @@ class UpsertPeriodParams(BaseModel):
   anchor_event: str | None = None
   close_type: int = 0
   status: int = 1
+  numbers_recid: int | None = None
 
 
 class DeletePeriodParams(BaseModel):
@@ -78,5 +79,6 @@ class PeriodRecord(TypedDict):
   element_anchor_event: str | None
   element_close_type: int
   element_status: int
+  numbers_recid: int | None
   element_created_on: str
   element_modified_on: str

--- a/queryregistry/finance/periods/mssql.py
+++ b/queryregistry/finance/periods/mssql.py
@@ -28,6 +28,7 @@ async def list_v1(args: Mapping[str, Any]) -> DBResponse:
       element_anchor_event,
       element_close_type,
       element_status,
+      numbers_recid,
       element_created_on,
       element_modified_on
     FROM finance_periods
@@ -53,6 +54,7 @@ async def list_by_year_v1(args: Mapping[str, Any]) -> DBResponse:
       element_anchor_event,
       element_close_type,
       element_status,
+      numbers_recid,
       element_created_on,
       element_modified_on
     FROM finance_periods
@@ -79,6 +81,7 @@ async def get_v1(args: Mapping[str, Any]) -> DBResponse:
       element_anchor_event,
       element_close_type,
       element_status,
+      numbers_recid,
       element_created_on,
       element_modified_on
     FROM finance_periods
@@ -105,7 +108,8 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
         ? AS element_is_leap_adjustment,
         ? AS element_anchor_event,
         ? AS element_close_type,
-        ? AS element_status
+        ? AS element_status,
+        ? AS numbers_recid
     ) AS source
     ON target.element_year = source.element_year
       AND target.element_period_number = source.element_period_number
@@ -121,6 +125,7 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
         target.element_anchor_event = source.element_anchor_event,
         target.element_close_type = source.element_close_type,
         target.element_status = source.element_status,
+        target.numbers_recid = source.numbers_recid,
         target.element_modified_on = SYSUTCDATETIME()
     WHEN NOT MATCHED THEN
       INSERT (
@@ -137,6 +142,7 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
         element_anchor_event,
         element_close_type,
         element_status,
+        numbers_recid,
         element_created_on,
         element_modified_on
       )
@@ -154,6 +160,7 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
         source.element_anchor_event,
         source.element_close_type,
         source.element_status,
+        source.numbers_recid,
         SYSUTCDATETIME(),
         SYSUTCDATETIME()
       )
@@ -171,6 +178,7 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
       inserted.element_anchor_event,
       inserted.element_close_type,
       inserted.element_status,
+      inserted.numbers_recid,
       inserted.element_created_on,
       inserted.element_modified_on
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
@@ -189,6 +197,7 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
     args.get("anchor_event"),
     args["close_type"],
     args["status"],
+    args.get("numbers_recid"),
   )
   return await run_json_one(sql, params)
 

--- a/rpc/__init__.py
+++ b/rpc/__init__.py
@@ -14,6 +14,7 @@ from .system.handler import handle_system_request
 from .users.handler import handle_users_request
 from .account.handler import handle_account_request
 from .discord.handler import handle_discord_request
+from .finance.handler import handle_finance_request
 
 
 HANDLERS: dict[str, callable] = {
@@ -27,6 +28,7 @@ HANDLERS: dict[str, callable] = {
   "users": handle_users_request,
   "account": handle_account_request,
   "discord": handle_discord_request,
+  "finance": handle_finance_request,
 }
 
 

--- a/rpc/finance/__init__.py
+++ b/rpc/finance/__init__.py
@@ -1,0 +1,28 @@
+from .accounts.handler import handle_accounts_request
+from .dimensions.handler import handle_dimensions_request
+from .numbers.handler import handle_numbers_request
+from .periods.handler import handle_periods_request
+
+
+HANDLERS: dict[str, callable] = {
+  "accounts": handle_accounts_request,
+  "dimensions": handle_dimensions_request,
+  "numbers": handle_numbers_request,
+  "periods": handle_periods_request,
+}
+
+
+REQUIRED_ROLES: dict[str, str] = {
+  "accounts": "ROLE_FINANCE_ADMIN",
+  "dimensions": "ROLE_FINANCE_ADMIN",
+  "numbers": "ROLE_FINANCE_ADMIN",
+  "periods": "ROLE_FINANCE_ADMIN",
+}
+
+
+FORBIDDEN_DETAILS: dict[str, str] = {
+  "accounts": "Forbidden",
+  "dimensions": "Forbidden",
+  "numbers": "Forbidden",
+  "periods": "Forbidden",
+}

--- a/rpc/finance/accounts/__init__.py
+++ b/rpc/finance/accounts/__init__.py
@@ -1,0 +1,16 @@
+from .services import (
+  finance_accounts_delete_v1,
+  finance_accounts_get_v1,
+  finance_accounts_list_children_v1,
+  finance_accounts_list_v1,
+  finance_accounts_upsert_v1,
+)
+
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list", "1"): finance_accounts_list_v1,
+  ("get", "1"): finance_accounts_get_v1,
+  ("upsert", "1"): finance_accounts_upsert_v1,
+  ("delete", "1"): finance_accounts_delete_v1,
+  ("list_children", "1"): finance_accounts_list_children_v1,
+}

--- a/rpc/finance/accounts/handler.py
+++ b/rpc/finance/accounts/handler.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_accounts_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/finance/accounts/models.py
+++ b/rpc/finance/accounts/models.py
@@ -1,0 +1,31 @@
+from pydantic import BaseModel
+
+
+class FinanceAccountsItem1(BaseModel):
+  guid: str | None = None
+  number: str
+  name: str
+  account_type: int
+  parent: str | None = None
+  is_posting: bool = True
+  status: int = 1
+
+
+class FinanceAccountsList1(BaseModel):
+  accounts: list[FinanceAccountsItem1]
+
+
+class FinanceAccountsGet1(BaseModel):
+  guid: str
+
+
+class FinanceAccountsListChildren1(BaseModel):
+  parent_guid: str
+
+
+class FinanceAccountsUpsert1(FinanceAccountsItem1):
+  pass
+
+
+class FinanceAccountsDelete1(BaseModel):
+  guid: str

--- a/rpc/finance/accounts/services.py
+++ b/rpc/finance/accounts/services.py
@@ -1,0 +1,64 @@
+from fastapi import HTTPException, Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+
+from .models import (
+  FinanceAccountsDelete1,
+  FinanceAccountsGet1,
+  FinanceAccountsItem1,
+  FinanceAccountsList1,
+  FinanceAccountsListChildren1,
+  FinanceAccountsUpsert1,
+)
+
+
+async def finance_accounts_list_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  module = request.app.state.finance
+  await module.on_ready()
+  rows = await module.list_accounts()
+  payload = FinanceAccountsList1(accounts=[FinanceAccountsItem1(**row) for row in rows])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_accounts_get_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinanceAccountsGet1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.get_account(input_payload.guid)
+  if not row:
+    raise HTTPException(status_code=404, detail="Account not found")
+  payload = FinanceAccountsItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_accounts_upsert_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinanceAccountsUpsert1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.upsert_account(input_payload.model_dump())
+  payload = FinanceAccountsItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_accounts_delete_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinanceAccountsDelete1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.delete_account(input_payload.guid)
+  payload = FinanceAccountsDelete1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_accounts_list_children_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinanceAccountsListChildren1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  rows = await module.list_account_children(input_payload.parent_guid)
+  payload = FinanceAccountsList1(accounts=[FinanceAccountsItem1(**row) for row in rows])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)

--- a/rpc/finance/dimensions/__init__.py
+++ b/rpc/finance/dimensions/__init__.py
@@ -1,0 +1,16 @@
+from .services import (
+  finance_dimensions_delete_v1,
+  finance_dimensions_get_v1,
+  finance_dimensions_list_by_name_v1,
+  finance_dimensions_list_v1,
+  finance_dimensions_upsert_v1,
+)
+
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list", "1"): finance_dimensions_list_v1,
+  ("list_by_name", "1"): finance_dimensions_list_by_name_v1,
+  ("get", "1"): finance_dimensions_get_v1,
+  ("upsert", "1"): finance_dimensions_upsert_v1,
+  ("delete", "1"): finance_dimensions_delete_v1,
+}

--- a/rpc/finance/dimensions/handler.py
+++ b/rpc/finance/dimensions/handler.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_dimensions_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/finance/dimensions/models.py
+++ b/rpc/finance/dimensions/models.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel
+
+
+class FinanceDimensionsItem1(BaseModel):
+  recid: int | None = None
+  name: str
+  value: str
+  description: str | None = None
+  status: int = 1
+
+
+class FinanceDimensionsList1(BaseModel):
+  dimensions: list[FinanceDimensionsItem1]
+
+
+class FinanceDimensionsListByName1(BaseModel):
+  name: str
+
+
+class FinanceDimensionsGet1(BaseModel):
+  recid: int
+
+
+class FinanceDimensionsUpsert1(FinanceDimensionsItem1):
+  pass
+
+
+class FinanceDimensionsDelete1(BaseModel):
+  recid: int

--- a/rpc/finance/dimensions/services.py
+++ b/rpc/finance/dimensions/services.py
@@ -1,0 +1,64 @@
+from fastapi import HTTPException, Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+
+from .models import (
+  FinanceDimensionsDelete1,
+  FinanceDimensionsGet1,
+  FinanceDimensionsItem1,
+  FinanceDimensionsList1,
+  FinanceDimensionsListByName1,
+  FinanceDimensionsUpsert1,
+)
+
+
+async def finance_dimensions_list_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  module = request.app.state.finance
+  await module.on_ready()
+  rows = await module.list_dimensions()
+  payload = FinanceDimensionsList1(dimensions=[FinanceDimensionsItem1(**row) for row in rows])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_dimensions_list_by_name_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinanceDimensionsListByName1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  rows = await module.list_dimensions_by_name(input_payload.name)
+  payload = FinanceDimensionsList1(dimensions=[FinanceDimensionsItem1(**row) for row in rows])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_dimensions_get_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinanceDimensionsGet1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.get_dimension(input_payload.recid)
+  if not row:
+    raise HTTPException(status_code=404, detail="Dimension not found")
+  payload = FinanceDimensionsItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_dimensions_upsert_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinanceDimensionsUpsert1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.upsert_dimension(input_payload.model_dump())
+  payload = FinanceDimensionsItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_dimensions_delete_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinanceDimensionsDelete1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.delete_dimension(input_payload.recid)
+  payload = FinanceDimensionsDelete1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)

--- a/rpc/finance/handler.py
+++ b/rpc/finance/handler.py
@@ -1,0 +1,22 @@
+from fastapi import HTTPException, Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.auth_module import AuthModule
+
+from . import FORBIDDEN_DETAILS, HANDLERS, REQUIRED_ROLES
+
+
+async def handle_finance_request(parts: list[str], request: Request) -> RPCResponse:
+  subdomain = parts[0]
+  handler = HANDLERS.get(subdomain)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC subdomain')
+  _, auth_ctx, _ = await unbox_request(request)
+  auth: AuthModule = request.app.state.auth
+  role_name = REQUIRED_ROLES.get(subdomain)
+  required_mask = auth.roles.get(role_name, 0) if role_name else 0
+  if required_mask and not await auth.user_has_role(auth_ctx.user_guid, required_mask):
+    detail = FORBIDDEN_DETAILS.get(subdomain, 'Forbidden')
+    raise HTTPException(status_code=403, detail=detail)
+  return await handler(parts[1:], request)

--- a/rpc/finance/numbers/__init__.py
+++ b/rpc/finance/numbers/__init__.py
@@ -1,0 +1,16 @@
+from .services import (
+  finance_numbers_delete_v1,
+  finance_numbers_get_v1,
+  finance_numbers_list_v1,
+  finance_numbers_next_number_v1,
+  finance_numbers_upsert_v1,
+)
+
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list", "1"): finance_numbers_list_v1,
+  ("get", "1"): finance_numbers_get_v1,
+  ("upsert", "1"): finance_numbers_upsert_v1,
+  ("delete", "1"): finance_numbers_delete_v1,
+  ("next_number", "1"): finance_numbers_next_number_v1,
+}

--- a/rpc/finance/numbers/handler.py
+++ b/rpc/finance/numbers/handler.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_numbers_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/finance/numbers/models.py
+++ b/rpc/finance/numbers/models.py
@@ -1,0 +1,31 @@
+from pydantic import BaseModel
+
+
+class FinanceNumbersItem1(BaseModel):
+  recid: int | None = None
+  accounts_guid: str
+  prefix: str | None = None
+  account_number: str
+  last_number: int = 1000
+  allocation_size: int = 10
+  reset_policy: str = "Never"
+  pattern: str | None = None
+  display_format: str | None = None
+  account_name: str | None = None
+
+
+class FinanceNumbersList1(BaseModel):
+  numbers: list[FinanceNumbersItem1]
+
+
+class FinanceNumbersUpsert1(FinanceNumbersItem1):
+  pattern: str | None = None
+  display_format: str | None = None
+
+
+class FinanceNumbersDelete1(BaseModel):
+  recid: int
+
+
+class FinanceNumbersNextNumber1(BaseModel):
+  recid: int

--- a/rpc/finance/numbers/services.py
+++ b/rpc/finance/numbers/services.py
@@ -1,0 +1,65 @@
+from fastapi import HTTPException, Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+
+from .models import (
+  FinanceNumbersDelete1,
+  FinanceNumbersItem1,
+  FinanceNumbersList1,
+  FinanceNumbersNextNumber1,
+  FinanceNumbersUpsert1,
+)
+
+
+async def finance_numbers_list_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  module = request.app.state.finance
+  await module.on_ready()
+  rows = await module.list_numbers()
+  payload = FinanceNumbersList1(numbers=[FinanceNumbersItem1(**row) for row in rows])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_numbers_get_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinanceNumbersDelete1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.get_number(input_payload.recid)
+  if not row:
+    raise HTTPException(status_code=404, detail="Number sequence not found")
+  payload = FinanceNumbersItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_numbers_upsert_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinanceNumbersUpsert1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.upsert_number(input_payload.model_dump())
+  payload = FinanceNumbersItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_numbers_delete_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinanceNumbersDelete1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.delete_number(input_payload.recid)
+  payload = FinanceNumbersDelete1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_numbers_next_number_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinanceNumbersNextNumber1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.next_number(input_payload.recid)
+  if not row:
+    raise HTTPException(status_code=404, detail="Number sequence not found")
+  payload = FinanceNumbersItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)

--- a/rpc/finance/periods/__init__.py
+++ b/rpc/finance/periods/__init__.py
@@ -1,0 +1,18 @@
+from .services import (
+  finance_periods_delete_v1,
+  finance_periods_generate_calendar_v1,
+  finance_periods_get_v1,
+  finance_periods_list_by_year_v1,
+  finance_periods_list_v1,
+  finance_periods_upsert_v1,
+)
+
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list", "1"): finance_periods_list_v1,
+  ("list_by_year", "1"): finance_periods_list_by_year_v1,
+  ("get", "1"): finance_periods_get_v1,
+  ("upsert", "1"): finance_periods_upsert_v1,
+  ("delete", "1"): finance_periods_delete_v1,
+  ("generate_calendar", "1"): finance_periods_generate_calendar_v1,
+}

--- a/rpc/finance/periods/handler.py
+++ b/rpc/finance/periods/handler.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_periods_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/finance/periods/models.py
+++ b/rpc/finance/periods/models.py
@@ -1,0 +1,43 @@
+from pydantic import BaseModel
+
+
+class FinancePeriodsItem1(BaseModel):
+  guid: str | None = None
+  year: int
+  period_number: int
+  period_name: str
+  start_date: str
+  end_date: str
+  days_in_period: int
+  quarter_number: int
+  has_closing_week: bool = False
+  is_leap_adjustment: bool = False
+  anchor_event: str | None = None
+  close_type: int = 0
+  status: int = 1
+  numbers_recid: int | None = None
+
+
+class FinancePeriodsList1(BaseModel):
+  periods: list[FinancePeriodsItem1]
+
+
+class FinancePeriodsListByYear1(BaseModel):
+  year: int
+
+
+class FinancePeriodsGet1(BaseModel):
+  guid: str
+
+
+class FinancePeriodsUpsert1(FinancePeriodsItem1):
+  numbers_recid: int | None = None
+
+
+class FinancePeriodsDelete1(BaseModel):
+  guid: str
+
+
+class FinancePeriodsGenerateCalendar1(BaseModel):
+  fiscal_year: int
+  start_date: str

--- a/rpc/finance/periods/services.py
+++ b/rpc/finance/periods/services.py
@@ -1,0 +1,78 @@
+from fastapi import HTTPException, Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+
+from .models import (
+  FinancePeriodsDelete1,
+  FinancePeriodsGenerateCalendar1,
+  FinancePeriodsGet1,
+  FinancePeriodsItem1,
+  FinancePeriodsList1,
+  FinancePeriodsListByYear1,
+  FinancePeriodsUpsert1,
+)
+
+
+async def finance_periods_list_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  module = request.app.state.finance
+  await module.on_ready()
+  rows = await module.list_periods()
+  periods = [FinancePeriodsItem1(**row) for row in rows]
+  payload = FinancePeriodsList1(periods=periods)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_periods_list_by_year_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinancePeriodsListByYear1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  rows = await module.list_periods_by_year(input_payload.year)
+  periods = [FinancePeriodsItem1(**row) for row in rows]
+  payload = FinancePeriodsList1(periods=periods)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_periods_get_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinancePeriodsGet1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.get_period(input_payload.guid)
+  if not row:
+    raise HTTPException(status_code=404, detail="Period not found")
+  payload = FinancePeriodsItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_periods_upsert_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinancePeriodsUpsert1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.upsert_period(input_payload.model_dump())
+  payload = FinancePeriodsItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_periods_delete_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinancePeriodsDelete1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.delete_period(input_payload.guid)
+  payload = FinancePeriodsDelete1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_periods_generate_calendar_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = FinancePeriodsGenerateCalendar1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  rows = await module.generate_calendar(input_payload.fiscal_year, input_payload.start_date)
+  periods = [FinancePeriodsItem1(**row) for row in rows]
+  payload = FinancePeriodsList1(periods=periods)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)

--- a/server/modules/finance_module.py
+++ b/server/modules/finance_module.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import calendar
+import logging
+import uuid
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from fastapi import FastAPI
+
+from . import BaseModule
+from .db_module import DbModule
+from queryregistry.finance.accounts import (
+  delete_account_request,
+  get_account_request,
+  list_account_children_request,
+  list_accounts_request,
+  upsert_account_request,
+)
+from queryregistry.finance.accounts.models import (
+  DeleteAccountParams,
+  GetAccountParams,
+  ListAccountsParams,
+  ListChildrenParams,
+  UpsertAccountParams,
+)
+from queryregistry.finance.dimensions import (
+  delete_dimension_request,
+  get_dimension_request,
+  list_dimensions_by_name_request,
+  list_dimensions_request,
+  upsert_dimension_request,
+)
+from queryregistry.finance.dimensions.models import (
+  DeleteDimensionParams,
+  GetDimensionParams,
+  ListDimensionsByNameParams,
+  ListDimensionsParams,
+  UpsertDimensionParams,
+)
+from queryregistry.finance.numbers import (
+  delete_number_request,
+  get_number_request,
+  list_numbers_request,
+  next_number_request,
+  upsert_number_request,
+)
+from queryregistry.finance.numbers.models import (
+  DeleteNumberParams,
+  GetNumberParams,
+  ListNumbersParams,
+  NextNumberParams,
+  UpsertNumberParams,
+)
+from queryregistry.finance.periods import (
+  delete_period_request,
+  get_period_request,
+  list_periods_by_year_request,
+  list_periods_request,
+  upsert_period_request,
+)
+from queryregistry.finance.periods.models import (
+  DeletePeriodParams,
+  GetPeriodParams,
+  ListPeriodsByYearParams,
+  ListPeriodsParams,
+  UpsertPeriodParams,
+)
+
+
+class FinanceModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.app.state.finance = self
+    logging.debug("[FinanceModule] loaded")
+    self.mark_ready()
+
+  async def shutdown(self):
+    logging.info("[FinanceModule] shutdown")
+    self.db = None
+
+  def _map_period(self, row: dict[str, Any]) -> dict[str, Any]:
+    return {
+      "guid": row.get("element_guid"),
+      "year": row.get("element_year"),
+      "period_number": row.get("element_period_number"),
+      "period_name": row.get("element_period_name"),
+      "start_date": row.get("element_start_date"),
+      "end_date": row.get("element_end_date"),
+      "days_in_period": row.get("element_days_in_period"),
+      "quarter_number": row.get("element_quarter_number"),
+      "has_closing_week": row.get("element_has_closing_week"),
+      "is_leap_adjustment": row.get("element_is_leap_adjustment"),
+      "anchor_event": row.get("element_anchor_event"),
+      "close_type": row.get("element_close_type"),
+      "status": row.get("element_status"),
+      "numbers_recid": row.get("numbers_recid"),
+    }
+
+  def _map_account(self, row: dict[str, Any]) -> dict[str, Any]:
+    return {
+      "guid": row.get("element_guid"),
+      "number": row.get("element_number"),
+      "name": row.get("element_name"),
+      "account_type": row.get("element_type"),
+      "parent": row.get("element_parent"),
+      "is_posting": row.get("is_posting"),
+      "status": row.get("element_status"),
+    }
+
+  def _map_number(self, row: dict[str, Any]) -> dict[str, Any]:
+    return {
+      "recid": row.get("recid"),
+      "accounts_guid": row.get("accounts_guid"),
+      "prefix": row.get("element_prefix"),
+      "account_number": row.get("element_account_number"),
+      "last_number": row.get("element_last_number"),
+      "allocation_size": row.get("element_allocation_size"),
+      "reset_policy": row.get("element_reset_policy"),
+      "pattern": row.get("element_pattern"),
+      "display_format": row.get("element_display_format"),
+      "account_name": row.get("account_name"),
+    }
+
+  def _map_dimension(self, row: dict[str, Any]) -> dict[str, Any]:
+    return {
+      "recid": row.get("recid"),
+      "name": row.get("element_name"),
+      "value": row.get("element_value"),
+      "description": row.get("element_description"),
+      "status": row.get("element_status"),
+    }
+
+  async def list_periods(self) -> list[dict[str, Any]]:
+    assert self.db
+    res = await self.db.run(list_periods_request(ListPeriodsParams()))
+    return [self._map_period(row) for row in res.rows]
+
+  async def list_periods_by_year(self, year: int) -> list[dict[str, Any]]:
+    assert self.db
+    res = await self.db.run(list_periods_by_year_request(ListPeriodsByYearParams(year=year)))
+    return [self._map_period(row) for row in res.rows]
+
+  async def get_period(self, guid: str) -> dict[str, Any] | None:
+    assert self.db
+    res = await self.db.run(get_period_request(GetPeriodParams(guid=guid)))
+    if not res.rows:
+      return None
+    return self._map_period(dict(res.rows[0]))
+
+  async def upsert_period(self, data: dict[str, Any]) -> dict[str, Any]:
+    assert self.db
+    params = UpsertPeriodParams(**data)
+    res = await self.db.run(upsert_period_request(params))
+    row = dict(res.rows[0]) if res.rows else params.model_dump()
+    return self._map_period(row)
+
+  async def delete_period(self, guid: str) -> dict[str, Any]:
+    assert self.db
+    await self.db.run(delete_period_request(DeletePeriodParams(guid=guid)))
+    return {"guid": guid}
+
+  async def generate_calendar(self, fiscal_year: int, start_date: str) -> list[dict[str, Any]]:
+    start = datetime.fromisoformat(start_date).date()
+    if start.weekday() != 6:
+      raise ValueError("start_date must be a Sunday")
+
+    fiscal_end = start + timedelta(days=365)
+    has_leap_adjustment = calendar.isleap(fiscal_year) and start <= date(fiscal_year, 2, 29) < fiscal_end
+
+    generated: list[dict[str, Any]] = []
+    cursor = start
+    period_number = 1
+
+    for quarter in range(1, 5):
+      for month_idx in range(1, 5):
+        days_in_period = 28
+        is_leap_adjustment = False
+        if quarter == 1 and month_idx == 4 and has_leap_adjustment:
+          days_in_period = 8
+          is_leap_adjustment = True
+        end = cursor + timedelta(days=days_in_period - 1)
+        name = f"Q{quarter}M{month_idx}"
+        payload = {
+          "guid": None,
+          "year": fiscal_year,
+          "period_number": period_number,
+          "period_name": name,
+          "start_date": cursor.isoformat(),
+          "end_date": end.isoformat(),
+          "days_in_period": days_in_period,
+          "quarter_number": quarter,
+          "has_closing_week": False,
+          "is_leap_adjustment": is_leap_adjustment,
+          "anchor_event": None,
+          "close_type": 0,
+          "status": 1,
+          "numbers_recid": None,
+        }
+        row = await self.upsert_period(payload)
+        generated.append(row)
+        cursor = end + timedelta(days=1)
+        period_number += 1
+
+      m4 = generated[-1]
+      closing_payload = {
+        "guid": None,
+        "year": fiscal_year,
+        "period_number": period_number,
+        "period_name": f"Q{quarter}MC",
+        "start_date": m4["start_date"],
+        "end_date": m4["end_date"],
+        "days_in_period": 0,
+        "quarter_number": quarter,
+        "has_closing_week": True,
+        "is_leap_adjustment": False,
+        "anchor_event": "period_close",
+        "close_type": 0,
+        "status": 1,
+        "numbers_recid": None,
+      }
+      row = await self.upsert_period(closing_payload)
+      generated.append(row)
+      period_number += 1
+
+    return generated
+
+  async def list_accounts(self) -> list[dict[str, Any]]:
+    assert self.db
+    res = await self.db.run(list_accounts_request(ListAccountsParams()))
+    return [self._map_account(row) for row in res.rows]
+
+  async def get_account(self, guid: str) -> dict[str, Any] | None:
+    assert self.db
+    res = await self.db.run(get_account_request(GetAccountParams(guid=guid)))
+    if not res.rows:
+      return None
+    return self._map_account(dict(res.rows[0]))
+
+  async def upsert_account(self, data: dict[str, Any]) -> dict[str, Any]:
+    assert self.db
+    next_data = dict(data)
+    if not next_data.get("guid"):
+      next_data["guid"] = str(uuid.uuid4())
+    params = UpsertAccountParams(**next_data)
+    res = await self.db.run(upsert_account_request(params))
+    row = dict(res.rows[0]) if res.rows else params.model_dump()
+    return self._map_account(row)
+
+  async def delete_account(self, guid: str) -> dict[str, Any]:
+    assert self.db
+    await self.db.run(delete_account_request(DeleteAccountParams(guid=guid)))
+    return {"guid": guid}
+
+  async def list_account_children(self, parent_guid: str) -> list[dict[str, Any]]:
+    assert self.db
+    res = await self.db.run(
+      list_account_children_request(ListChildrenParams(parent_guid=parent_guid)),
+    )
+    return [self._map_account(row) for row in res.rows]
+
+  async def list_numbers(self) -> list[dict[str, Any]]:
+    assert self.db
+    res = await self.db.run(list_numbers_request(ListNumbersParams()))
+    return [self._map_number(row) for row in res.rows]
+
+  async def get_number(self, recid: int) -> dict[str, Any] | None:
+    assert self.db
+    res = await self.db.run(get_number_request(GetNumberParams(recid=recid)))
+    if not res.rows:
+      return None
+    return self._map_number(dict(res.rows[0]))
+
+  async def upsert_number(self, data: dict[str, Any]) -> dict[str, Any]:
+    assert self.db
+    params = UpsertNumberParams(**data)
+    res = await self.db.run(upsert_number_request(params))
+    row = dict(res.rows[0]) if res.rows else params.model_dump()
+    return self._map_number(row)
+
+  async def delete_number(self, recid: int) -> dict[str, Any]:
+    assert self.db
+    await self.db.run(delete_number_request(DeleteNumberParams(recid=recid)))
+    return {"recid": recid}
+
+  async def next_number(self, recid: int) -> dict[str, Any] | None:
+    assert self.db
+    res = await self.db.run(next_number_request(NextNumberParams(recid=recid)))
+    if not res.rows:
+      return None
+    return self._map_number(dict(res.rows[0]))
+
+  async def list_dimensions(self) -> list[dict[str, Any]]:
+    assert self.db
+    res = await self.db.run(list_dimensions_request(ListDimensionsParams()))
+    return [self._map_dimension(row) for row in res.rows]
+
+  async def list_dimensions_by_name(self, name: str) -> list[dict[str, Any]]:
+    assert self.db
+    res = await self.db.run(list_dimensions_by_name_request(ListDimensionsByNameParams(name=name)))
+    return [self._map_dimension(row) for row in res.rows]
+
+  async def get_dimension(self, recid: int) -> dict[str, Any] | None:
+    assert self.db
+    res = await self.db.run(get_dimension_request(GetDimensionParams(recid=recid)))
+    if not res.rows:
+      return None
+    return self._map_dimension(dict(res.rows[0]))
+
+  async def upsert_dimension(self, data: dict[str, Any]) -> dict[str, Any]:
+    assert self.db
+    params = UpsertDimensionParams(**data)
+    res = await self.db.run(upsert_dimension_request(params))
+    row = dict(res.rows[0]) if res.rows else params.model_dump()
+    return self._map_dimension(row)
+
+  async def delete_dimension(self, recid: int) -> dict[str, Any]:
+    assert self.db
+    await self.db.run(delete_dimension_request(DeleteDimensionParams(recid=recid)))
+    return {"recid": recid}


### PR DESCRIPTION
### Motivation
- Provide an administrative interface and backend support for finance functionality including fiscal periods, chart of accounts, number sequences, and financial dimensions.
- Expose finance operations over RPC with role-based access control so only authorized users (e.g. `ROLE_FINANCE_ADMIN`) can perform finance actions.
- Persist new fields and relations required for number sequence formats and link number sequences to periods in the database schema.

### Description
- Frontend: add `FinanceAdminPage` component and register the `/finance-admin` lazy route in `App.tsx` to manage periods, accounts, numbers, and dimensions via RPC (`frontend/src/pages/finance/FinanceAdminPage.tsx`).
- Database migrations: add `v0.8.3.1_finance_admin_route.sql` to insert the frontend route and `v0.8.3.2_number_sequence_formats.sql` to add `element_pattern` and `element_display_format` to `finance_numbers` and `numbers_recid` FK on `finance_periods`.
- Query registry and MSSQL: extend finance `numbers` and `periods` models and MSSQL implementations to include `pattern`, `display_format`, and `numbers_recid` in selects, upserts, and outputs.
- RPC and server: introduce a `finance` RPC namespace with subdomains (`accounts`, `dimensions`, `numbers`, `periods`), handlers, request/response models and services, add role enforcement in `rpc/finance/handler.py`, register the finance handler in `rpc/__init__.py`, and implement a `FinanceModule` (`server/modules/finance_module.py`) to encapsulate business logic and DB interactions.

### Testing
- Ran the backend unit/integration test suite with `pytest` against the updated modules and the tests passed.
- Performed a local frontend build/type-check to ensure the new `FinanceAdminPage` compiles and the new route bundles successfully.
- No new automated tests were added in this change; existing tests covering the modified areas were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2418c33f88325acdff41d3487a913)