### PR TITLE
Register DATETIMEOFFSET output converter on MSSQL pool connections

### DIFF
--- a/server/modules/providers/database/mssql_provider/logic.py
+++ b/server/modules/providers/database/mssql_provider/logic.py
@@ -1,9 +1,36 @@
 # providers/database/mssql_provider/logic.py
 import aioodbc, logging
+import struct
+from datetime import datetime, timedelta, timezone
 from contextlib import asynccontextmanager
 from typing import Callable, Optional
 
 _pool: aioodbc.pool.Pool | None = None
+
+
+def _handle_datetimeoffset(dto_value):
+  """Convert raw DATETIMEOFFSET bytes to an ISO 8601 string.
+
+  pyodbc receives DATETIMEOFFSET as raw bytes with the struct format
+  ``<6hI2h`` (20 bytes): year, month, day, hour, minute, second,
+  nanoseconds, offset_hours, offset_minutes.
+
+  Returns an ISO 8601 string to match the existing codebase convention
+  where all datetime values are transported as strings.
+  """
+  tup = struct.unpack("<6hI2h", dto_value)
+  dt = datetime(
+    tup[0], tup[1], tup[2],
+    tup[3], tup[4], tup[5],
+    tup[6] // 1000,
+    tzinfo=timezone(timedelta(hours=tup[7], minutes=tup[8])),
+  )
+  return dt.isoformat()
+
+
+async def _on_connection_created(conn):
+  """Register custom type converters on new pool connections."""
+  await conn.add_output_converter(-155, _handle_datetimeoffset)
 
 
 def _parse_dsn_info(dsn: str) -> dict[str, str]:
@@ -32,7 +59,9 @@ async def init_pool(*, dsn: str | None = None, **cfg):
   server = info.get("server", "unknown")
   database = info.get("database", "unknown")
   driver = info.get("driver", "unknown")
-  _pool = await aioodbc.create_pool(dsn=dsn, autocommit=True)
+  _pool = await aioodbc.create_pool(
+    dsn=dsn, autocommit=True, after_created=_on_connection_created,
+  )
   logging.info(
     "MSSQL ODBC Connection Pool Created: server=%s database=%s driver=%s",
     server,


### PR DESCRIPTION
### Motivation
- The `pyodbc`/`aioodbc` stack raises `ProgrammingError` for MSSQL `DATETIMEOFFSET` (ODBC type `-155`) because no output converter is registered.  
- Converting `datetimeoffset` columns in every query is fragile, so the pool should automatically handle the type at the connection level.

### Description
- Added `struct` and `datetime`-related imports and a module-level `_handle_datetimeoffset` function that decodes raw ODBC `DATETIMEOFFSET` bytes using the struct format `"<6hI2h"` and returns an ISO 8601 string.  
- Added an async `_on_connection_created(conn)` callback that registers the converter via `conn.add_output_converter(-155, _handle_datetimeoffset)`.  
- Wired the callback into the pool creation by passing `after_created=_on_connection_created` to `aioodbc.create_pool(...)` while preserving the existing `dsn` and `autocommit=True` settings in `init_pool`.  
- Change is limited to `server/modules/providers/database/mssql_provider/logic.py` and does not modify pool semantics beyond adding the `after_created` hook.

### Testing
- Ran `python -m py_compile server/modules/providers/database/mssql_provider/logic.py` and the file compiled successfully.  
- No other automated test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3424c71e48325ab4844810b98bffb)