### PR TITLE
Add finance staging subdomain and Azure billing import module

### DIFF
--- a/queryregistry/finance/handler.py
+++ b/queryregistry/finance/handler.py
@@ -13,6 +13,7 @@ from .credits.handler import handle_credits_request
 from .dimensions.handler import handle_dimensions_request
 from .numbers.handler import handle_numbers_request
 from .periods.handler import handle_periods_request
+from .staging.handler import handle_staging_request
 from .status.handler import handle_status_request
 
 __all__ = ["handle_finance_request"]
@@ -23,6 +24,7 @@ HANDLERS = {
   "dimensions": handle_dimensions_request,
   "numbers": handle_numbers_request,
   "periods": handle_periods_request,
+  "staging": handle_staging_request,
   "status": handle_status_request,
 }
 

--- a/queryregistry/finance/staging/__init__.py
+++ b/queryregistry/finance/staging/__init__.py
@@ -1,0 +1,47 @@
+"""Finance staging query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import (
+  CreateImportParams,
+  InsertCostDetailBatchParams,
+  ListCostDetailsByImportParams,
+  ListImportsParams,
+  UpdateImportStatusParams,
+)
+
+__all__ = [
+  "create_import_request",
+  "insert_cost_detail_batch_request",
+  "list_cost_details_by_import_request",
+  "list_imports_request",
+  "update_import_status_request",
+]
+
+
+def create_import_request(params: CreateImportParams) -> DBRequest:
+  return DBRequest(op="db:finance:staging:create_import:1", payload=params.model_dump())
+
+
+def update_import_status_request(params: UpdateImportStatusParams) -> DBRequest:
+  return DBRequest(op="db:finance:staging:update_import_status:1", payload=params.model_dump())
+
+
+def insert_cost_detail_batch_request(params: InsertCostDetailBatchParams) -> DBRequest:
+  return DBRequest(
+    op="db:finance:staging:insert_cost_detail_batch:1",
+    payload=params.model_dump(),
+  )
+
+
+def list_imports_request(params: ListImportsParams) -> DBRequest:
+  return DBRequest(op="db:finance:staging:list_imports:1", payload=params.model_dump())
+
+
+def list_cost_details_by_import_request(params: ListCostDetailsByImportParams) -> DBRequest:
+  return DBRequest(
+    op="db:finance:staging:list_cost_details_by_import:1",
+    payload=params.model_dump(),
+  )

--- a/queryregistry/finance/staging/handler.py
+++ b/queryregistry/finance/staging/handler.py
@@ -1,0 +1,41 @@
+"""Finance staging subdomain handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import (
+  create_import_v1,
+  insert_cost_detail_batch_v1,
+  list_cost_details_by_import_v1,
+  list_imports_v1,
+  update_import_status_v1,
+)
+
+__all__ = ["handle_staging_request"]
+
+DISPATCHERS = {
+  ("create_import", "1"): create_import_v1,
+  ("update_import_status", "1"): update_import_status_v1,
+  ("insert_cost_detail_batch", "1"): insert_cost_detail_batch_v1,
+  ("list_imports", "1"): list_imports_v1,
+  ("list_cost_details_by_import", "1"): list_cost_details_by_import_v1,
+}
+
+
+async def handle_staging_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown finance staging operation",
+  )

