### PR TITLE
Fix finance staging import/list payload mapping

### DIFF
--- a/queryregistry/finance/staging/mssql.py
+++ b/queryregistry/finance/staging/mssql.py
@@ -30,6 +30,20 @@ def _to_element_column_name(field_name: str) -> str:
 
 async def create_import_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
+    DECLARE @inserted TABLE (
+      recid bigint,
+      element_source nvarchar(max),
+      element_scope nvarchar(max),
+      element_metric nvarchar(max),
+      element_period_start date,
+      element_period_end date,
+      element_status int,
+      element_row_count int,
+      element_error nvarchar(max),
+      element_created_on datetimeoffset,
+      element_modified_on datetimeoffset
+    );
+
     INSERT INTO finance_staging_imports (
       element_source,
       element_scope,
@@ -42,8 +56,24 @@ async def create_import_v1(args: Mapping[str, Any]) -> DBResponse:
       element_created_on,
       element_modified_on
     )
-    OUTPUT inserted.*
+    OUTPUT
+      inserted.recid,
+      inserted.element_source,
+      inserted.element_scope,
+      inserted.element_metric,
+      inserted.element_period_start,
+      inserted.element_period_end,
+      inserted.element_status,
+      inserted.element_row_count,
+      inserted.element_error,
+      inserted.element_created_on,
+      inserted.element_modified_on
+    INTO @inserted
     VALUES (?, ?, ?, ?, ?, 0, 0, NULL, SYSUTCDATETIME(), SYSUTCDATETIME());
+
+    SELECT *
+    FROM @inserted
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
   """
   params = (
     args["source"],
@@ -100,16 +130,16 @@ async def list_imports_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
     SELECT
       recid,
-      element_source,
-      element_scope,
-      element_metric,
-      element_period_start,
-      element_period_end,
-      element_status,
-      element_row_count,
-      element_error,
-      element_created_on,
-      element_modified_on
+      element_source AS source,
+      element_scope AS scope,
+      element_metric AS metric,
+      element_period_start AS period_start,
+      element_period_end AS period_end,
+      element_status AS status,
+      element_row_count AS row_count,
+      element_error AS error,
+      element_created_on AS created_on,
+      element_modified_on AS modified_on
     FROM finance_staging_imports
     ORDER BY recid DESC
     FOR JSON PATH, INCLUDE_NULL_VALUES;

--- a/tests/test_queryregistry_finance_staging_mssql.py
+++ b/tests/test_queryregistry_finance_staging_mssql.py
@@ -1,0 +1,55 @@
+import asyncio
+
+from queryregistry.finance.staging import mssql
+
+
+def test_list_imports_v1_maps_element_columns_to_rpc_shape(monkeypatch):
+  captured = {}
+
+  async def fake_run_json_many(sql, params=()):
+    captured['sql'] = sql
+    captured['params'] = params
+    return {'rows': []}
+
+  monkeypatch.setattr(mssql, 'run_json_many', fake_run_json_many)
+
+  asyncio.run(mssql.list_imports_v1({}))
+
+  sql = captured['sql']
+  assert 'element_source AS source' in sql
+  assert 'element_metric AS metric' in sql
+  assert 'element_period_start AS period_start' in sql
+  assert captured['params'] == ()
+
+
+def test_create_import_v1_returns_json_payload(monkeypatch):
+  captured = {}
+
+  async def fake_run_json_one(sql, params=()):
+    captured['sql'] = sql
+    captured['params'] = params
+    return {'rows': [{'recid': 1}]}
+
+  monkeypatch.setattr(mssql, 'run_json_one', fake_run_json_one)
+
+  args = {
+    'source': 'azure_cost_details',
+    'scope': 'subscriptions/sub-id',
+    'metric': 'ActualCost',
+    'period_start': '2024-01-01',
+    'period_end': '2024-01-31',
+  }
+
+  result = asyncio.run(mssql.create_import_v1(args))
+
+  sql = captured['sql']
+  assert 'FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES' in sql
+  assert 'INTO @inserted' in sql
+  assert captured['params'] == (
+    'azure_cost_details',
+    'subscriptions/sub-id',
+    'ActualCost',
+    '2024-01-01',
+    '2024-01-31',
+  )
+  assert result == {'rows': [{'recid': 1}]}


### PR DESCRIPTION
### Motivation
- Fix Pydantic validation failures when listing staging imports by returning fields with the RPC-expected names and shapes. 
- Prevent `fetch_json` from failing when `OUTPUT inserted.*` yields non-string parts by producing a JSON payload server-side.

### Description
- Updated `queryregistry/finance/staging/mssql.py` `create_import_v1` to capture the inserted row into a table variable and return it with `FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES` so the provider returns a well-formed JSON string.
- Aliased `element_*` columns to RPC payload names in `list_imports_v1` (e.g. `element_source AS source`, `element_period_start AS period_start`, etc.) to match `StagingImportItem1` expectations.
- Added `tests/test_queryregistry_finance_staging_mssql.py` with two regression tests that assert the SQL shape/aliases and parameter ordering used by `create_import_v1` and `list_imports_v1`.

### Testing
- Ran `pytest -q tests/test_queryregistry_finance_staging_mssql.py` which executed the two new tests and they both passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b34f087e648325a3ed7c3d4d3ef837)