### PR TITLE
Initialize MCP session manager during main FastAPI lifespan

### DIFF
--- a/server/lifespan.py
+++ b/server/lifespan.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
 from server.modules import ModuleManager
+import logging
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -8,8 +10,16 @@ async def lifespan(app: FastAPI):
   await manager.startup_all()
   app.state.module_manager = manager
 
-  try:
-    yield
-  finally:
-    await manager.shutdown_all()
-
+  from server.mcp_server import session_manager
+  if session_manager is not None:
+    async with session_manager.run():
+      logging.info("[MCP] server mounted at /mcp")
+      try:
+        yield
+      finally:
+        await manager.shutdown_all()
+  else:
+    try:
+      yield
+    finally:
+      await manager.shutdown_all()

--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import logging
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException
 from mcp.server.fastmcp import Context, FastMCP
@@ -21,6 +21,9 @@ from queryregistry.handler import dispatch_query_request
 from queryregistry.models import DBRequest
 from queryregistry.providers.mssql import run_json_many
 from rpc import HANDLERS as RPC_HANDLERS
+
+if TYPE_CHECKING:
+  from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 
 _MCP_TOKEN = os.environ.get("MCP_AGENT_TOKEN", "")
 _ALLOWED_VIEWS = frozenset({
@@ -38,6 +41,7 @@ _ALLOWED_VIEWS = frozenset({
 })
 
 mcp = FastMCP("oracle_rpc_mcp")
+session_manager: StreamableHTTPSessionManager | None = None
 _TOOL_ANNOTATIONS = ToolAnnotations(
   readOnlyHint=True,
   destructiveHint=False,
@@ -191,27 +195,20 @@ async def oracle_list_rpc_endpoints(ctx: Context) -> list[str]:
 
 def get_mcp_app() -> Starlette | None:
   """Return the MCP ASGI app wrapped with auth middleware, or None if unconfigured."""
+  global session_manager
   if not _MCP_TOKEN:
     logging.info("[MCP] skipped (MCP_AGENT_TOKEN not set)")
     return None
 
-  from contextlib import asynccontextmanager
-  from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+  from mcp.server.streamable_http_manager import StreamableHTTPSessionManager as _Manager
 
-  session_manager = StreamableHTTPSessionManager(
+  session_manager = _Manager(
     app=mcp._mcp_server,
     json_response=True,
     stateless=True,
   )
 
-  @asynccontextmanager
-  async def mcp_lifespan(app: Any):
-    async with session_manager.run():
-      logging.info("[MCP] server mounted at /mcp")
-      yield
-
   mcp_inner = Starlette(
-    lifespan=mcp_lifespan,
     routes=[
       Mount("/mcp", app=session_manager.handle_request),
     ],
@@ -219,4 +216,5 @@ def get_mcp_app() -> Starlette | None:
 
   app = Starlette(middleware=[Middleware(MCPAuthMiddleware)])
   app.mount("/", mcp_inner)
+  logging.info("[MCP] app built, waiting for lifespan init")
   return app


### PR DESCRIPTION
### Motivation
- Azure-hosted process does not reliably run Starlette sub-app lifespans, and `StreamableHTTPSessionManager` requires entering `async with session_manager.run()` to initialize and keep its task group alive for the app lifetime.

### Description
- Export a module-level `session_manager` in `server/mcp_server.py` and add `TYPE_CHECKING` support for its type so other modules can reference it without creating runtime imports. 
- Change `get_mcp_app()` to construct and assign the `StreamableHTTPSessionManager` to the module-level `session_manager`, mount `session_manager.handle_request` at `/mcp`, and log that the MCP app is built and awaiting lifespan init. 
- Remove the sub-app lifespan wrapper previously used to drive the manager and instead rely on the main application lifespan to start it. 
- Wire `session_manager.run()` into the main FastAPI lifespan in `server/lifespan.py` so the MCP task group is entered during root app startup while preserving `ModuleManager` startup/shutdown behavior.

### Testing
- Ran the repository unified harness via `python scripts/run_tests.py`, which completed successfully and returned passing results for the test suite. 
- Python backend tests completed with all tests passing (`69 passed`) and frontend unit tests also passed. 
- The harness logged an environment/database warning about a missing ODBC driver (`ODBC Driver 18 for SQL Server`) during a later DB connection attempt, but this did not cause the test run to fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4d18d1f9c83259fbbe04aeda11733)