### PR TITLE
Fix MCP StreamableHTTPSessionManager import path

### DIFF
--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -196,7 +196,7 @@ def get_mcp_app() -> Starlette | None:
     return None
 
   from contextlib import asynccontextmanager
-  from mcp.server.streamable_http import StreamableHTTPSessionManager
+  from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 
   session_manager = StreamableHTTPSessionManager(
     app=mcp._mcp_server,


### PR DESCRIPTION
### Motivation
- Correct the import in `server/mcp_server.py` so `StreamableHTTPSessionManager` is imported from the module where the class is actually defined at runtime.

### Description
- Replace `from mcp.server.streamable_http import StreamableHTTPSessionManager` with `from mcp.server.streamable_http_manager import StreamableHTTPSessionManager` in `server/mcp_server.py`.

### Testing
- Verified the updated import line with `nl -ba /workspace/elideus-group/server/mcp_server.py | sed -n '195,202p'` and confirmed a single-line change in the file diff.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c08cbd488325a648608e2ebee8a3)