### PR TITLE
Align finance staging imports to element_ columns and enable NOCOUNT

### DIFF
--- a/frontend/src/pages/finance/FinanceAdminPage.tsx
+++ b/frontend/src/pages/finance/FinanceAdminPage.tsx
@@ -66,16 +66,16 @@ type FinanceDimension = {
 
 type StagingImport = {
 	recid: number;
-	source: string;
-	scope: string | null;
-	metric: string;
-	period_start: string;
-	period_end: string;
-	row_count: number;
-	status: number;
-	error: string | null;
-	created_on: string;
-	modified_on: string;
+	element_source: string;
+	element_scope: string | null;
+	element_metric: string;
+	element_period_start: string;
+	element_period_end: string;
+	element_row_count: number;
+	element_status: number;
+	element_error: string | null;
+	element_created_on: string;
+	element_modified_on: string;
 };
 
 const ACCOUNT_TYPES: { value: number; label: string }[] = [
@@ -479,14 +479,14 @@ const FinanceAdminPage = (): JSX.Element => {
 									}}
 								>
 									<TableCell>{row.recid}</TableCell>
-									<TableCell>{row.source}</TableCell>
-									<TableCell>{row.metric}</TableCell>
-									<TableCell>{row.period_start}</TableCell>
-									<TableCell>{row.period_end}</TableCell>
-									<TableCell>{row.row_count}</TableCell>
-									<TableCell>{row.status === 0 ? "Pending" : row.status === 1 ? "Completed" : row.status === 2 ? "Failed" : row.status}</TableCell>
-									<TableCell>{row.error ? `${row.error.slice(0, 80)}${row.error.length > 80 ? "..." : ""}` : ""}</TableCell>
-									<TableCell>{row.created_on}</TableCell>
+									<TableCell>{row.element_source}</TableCell>
+									<TableCell>{row.element_metric}</TableCell>
+									<TableCell>{row.element_period_start}</TableCell>
+									<TableCell>{row.element_period_end}</TableCell>
+									<TableCell>{row.element_row_count}</TableCell>
+									<TableCell>{row.element_status === 0 ? "Pending" : row.element_status === 1 ? "Completed" : row.element_status === 2 ? "Failed" : row.element_status}</TableCell>
+									<TableCell>{row.element_error ? `${row.element_error.slice(0, 80)}${row.element_error.length > 80 ? "..." : ""}` : ""}</TableCell>
+									<TableCell>{row.element_created_on}</TableCell>
 								</TableRow>
 							))}
 						</TableBody>
@@ -495,7 +495,7 @@ const FinanceAdminPage = (): JSX.Element => {
 					{selectedImport !== null && (
 						<Stack spacing={1}>
 							<Typography variant="h6">
-								Import #{selectedImport} — {imports.find((row) => row.recid === selectedImport)?.row_count || 0} rows
+								Import #{selectedImport} — {imports.find((row) => row.recid === selectedImport)?.element_row_count || 0} rows
 							</Typography>
 							<Table size="small">
 								<TableHead>

--- a/queryregistry/finance/staging/mssql.py
+++ b/queryregistry/finance/staging/mssql.py
@@ -30,6 +30,8 @@ def _to_element_column_name(field_name: str) -> str:
 
 async def create_import_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
+    SET NOCOUNT ON;
+
     DECLARE @inserted TABLE (
       recid bigint,
       element_source nvarchar(max),
@@ -130,16 +132,16 @@ async def list_imports_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
     SELECT
       recid,
-      element_source AS source,
-      element_scope AS scope,
-      element_metric AS metric,
-      element_period_start AS period_start,
-      element_period_end AS period_end,
-      element_status AS status,
-      element_row_count AS row_count,
-      element_error AS error,
-      element_created_on AS created_on,
-      element_modified_on AS modified_on
+      element_source,
+      element_scope,
+      element_metric,
+      element_period_start,
+      element_period_end,
+      element_status,
+      element_row_count,
+      element_error,
+      element_created_on,
+      element_modified_on
     FROM finance_staging_imports
     ORDER BY recid DESC
     FOR JSON PATH, INCLUDE_NULL_VALUES;

--- a/rpc/finance/staging/models.py
+++ b/rpc/finance/staging/models.py
@@ -15,16 +15,16 @@ class StagingImportResult1(BaseModel):
 
 class StagingImportItem1(BaseModel):
   recid: int
-  source: str
-  scope: str | None = None
-  metric: str
-  period_start: str
-  period_end: str
-  row_count: int
-  status: int
-  error: str | None = None
-  created_on: str
-  modified_on: str
+  element_source: str
+  element_scope: str | None = None
+  element_metric: str
+  element_period_start: str
+  element_period_end: str
+  element_row_count: int
+  element_status: int
+  element_error: str | None = None
+  element_created_on: str | None = None
+  element_modified_on: str | None = None
 
 
 class StagingImportList1(BaseModel):


### PR DESCRIPTION
### Motivation
- Remove SQL column aliases so the staging queries return canonical `element_*` database column names per repository conventions.
- Prevent INSERT rowcount messages from interfering with JSON output by enabling `SET NOCOUNT ON` in the import creation path.
- Keep RPC models and frontend types aligned with the database column names so callers consume the real column keys.

### Description
- Added `SET NOCOUNT ON;` at the top of `create_import_v1` to suppress rowcount messages in the returned JSON from the INSERT/OUTPUT flow in `queryregistry/finance/staging/mssql.py`.
- Removed all `AS` aliases from the `list_imports_v1` SQL so the query now returns `element_source`, `element_scope`, `element_metric`, `element_period_start`, `element_period_end`, `element_status`, `element_row_count`, `element_error`, `element_created_on`, and `element_modified_on` directly.
- Updated the RPC model `StagingImportItem1` in `rpc/finance/staging/models.py` to use `element_*` field names and made `element_created_on` and `element_modified_on` nullable (`str | None = None`).
- Updated the frontend `StagingImport` type and all table/detail references in `frontend/src/pages/finance/FinanceAdminPage.tsx` to use the `element_` prefixed properties, including the selected import row count lookup.

### Testing
- Ran Python syntax check with `python -m py_compile queryregistry/finance/staging/mssql.py rpc/finance/staging/models.py` and it succeeded.
- Ran frontend type checking with `npm --prefix frontend run type-check` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b35588af648325a6fe1bdec51e3ee6)