### PR TITLE
Fix staging MSSQL import SQL alias assertions

### DIFF
--- a/tests/test_queryregistry_finance_staging_mssql.py
+++ b/tests/test_queryregistry_finance_staging_mssql.py
@@ -16,9 +16,12 @@ def test_list_imports_v1_maps_element_columns_to_rpc_shape(monkeypatch):
   asyncio.run(mssql.list_imports_v1({}))
 
   sql = captured['sql']
-  assert 'element_source AS source' in sql
-  assert 'element_metric AS metric' in sql
-  assert 'element_period_start AS period_start' in sql
+  assert 'element_source' in sql
+  assert 'AS source' not in sql
+  assert 'element_metric' in sql
+  assert 'AS metric' not in sql
+  assert 'element_period_start' in sql
+  assert 'AS period_start' not in sql
   assert captured['params'] == ()
 
 


### PR DESCRIPTION
### Motivation
- The staging MSSQL code no longer emits column aliases, so the test must assert raw database column names are present and that `AS ...` aliases are absent.

### Description
- Update `test_list_imports_v1_maps_element_columns_to_rpc_shape` in `tests/test_queryregistry_finance_staging_mssql.py` to assert that `element_source`, `element_metric`, and `element_period_start` appear in the generated SQL and that `AS source`, `AS metric`, and `AS period_start` do not, leaving other tests unchanged.

### Testing
- Ran `pytest -q tests/test_queryregistry_finance_staging_mssql.py` which completed successfully (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b35b8d02888325aaec0a143a8ed168)