### PR TITLE
Link fiscal periods to FY number sequences and display FY-prefixed names

### DIFF
--- a/frontend/src/pages/finance/FinanceAdminPage.tsx
+++ b/frontend/src/pages/finance/FinanceAdminPage.tsx
@@ -32,7 +32,8 @@ type FinancePeriod = {
 	quarter_number: number;
 	has_closing_week: boolean;
 	status: number;
-	is_leap_adjustment: boolean;
+	numbers_recid: number | null;
+	element_display_format: string | null;
 };
 
 type FinanceAccount = {
@@ -238,20 +239,22 @@ const FinanceAdminPage = (): JSX.Element => {
 								<TableCell>Days</TableCell>
 								<TableCell>Close</TableCell>
 								<TableCell>Status</TableCell>
-								<TableCell>Leap</TableCell>
 							</TableRow>
 						</TableHead>
 						<TableBody>
 							{periods.map((item) => (
 								<TableRow key={item.guid || `${item.year}-${item.period_number}`}>
-									<TableCell>{item.period_name}</TableCell>
+									<TableCell>
+										{item.element_display_format
+											? `${item.element_display_format}-${item.period_name}`
+											: item.period_name}
+									</TableCell>
 									<TableCell>{item.quarter_number}</TableCell>
 									<TableCell>{item.start_date}</TableCell>
 									<TableCell>{item.end_date}</TableCell>
 									<TableCell>{item.days_in_period}</TableCell>
 									<TableCell>{item.has_closing_week ? "Yes" : "No"}</TableCell>
 									<TableCell>{item.status}</TableCell>
-									<TableCell>{item.is_leap_adjustment ? "Yes" : "No"}</TableCell>
 								</TableRow>
 							))}
 						</TableBody>

--- a/queryregistry/finance/numbers/__init__.py
+++ b/queryregistry/finance/numbers/__init__.py
@@ -6,6 +6,7 @@ from queryregistry.models import DBRequest
 
 from .models import (
   DeleteNumberParams,
+  GetByPrefixAndAccountNumberParams,
   GetNumberParams,
   ListNumbersParams,
   NextNumberParams,
@@ -14,6 +15,7 @@ from .models import (
 
 __all__ = [
   "delete_number_request",
+  "get_by_prefix_account_number_request",
   "get_number_request",
   "list_numbers_request",
   "next_number_request",
@@ -24,6 +26,11 @@ __all__ = [
 def list_numbers_request(params: ListNumbersParams) -> DBRequest:
   return DBRequest(op="db:finance:numbers:list:1", payload=params.model_dump())
 
+
+
+
+def get_by_prefix_account_number_request(params: GetByPrefixAndAccountNumberParams) -> DBRequest:
+  return DBRequest(op="db:finance:numbers:get_by_prefix_account:1", payload=params.model_dump())
 
 def get_number_request(params: GetNumberParams) -> DBRequest:
   return DBRequest(op="db:finance:numbers:get:1", payload=params.model_dump())

--- a/queryregistry/finance/numbers/handler.py
+++ b/queryregistry/finance/numbers/handler.py
@@ -7,13 +7,14 @@ from typing import Sequence
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
 
-from .services import delete_v1, get_v1, list_v1, next_number_v1, upsert_v1
+from .services import delete_v1, get_by_prefix_account_v1, get_v1, list_v1, next_number_v1, upsert_v1
 
 __all__ = ["handle_numbers_request"]
 
 DISPATCHERS = {
   ("list", "1"): list_v1,
   ("get", "1"): get_v1,
+  ("get_by_prefix_account", "1"): get_by_prefix_account_v1,
   ("upsert", "1"): upsert_v1,
   ("delete", "1"): delete_v1,
   ("next_number", "1"): next_number_v1,

--- a/queryregistry/finance/numbers/models.py
+++ b/queryregistry/finance/numbers/models.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict
 
 __all__ = [
   "DeleteNumberParams",
+  "GetByPrefixAndAccountNumberParams",
   "GetNumberParams",
   "ListNumbersParams",
   "NextNumberParams",
@@ -24,6 +25,13 @@ class GetNumberParams(BaseModel):
   model_config = ConfigDict(extra="forbid")
 
   recid: int
+
+
+class GetByPrefixAndAccountNumberParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  prefix: str
+  account_number: str
 
 
 class UpsertNumberParams(BaseModel):

--- a/queryregistry/finance/numbers/mssql.py
+++ b/queryregistry/finance/numbers/mssql.py
@@ -8,7 +8,7 @@ from typing import Any
 from queryregistry.models import DBResponse
 from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
 
-__all__ = ["delete_v1", "get_v1", "list_v1", "next_number_v1", "upsert_v1"]
+__all__ = ["delete_v1", "get_by_prefix_and_account_v1", "get_v1", "list_v1", "next_number_v1", "upsert_v1"]
 
 
 async def list_v1(args: Mapping[str, Any]) -> DBResponse:
@@ -35,6 +35,22 @@ async def list_v1(args: Mapping[str, Any]) -> DBResponse:
   """
   return await run_json_many(sql)
 
+
+
+
+async def get_by_prefix_and_account_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT TOP 1
+      recid,
+      element_prefix,
+      element_account_number,
+      element_display_format
+    FROM finance_numbers
+    WHERE element_prefix = ?
+      AND element_account_number = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (args["prefix"], args["account_number"]))
 
 async def get_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
@@ -77,7 +93,11 @@ async def upsert_v1(args: Mapping[str, Any]) -> DBResponse:
     ) AS source
     ON (
       (source.recid IS NOT NULL AND target.recid = source.recid)
-      OR (source.recid IS NULL AND target.accounts_guid = source.accounts_guid)
+      OR (
+        source.recid IS NULL
+        AND target.element_prefix = source.element_prefix
+        AND target.element_account_number = source.element_account_number
+      )
     )
     WHEN MATCHED THEN
       UPDATE SET

--- a/queryregistry/finance/numbers/services.py
+++ b/queryregistry/finance/numbers/services.py
@@ -10,18 +10,20 @@ from queryregistry.models import DBRequest, DBResponse
 from . import mssql
 from .models import (
   DeleteNumberParams,
+  GetByPrefixAndAccountNumberParams,
   GetNumberParams,
   ListNumbersParams,
   NextNumberParams,
   UpsertNumberParams,
 )
 
-__all__ = ["delete_v1", "get_v1", "list_v1", "next_number_v1", "upsert_v1"]
+__all__ = ["delete_v1", "get_by_prefix_account_v1", "get_v1", "list_v1", "next_number_v1", "upsert_v1"]
 
 _Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
 
 _LIST_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_v1}
 _GET_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_v1}
+_GET_BY_PREFIX_ACCOUNT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_by_prefix_and_account_v1}
 _UPSERT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_v1}
 _DELETE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_v1}
 _NEXT_NUMBER_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.next_number_v1}
@@ -39,6 +41,13 @@ async def list_v1(request: DBRequest, *, provider: str) -> DBResponse:
   result = await _select_dispatcher(provider, _LIST_DISPATCHERS)(params.model_dump())
   return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
 
+
+
+
+async def get_by_prefix_account_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = GetByPrefixAndAccountNumberParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_BY_PREFIX_ACCOUNT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
 
 async def get_v1(request: DBRequest, *, provider: str) -> DBResponse:
   params = GetNumberParams.model_validate(request.payload)

--- a/queryregistry/finance/periods/models.py
+++ b/queryregistry/finance/periods/models.py
@@ -80,5 +80,6 @@ class PeriodRecord(TypedDict):
   element_close_type: int
   element_status: int
   numbers_recid: int | None
+  element_display_format: str | None
   element_created_on: str
   element_modified_on: str

--- a/queryregistry/finance/periods/mssql.py
+++ b/queryregistry/finance/periods/mssql.py
@@ -15,24 +15,26 @@ async def list_v1(args: Mapping[str, Any]) -> DBResponse:
   del args
   sql = """
     SELECT
-      element_guid,
-      element_year,
-      element_period_number,
-      element_period_name,
-      element_start_date,
-      element_end_date,
-      element_days_in_period,
-      element_quarter_number,
-      element_has_closing_week,
-      element_is_leap_adjustment,
-      element_anchor_event,
-      element_close_type,
-      element_status,
-      numbers_recid,
-      element_created_on,
-      element_modified_on
-    FROM finance_periods
-    ORDER BY element_year ASC, element_period_number ASC
+      fp.element_guid,
+      fp.element_year,
+      fp.element_period_number,
+      fp.element_period_name,
+      fp.element_start_date,
+      fp.element_end_date,
+      fp.element_days_in_period,
+      fp.element_quarter_number,
+      fp.element_has_closing_week,
+      fp.element_is_leap_adjustment,
+      fp.element_anchor_event,
+      fp.element_close_type,
+      fp.element_status,
+      fp.numbers_recid,
+      fn.element_display_format,
+      fp.element_created_on,
+      fp.element_modified_on
+    FROM finance_periods fp
+    LEFT JOIN finance_numbers fn ON fn.recid = fp.numbers_recid
+    ORDER BY fp.element_year ASC, fp.element_period_number ASC
     FOR JSON PATH, INCLUDE_NULL_VALUES;
   """
   return await run_json_many(sql)
@@ -41,25 +43,27 @@ async def list_v1(args: Mapping[str, Any]) -> DBResponse:
 async def list_by_year_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
     SELECT
-      element_guid,
-      element_year,
-      element_period_number,
-      element_period_name,
-      element_start_date,
-      element_end_date,
-      element_days_in_period,
-      element_quarter_number,
-      element_has_closing_week,
-      element_is_leap_adjustment,
-      element_anchor_event,
-      element_close_type,
-      element_status,
-      numbers_recid,
-      element_created_on,
-      element_modified_on
-    FROM finance_periods
-    WHERE element_year = ?
-    ORDER BY element_period_number ASC
+      fp.element_guid,
+      fp.element_year,
+      fp.element_period_number,
+      fp.element_period_name,
+      fp.element_start_date,
+      fp.element_end_date,
+      fp.element_days_in_period,
+      fp.element_quarter_number,
+      fp.element_has_closing_week,
+      fp.element_is_leap_adjustment,
+      fp.element_anchor_event,
+      fp.element_close_type,
+      fp.element_status,
+      fp.numbers_recid,
+      fn.element_display_format,
+      fp.element_created_on,
+      fp.element_modified_on
+    FROM finance_periods fp
+    LEFT JOIN finance_numbers fn ON fn.recid = fp.numbers_recid
+    WHERE fp.element_year = ?
+    ORDER BY fp.element_period_number ASC
     FOR JSON PATH, INCLUDE_NULL_VALUES;
   """
   return await run_json_many(sql, (args["year"],))
@@ -68,24 +72,26 @@ async def list_by_year_v1(args: Mapping[str, Any]) -> DBResponse:
 async def get_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
     SELECT
-      element_guid,
-      element_year,
-      element_period_number,
-      element_period_name,
-      element_start_date,
-      element_end_date,
-      element_days_in_period,
-      element_quarter_number,
-      element_has_closing_week,
-      element_is_leap_adjustment,
-      element_anchor_event,
-      element_close_type,
-      element_status,
-      numbers_recid,
-      element_created_on,
-      element_modified_on
-    FROM finance_periods
-    WHERE element_guid = ?
+      fp.element_guid,
+      fp.element_year,
+      fp.element_period_number,
+      fp.element_period_name,
+      fp.element_start_date,
+      fp.element_end_date,
+      fp.element_days_in_period,
+      fp.element_quarter_number,
+      fp.element_has_closing_week,
+      fp.element_is_leap_adjustment,
+      fp.element_anchor_event,
+      fp.element_close_type,
+      fp.element_status,
+      fp.numbers_recid,
+      fn.element_display_format,
+      fp.element_created_on,
+      fp.element_modified_on
+    FROM finance_periods fp
+    LEFT JOIN finance_numbers fn ON fn.recid = fp.numbers_recid
+    WHERE fp.element_guid = ?
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
   """
   return await run_json_one(sql, (args["guid"],))

--- a/queryregistry/finance/periods/services.py
+++ b/queryregistry/finance/periods/services.py
@@ -9,6 +9,10 @@ import uuid
 
 from queryregistry.models import DBRequest, DBResponse
 
+from queryregistry.finance.numbers.models import GetByPrefixAndAccountNumberParams, UpsertNumberParams
+from queryregistry.finance.numbers.services import get_by_prefix_account_v1 as get_number_by_prefix_account_v1
+from queryregistry.finance.numbers.services import upsert_v1 as upsert_number_v1
+
 from . import mssql
 from .models import (
   DeletePeriodParams,
@@ -35,6 +39,8 @@ _LIST_BY_YEAR_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_by_year
 _GET_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_v1}
 _UPSERT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_v1}
 _DELETE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_v1}
+
+_FISCAL_PERIODS_ACCOUNTS_GUID = "00000000-0000-0000-0000-000000000000"
 
 
 def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
@@ -80,6 +86,37 @@ async def generate_calendar_v1(request: DBRequest, *, provider: str) -> DBRespon
   if fy_start.weekday() != 6:
     raise ValueError("Fiscal year start_date must be a Sunday")
 
+  lookup_request = DBRequest(
+    op="db:finance:numbers:get_by_prefix_account:1",
+    payload=GetByPrefixAndAccountNumberParams(
+      prefix="FP",
+      account_number=str(params.fiscal_year),
+    ).model_dump(),
+  )
+  number_result = await get_number_by_prefix_account_v1(lookup_request, provider=provider)
+
+  number_payload = number_result.payload if isinstance(number_result.payload, dict) else None
+  if number_payload and number_payload.get("recid") is not None:
+    numbers_recid = int(number_payload["recid"])
+  else:
+    upsert_request = DBRequest(
+      op="db:finance:numbers:upsert:1",
+      payload=UpsertNumberParams(
+        accounts_guid=_FISCAL_PERIODS_ACCOUNTS_GUID,
+        prefix="FP",
+        account_number=str(params.fiscal_year),
+        last_number=0,
+        allocation_size=1,
+        reset_policy="Never",
+        display_format=f"FY{params.fiscal_year}",
+      ).model_dump(),
+    )
+    upsert_result = await upsert_number_v1(upsert_request, provider=provider)
+    upsert_payload = upsert_result.payload if isinstance(upsert_result.payload, dict) else None
+    if not upsert_payload or upsert_payload.get("recid") is None:
+      raise ValueError(f"Failed to create number sequence for fiscal year {params.fiscal_year}")
+    numbers_recid = int(upsert_payload["recid"])
+
   periods: list[dict[str, Any]] = []
   cursor = fy_start
 
@@ -104,6 +141,7 @@ async def generate_calendar_v1(request: DBRequest, *, provider: str) -> DBRespon
           "anchor_event": None,
           "close_type": 0,
           "status": 1,
+          "numbers_recid": numbers_recid,
         }
       )
       cursor = period_end + timedelta(days=1)
@@ -125,6 +163,7 @@ async def generate_calendar_v1(request: DBRequest, *, provider: str) -> DBRespon
         "anchor_event": "period_close",
         "close_type": 0,
         "status": 1,
+        "numbers_recid": numbers_recid,
       }
     )
     cursor = mc_end + timedelta(days=1)

--- a/rpc/finance/periods/models.py
+++ b/rpc/finance/periods/models.py
@@ -16,6 +16,7 @@ class FinancePeriodsItem1(BaseModel):
   close_type: int = 0
   status: int = 1
   numbers_recid: int | None = None
+  element_display_format: str | None = None
 
 
 class FinancePeriodsList1(BaseModel):
@@ -32,6 +33,7 @@ class FinancePeriodsGet1(BaseModel):
 
 class FinancePeriodsUpsert1(FinancePeriodsItem1):
   numbers_recid: int | None = None
+  element_display_format: str | None = None
 
 
 class FinancePeriodsDelete1(BaseModel):

--- a/server/modules/finance_module.py
+++ b/server/modules/finance_module.py
@@ -40,6 +40,7 @@ from queryregistry.finance.dimensions.models import (
 )
 from queryregistry.finance.numbers import (
   delete_number_request,
+  get_by_prefix_account_number_request,
   get_number_request,
   list_numbers_request,
   next_number_request,
@@ -47,6 +48,7 @@ from queryregistry.finance.numbers import (
 )
 from queryregistry.finance.numbers.models import (
   DeleteNumberParams,
+  GetByPrefixAndAccountNumberParams,
   GetNumberParams,
   ListNumbersParams,
   NextNumberParams,
@@ -66,6 +68,9 @@ from queryregistry.finance.periods.models import (
   ListPeriodsParams,
   UpsertPeriodParams,
 )
+
+
+_FISCAL_PERIODS_ACCOUNTS_GUID = "00000000-0000-0000-0000-000000000000"
 
 
 class FinanceModule(BaseModule):
@@ -100,6 +105,7 @@ class FinanceModule(BaseModule):
       "close_type": row.get("element_close_type"),
       "status": row.get("element_status"),
       "numbers_recid": row.get("numbers_recid"),
+      "element_display_format": row.get("element_display_format"),
     }
 
   def _map_account(self, row: dict[str, Any]) -> dict[str, Any]:
@@ -170,6 +176,35 @@ class FinanceModule(BaseModule):
     if start.weekday() != 6:
       raise ValueError("start_date must be a Sunday")
 
+    assert self.db
+    lookup_res = await self.db.run(
+      get_by_prefix_account_number_request(
+        GetByPrefixAndAccountNumberParams(prefix="FP", account_number=str(fiscal_year))
+      )
+    )
+    lookup_row = dict(lookup_res.rows[0]) if lookup_res.rows else None
+
+    if lookup_row and lookup_row.get("recid") is not None:
+      numbers_recid = int(lookup_row["recid"])
+    else:
+      upsert_res = await self.db.run(
+        upsert_number_request(
+          UpsertNumberParams(
+            accounts_guid=_FISCAL_PERIODS_ACCOUNTS_GUID,
+            prefix="FP",
+            account_number=str(fiscal_year),
+            last_number=0,
+            allocation_size=1,
+            reset_policy="Never",
+            display_format=f"FY{fiscal_year}",
+          )
+        )
+      )
+      upsert_row = dict(upsert_res.rows[0]) if upsert_res.rows else None
+      if not upsert_row or upsert_row.get("recid") is None:
+        raise ValueError(f"Failed to create number sequence for fiscal year {fiscal_year}")
+      numbers_recid = int(upsert_row["recid"])
+
     fiscal_end = start + timedelta(days=365)
     has_leap_adjustment = calendar.isleap(fiscal_year) and start <= date(fiscal_year, 2, 29) < fiscal_end
 
@@ -200,7 +235,7 @@ class FinanceModule(BaseModule):
           "anchor_event": None,
           "close_type": 0,
           "status": 1,
-          "numbers_recid": None,
+          "numbers_recid": numbers_recid,
         }
         row = await self.upsert_period(payload)
         generated.append(row)
@@ -222,7 +257,7 @@ class FinanceModule(BaseModule):
         "anchor_event": "period_close",
         "close_type": 0,
         "status": 1,
-        "numbers_recid": None,
+        "numbers_recid": numbers_recid,
       }
       row = await self.upsert_period(closing_payload)
       generated.append(row)


### PR DESCRIPTION
### Motivation
- Fiscal periods were not linked to number sequences (`numbers_recid` stayed NULL) and the UI showed raw period names like `Q1M1` without a fiscal year prefix. 
- `generate_calendar_v1` must create or reuse an FY-specific number sequence and link generated periods so the frontend can display a formatted FY-prefixed name.

### Description
- Add a numbers lookup operation `db:finance:numbers:get_by_prefix_account:1` (models, MSSQL query, service dispatcher, handler, and request builder) to find sequences by `element_prefix` + `element_account_number`.
- Update `generate_calendar_v1` (queryregistry and server module) to look up or upsert an `FP`+`<year>` number sequence (with `element_display_format = f"FY{year}"`) and pass `numbers_recid` on every generated period upsert.
- Modify finance periods MSSQL queries (`list_v1`, `list_by_year_v1`, `get_v1`) to LEFT JOIN `finance_numbers` and include `fn.element_display_format` in results, and expose `element_display_format` through RPC/registry models and module mapping.
- Update the frontend `FinanceAdminPage` types and table to remove the Leap column and render the Period Name as `FY####-<period_name>` when `element_display_format` is present, falling back to the raw period name otherwise.

### Testing
- Ran Python compilation for the modified queryregistry and server modules via `python -m compileall` which completed successfully. 
- Ran frontend checks `npm run lint` and `npm run type-check` which completed without errors. 
- Ran frontend unit tests via `npm test -- --run` (Vitest) and observed the test suite pass (2 tests passed). 
- Executed the unified pipeline `python scripts/run_tests.py` which produced the expected lint/type-check/test outputs for this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b38fdfdb508325a6950c301464a6a9)