### PR TITLE
Fix Discord bot auth by adding sessionless security lookup

### DIFF
--- a/migrations/v0.8.4.0_discord_auth_view.sql
+++ b/migrations/v0.8.4.0_discord_auth_view.sql
@@ -1,0 +1,22 @@
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+-- ============================================================================
+-- v0.8.4.0 Discord Auth View
+-- ============================================================================
+
+CREATE VIEW [dbo].[vw_user_discord_security] AS
+SELECT
+  au.element_guid AS user_guid,
+  ur.element_roles AS user_roles,
+  ua.element_identifier AS discord_identifier,
+  ap.element_name AS provider_name,
+  ua.element_linked AS is_linked
+FROM dbo.account_users AS au
+JOIN dbo.users_roles AS ur ON au.element_guid = ur.users_guid
+JOIN dbo.users_auth AS ua ON ua.users_guid = au.element_guid
+JOIN dbo.auth_providers AS ap ON ap.recid = ua.providers_recid
+WHERE ap.element_name = 'discord'
+  AND ua.element_linked = 1;
+GO

--- a/queryregistry/identity/accounts/__init__.py
+++ b/queryregistry/identity/accounts/__init__.py
@@ -6,8 +6,15 @@ from queryregistry.models import DBRequest
 
 from .models import AccountExistsRequestPayload
 
-__all__ = ["account_exists_request"]
+__all__ = ["account_exists_request", "read_by_discord_request"]
 
 
 def account_exists_request(params: AccountExistsRequestPayload) -> DBRequest:
   return DBRequest(op="db:identity:accounts:exists:1", payload=dict(params))
+
+
+def read_by_discord_request(discord_id: str) -> DBRequest:
+  return DBRequest(
+    op="db:identity:accounts:read_by_discord:1",
+    payload={"discord_id": discord_id},
+  )

--- a/queryregistry/identity/accounts/handler.py
+++ b/queryregistry/identity/accounts/handler.py
@@ -7,13 +7,14 @@ from typing import Sequence
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
 
-from .services import account_exists_v1, read_accounts_v1
+from .services import account_exists_v1, read_accounts_v1, read_discord_security_v1
 
 __all__ = ["handle_accounts_request"]
 
 DISPATCHERS = {
   ("read", "1"): read_accounts_v1,
   ("exists", "1"): account_exists_v1,
+  ("read_by_discord", "1"): read_discord_security_v1,
 }
 
 

--- a/queryregistry/identity/accounts/models.py
+++ b/queryregistry/identity/accounts/models.py
@@ -12,6 +12,9 @@ __all__ = [
   "AccountExistsPayload",
   "AccountExistsRequestPayload",
   "AccountsReadCallable",
+  "DiscordSecurityCallable",
+  "DiscordSecurityPayload",
+  "DiscordSecurityRequestPayload",
   "SecurityProfilePayload",
   "SecurityProfileRequestPayload",
 ]
@@ -63,6 +66,17 @@ class SecurityProfilePayload(TypedDict, total=False):
   extra: dict[str, Any]
 
 
+
+
+class DiscordSecurityRequestPayload(TypedDict):
+  discord_id: str
+
+
+class DiscordSecurityPayload(TypedDict, total=False):
+  user_guid: str
+  user_roles: int
+
+
 class AccountExistsRequestPayload(TypedDict):
   user_guid: str
 
@@ -73,3 +87,4 @@ class AccountExistsPayload(TypedDict):
 
 AccountsReadCallable = Callable[[SecurityProfileRequestPayload], Awaitable[DBResponse]]
 AccountExistsCallable = Callable[[AccountExistsRequestPayload], Awaitable[DBResponse]]
+DiscordSecurityCallable = Callable[[DiscordSecurityRequestPayload], Awaitable[DBResponse]]

--- a/queryregistry/identity/accounts/mssql.py
+++ b/queryregistry/identity/accounts/mssql.py
@@ -10,10 +10,15 @@ from queryregistry.providers.mssql import run_json_one
 
 from queryregistry.models import DBResponse
 
-from .models import AccountExistsRequestPayload, SecurityProfileRequestPayload
+from .models import (
+  AccountExistsRequestPayload,
+  DiscordSecurityRequestPayload,
+  SecurityProfileRequestPayload,
+)
 
 __all__ = [
   "account_exists",
+  "get_by_discord_id",
   "get_security_profile",
 ]
 