--- a/queryregistry/finance/staging/models.py
+++ b/queryregistry/finance/staging/models.py
@@ -1,0 +1,51 @@
+"""Finance staging query registry models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "CreateImportParams",
+  "InsertCostDetailBatchParams",
+  "ListCostDetailsByImportParams",
+  "ListImportsParams",
+  "UpdateImportStatusParams",
+]
+
+
+class CreateImportParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  source: str
+  scope: str
+  metric: str
+  period_start: str
+  period_end: str
+
+
+class UpdateImportStatusParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+  status: int
+  row_count: int
+  error: str | None = None
+
+
+class InsertCostDetailBatchParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  imports_recid: int
+  rows: list[dict[str, Any]]
+
+
+class ListImportsParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+
+class ListCostDetailsByImportParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  imports_recid: int

--- a/queryregistry/finance/staging/mssql.py
+++ b/queryregistry/finance/staging/mssql.py
@@ -1,0 +1,127 @@
+"""MSSQL implementations for finance staging query registry services."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
+
+__all__ = [
+  "create_import_v1",
+  "insert_cost_detail_batch_v1",
+  "list_cost_details_by_import_v1",
+  "list_imports_v1",
+  "update_import_status_v1",
+]
+
+_VALID_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _to_element_column_name(field_name: str) -> str:
+  if not field_name:
+    raise ValueError("Cost detail row contains an empty field name")
+  if not _VALID_IDENTIFIER.fullmatch(field_name):
+    raise ValueError(f"Cost detail field name contains unsupported characters: {field_name}")
+  return f"element_{field_name}"
+
+
+async def create_import_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    INSERT INTO finance_staging_imports (
+      element_source,
+      element_scope,
+      element_metric,
+      element_period_start,
+      element_period_end,
+      element_status,
+      element_row_count,
+      element_error,
+      element_created_on,
+      element_modified_on
+    )
+    OUTPUT inserted.*
+    VALUES (?, ?, ?, ?, ?, 0, 0, NULL, SYSUTCDATETIME(), SYSUTCDATETIME());
+  """
+  params = (
+    args["source"],
+    args["scope"],
+    args["metric"],
+    args["period_start"],
+    args["period_end"],
+  )
+  return await run_json_one(sql, params)
+
+
+async def update_import_status_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    UPDATE finance_staging_imports
+    SET
+      element_status = ?,
+      element_row_count = ?,
+      element_error = ?,
+      element_modified_on = SYSUTCDATETIME()
+    WHERE recid = ?;
+  """
+  params = (args["status"], args["row_count"], args.get("error"), args["recid"])
+  return await run_exec(sql, params)
+
+
+async def insert_cost_detail_batch_v1(args: Mapping[str, Any]) -> DBResponse:
+  imports_recid = args["imports_recid"]
+  rows = args.get("rows") or []
+  inserted = 0
+
+  for row in rows:
+    columns = ["imports_recid"]
+    values: list[Any] = [imports_recid]
+
+    for field_name, field_value in row.items():
+      column_name = _to_element_column_name(field_name)
+      columns.append(column_name)
+      values.append(field_value)
+
+    columns_sql = ", ".join(f"[{column}]" for column in columns)
+    placeholders_sql = ", ".join("?" for _ in values)
+    sql = f"""
+      INSERT INTO finance_staging_cost_details ({columns_sql})
+      VALUES ({placeholders_sql});
+    """
+    await run_exec(sql, tuple(values))
+    inserted += 1
+
+  return DBResponse(rows=[], rowcount=inserted)
+
+
+async def list_imports_v1(args: Mapping[str, Any]) -> DBResponse:
+  del args
+  sql = """
+    SELECT
+      recid,
+      element_source,
+      element_scope,
+      element_metric,
+      element_period_start,
+      element_period_end,
+      element_status,
+      element_row_count,
+      element_error,
+      element_created_on,
+      element_modified_on
+    FROM finance_staging_imports
+    ORDER BY recid DESC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql)
+
+
+async def list_cost_details_by_import_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT *
+    FROM finance_staging_cost_details
+    WHERE imports_recid = ?
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, (args["imports_recid"],))

--- a/queryregistry/finance/staging/services.py
+++ b/queryregistry/finance/staging/services.py
@@ -1,0 +1,82 @@
+"""Finance staging query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  CreateImportParams,
+  InsertCostDetailBatchParams,
+  ListCostDetailsByImportParams,
+  ListImportsParams,
+  UpdateImportStatusParams,
+)
+
+__all__ = [
+  "create_import_v1",
+  "insert_cost_detail_batch_v1",
+  "list_cost_details_by_import_v1",
+  "list_imports_v1",
+  "update_import_status_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_CREATE_IMPORT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.create_import_v1}
+_UPDATE_IMPORT_STATUS_DISPATCHERS: dict[str, _Dispatcher] = {
+  "mssql": mssql.update_import_status_v1,
+}
+_INSERT_COST_DETAIL_BATCH_DISPATCHERS: dict[str, _Dispatcher] = {
+  "mssql": mssql.insert_cost_detail_batch_v1,
+}
+_LIST_IMPORTS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_imports_v1}
+_LIST_COST_DETAILS_BY_IMPORT_DISPATCHERS: dict[str, _Dispatcher] = {
+  "mssql": mssql.list_cost_details_by_import_v1,
+}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for finance staging registry")
+  return dispatcher
+
+
+async def create_import_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = CreateImportParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _CREATE_IMPORT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def update_import_status_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpdateImportStatusParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPDATE_IMPORT_STATUS_DISPATCHERS)(
+    params.model_dump(),
+  )
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def insert_cost_detail_batch_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = InsertCostDetailBatchParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _INSERT_COST_DETAIL_BATCH_DISPATCHERS)(
+    params.model_dump(),
+  )
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_imports_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListImportsParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_IMPORTS_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_cost_details_by_import_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListCostDetailsByImportParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_COST_DETAILS_BY_IMPORT_DISPATCHERS)(
+    params.model_dump(),
+  )
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/server/modules/azure_billing_import_module.py
+++ b/server/modules/azure_billing_import_module.py
@@ -1,0 +1,292 @@
+"""Azure billing import module for Cost Details staging ingestion."""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+import logging
+
+import aiohttp
+from azure.identity.aio import ClientSecretCredential
+from fastapi import FastAPI
+
+from queryregistry.finance.staging import (
+  create_import_request,
+  insert_cost_detail_batch_request,
+  update_import_status_request,
+)
+from queryregistry.finance.staging.models import (
+  CreateImportParams,
+  InsertCostDetailBatchParams,
+  UpdateImportStatusParams,
+)
+from queryregistry.system.config import get_config_request
+from queryregistry.system.config.models import ConfigKeyParams
+
+from . import BaseModule
+from .db_module import DbModule
+from .env_module import EnvModule
+
+
+class AzureBillingImportModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+    self.env: EnvModule | None = None
+    self._tenant_id: str | None = None
+    self._client_id: str | None = None
+    self._client_secret: str | None = None
+    self._subscription_id: str | None = None
+    self._credential: ClientSecretCredential | None = None
+    self._credential_tenant_id: str | None = None
+    self._credential_client_id: str | None = None
+    self._credential_client_secret: str | None = None
+
+  async def startup(self):
+    self.db = self.app.state.db
+    await self.db.on_ready()
+    self.env = self.app.state.env
+    await self.env.on_ready()
+
+    self._client_id = await self._load_config("AzureBillingClientId")
+    self._tenant_id = await self._load_config("AzureBillingTenantId")
+    self._subscription_id = await self._load_config("AzureBillingSubscriptionId")
+    try:
+      self._client_secret = self.env.get("AZURE_BILLING_CLIENT_SECRET") if self.env else None
+    except Exception:
+      self._client_secret = None
+
+    if not self._client_id:
+      logging.warning("[AzureBillingImportModule] Missing config value for key: AzureBillingClientId")
+    if not self._tenant_id:
+      logging.warning("[AzureBillingImportModule] Missing config value for key: AzureBillingTenantId")
+    if not self._subscription_id:
+      logging.warning(
+        "[AzureBillingImportModule] Missing config value for key: AzureBillingSubscriptionId",
+      )
+    if not self._client_secret:
+      logging.warning(
+        "[AzureBillingImportModule] Missing env value for key: AZURE_BILLING_CLIENT_SECRET",
+      )
+
+    self.app.state.azure_billing_import = self
+    self.mark_ready()
+
+  async def shutdown(self):
+    if self._credential:
+      await self._credential.close()
+      self._credential = None
+    self._credential_tenant_id = None
+    self._credential_client_id = None
+    self._credential_client_secret = None
+    self._tenant_id = None
+    self._client_id = None
+    self._client_secret = None
+    self._subscription_id = None
+    self.db = None
+    self.env = None
+
+  async def _load_config(self, key: str) -> str:
+    if not self.db:
+      raise RuntimeError("AzureBillingImportModule requires database module")
+    res = await self.db.run(get_config_request(ConfigKeyParams(key=key)))
+    if not res.rows:
+      return ""
+    return res.rows[0].get("element_value") or ""
+
+  async def _get_management_token(self) -> str:
+    """Acquire an Azure Management API access token via client credentials."""
+    if not self.env:
+      raise RuntimeError("AzureBillingImportModule requires environment module")
+    try:
+      self._client_secret = self.env.get("AZURE_BILLING_CLIENT_SECRET")
+    except Exception:
+      self._client_secret = None
+
+    if not all([self._tenant_id, self._client_id, self._client_secret]):
+      raise ValueError("Azure AD credentials not configured")
+
+    if (
+      not self._credential
+      or self._credential_tenant_id != self._tenant_id
+      or self._credential_client_id != self._client_id
+      or self._credential_client_secret != self._client_secret
+    ):
+      if self._credential:
+        await self._credential.close()
+      self._credential = ClientSecretCredential(
+        tenant_id=self._tenant_id,
+        client_id=self._client_id,
+        client_secret=self._client_secret,
+      )
+      self._credential_tenant_id = self._tenant_id
+      self._credential_client_id = self._client_id
+      self._credential_client_secret = self._client_secret
+
+    token = await self._credential.get_token("https://management.azure.com/.default")
+    return token.token
+
+  def _parse_retry_after(self, value: str | None, default: int = 60) -> int:
+    if not value:
+      return default
+    try:
+      parsed = int(value)
+    except ValueError:
+      return default
+    return max(1, min(parsed, 300))
+
+  async def import_cost_details(
+    self,
+    period_start: str,
+    period_end: str,
+    metric: str = "ActualCost",
+  ) -> dict:
+    if not self.db:
+      raise RuntimeError("AzureBillingImportModule requires database module")
+
+    import_recid: int | None = None
+    total_rows = 0
+    status = "failed"
+
+    try:
+      if not self._subscription_id:
+        raise ValueError("Azure billing subscription not configured")
+
+      token = await self._get_management_token()
+
+      create_res = await self.db.run(
+        create_import_request(
+          CreateImportParams(
+            source="azure_cost_details",
+            scope=f"subscriptions/{self._subscription_id}",
+            metric=metric,
+            period_start=period_start,
+            period_end=period_end,
+          ),
+        ),
+      )
+      if not create_res.rows:
+        raise RuntimeError("Failed to create finance staging import record")
+      import_recid = int(create_res.rows[0]["recid"])
+
+      url = (
+        "https://management.azure.com/subscriptions/"
+        f"{self._subscription_id}/providers/Microsoft.CostManagement/"
+        "generateCostDetailsReport?api-version=2025-03-01"
+      )
+      headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+      }
+      body = {
+        "metric": metric,
+        "timePeriod": {
+          "start": period_start,
+          "end": period_end,
+        },
+      }
+
+      async with aiohttp.ClientSession() as session:
+        async with session.post(url, headers=headers, json=body) as response:
+          if response.status != 202:
+            response_text = await response.text()
+            raise RuntimeError(
+              "Azure Cost Details report request failed "
+              f"({response.status}): {response_text}",
+            )
+          location = response.headers.get("Location")
+          retry_after = self._parse_retry_after(response.headers.get("Retry-After"))
+          if not location:
+            raise RuntimeError("Azure Cost Details report response missing Location header")
+
+        manifest: dict | None = None
+        while True:
+          await asyncio.sleep(retry_after)
+          async with session.get(location, headers=headers) as poll_response:
+            poll_payload = await poll_response.json(content_type=None)
+            if poll_response.status >= 400:
+              raise RuntimeError(
+                "Azure Cost Details poll failed "
+                f"({poll_response.status}): {poll_payload}",
+              )
+            poll_status = (poll_payload.get("status") or "").strip()
+            retry_after = self._parse_retry_after(poll_response.headers.get("Retry-After"))
+            if poll_status == "Completed":
+              manifest = poll_payload.get("manifest") or {}
+              break
+            if poll_status == "Failed":
+              error_payload = poll_payload.get("error") or poll_payload
+              raise RuntimeError(f"Azure Cost Details report failed: {error_payload}")
+
+        blobs = manifest.get("blobs") if isinstance(manifest, dict) else None
+        if not isinstance(blobs, list) or not blobs:
+          raise RuntimeError("Azure Cost Details manifest missing blobs")
+        blob_link = blobs[0].get("blobLink") if isinstance(blobs[0], dict) else None
+        if not blob_link:
+          raise RuntimeError("Azure Cost Details blob link missing from manifest")
+
+        async with session.get(blob_link) as blob_response:
+          if blob_response.status >= 400:
+            response_text = await blob_response.text()
+            raise RuntimeError(
+              "Azure Cost Details blob download failed "
+              f"({blob_response.status}): {response_text}",
+            )
+          csv_text = await blob_response.text()
+
+      csv_reader = csv.DictReader(io.StringIO(csv_text))
+      batch: list[dict[str, object]] = []
+      for row in csv_reader:
+        clean_row = {key: value for key, value in row.items() if key}
+        batch.append(clean_row)
+        if len(batch) >= 100:
+          await self.db.run(
+            insert_cost_detail_batch_request(
+              InsertCostDetailBatchParams(imports_recid=import_recid, rows=batch),
+            ),
+          )
+          total_rows += len(batch)
+          batch = []
+
+      if batch:
+        await self.db.run(
+          insert_cost_detail_batch_request(
+            InsertCostDetailBatchParams(imports_recid=import_recid, rows=batch),
+          ),
+        )
+        total_rows += len(batch)
+
+      await self.db.run(
+        update_import_status_request(
+          UpdateImportStatusParams(
+            recid=import_recid,
+            status=1,
+            row_count=total_rows,
+            error=None,
+          ),
+        ),
+      )
+      status = "completed"
+      return {
+        "import_recid": import_recid,
+        "status": status,
+        "row_count": total_rows,
+      }
+    except Exception as exc:
+      logging.exception("[AzureBillingImportModule] Cost details import failed")
+      if import_recid and self.db:
+        try:
+          await self.db.run(
+            update_import_status_request(
+              UpdateImportStatusParams(
+                recid=import_recid,
+                status=2,
+                row_count=total_rows,
+                error=str(exc),
+              ),
+            ),
+          )
+        except Exception:
+          logging.exception("[AzureBillingImportModule] Failed to update import failure status")
+      raise


