### PR TITLE
Add account_api_tokens SQL schema and seed

### DIFF
--- a/v0.8.4.0_20260312.sql
+++ b/v0.8.4.0_20260312.sql
@@ -1,0 +1,14 @@
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+
+CREATE TABLE [dbo].[account_api_tokens] (
+  [element_token] UNIQUEIDENTIFIER NOT NULL DEFAULT NEWID(),
+  [users_recid] BIGINT NOT NULL,
+  [element_label] NVARCHAR(256) NOT NULL,
+  [element_roles] BIGINT NOT NULL DEFAULT ((0)),
+  [element_created_on] datetimeoffset(7) NOT NULL DEFAULT (sysutcdatetime()),
+  [element_expires_on] datetimeoffset(7) NULL,
+  CONSTRAINT [PK_account_api_tokens] PRIMARY KEY ([element_token]),
+  CONSTRAINT [FK_account_api_tokens_users] FOREIGN KEY ([users_recid])
+    REFERENCES [dbo].[account_users] ([recid])
+);

--- a/v0.8.4.0_seed_20260312.sql
+++ b/v0.8.4.0_seed_20260312.sql
@@ -1,0 +1,23 @@
+SET NOCOUNT ON;
+
+INSERT INTO system_schema_tables (element_name, element_schema) VALUES
+  ('account_api_tokens', 'dbo');
+
+INSERT INTO system_schema_columns (
+  tables_recid, edt_recid, element_name, element_ordinal, element_nullable,
+  element_default, element_max_length, element_is_primary_key, element_is_identity
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_api_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'UUID'), 'element_token', 1, 0, '(newid())', NULL, 1, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_api_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'users_recid', 2, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_api_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_label', 3, 0, NULL, 256, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_api_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'element_roles', 4, 0, '((0))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_api_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_created_on', 5, 0, '(sysutcdatetime())', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_api_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_expires_on', 6, 1, NULL, NULL, 0, 0);
+
+-- No additional indexes to register in system_schema_indexes;
+-- the PK constraint creates the clustered index automatically.
+
+INSERT INTO system_schema_foreign_keys (
+  tables_recid, element_column_name, referenced_tables_recid, element_referenced_column
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_api_tokens' AND element_schema = 'dbo'), 'users_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'account_users' AND element_schema = 'dbo'), 'recid');


### PR DESCRIPTION
### Motivation
- Provide a new persistent table to store per-user API tokens and register it in the reflection catalog so services can manage and discover API tokens programmatically.

### Description
- Add `v0.8.4.0_20260312.sql` with `SET ANSI_NULLS ON;`, `SET QUOTED_IDENTIFIER ON;` and the `dbo.account_api_tokens` DDL (columns, PK on `element_token`, FK `users_recid -> account_users.recid`) and add `v0.8.4.0_seed_20260312.sql` to register the table and its columns in `system_schema_tables`, `system_schema_columns`, and `system_schema_foreign_keys` using the existing EDT mappings and ordinals while noting no extra `system_schema_indexes` entries are required.

### Testing
- Validated the new files and their contents with `sed -n` and `nl -ba`, confirmed repository status with `git status --short`, and committed the changes; all verification commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b39dd18dc8832590cdcc7a1504da95)