### PR TITLE
Add mcp dependency and MCP_AGENT_TOKEN placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ DISCORD_SECRET=0123456789
 DISCORD_AUTH_SECRET=""
 DATABASE_PROVIDER=mssql
 GOOGLE_AUTH_SECRET=""
+MCP_AGENT_TOKEN=""
 POSTGRES_CONNECTION_STRING="postgresql://user:pass@server:port/database?sslmode=require"
 AZURE_SQL_CONNECTION_STRING="Driver={ODBC Driver 18 for SQL Server};Server=server;Database=database;UID=user;PWD=pass;Encrypt=yes"
 AZURE_BLOB_CONNECTION_STRING=""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@ fastapi
 gunicorn
 uvicorn
 discord.py
-openai
 lumaai
+mcp
+openai
 azure-storage-blob
 azure-identity
 azure-containerregistry


### PR DESCRIPTION
### Motivation
- Add the `mcp` package to the Python dependencies and provide an environment placeholder for the MCP agent token so the project can be configured to use MCP-based integrations.

### Description
- Inserted `mcp` into `requirements.txt` between `lumaai` and `openai`, and added `MCP_AGENT_TOKEN=""` to `.env.example` immediately after `GOOGLE_AUTH_SECRET`.

### Testing
- Verified the updated files with `nl -ba requirements.txt | sed -n '1,40p'` and `nl -ba .env.example | sed -n '1,40p'`, and the new lines appear in the expected locations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4a942c8bc8325992dd3ac68c74528)