### PR TITLE
Add migration for missing Azure Cost Details staging columns

### DIFF
--- a/v0.8.3.1_20260312.sql
+++ b/v0.8.3.1_20260312.sql
@@ -1,0 +1,11 @@
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+
+ALTER TABLE [dbo].[finance_staging_cost_details]
+    ADD [element_resourceGroupName] NVARCHAR(512) NULL;
+
+ALTER TABLE [dbo].[finance_staging_cost_details]
+    ADD [element_location] NVARCHAR(256) NULL;
+
+ALTER TABLE [dbo].[finance_staging_cost_details]
+    ADD [element_provider] NVARCHAR(256) NULL;


### PR DESCRIPTION
### Motivation

- The Azure Cost Details CSV includes fields that are used directly as `element_`-prefixed column names by the dynamic INSERT logic, and the staging table lacked matching columns causing ingestion issues.
- The new columns must exactly match the CSV header casing so the existing `_to_element_column_name` behavior continues to work without code changes.

### Description

- Add new root-level migration `v0.8.3.1_20260312.sql` to the repository.
- The migration sets `ANSI_NULLS` and `QUOTED_IDENTIFIER` and alters `[dbo].[finance_staging_cost_details]` to add `element_resourceGroupName` (`NVARCHAR(512) NULL`), `element_location` (`NVARCHAR(256) NULL`), and `element_provider` (`NVARCHAR(256) NULL`).
- No Python or other source files were modified and no existing column names or casing were changed.

### Testing

- Verified the new file contents with `sed -n '1,120p' v0.8.3.1_20260312.sql` which printed the expected SQL statements successfully.
- Inspected the file with `nl -ba v0.8.3.1_20260312.sql` to confirm line layout and content successfully.
- Added and committed the migration using `git add` and `git commit`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b36968a4e08325bc2d7c402f033b7d)