@@ -141,3 +146,26 @@ async def account_exists(args: AccountExistsRequestPayload) -> DBResponse:
   """
   response = await run_json_one(sql, (guid,))
   return DBResponse(payload=response.payload)
+
+
+async def get_by_discord_id(params: DiscordSecurityRequestPayload) -> DBResponse:
+  """Look up a user's GUID and role mask by Discord numeric ID.
+
+  The Discord auth provider stores identifiers as
+  uuid5(NAMESPACE_URL, f"discord:{discord_id}") — the prefix is
+  required to match.
+  """
+  from uuid import NAMESPACE_URL, uuid5
+
+  discord_id = str(params["discord_id"])
+  identifier = str(UUID(str(uuid5(NAMESPACE_URL, f"discord:{discord_id}"))))
+
+  sql = """
+    SELECT TOP 1
+      user_guid,
+      user_roles
+    FROM vw_user_discord_security
+    WHERE discord_identifier = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (identifier,))

--- a/queryregistry/identity/accounts/services.py
+++ b/queryregistry/identity/accounts/services.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from queryregistry.models import DBRequest, DBResponse
 
 from . import mssql
-from .models import AccountExistsCallable, AccountsReadCallable
+from .models import AccountExistsCallable, AccountsReadCallable, DiscordSecurityCallable
 
 __all__ = [
   "account_exists_v1",
   "read_accounts_v1",
+  "read_discord_security_v1",
 ]
 
 _READ_DISPATCHERS: dict[str, AccountsReadCallable] = {
@@ -18,6 +19,11 @@ _READ_DISPATCHERS: dict[str, AccountsReadCallable] = {
 
 _EXISTS_DISPATCHERS: dict[str, AccountExistsCallable] = {
   "mssql": mssql.account_exists,
+}
+
+
+_DISCORD_SECURITY_DISPATCHERS: dict[str, DiscordSecurityCallable] = {
+  "mssql": mssql.get_by_discord_id,
 }
 
 
@@ -39,6 +45,18 @@ async def account_exists_v1(
   provider: str,
 ) -> DBResponse:
   dispatcher = _EXISTS_DISPATCHERS.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity accounts registry")
+  result = await dispatcher(request.payload)
+  return DBResponse(op=request.op, payload=result.payload)
+
+
+async def read_discord_security_v1(
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  dispatcher = _DISCORD_SECURITY_DISPATCHERS.get(provider)
   if dispatcher is None:
     raise KeyError(f"Unsupported provider '{provider}' for identity accounts registry")
   result = await dispatcher(request.payload)

--- a/server/modules/auth_module.py
+++ b/server/modules/auth_module.py
@@ -371,14 +371,16 @@ class AuthModule(BaseModule):
     return self.role_cache.get_role_names(exclude_registered)
 
   async def get_discord_user_security(self, discord_id: str) -> tuple[str, list[str], int]:
-    res = await self.db.run(
-      DBRequest(op="db:identity:accounts:read:1", payload={"discord_id": discord_id}),
-    )
+    from queryregistry.identity.accounts import read_by_discord_request
+
+    res = await self.db.run(read_by_discord_request(discord_id))
     rows = res.rows
     if not rows:
       return "", [], 0
     row = rows[0]
     guid = row.get("user_guid")
+    if not guid:
+      return "", [], 0
     mask = int(row.get("user_roles", 0) or 0)
     names = self.role_cache.mask_to_names(mask)
     return guid, names, mask


### PR DESCRIPTION
### Motivation
- Discord bot requests failed with 403 because the existing auth path queried `vw_user_session_security`, which INNER JOINs session tables and returns no rows for Discord-only requests.  
- The goal is to resolve a Discord-linked user's GUID and roles without requiring a web session so bot commands can authenticate correctly.  

### Description
- Add migration `migrations/v0.8.4.0_discord_auth_view.sql` which creates `vw_user_discord_security` and includes `SET ANSI_NULLS ON`, `SET QUOTED_IDENTIFIER ON`, and `GO` separators.  
- Add a new queryregistry operation `db:identity:accounts:read_by_discord:1` with request builder `read_by_discord_request`, handler dispatch entry `(

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3899878cc83258e0e54ea7222142c)