### PR TITLE
Initialize MCP StreamableHTTPSessionManager lifespan when mounted as sub-app

### DIFF
--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -14,6 +14,7 @@ from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
+from starlette.routing import Mount
 
 from queryregistry.handler import HANDLERS as QR_HANDLERS
 from queryregistry.handler import dispatch_query_request
@@ -189,12 +190,33 @@ async def oracle_list_rpc_endpoints(ctx: Context) -> list[str]:
 
 
 def get_mcp_app() -> Starlette | None:
-  """Return the MCP ASGI app wrapped with auth middleware."""
+  """Return the MCP ASGI app wrapped with auth middleware, or None if unconfigured."""
   if not _MCP_TOKEN:
     logging.info("[MCP] skipped (MCP_AGENT_TOKEN not set)")
     return None
-  mcp_asgi = mcp.streamable_http_app()
+
+  from contextlib import asynccontextmanager
+  from mcp.server.streamable_http import StreamableHTTPSessionManager
+
+  session_manager = StreamableHTTPSessionManager(
+    app=mcp._mcp_server,
+    json_response=True,
+    stateless=True,
+  )
+
+  @asynccontextmanager
+  async def mcp_lifespan(app: Any):
+    async with session_manager.run():
+      logging.info("[MCP] server mounted at /mcp")
+      yield
+
+  mcp_inner = Starlette(
+    lifespan=mcp_lifespan,
+    routes=[
+      Mount("/mcp", app=session_manager.handle_request),
+    ],
+  )
+
   app = Starlette(middleware=[Middleware(MCPAuthMiddleware)])
-  app.mount("/", mcp_asgi)
-  logging.info("[MCP] server mounted at /mcp")
+  app.mount("/", mcp_inner)
   return app


### PR DESCRIPTION
### Motivation

- Fix the RuntimeError "Task group is not initialized" that occurs when the MCP app is embedded as a sub-application because the MCP SDK's session manager lifespan wasn't being run.

### Description

- Replace `mcp.streamable_http_app()` usage in `get_mcp_app()` with an explicit `StreamableHTTPSessionManager` created from `mcp._mcp_server` and configured with `json_response=True` and `stateless=True`.
- Add an `@asynccontextmanager` lifespan (`mcp_lifespan`) that calls `session_manager.run()` so the session manager's async task group is initialized when the inner app starts.
- Create an inner `Starlette` app that mounts `session_manager.handle_request` at `"/mcp"` and mount that inner app on the outer auth-wrapped `Starlette` app, preserving `MCPAuthMiddleware` behavior (resulting in the expected `/mcp/mcp` path when embedded).
- Add the required `from starlette.routing import Mount` import and keep the outer middleware wrapping intact.

### Testing

- Compiled the file with `python -m compileall server/mcp_server.py` which succeeded without syntax errors. 
- Ran the unified test harness with `python scripts/run_tests.py`, which completed successfully and reported `69 passed, 1 warning` for the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b8ea55848325ad42275b8d68c01c)