### PR TITLE
Move MCP session manager lifecycle into main FastAPI lifespan

### DIFF
--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -1,6 +1,10 @@
-from fastapi import FastAPI
 from contextlib import asynccontextmanager
+import logging
+
+from fastapi import FastAPI
+
 from server.modules import ModuleManager
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -8,8 +12,18 @@ async def lifespan(app: FastAPI):
   await manager.startup_all()
   app.state.module_manager = manager
 
-  try:
-    yield
-  finally:
-    await manager.shutdown_all()
+  # Start MCP session manager if configured
+  from server.mcp_server import session_manager
 
+  if session_manager is not None:
+    async with session_manager.run():
+      logging.info("[MCP] server mounted at /mcp")
+      try:
+        yield
+      finally:
+        await manager.shutdown_all()
+  else:
+    try:
+      yield
+    finally:
+      await manager.shutdown_all()

--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -1,0 +1,67 @@
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Mount
+
+if TYPE_CHECKING:
+  from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+_MCP_TOKEN = os.getenv("MCP_AGENT_TOKEN")
+
+mcp: Any | None = None
+if _MCP_TOKEN:
+  from mcp.server.fastmcp import FastMCP
+
+  mcp = FastMCP("elideus-group")
+
+
+class MCPAuthMiddleware(BaseHTTPMiddleware):
+  async def dispatch(self, request: Request, call_next) -> Response:
+    if not _MCP_TOKEN:
+      return JSONResponse(status_code=503, content={"detail": "MCP token not configured"})
+
+    if request.headers.get("authorization") != f"Bearer {_MCP_TOKEN}":
+      return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
+
+    return await call_next(request)
+
+
+# Module-level session manager (initialized when token is configured)
+session_manager: StreamableHTTPSessionManager | None = None
+
+
+def _build_mcp_app() -> None:
+  """Initialize the module-level session_manager."""
+  global session_manager
+  from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+  session_manager = StreamableHTTPSessionManager(
+    app=mcp._mcp_server,
+    json_response=True,
+    stateless=True,
+  )
+
+
+def get_mcp_app() -> Starlette | None:
+  """Return the MCP ASGI app wrapped with auth middleware, or None if unconfigured."""
+  if not _MCP_TOKEN:
+    logging.info("[MCP] skipped (MCP_AGENT_TOKEN not set)")
+    return None
+
+  _build_mcp_app()
+
+  mcp_inner = Starlette(
+    routes=[
+      Mount("/mcp", app=session_manager.handle_request),
+    ],
+  )
+
+  app = Starlette(middleware=[Middleware(MCPAuthMiddleware)])
+  app.mount("/", mcp_inner)
+  return app


### PR DESCRIPTION
### Motivation
- Nested Starlette lifespans inside the MCP sub-app do not propagate when mounted under FastAPI on the target hosting environment, so the MCP session manager must be started from the main application lifespan where the event loop is guaranteed to run.

### Description
- Add `server/mcp_server.py` which exposes a module-level `session_manager`, initializes it via `_build_mcp_app()`, and returns the MCP Starlette app via `get_mcp_app()` built with `Mount` and auth middleware but without an inner lifespan.
- Update `server/lifespan.py` to enter `async with session_manager.run():` from the main FastAPI lifespan so the MCP task group runs for the application lifetime and to emit the MCP mounted log from the main lifespan.
- Preserve the existing module manager startup and shutdown sequence while conditionally starting the MCP session manager when `session_manager` is configured.

### Testing
- Ran the unified test harness with `python scripts/run_tests.py`, which completed successfully with the test suite passing (67 passed, 1 warning). 
- Frontend checks (lint/type-check/tests) included in the harness also completed successfully during the run. 
- The test run produced a non-fatal warning about inability to connect to a production DB step due to a missing ODBC driver (`ODBC Driver 18 for SQL Server`), which did not cause test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c58c0c388325a45c208ec94239a9)