### PR TITLE
Add MCP startup mount status logging

### DIFF
--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import os
 from typing import Any
 
@@ -190,8 +191,10 @@ async def oracle_list_rpc_endpoints(ctx: Context) -> list[str]:
 def get_mcp_app() -> Starlette | None:
   """Return the MCP ASGI app wrapped with auth middleware."""
   if not _MCP_TOKEN:
+    logging.info("[MCP] skipped (MCP_AGENT_TOKEN not set)")
     return None
   mcp_asgi = mcp.streamable_http_app()
   app = Starlette(middleware=[Middleware(MCPAuthMiddleware)])
   app.mount("/", mcp_asgi)
+  logging.info("[MCP] server mounted at /mcp")
   return app


### PR DESCRIPTION
### Motivation
- Surface MCP mount state during server startup so logs indicate when the MCP bridge is skipped for missing token or when it is mounted, following the repository log prefix convention (`[MCP]`).

### Description
- Add `import logging` and insert `logging.info("[MCP] skipped (MCP_AGENT_TOKEN not set)")` when the token is not set and `logging.info("[MCP] server mounted at /mcp")` after the app is mounted in `get_mcp_app()` in `server/mcp_server.py`.

### Testing
- Ran `python -m py_compile server/mcp_server.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b67ea7d08325a315363e9433b5c2)