### PR DESCRIPTION
### Motivation

- Introduce a staging subdomain for finance to support ingestion and temporary storage of cost detail data prior to downstream processing.
- Provide MSSQL-backed service implementations and request builders to create imports, insert cost detail batches, list imports, and update import status.
- Add a server module to import Azure Cost Details reports, poll for report completion, download CSV blobs, and push rows into the staging registry.

### Description

- Register the new `staging` subdomain handler by adding `handle_staging_request` to the finance `HANDLERS` mapping and implementing `queryregistry/finance/staging/handler.py` with dispatcher logic using `dispatch_subdomain_request`.
- Add request builders in `queryregistry/finance/staging/__init__.py` and Pydantic parameter models in `queryregistry/finance/staging/models.py` for `create_import`, `insert_cost_detail_batch`, `list_imports`, `list_cost_details_by_import`, and `update_import_status` operations.
- Implement service dispatchers in `queryregistry/finance/staging/services.py` that validate incoming `DBRequest` payloads and route to provider-specific implementations, and add MSSQL implementations in `queryregistry/finance/staging/mssql.py` that perform the actual SQL operations including dynamic column handling for cost detail rows.
- Add `server/modules/azure_billing_import_module.py` which implements `AzureBillingImportModule` to retrieve config, obtain an Azure Management token via `ClientSecretCredential`, request and poll the Cost Details report, download the CSV blob, batch rows, and call `create_import_request`, `insert_cost_detail_batch_request`, and `update_import_status_request` to persist staging data.

### Testing

- No automated tests were run as part of this change.
- No new unit or integration tests were added for the staging services or the Azure import module in this PR.
- Recommend adding unit tests for `mssql` SQL generation and parsing logic and integration tests for `AzureBillingImportModule` to validate polling, CSV parsing, and batch inserts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b318426f9483259b67372e60a582db)