### PR TITLE
Add finance.staging RPC endpoints and Billing Import tab

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -278,3 +278,15 @@ Currently exposes Discord command, chat, persona, and Bluesky bridge operations.
 !summarize 24
 ```
 Summarize the last 24 hours of messages in the current channel and send the result as a DM.
+
+## Finance Domain
+
+All Finance domain calls require `ROLE_FINANCE_ADMIN`.
+
+### `staging`
+
+| Operation | Description |
+| --- | --- |
+| `urn:finance:staging:import:1` | Trigger an Azure billing cost-details import for a date range. |
+| `urn:finance:staging:list_imports:1` | List finance staging import batches. |
+| `urn:finance:staging:list_details:1` | List imported cost detail rows for a staging import batch. |

--- a/frontend/src/pages/finance/FinanceAdminPage.tsx
+++ b/frontend/src/pages/finance/FinanceAdminPage.tsx
@@ -64,6 +64,20 @@ type FinanceDimension = {
 	status: number;
 };
 
+type StagingImport = {
+	recid: number;
+	source: string;
+	scope: string | null;
+	metric: string;
+	period_start: string;
+	period_end: string;
+	row_count: number;
+	status: number;
+	error: string | null;
+	created_on: string;
+	modified_on: string;
+};
+
 const ACCOUNT_TYPES: { value: number; label: string }[] = [
 	{ value: 0, label: "Asset" },
 	{ value: 1, label: "Liability" },
@@ -109,6 +123,12 @@ const FinanceAdminPage = (): JSX.Element => {
 		description: "",
 		status: 1,
 	});
+	const [importStartDate, setImportStartDate] = useState("");
+	const [importEndDate, setImportEndDate] = useState("");
+	const [importing, setImporting] = useState(false);
+	const [imports, setImports] = useState<StagingImport[]>([]);
+	const [selectedImport, setSelectedImport] = useState<number | null>(null);
+	const [importDetails, setImportDetails] = useState<Record<string, any>[]>([]);
 
 	const loadPeriods = useCallback(async (): Promise<void> => {
 		const res = await rpcCall<{ periods: FinancePeriod[] }>("urn:finance:periods:list:1");
@@ -130,6 +150,11 @@ const FinanceAdminPage = (): JSX.Element => {
 		setDimensions(res.dimensions || []);
 	}, []);
 
+	const loadImports = useCallback(async (): Promise<void> => {
+		const res = await rpcCall<{ imports: StagingImport[] }>("urn:finance:staging:list_imports:1");
+		setImports(res.imports || []);
+	}, []);
+
 	const loadAll = useCallback(async (): Promise<void> => {
 		try {
 			await Promise.all([loadPeriods(), loadAccounts(), loadNumbers(), loadDimensions()]);
@@ -146,6 +171,13 @@ const FinanceAdminPage = (): JSX.Element => {
 	useEffect(() => {
 		void loadAll();
 	}, [loadAll]);
+
+	useEffect(() => {
+		if (tab !== 4) {
+			return;
+		}
+		void loadImports();
+	}, [tab, loadImports]);
 
 	if (forbidden) {
 		return (
@@ -164,6 +196,7 @@ const FinanceAdminPage = (): JSX.Element => {
 				<Tab label="Chart of Accounts" />
 				<Tab label="Number Sequences" />
 				<Tab label="Financial Dimensions" />
+				<Tab label="Billing Import" />
 			</Tabs>
 
 			{tab === 0 && (
@@ -378,6 +411,120 @@ const FinanceAdminPage = (): JSX.Element => {
 							))}
 						</TableBody>
 					</Table>
+				</Stack>
+			)}
+
+			{tab === 4 && (
+				<Stack spacing={2} sx={{ mt: 2 }}>
+					<Paper sx={{ p: 2 }}>
+						<Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+							<TextField
+								label="Start Date (YYYY-MM-DD)"
+								value={importStartDate}
+								onChange={(e) => setImportStartDate(e.target.value)}
+							/>
+							<TextField
+								label="End Date (YYYY-MM-DD)"
+								value={importEndDate}
+								onChange={(e) => setImportEndDate(e.target.value)}
+							/>
+							<Button
+								variant="contained"
+								disabled={importing}
+								onClick={async () => {
+									setImporting(true);
+									try {
+										await rpcCall("urn:finance:staging:import:1", {
+											period_start: importStartDate,
+											period_end: importEndDate,
+										});
+										await loadImports();
+									} finally {
+										setImporting(false);
+									}
+								}}
+							>
+								{importing ? "Importing..." : "Import"}
+							</Button>
+						</Stack>
+					</Paper>
+
+					<Table size="small">
+						<TableHead>
+							<TableRow>
+								<TableCell>RecId</TableCell>
+								<TableCell>Source</TableCell>
+								<TableCell>Metric</TableCell>
+								<TableCell>Period Start</TableCell>
+								<TableCell>Period End</TableCell>
+								<TableCell>Rows</TableCell>
+								<TableCell>Status</TableCell>
+								<TableCell>Error</TableCell>
+								<TableCell>Created On</TableCell>
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							{imports.map((row) => (
+								<TableRow
+									hover
+									key={row.recid}
+									selected={selectedImport === row.recid}
+									sx={{ cursor: "pointer" }}
+									onClick={async () => {
+										setSelectedImport(row.recid);
+										const details = await rpcCall<Record<string, any>[]>("urn:finance:staging:list_details:1", {
+											imports_recid: row.recid,
+										});
+										setImportDetails(details || []);
+									}}
+								>
+									<TableCell>{row.recid}</TableCell>
+									<TableCell>{row.source}</TableCell>
+									<TableCell>{row.metric}</TableCell>
+									<TableCell>{row.period_start}</TableCell>
+									<TableCell>{row.period_end}</TableCell>
+									<TableCell>{row.row_count}</TableCell>
+									<TableCell>{row.status === 0 ? "Pending" : row.status === 1 ? "Completed" : row.status === 2 ? "Failed" : row.status}</TableCell>
+									<TableCell>{row.error ? `${row.error.slice(0, 80)}${row.error.length > 80 ? "..." : ""}` : ""}</TableCell>
+									<TableCell>{row.created_on}</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+
+					{selectedImport !== null && (
+						<Stack spacing={1}>
+							<Typography variant="h6">
+								Import #{selectedImport} — {imports.find((row) => row.recid === selectedImport)?.row_count || 0} rows
+							</Typography>
+							<Table size="small">
+								<TableHead>
+									<TableRow>
+										<TableCell>Date</TableCell>
+										<TableCell>Subscription</TableCell>
+										<TableCell>Resource Group</TableCell>
+										<TableCell>Meter Category</TableCell>
+										<TableCell>Quantity</TableCell>
+										<TableCell>Cost</TableCell>
+										<TableCell>Currency</TableCell>
+									</TableRow>
+								</TableHead>
+								<TableBody>
+									{importDetails.slice(0, 50).map((detail, index) => (
+										<TableRow key={`${selectedImport}-${index}`}>
+											<TableCell>{detail.element_Date}</TableCell>
+											<TableCell>{detail.element_SubscriptionName}</TableCell>
+											<TableCell>{detail.element_ResourceGroup}</TableCell>
+											<TableCell>{detail.element_MeterCategory}</TableCell>
+											<TableCell>{detail.element_Quantity}</TableCell>
+											<TableCell>{detail.element_CostInBillingCurrency}</TableCell>
+											<TableCell>{detail.element_BillingCurrency}</TableCell>
+										</TableRow>
+									))}
+								</TableBody>
+							</Table>
+						</Stack>
+					)}
 				</Stack>
 			)}
 		</Box>

--- a/rpc/finance/__init__.py
+++ b/rpc/finance/__init__.py
@@ -2,6 +2,7 @@ from .accounts.handler import handle_accounts_request
 from .dimensions.handler import handle_dimensions_request
 from .numbers.handler import handle_numbers_request
 from .periods.handler import handle_periods_request
+from .staging.handler import handle_staging_request
 
 
 HANDLERS: dict[str, callable] = {
@@ -9,6 +10,7 @@ HANDLERS: dict[str, callable] = {
   "dimensions": handle_dimensions_request,
   "numbers": handle_numbers_request,
   "periods": handle_periods_request,
+  "staging": handle_staging_request,
 }
 
 
@@ -17,6 +19,7 @@ REQUIRED_ROLES: dict[str, str] = {
   "dimensions": "ROLE_FINANCE_ADMIN",
   "numbers": "ROLE_FINANCE_ADMIN",
   "periods": "ROLE_FINANCE_ADMIN",
+  "staging": "ROLE_FINANCE_ADMIN",
 }
 
 
@@ -25,4 +28,5 @@ FORBIDDEN_DETAILS: dict[str, str] = {
   "dimensions": "Forbidden",
   "numbers": "Forbidden",
   "periods": "Forbidden",
+  "staging": "Forbidden",
 }

--- a/rpc/finance/staging/__init__.py
+++ b/rpc/finance/staging/__init__.py
@@ -1,0 +1,12 @@
+from .services import (
+  finance_staging_import_v1,
+  finance_staging_list_details_v1,
+  finance_staging_list_imports_v1,
+)
+
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("import", "1"): finance_staging_import_v1,
+  ("list_imports", "1"): finance_staging_list_imports_v1,
+  ("list_details", "1"): finance_staging_list_details_v1,
+}

--- a/rpc/finance/staging/handler.py
+++ b/rpc/finance/staging/handler.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_staging_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/finance/staging/models.py
+++ b/rpc/finance/staging/models.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel
+
+
+class StagingImport1(BaseModel):
+  period_start: str
+  period_end: str
+  metric: str = "ActualCost"
+
+
+class StagingImportResult1(BaseModel):
+  import_recid: int
+  status: str
+  row_count: int
+
+
+class StagingImportItem1(BaseModel):
+  recid: int
+  source: str
+  scope: str | None = None
+  metric: str
+  period_start: str
+  period_end: str
+  row_count: int
+  status: int
+  error: str | None = None
+  created_on: str
+  modified_on: str
+
+
+class StagingImportList1(BaseModel):
+  imports: list[StagingImportItem1]
+
+
+class StagingListDetails1(BaseModel):
+  imports_recid: int
+

--- a/rpc/finance/staging/services.py
+++ b/rpc/finance/staging/services.py
@@ -1,0 +1,52 @@
+from fastapi import Request
+
+from queryregistry.finance.staging import list_cost_details_by_import_request, list_imports_request
+from queryregistry.finance.staging.models import ListCostDetailsByImportParams, ListImportsParams
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.db_module import DbModule
+
+from .models import (
+  StagingImport1,
+  StagingImportItem1,
+  StagingImportList1,
+  StagingImportResult1,
+  StagingListDetails1,
+)
+
+
+async def finance_staging_import_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  payload = StagingImport1(**(rpc_request.payload or {}))
+  module = request.app.state.azure_billing_import
+  await module.on_ready()
+  result = await module.import_cost_details(
+    payload.period_start,
+    payload.period_end,
+    payload.metric,
+  )
+  response_payload = StagingImportResult1(**result)
+  return RPCResponse(op=rpc_request.op, payload=response_payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_staging_list_imports_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  result = await db.run(list_imports_request(ListImportsParams()))
+  imports = [StagingImportItem1(**row) for row in (result.rows or [])]
+  response_payload = StagingImportList1(imports=imports)
+  return RPCResponse(op=rpc_request.op, payload=response_payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_staging_list_details_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  payload = StagingListDetails1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  result = await db.run(
+    list_cost_details_by_import_request(
+      ListCostDetailsByImportParams(imports_recid=payload.imports_recid),
+    ),
+  )
+  return RPCResponse(op=rpc_request.op, payload=(result.rows or []), version=rpc_request.version)


### PR DESCRIPTION
### Motivation
- Expose the existing `AzureBillingImportModule` through the RPC surface so imports can be triggered and monitored remotely. 
- Provide a simple admin UI to start imports and inspect staging batches and detail rows from the Finance admin page.

### Description
- Added a new RPC subdomain `rpc/finance/staging` with dispatcher, handler, Pydantic models, and services implementing `urn:finance:staging:import:1`, `urn:finance:staging:list_imports:1`, and `urn:finance:staging:list_details:1`. (`rpc/finance/staging/__init__.py`, `handler.py`, `models.py`, `services.py`).
- Service implementations call the `azure_billing_import` module (`import_cost_details`) for imports and `request.app.state.db` via `queryregistry.finance.staging` request builders for listing imports and details. (`rpc/finance/staging/services.py`).
- Wired the new `staging` subdomain into the finance domain dispatch and security maps using `ROLE_FINANCE_ADMIN` and the existing forbidden detail policy. (`rpc/finance/__init__.py`).
- Added a “Billing Import” tab to `FinanceAdminPage` with types/state for staging imports, an import form (start/end date + in-flight state), imports list table, and a detail view showing the first 50 rows (key columns). (`frontend/src/pages/finance/FinanceAdminPage.tsx`).
- Updated `RPC.md` and regenerated frontend RPC bindings so the new RPCs are available to the client; generator emitted `frontend/src/rpc/finance/staging/index.ts` and updated shared models. (`python scripts/generate_rpc_bindings.py`).

### Testing
- Ran `python scripts/generate_rpc_bindings.py` to extract models and generate TypeScript RPC stubs and shared types, which completed successfully and produced `frontend/src/rpc/finance/staging/index.ts` and updated `frontend/src/shared/RpcModels.tsx`.
- Executed the unified harness `python scripts/run_tests.py`, which ran the backend and frontend checks and tests; the test suite completed successfully (`67 passed`) with an environment warning about a missing local ODBC SQL driver used by an optional DB connection step (non-failing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3227293f08325ad5649e5ae7f0be8)