### PR TITLE
Add MCP OAuth DCR DB schema, identity queryregistry, and McpGateway module

### DIFF
--- a/migrations/v0.8.5.0_mcp_oauth_tables.sql
+++ b/migrations/v0.8.5.0_mcp_oauth_tables.sql
@@ -1,0 +1,114 @@
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+-- ============================================================================
+-- v0.8.5.0 MCP OAuth 2.1 Tables
+-- ============================================================================
+
+-- A1. account_mcp_agents — registered MCP clients (DCR or manual)
+CREATE TABLE [dbo].[account_mcp_agents] (
+  [recid]                   bigint IDENTITY(1,1) NOT NULL,
+  [element_client_id]       UNIQUEIDENTIFIER NOT NULL DEFAULT NEWID(),
+  [element_client_secret]   NVARCHAR(512) NULL,
+  [element_client_name]     NVARCHAR(256) NOT NULL,
+  [element_redirect_uris]   NVARCHAR(MAX) NULL,
+  [element_grant_types]     NVARCHAR(1024) NOT NULL DEFAULT 'authorization_code',
+  [element_response_types]  NVARCHAR(256) NOT NULL DEFAULT 'code',
+  [element_scopes]          NVARCHAR(1024) NOT NULL DEFAULT 'mcp:schema:read',
+  [element_roles]           BIGINT NOT NULL DEFAULT ((0)),
+  [users_recid]             BIGINT NULL,
+  [element_ip_address]      NVARCHAR(64) NULL,
+  [element_user_agent]      NVARCHAR(1024) NULL,
+  [element_is_active]       BIT NOT NULL DEFAULT ((1)),
+  [element_revoked_at]      datetimeoffset(7) NULL,
+  [element_created_on]      datetimeoffset(7) NOT NULL DEFAULT (sysutcdatetime()),
+  [element_modified_on]     datetimeoffset(7) NOT NULL DEFAULT (sysutcdatetime()),
+  CONSTRAINT [PK_account_mcp_agents] PRIMARY KEY ([recid]),
+  CONSTRAINT [FK_account_mcp_agents_users] FOREIGN KEY ([users_recid])
+    REFERENCES [dbo].[account_users] ([recid])
+);
+GO
+
+CREATE UNIQUE INDEX [UQ_account_mcp_agents_client_id]
+  ON [dbo].[account_mcp_agents] ([element_client_id]);
+GO
+
+CREATE INDEX [IX_account_mcp_agents_users]
+  ON [dbo].[account_mcp_agents] ([users_recid]);
+GO
+
+-- A2. account_mcp_agent_tokens — access/refresh tokens for MCP agents
+CREATE TABLE [dbo].[account_mcp_agent_tokens] (
+  [recid]                   bigint IDENTITY(1,1) NOT NULL,
+  [agents_recid]            BIGINT NOT NULL,
+  [element_access_token]    NVARCHAR(MAX) NOT NULL,
+  [element_refresh_token]   NVARCHAR(MAX) NULL,
+  [element_access_exp]      datetimeoffset(7) NOT NULL,
+  [element_refresh_exp]     datetimeoffset(7) NULL,
+  [element_scopes]          NVARCHAR(1024) NOT NULL,
+  [element_revoked_at]      datetimeoffset(7) NULL,
+  [element_created_on]      datetimeoffset(7) NOT NULL DEFAULT (sysutcdatetime()),
+  CONSTRAINT [PK_account_mcp_agent_tokens] PRIMARY KEY ([recid]),
+  CONSTRAINT [FK_account_mcp_agent_tokens_agents] FOREIGN KEY ([agents_recid])
+    REFERENCES [dbo].[account_mcp_agents] ([recid])
+);
+GO
+
+CREATE INDEX [IX_account_mcp_agent_tokens_agents]
+  ON [dbo].[account_mcp_agent_tokens] ([agents_recid]);
+GO
+
+-- A3. account_mcp_auth_codes — single-use authorization codes (60s TTL)
+CREATE TABLE [dbo].[account_mcp_auth_codes] (
+  [recid]                   bigint IDENTITY(1,1) NOT NULL,
+  [agents_recid]            BIGINT NOT NULL,
+  [users_recid]             BIGINT NOT NULL,
+  [element_code]            NVARCHAR(256) NOT NULL,
+  [element_code_challenge]  NVARCHAR(256) NOT NULL,
+  [element_code_method]     NVARCHAR(16) NOT NULL DEFAULT 'S256',
+  [element_redirect_uri]    NVARCHAR(2048) NOT NULL,
+  [element_scopes]          NVARCHAR(1024) NOT NULL,
+  [element_consumed]        BIT NOT NULL DEFAULT ((0)),
+  [element_expires_on]      datetimeoffset(7) NOT NULL,
+  [element_created_on]      datetimeoffset(7) NOT NULL DEFAULT (sysutcdatetime()),
+  CONSTRAINT [PK_account_mcp_auth_codes] PRIMARY KEY ([recid]),
+  CONSTRAINT [FK_account_mcp_auth_codes_agents] FOREIGN KEY ([agents_recid])
+    REFERENCES [dbo].[account_mcp_agents] ([recid]),
+  CONSTRAINT [FK_account_mcp_auth_codes_users] FOREIGN KEY ([users_recid])
+    REFERENCES [dbo].[account_users] ([recid])
+);
+GO
+
+CREATE UNIQUE INDEX [UQ_account_mcp_auth_codes_code]
+  ON [dbo].[account_mcp_auth_codes] ([element_code]);
+GO
+
+-- B1. Add ROLE_MCP_ACCESS (bit 5, mask 32)
+IF NOT EXISTS (SELECT 1 FROM system_roles WHERE element_name = 'ROLE_MCP_ACCESS')
+  INSERT INTO system_roles (element_mask, element_enablement, element_name, element_display)
+    VALUES (32, '0', 'ROLE_MCP_ACCESS', 'MCP Agent Access');
+GO
+
+-- B2. Add auth provider for MCP
+IF NOT EXISTS (SELECT 1 FROM auth_providers WHERE element_name = 'mcp')
+  INSERT INTO auth_providers (element_name, element_display)
+    VALUES ('mcp', 'MCP Agent');
+GO
+
+-- B3. System config entries (kill switch + rate limits)
+IF NOT EXISTS (SELECT 1 FROM system_config WHERE element_key = 'MCP_DCR_ENABLED')
+  INSERT INTO system_config (element_key, element_value) VALUES ('MCP_DCR_ENABLED', 'false');
+GO
+IF NOT EXISTS (SELECT 1 FROM system_config WHERE element_key = 'MCP_RATE_LIMIT_REGISTER_IP')
+  INSERT INTO system_config (element_key, element_value) VALUES ('MCP_RATE_LIMIT_REGISTER_IP', '5');
+GO
+IF NOT EXISTS (SELECT 1 FROM system_config WHERE element_key = 'MCP_RATE_LIMIT_REGISTER_GLOBAL')
+  INSERT INTO system_config (element_key, element_value) VALUES ('MCP_RATE_LIMIT_REGISTER_GLOBAL', '50');
+GO
+IF NOT EXISTS (SELECT 1 FROM system_config WHERE element_key = 'MCP_RATE_LIMIT_TOKEN_IP')
+  INSERT INTO system_config (element_key, element_value) VALUES ('MCP_RATE_LIMIT_TOKEN_IP', '60');
+GO
+IF NOT EXISTS (SELECT 1 FROM system_config WHERE element_key = 'MCP_RATE_LIMIT_TOKEN_GLOBAL')
+  INSERT INTO system_config (element_key, element_value) VALUES ('MCP_RATE_LIMIT_TOKEN_GLOBAL', '500');
+GO

--- a/migrations/v0.8.5.0_mcp_oauth_tables_seed.sql
+++ b/migrations/v0.8.5.0_mcp_oauth_tables_seed.sql
@@ -1,0 +1,63 @@
+SET NOCOUNT ON;
+
+INSERT INTO system_schema_tables (element_name, element_schema) VALUES
+  ('account_mcp_agents', 'dbo'),
+  ('account_mcp_agent_tokens', 'dbo'),
+  ('account_mcp_auth_codes', 'dbo');
+
+INSERT INTO system_schema_columns (
+  tables_recid, edt_recid, element_name, element_ordinal, element_nullable,
+  element_default, element_max_length, element_is_primary_key, element_is_identity
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64_IDENTITY'), 'recid', 1, 0, NULL, NULL, 1, 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'UUID'), 'element_client_id', 2, 0, '(newid())', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_client_secret', 3, 1, NULL, 512, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_client_name', 4, 0, NULL, 256, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'TEXT'), 'element_redirect_uris', 5, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_grant_types', 6, 0, 'authorization_code', 1024, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_response_types', 7, 0, 'code', 256, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_scopes', 8, 0, 'mcp:schema:read', 1024, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'element_roles', 9, 0, '((0))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'users_recid', 10, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_ip_address', 11, 1, NULL, 64, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_user_agent', 12, 1, NULL, 1024, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'BOOL'), 'element_is_active', 13, 0, '((1))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_revoked_at', 14, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_created_on', 15, 0, '(sysutcdatetime())', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_modified_on', 16, 0, '(sysutcdatetime())', NULL, 0, 0),
+
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agent_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64_IDENTITY'), 'recid', 1, 0, NULL, NULL, 1, 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agent_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'agents_recid', 2, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agent_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'TEXT'), 'element_access_token', 3, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agent_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'TEXT'), 'element_refresh_token', 4, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agent_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_access_exp', 5, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agent_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_refresh_exp', 6, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agent_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_scopes', 7, 0, NULL, 1024, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agent_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_revoked_at', 8, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agent_tokens' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_created_on', 9, 0, '(sysutcdatetime())', NULL, 0, 0),
+
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64_IDENTITY'), 'recid', 1, 0, NULL, NULL, 1, 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'agents_recid', 2, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'users_recid', 3, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_code', 4, 0, NULL, 256, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_code_challenge', 5, 0, NULL, 256, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_code_method', 6, 0, 'S256', 16, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_redirect_uri', 7, 0, NULL, 2048, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_scopes', 8, 0, NULL, 1024, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'BOOL'), 'element_consumed', 9, 0, '((0))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_expires_on', 10, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_created_on', 11, 0, '(sysutcdatetime())', NULL, 0, 0);
+
+INSERT INTO system_schema_indexes (tables_recid, element_name, element_columns, element_is_unique) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), 'UQ_account_mcp_agents_client_id', 'element_client_id', 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), 'IX_account_mcp_agents_users', 'users_recid', 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agent_tokens' AND element_schema = 'dbo'), 'IX_account_mcp_agent_tokens_agents', 'agents_recid', 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), 'UQ_account_mcp_auth_codes_code', 'element_code', 1);
+
+INSERT INTO system_schema_foreign_keys (
+  tables_recid, element_column_name, referenced_tables_recid, element_referenced_column
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), 'users_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'account_users' AND element_schema = 'dbo'), 'recid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agent_tokens' AND element_schema = 'dbo'), 'agents_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), 'recid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), 'agents_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_agents' AND element_schema = 'dbo'), 'recid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'account_mcp_auth_codes' AND element_schema = 'dbo'), 'users_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'account_users' AND element_schema = 'dbo'), 'recid');

--- a/queryregistry/identity/handler.py
+++ b/queryregistry/identity/handler.py
@@ -10,6 +10,7 @@ from queryregistry.models import DBRequest, DBResponse
 
 from .accounts.handler import handle_accounts_request
 from .audit.handler import handle_audit_request
+from .mcp_agents.handler import handle_mcp_agents_request
 from .profiles.handler import handle_profiles_request
 from .providers.handler import handle_providers_request
 from .role_memberships.handler import handle_role_memberships_request
@@ -20,6 +21,7 @@ __all__ = ["handle_identity_request"]
 HANDLERS = {
   "accounts": handle_accounts_request,
   "audit": handle_audit_request,
+  "mcp_agents": handle_mcp_agents_request,
   "profiles": handle_profiles_request,
   "providers": handle_providers_request,
   "role_memberships": handle_role_memberships_request,

--- a/queryregistry/identity/mcp_agents/__init__.py
+++ b/queryregistry/identity/mcp_agents/__init__.py
@@ -1,0 +1,74 @@
+"""Identity MCP agents query registry helpers."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import (
+  ClientIdParams,
+  CreateAgentTokenParams,
+  CreateAuthCodeParams,
+  ConsumeAuthCodeParams,
+  LinkAgentUserParams,
+  RefreshTokenParams,
+  RegisterAgentParams,
+  RevokeTokenParams,
+  UserRecidParams,
+)
+
+__all__ = [
+  "create_agent_token_request",
+  "create_auth_code_request",
+  "consume_auth_code_request",
+  "get_agent_by_client_id_request",
+  "get_agent_token_request",
+  "link_agent_user_request",
+  "list_user_agents_request",
+  "register_agent_request",
+  "revoke_agent_request",
+  "revoke_agent_token_request",
+]
+
+
+def _request(name: str, payload: dict[str, object]) -> DBRequest:
+  return DBRequest(op=f"db:identity:mcp_agents:{name}:1", payload=payload)
+
+
+def register_agent_request(params: RegisterAgentParams) -> DBRequest:
+  return _request("register", params.model_dump(exclude_none=True))
+
+
+def get_agent_by_client_id_request(params: ClientIdParams) -> DBRequest:
+  return _request("get_by_client_id", params.model_dump())
+
+
+def link_agent_user_request(params: LinkAgentUserParams) -> DBRequest:
+  return _request("link_user", params.model_dump())
+
+
+def revoke_agent_request(params: ClientIdParams) -> DBRequest:
+  return _request("revoke", params.model_dump())
+
+
+def list_user_agents_request(params: UserRecidParams) -> DBRequest:
+  return _request("list_by_user", params.model_dump())
+
+
+def create_auth_code_request(params: CreateAuthCodeParams) -> DBRequest:
+  return _request("create_auth_code", params.model_dump())
+
+
+def consume_auth_code_request(params: ConsumeAuthCodeParams) -> DBRequest:
+  return _request("consume_auth_code", params.model_dump())
+
+
+def create_agent_token_request(params: CreateAgentTokenParams) -> DBRequest:
+  return _request("create_token", params.model_dump(exclude_none=True))
+
+
+def get_agent_token_request(params: RefreshTokenParams) -> DBRequest:
+  return _request("get_token", params.model_dump())
+
+
+def revoke_agent_token_request(params: RevokeTokenParams) -> DBRequest:
+  return _request("revoke_token", params.model_dump())

--- a/queryregistry/identity/mcp_agents/handler.py
+++ b/queryregistry/identity/mcp_agents/handler.py
@@ -1,0 +1,53 @@
+"""Identity MCP agents handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import (
+  consume_auth_code_v1,
+  create_auth_code_v1,
+  create_token_v1,
+  get_by_client_id_v1,
+  get_by_recid_v1,
+  get_token_v1,
+  link_user_v1,
+  list_by_user_v1,
+  register_v1,
+  revoke_token_v1,
+  revoke_v1,
+)
+
+__all__ = ["handle_mcp_agents_request"]
+
+DISPATCHERS = {
+  ("register", "1"): register_v1,
+  ("get_by_client_id", "1"): get_by_client_id_v1,
+  ("get_by_recid", "1"): get_by_recid_v1,
+  ("link_user", "1"): link_user_v1,
+  ("revoke", "1"): revoke_v1,
+  ("list_by_user", "1"): list_by_user_v1,
+  ("create_auth_code", "1"): create_auth_code_v1,
+  ("consume_auth_code", "1"): consume_auth_code_v1,
+  ("create_token", "1"): create_token_v1,
+  ("get_token", "1"): get_token_v1,
+  ("revoke_token", "1"): revoke_token_v1,
+}
+
+
+async def handle_mcp_agents_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown identity mcp_agents operation",
+  )

--- a/queryregistry/identity/mcp_agents/models.py
+++ b/queryregistry/identity/mcp_agents/models.py
@@ -1,0 +1,99 @@
+"""Identity MCP agents query registry service models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "AgentRecidParams",
+  "ClientIdParams",
+  "CreateAgentTokenParams",
+  "CreateAuthCodeParams",
+  "ConsumeAuthCodeParams",
+  "LinkAgentUserParams",
+  "RefreshTokenParams",
+  "RegisterAgentParams",
+  "RevokeTokenParams",
+  "UserRecidParams",
+]
+
+
+class RegisterAgentParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  client_name: str
+  redirect_uris: str | None = None
+  grant_types: str = "authorization_code"
+  response_types: str = "code"
+  scopes: str = "mcp:schema:read mcp:data:read mcp:rpc:list"
+  ip_address: str | None = None
+  user_agent: str | None = None
+
+
+class AgentRecidParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  agents_recid: int
+
+
+class ClientIdParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  client_id: str
+
+
+class LinkAgentUserParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  client_id: str
+  users_recid: int
+
+
+class UserRecidParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  users_recid: int
+
+
+class CreateAuthCodeParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  agents_recid: int
+  users_recid: int
+  code: str
+  code_challenge: str
+  code_method: str = "S256"
+  redirect_uri: str
+  scopes: str
+  expires_on: datetime
+
+
+class ConsumeAuthCodeParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  code: str
+
+
+class CreateAgentTokenParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  agents_recid: int
+  access_token: str
+  refresh_token: str | None = None
+  access_exp: datetime
+  refresh_exp: datetime | None = None
+  scopes: str
+
+
+class RefreshTokenParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  refresh_token: str
+
+
+class RevokeTokenParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  agents_recid: int

--- a/queryregistry/identity/mcp_agents/mssql.py
+++ b/queryregistry/identity/mcp_agents/mssql.py
@@ -1,0 +1,343 @@
+"""MSSQL implementations for identity MCP agents query registry services."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
+
+from .models import (
+  AgentRecidParams,
+  ClientIdParams,
+  CreateAgentTokenParams,
+  CreateAuthCodeParams,
+  ConsumeAuthCodeParams,
+  LinkAgentUserParams,
+  RefreshTokenParams,
+  RegisterAgentParams,
+  RevokeTokenParams,
+  UserRecidParams,
+)
+
+__all__ = [
+  "consume_auth_code_v1",
+  "create_auth_code_v1",
+  "create_token_v1",
+  "get_by_client_id_v1",
+  "get_by_recid_v1",
+  "get_token_v1",
+  "link_user_v1",
+  "list_by_user_v1",
+  "register_v1",
+  "revoke_token_v1",
+  "revoke_v1",
+]
+
+
+async def register_v1(args: dict[str, Any]) -> DBResponse:
+  params = RegisterAgentParams.model_validate(args)
+  sql = """
+    SET NOCOUNT ON;
+    DECLARE @inserted TABLE (
+      recid bigint,
+      element_client_id uniqueidentifier,
+      element_client_name nvarchar(256),
+      element_scopes nvarchar(1024),
+      element_created_on datetimeoffset(7)
+    );
+
+    INSERT INTO account_mcp_agents (
+      element_client_name,
+      element_redirect_uris,
+      element_grant_types,
+      element_response_types,
+      element_scopes,
+      element_ip_address,
+      element_user_agent
+    )
+    OUTPUT
+      inserted.recid,
+      inserted.element_client_id,
+      inserted.element_client_name,
+      inserted.element_scopes,
+      inserted.element_created_on
+    INTO @inserted
+    VALUES (?, ?, ?, ?, ?, ?, ?);
+
+    SELECT *
+    FROM @inserted
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(
+    sql,
+    (
+      params.client_name,
+      params.redirect_uris,
+      params.grant_types,
+      params.response_types,
+      params.scopes,
+      params.ip_address,
+      params.user_agent,
+    ),
+  )
+
+
+async def get_by_client_id_v1(args: dict[str, Any]) -> DBResponse:
+  params = ClientIdParams.model_validate(args)
+  sql = """
+    SELECT
+      a.recid,
+      a.element_client_id,
+      a.element_client_name,
+      a.element_scopes,
+      a.element_roles,
+      a.users_recid,
+      a.element_is_active,
+      a.element_revoked_at,
+      a.element_redirect_uris,
+      au.element_guid AS user_guid
+    FROM account_mcp_agents a
+    LEFT JOIN account_users au ON au.recid = a.users_recid
+    WHERE a.element_client_id = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (params.client_id,))
+
+
+async def get_by_recid_v1(args: dict[str, Any]) -> DBResponse:
+  params = AgentRecidParams.model_validate(args)
+  sql = """
+    SELECT
+      a.recid,
+      a.element_client_id,
+      a.element_client_name,
+      a.element_scopes,
+      a.element_roles,
+      a.users_recid,
+      a.element_is_active,
+      a.element_revoked_at,
+      a.element_redirect_uris,
+      au.element_guid AS user_guid
+    FROM account_mcp_agents a
+    LEFT JOIN account_users au ON au.recid = a.users_recid
+    WHERE a.recid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (params.agents_recid,))
+
+
+async def link_user_v1(args: dict[str, Any]) -> DBResponse:
+  params = LinkAgentUserParams.model_validate(args)
+  sql = """
+    UPDATE account_mcp_agents
+    SET users_recid = ?, element_modified_on = SYSUTCDATETIME()
+    WHERE element_client_id = ?;
+  """
+  return await run_exec(sql, (params.users_recid, params.client_id))
+
+
+async def revoke_v1(args: dict[str, Any]) -> DBResponse:
+  params = ClientIdParams.model_validate(args)
+  sql = """
+    UPDATE account_mcp_agents
+    SET element_is_active = 0,
+        element_revoked_at = SYSUTCDATETIME(),
+        element_modified_on = SYSUTCDATETIME()
+    WHERE element_client_id = ?;
+  """
+  return await run_exec(sql, (params.client_id,))
+
+
+async def list_by_user_v1(args: dict[str, Any]) -> DBResponse:
+  params = UserRecidParams.model_validate(args)
+  sql = """
+    SELECT
+      recid,
+      element_client_id,
+      element_client_name,
+      element_redirect_uris,
+      element_grant_types,
+      element_response_types,
+      element_scopes,
+      element_roles,
+      users_recid,
+      element_is_active,
+      element_revoked_at,
+      element_created_on,
+      element_modified_on
+    FROM account_mcp_agents
+    WHERE users_recid = ?
+    ORDER BY recid DESC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, (params.users_recid,))
+
+
+async def create_auth_code_v1(args: dict[str, Any]) -> DBResponse:
+  params = CreateAuthCodeParams.model_validate(args)
+  sql = """
+    SET NOCOUNT ON;
+    DECLARE @inserted TABLE (
+      recid bigint,
+      agents_recid bigint,
+      users_recid bigint,
+      element_code nvarchar(256),
+      element_expires_on datetimeoffset(7)
+    );
+
+    INSERT INTO account_mcp_auth_codes (
+      agents_recid,
+      users_recid,
+      element_code,
+      element_code_challenge,
+      element_code_method,
+      element_redirect_uri,
+      element_scopes,
+      element_expires_on
+    )
+    OUTPUT
+      inserted.recid,
+      inserted.agents_recid,
+      inserted.users_recid,
+      inserted.element_code,
+      inserted.element_expires_on
+    INTO @inserted
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+
+    SELECT *
+    FROM @inserted
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(
+    sql,
+    (
+      params.agents_recid,
+      params.users_recid,
+      params.code,
+      params.code_challenge,
+      params.code_method,
+      params.redirect_uri,
+      params.scopes,
+      params.expires_on,
+    ),
+  )
+
+
+async def consume_auth_code_v1(args: dict[str, Any]) -> DBResponse:
+  params = ConsumeAuthCodeParams.model_validate(args)
+  sql = """
+    SET NOCOUNT ON;
+    DECLARE @consumed TABLE (
+      recid bigint,
+      agents_recid bigint,
+      users_recid bigint,
+      element_code_challenge nvarchar(256),
+      element_code_method nvarchar(16),
+      element_redirect_uri nvarchar(2048),
+      element_scopes nvarchar(1024),
+      element_expires_on datetimeoffset(7)
+    );
+
+    UPDATE account_mcp_auth_codes
+    SET element_consumed = 1
+    OUTPUT
+      inserted.recid,
+      inserted.agents_recid,
+      inserted.users_recid,
+      inserted.element_code_challenge,
+      inserted.element_code_method,
+      inserted.element_redirect_uri,
+      inserted.element_scopes,
+      inserted.element_expires_on
+    INTO @consumed
+    WHERE element_code = ?
+      AND element_consumed = 0
+      AND element_expires_on > SYSUTCDATETIME();
+
+    SELECT TOP 1 *
+    FROM @consumed
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (params.code,))
+
+
+async def create_token_v1(args: dict[str, Any]) -> DBResponse:
+  params = CreateAgentTokenParams.model_validate(args)
+  sql = """
+    SET NOCOUNT ON;
+    DECLARE @inserted TABLE (
+      recid bigint,
+      agents_recid bigint,
+      element_access_exp datetimeoffset(7),
+      element_refresh_exp datetimeoffset(7),
+      element_scopes nvarchar(1024),
+      element_created_on datetimeoffset(7)
+    );
+
+    INSERT INTO account_mcp_agent_tokens (
+      agents_recid,
+      element_access_token,
+      element_refresh_token,
+      element_access_exp,
+      element_refresh_exp,
+      element_scopes
+    )
+    OUTPUT
+      inserted.recid,
+      inserted.agents_recid,
+      inserted.element_access_exp,
+      inserted.element_refresh_exp,
+      inserted.element_scopes,
+      inserted.element_created_on
+    INTO @inserted
+    VALUES (?, ?, ?, ?, ?, ?);
+
+    SELECT TOP 1 *
+    FROM @inserted
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(
+    sql,
+    (
+      params.agents_recid,
+      params.access_token,
+      params.refresh_token,
+      params.access_exp,
+      params.refresh_exp,
+      params.scopes,
+    ),
+  )
+
+
+async def get_token_v1(args: dict[str, Any]) -> DBResponse:
+  params = RefreshTokenParams.model_validate(args)
+  sql = """
+    SELECT
+      t.recid,
+      t.agents_recid,
+      t.element_refresh_token,
+      t.element_refresh_exp,
+      t.element_scopes,
+      t.element_revoked_at,
+      a.element_client_id,
+      a.users_recid,
+      a.element_is_active,
+      au.element_guid AS user_guid
+    FROM account_mcp_agent_tokens t
+    JOIN account_mcp_agents a ON a.recid = t.agents_recid
+    LEFT JOIN account_users au ON au.recid = a.users_recid
+    WHERE t.element_refresh_token = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (params.refresh_token,))
+
+
+async def revoke_token_v1(args: dict[str, Any]) -> DBResponse:
+  params = RevokeTokenParams.model_validate(args)
+  sql = """
+    UPDATE account_mcp_agent_tokens
+    SET element_revoked_at = SYSUTCDATETIME()
+    WHERE agents_recid = ? AND element_revoked_at IS NULL;
+  """
+  return await run_exec(sql, (params.agents_recid,))

--- a/queryregistry/identity/mcp_agents/services.py
+++ b/queryregistry/identity/mcp_agents/services.py
@@ -1,0 +1,152 @@
+"""Identity MCP agents query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  AgentRecidParams,
+  ClientIdParams,
+  CreateAgentTokenParams,
+  CreateAuthCodeParams,
+  ConsumeAuthCodeParams,
+  LinkAgentUserParams,
+  RefreshTokenParams,
+  RegisterAgentParams,
+  RevokeTokenParams,
+  UserRecidParams,
+)
+
+__all__ = [
+  "consume_auth_code_v1",
+  "create_auth_code_v1",
+  "create_token_v1",
+  "get_by_client_id_v1",
+  "get_by_recid_v1",
+  "get_token_v1",
+  "link_user_v1",
+  "list_by_user_v1",
+  "register_v1",
+  "revoke_token_v1",
+  "revoke_v1",
+]
+
+AgentOperationCallable = Callable[[dict[str, Any]], Awaitable[DBResponse]]
+
+_REGISTER_DISPATCHERS: dict[str, AgentOperationCallable] = {"mssql": mssql.register_v1}
+_GET_BY_CLIENT_ID_DISPATCHERS: dict[str, AgentOperationCallable] = {
+  "mssql": mssql.get_by_client_id_v1,
+}
+_GET_BY_RECID_DISPATCHERS: dict[str, AgentOperationCallable] = {
+  "mssql": mssql.get_by_recid_v1,
+}
+_LINK_USER_DISPATCHERS: dict[str, AgentOperationCallable] = {"mssql": mssql.link_user_v1}
+_REVOKE_DISPATCHERS: dict[str, AgentOperationCallable] = {"mssql": mssql.revoke_v1}
+_LIST_BY_USER_DISPATCHERS: dict[str, AgentOperationCallable] = {
+  "mssql": mssql.list_by_user_v1,
+}
+_CREATE_AUTH_CODE_DISPATCHERS: dict[str, AgentOperationCallable] = {
+  "mssql": mssql.create_auth_code_v1,
+}
+_CONSUME_AUTH_CODE_DISPATCHERS: dict[str, AgentOperationCallable] = {
+  "mssql": mssql.consume_auth_code_v1,
+}
+_CREATE_TOKEN_DISPATCHERS: dict[str, AgentOperationCallable] = {"mssql": mssql.create_token_v1}
+_GET_TOKEN_DISPATCHERS: dict[str, AgentOperationCallable] = {"mssql": mssql.get_token_v1}
+_REVOKE_TOKEN_DISPATCHERS: dict[str, AgentOperationCallable] = {
+  "mssql": mssql.revoke_token_v1,
+}
+
+
+def _resolve_dispatcher(
+  dispatchers: dict[str, AgentOperationCallable],
+  *,
+  provider: str,
+) -> AgentOperationCallable:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for identity mcp_agents registry")
+  return dispatcher
+
+
+async def register_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_REGISTER_DISPATCHERS, provider=provider)
+  params = RegisterAgentParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump(exclude_none=True))
+  return DBResponse(op=request.op, payload=result.payload, rows=result.rows, rowcount=result.rowcount)
+
+
+
+
+async def get_by_recid_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_GET_BY_RECID_DISPATCHERS, provider=provider)
+  params = AgentRecidParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rows=result.rows, rowcount=result.rowcount)
+
+
+async def get_by_client_id_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_GET_BY_CLIENT_ID_DISPATCHERS, provider=provider)
+  params = ClientIdParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rows=result.rows, rowcount=result.rowcount)
+
+
+async def link_user_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_LINK_USER_DISPATCHERS, provider=provider)
+  params = LinkAgentUserParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def revoke_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_REVOKE_DISPATCHERS, provider=provider)
+  params = ClientIdParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_by_user_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_LIST_BY_USER_DISPATCHERS, provider=provider)
+  params = UserRecidParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rows=result.rows, rowcount=result.rowcount)
+
+
+async def create_auth_code_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_CREATE_AUTH_CODE_DISPATCHERS, provider=provider)
+  params = CreateAuthCodeParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rows=result.rows, rowcount=result.rowcount)
+
+
+async def consume_auth_code_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_CONSUME_AUTH_CODE_DISPATCHERS, provider=provider)
+  params = ConsumeAuthCodeParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rows=result.rows, rowcount=result.rowcount)
+
+
+async def create_token_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_CREATE_TOKEN_DISPATCHERS, provider=provider)
+  params = CreateAgentTokenParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump(exclude_none=True))
+  return DBResponse(op=request.op, payload=result.payload, rows=result.rows, rowcount=result.rowcount)
+
+
+async def get_token_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_GET_TOKEN_DISPATCHERS, provider=provider)
+  params = RefreshTokenParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rows=result.rows, rowcount=result.rowcount)
+
+
+async def revoke_token_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  dispatcher = _resolve_dispatcher(_REVOKE_TOKEN_DISPATCHERS, provider=provider)
+  params = RevokeTokenParams.model_validate(request.payload)
+  result = await dispatcher(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/server/modules/mcp_gateway_module.py
+++ b/server/modules/mcp_gateway_module.py
@@ -1,0 +1,433 @@
+"""MCP OAuth gateway module."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import secrets
+import time
+from collections import deque
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException
+from jose import jwt
+
+from queryregistry.finance.credits import get_credits_request
+from queryregistry.finance.credits.models import GetCreditsParams
+from queryregistry.identity.mcp_agents import (
+  consume_auth_code_request,
+  create_agent_token_request,
+  create_auth_code_request,
+  get_agent_by_client_id_request,
+  get_agent_token_request,
+  link_agent_user_request,
+  list_user_agents_request,
+  register_agent_request,
+  revoke_agent_request,
+  revoke_agent_token_request,
+)
+from queryregistry.identity.mcp_agents.models import (
+  ClientIdParams,
+  CreateAgentTokenParams,
+  CreateAuthCodeParams,
+  ConsumeAuthCodeParams,
+  LinkAgentUserParams,
+  RefreshTokenParams,
+  RegisterAgentParams,
+  RevokeTokenParams,
+  UserRecidParams,
+)
+from queryregistry.models import DBRequest
+from queryregistry.system.config import get_config_request, upsert_config_request
+from queryregistry.system.config.models import ConfigKeyParams, UpsertConfigParams
+
+from . import BaseModule
+from .auth_module import AuthModule
+from .db_module import DbModule
+from .discord_bot_module import DiscordBotModule
+from .oauth_module import OauthModule
+
+
+def _coerce_datetime(value) -> datetime | None:
+  if value is None:
+    return None
+  if isinstance(value, datetime):
+    dt = value
+  else:
+    text = str(value).replace("Z", "+00:00")
+    dt = datetime.fromisoformat(text)
+  if dt.tzinfo is None:
+    return dt.replace(tzinfo=timezone.utc)
+  return dt
+
+
+class SlidingWindowRateLimiter:
+  def __init__(self, window_seconds: float):
+    self._window = window_seconds
+    self._counters: dict[str, deque[float]] = {}
+    self._global: deque[float] = deque()
+
+  def check(self, key: str, per_key_limit: int, global_limit: int) -> bool:
+    """Return True if request is allowed, False if rate limited."""
+    now = time.monotonic()
+    cutoff = now - self._window
+    while self._global and self._global[0] < cutoff:
+      self._global.popleft()
+    if len(self._global) >= global_limit:
+      return False
+    counter = self._counters.get(key)
+    if counter is None:
+      counter = deque()
+      self._counters[key] = counter
+    while counter and counter[0] < cutoff:
+      counter.popleft()
+    if len(counter) >= per_key_limit:
+      return False
+    counter.append(now)
+    self._global.append(now)
+    return True
+
+  @property
+  def global_count(self) -> int:
+    return len(self._global)
+
+
+class McpGatewayModule(BaseModule):
+  ROLE_MCP_ACCESS_MASK = 32
+
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.dcr_enabled: bool = False
+    self.hostname: str = ""
+    self.register_ip_limit: int = 5
+    self.register_global_limit: int = 50
+    self.token_ip_limit: int = 60
+    self.token_global_limit: int = 500
+    self.register_rate_limiter = SlidingWindowRateLimiter(window_seconds=60.0)
+    self.token_rate_limiter = SlidingWindowRateLimiter(window_seconds=60.0)
+
+  async def startup(self):
+    self.db: DbModule = self.app.state.db
+    await self.db.on_ready()
+    self.auth: AuthModule = self.app.state.auth
+    await self.auth.on_ready()
+    self.oauth: OauthModule = self.app.state.oauth
+    await self.oauth.on_ready()
+    self.discord: DiscordBotModule | None = getattr(self.app.state, "discord_bot", None)
+    if self.discord:
+      await self.discord.on_ready()
+    await self.refresh_runtime_config()
+    self.mark_ready()
+
+  async def shutdown(self):
+    pass
+
+  async def _audit(self, level: str, message: str):
+    log_line = f"[McpGatewayModule] [{level}] {message}"
+    getattr(logging, level.lower(), logging.info)(log_line)
+    if self.discord:
+      try:
+        await self.discord.send_sys_message(log_line)
+      except Exception:
+        logging.exception("[McpGatewayModule] Failed to send Discord audit event")
+
+  async def refresh_runtime_config(self):
+    self.dcr_enabled = await self.is_dcr_enabled(refresh=True)
+    self.hostname = await self._get_config_value("Hostname", fallback="")
+    self.register_ip_limit = await self._get_config_int("MCP_RATE_LIMIT_REGISTER_IP", fallback=5)
+    self.register_global_limit = await self._get_config_int(
+      "MCP_RATE_LIMIT_REGISTER_GLOBAL", fallback=50
+    )
+    self.token_ip_limit = await self._get_config_int("MCP_RATE_LIMIT_TOKEN_IP", fallback=60)
+    self.token_global_limit = await self._get_config_int("MCP_RATE_LIMIT_TOKEN_GLOBAL", fallback=500)
+
+  async def _get_config_value(self, key: str, *, fallback: str = "") -> str:
+    res = await self.db.run(get_config_request(ConfigKeyParams(key=key)))
+    if not res.rows:
+      return fallback
+    value = res.rows[0].get("element_value")
+    return str(value) if value is not None else fallback
+
+  async def _get_config_int(self, key: str, *, fallback: int) -> int:
+    value = await self._get_config_value(key, fallback=str(fallback))
+    try:
+      return int(value)
+    except (TypeError, ValueError):
+      logging.warning("[McpGatewayModule] Invalid integer config %s=%s", key, value)
+      return fallback
+
+  async def is_dcr_enabled(self, refresh: bool = False) -> bool:
+    if not refresh:
+      return self.dcr_enabled
+    value = await self._get_config_value("MCP_DCR_ENABLED", fallback="false")
+    self.dcr_enabled = value.lower() in ("1", "true", "yes", "on")
+    return self.dcr_enabled
+
+  async def _set_dcr_enabled(self, enabled: bool):
+    value = "true" if enabled else "false"
+    await self.db.run(upsert_config_request(UpsertConfigParams(key="MCP_DCR_ENABLED", value=value)))
+    self.dcr_enabled = enabled
+
+  async def check_register_rate(self, ip: str) -> bool:
+    allowed = self.register_rate_limiter.check(ip, self.register_ip_limit, self.register_global_limit)
+    if not allowed:
+      await self._audit("warning", f"Registration rate limit hit for ip={ip}")
+      if self.register_rate_limiter.global_count >= self.register_global_limit:
+        await self._set_dcr_enabled(False)
+        await self._audit("critical", "Registration global limit reached. MCP_DCR_ENABLED set to false")
+      return False
+    if self.register_rate_limiter.global_count >= int(self.register_global_limit * 0.8):
+      await self._audit(
+        "warning",
+        f"Registration global counter nearing limit {self.register_rate_limiter.global_count}/{self.register_global_limit}",
+      )
+    return True
+
+  async def check_token_rate(self, ip: str) -> bool:
+    allowed = self.token_rate_limiter.check(ip, self.token_ip_limit, self.token_global_limit)
+    if not allowed:
+      await self._audit("warning", f"Token rate limit hit for ip={ip}")
+      return False
+    return True
+
+  async def register_client(
+    self,
+    client_name,
+    redirect_uris,
+    grant_types,
+    response_types,
+    scopes,
+    ip_address,
+    user_agent,
+  ) -> dict:
+    if not await self.is_dcr_enabled(refresh=False):
+      await self._audit("warning", "DCR registration blocked by kill switch")
+      raise HTTPException(status_code=503, detail="MCP DCR is disabled")
+    if not await self.check_register_rate(ip_address or "unknown"):
+      raise HTTPException(status_code=429, detail="Rate limit exceeded")
+    params = RegisterAgentParams(
+      client_name=client_name,
+      redirect_uris=redirect_uris,
+      grant_types=grant_types,
+      response_types=response_types,
+      scopes=scopes,
+      ip_address=ip_address,
+      user_agent=user_agent,
+    )
+    response = await self.db.run(register_agent_request(params))
+    row = response.rows[0] if response.rows else None
+    if not row:
+      await self._audit("error", f"Registration failed for client_name={client_name}")
+      raise HTTPException(status_code=500, detail="Client registration failed")
+    await self._audit("info", f"Registered MCP client client_id={row.get('element_client_id')}")
+    return row
+
+  async def get_client(self, client_id: str) -> dict | None:
+    response = await self.db.run(get_agent_by_client_id_request(ClientIdParams(client_id=client_id)))
+    return response.rows[0] if response.rows else None
+
+  async def link_client_to_user(self, client_id: str, users_recid: int) -> None:
+    await self.db.run(
+      link_agent_user_request(
+        LinkAgentUserParams(client_id=client_id, users_recid=users_recid),
+      ),
+    )
+
+  async def create_authorization_code(
+    self,
+    agents_recid,
+    users_recid,
+    code_challenge,
+    code_method,
+    redirect_uri,
+    scopes,
+  ) -> str:
+    code = secrets.token_urlsafe(32)
+    expires_on = datetime.now(timezone.utc) + timedelta(seconds=60)
+    await self.db.run(
+      create_auth_code_request(
+        CreateAuthCodeParams(
+          agents_recid=agents_recid,
+          users_recid=users_recid,
+          code=code,
+          code_challenge=code_challenge,
+          code_method=code_method,
+          redirect_uri=redirect_uri,
+          scopes=scopes,
+          expires_on=expires_on,
+        ),
+      ),
+    )
+    await self._audit("info", f"Authorization code issued for agents_recid={agents_recid}")
+    return code
+
+  async def exchange_authorization_code(self, code, code_verifier, client_id) -> dict:
+    consumed = await self.db.run(consume_auth_code_request(ConsumeAuthCodeParams(code=code)))
+    code_row = consumed.rows[0] if consumed.rows else None
+    if not code_row:
+      raise HTTPException(status_code=400, detail="Invalid or expired authorization code")
+    if (code_row.get("element_code_method") or "S256") != "S256":
+      raise HTTPException(status_code=400, detail="Unsupported code challenge method")
+    expected = code_row.get("element_code_challenge")
+    digest = hashlib.sha256(str(code_verifier).encode("utf-8")).digest()
+    verifier_challenge = base64.urlsafe_b64encode(digest).decode("utf-8").rstrip("=")
+    if verifier_challenge != expected:
+      raise HTTPException(status_code=400, detail="PKCE verification failed")
+
+    client = await self.get_client(client_id)
+    if not client or int(client.get("recid") or 0) != int(code_row.get("agents_recid") or 0):
+      raise HTTPException(status_code=400, detail="Client does not match authorization code")
+    if not client.get("element_is_active"):
+      raise HTTPException(status_code=401, detail="Client revoked")
+
+    users_recid = code_row.get("users_recid")
+    if users_recid is None:
+      raise HTTPException(status_code=400, detail="Authorization code is not linked to a user")
+
+    await self.db.run(
+      revoke_agent_token_request(RevokeTokenParams(agents_recid=int(code_row["agents_recid"]))),
+    )
+
+    user_guid, _ = await self.resolve_agent_credits(int(code_row["agents_recid"]))
+    now = datetime.now(timezone.utc)
+    access_exp = now + timedelta(minutes=5)
+    refresh_exp = now + timedelta(days=7)
+    claims = {
+      "sub": user_guid,
+      "client_id": str(client.get("element_client_id")),
+      "scopes": str(code_row.get("element_scopes") or ""),
+      "iss": self.hostname,
+      "iat": int(now.timestamp()),
+      "exp": int(access_exp.timestamp()),
+      "jti": uuid4().hex,
+      "type": "mcp_access",
+    }
+    if not self.auth.jwt_secret:
+      raise HTTPException(status_code=500, detail="JWT secret is not configured")
+    access_token = jwt.encode(
+      claims,
+      self.auth.jwt_secret,
+      algorithm=getattr(self.auth, "jwt_algo_int", "HS256"),
+    )
+    refresh_token = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode("utf-8").rstrip("=")
+
+    await self.db.run(
+      create_agent_token_request(
+        CreateAgentTokenParams(
+          agents_recid=int(code_row["agents_recid"]),
+          access_token=access_token,
+          refresh_token=refresh_token,
+          access_exp=access_exp,
+          refresh_exp=refresh_exp,
+          scopes=str(code_row.get("element_scopes") or ""),
+        ),
+      ),
+    )
+    await self._audit("info", f"Access token issued for agents_recid={code_row['agents_recid']}")
+    return {
+      "access_token": access_token,
+      "refresh_token": refresh_token,
+      "token_type": "Bearer",
+      "expires_in": 300,
+      "scope": str(code_row.get("element_scopes") or ""),
+    }
+
+  async def refresh_access_token(self, refresh_token: str) -> dict:
+    token_response = await self.db.run(
+      get_agent_token_request(RefreshTokenParams(refresh_token=refresh_token)),
+    )
+    row = token_response.rows[0] if token_response.rows else None
+    if not row:
+      raise HTTPException(status_code=401, detail="Invalid refresh token")
+    if row.get("element_revoked_at"):
+      raise HTTPException(status_code=401, detail="Refresh token revoked")
+    refresh_exp = _coerce_datetime(row.get("element_refresh_exp"))
+    if refresh_exp is not None and refresh_exp < datetime.now(timezone.utc):
+      raise HTTPException(status_code=401, detail="Refresh token expired")
+    if not row.get("element_is_active"):
+      raise HTTPException(status_code=401, detail="Client revoked")
+
+    user_guid = row.get("user_guid")
+    if not user_guid:
+      raise HTTPException(status_code=401, detail="Refresh token is not linked to a user")
+
+    now = datetime.now(timezone.utc)
+    access_exp = now + timedelta(minutes=5)
+    claims = {
+      "sub": str(user_guid),
+      "client_id": str(row.get("element_client_id")),
+      "scopes": str(row.get("element_scopes") or ""),
+      "iss": self.hostname,
+      "iat": int(now.timestamp()),
+      "exp": int(access_exp.timestamp()),
+      "jti": uuid4().hex,
+      "type": "mcp_access",
+    }
+    if not self.auth.jwt_secret:
+      raise HTTPException(status_code=500, detail="JWT secret is not configured")
+    new_access_token = jwt.encode(
+      claims,
+      self.auth.jwt_secret,
+      algorithm=getattr(self.auth, "jwt_algo_int", "HS256"),
+    )
+    await self.db.run(
+      create_agent_token_request(
+        CreateAgentTokenParams(
+          agents_recid=int(row["agents_recid"]),
+          access_token=new_access_token,
+          refresh_token=refresh_token,
+          access_exp=access_exp,
+          refresh_exp=refresh_exp,
+          scopes=str(row.get("element_scopes") or ""),
+        ),
+      ),
+    )
+    await self._audit("info", f"Refreshed access token for agents_recid={row['agents_recid']}")
+    return {
+      "access_token": new_access_token,
+      "refresh_token": refresh_token,
+      "token_type": "Bearer",
+      "expires_in": 300,
+      "scope": str(row.get("element_scopes") or ""),
+    }
+
+  async def validate_access_token(self, token: str) -> dict:
+    try:
+      claims = jwt.decode(
+        token,
+        self.auth.jwt_secret,
+        algorithms=[getattr(self.auth, "jwt_algo_int", "HS256")],
+      )
+    except Exception as exc:
+      raise HTTPException(status_code=401, detail="Invalid access token") from exc
+    if claims.get("type") != "mcp_access":
+      raise HTTPException(status_code=401, detail="Invalid token type")
+    exp = claims.get("exp")
+    if exp and datetime.fromtimestamp(int(exp), tz=timezone.utc) < datetime.now(timezone.utc):
+      raise HTTPException(status_code=401, detail="Token expired")
+    return claims
+
+  async def resolve_agent_credits(self, agents_recid: int) -> tuple[str, int]:
+    res = await self.db.run(
+      DBRequest(op="db:identity:mcp_agents:get_by_recid:1", payload={"agents_recid": agents_recid}),
+    )
+    agent = res.rows[0] if res.rows else None
+    if not agent or not agent.get("user_guid"):
+      raise HTTPException(status_code=404, detail="Agent is not linked to a user")
+    user_guid = str(agent["user_guid"])
+    credits_res = await self.db.run(get_credits_request(GetCreditsParams(guid=user_guid)))
+    credits_row = credits_res.rows[0] if credits_res.rows else {}
+    credits = int(credits_row.get("element_credits") or 0)
+    return user_guid, credits
+
+  async def check_user_mcp_role(self, user_guid: str) -> bool:
+    return await self.auth.user_has_role(user_guid, self.ROLE_MCP_ACCESS_MASK)
+
+  async def list_user_clients(self, users_recid: int) -> list[dict]:
+    response = await self.db.run(list_user_agents_request(UserRecidParams(users_recid=users_recid)))
+    return response.rows
+
+  async def revoke_client(self, client_id: str):
+    await self.db.run(revoke_agent_request(ClientIdParams(client_id=client_id)))


### PR DESCRIPTION
### Motivation
- Add MCP (MCP OAuth 2.1 / DCR) backend foundations: database schema, reflection metadata, queryregistry data-access, and a server module to implement registration, PKCE auth-code exchange, token issuance, and runtime controls. 
- Provide a kill-switch, rate limits, and audit hooks (Discord/system channel) to safely operate dynamic client registration and token issuance in production.

### Description
- Added DB migrations `migrations/v0.8.5.0_mcp_oauth_tables.sql` and `migrations/v0.8.5.0_mcp_oauth_tables_seed.sql` which create `account_mcp_agents`, `account_mcp_agent_tokens`, `account_mcp_auth_codes`, indexes/FKs, `ROLE_MCP_ACCESS`, `mcp` auth provider seed, and MCP-related `system_config` keys. 
- Implemented a new queryregistry subdomain `queryregistry/identity/mcp_agents/` with request builders (`__init__.py`), strict Pydantic param models (`models.py`), subdomain handler (`handler.py`), service dispatch wrappers (`services.py`), and MSSQL provider implementations (`mssql.py`) using parameterized SQL and `run_json_one`/`run_json_many`/`run_exec`. 
- Wired the subdomain into identity dispatch by registering `mcp_agents` in `queryregistry/identity/handler.py`. 
- Added `server/modules/mcp_gateway_module.py` as a `BaseModule` that awaits `db`, `auth`, `oauth` (and optional `discord_bot`) on startup and exposes business logic for: in-memory sliding-window rate limiting (`deque[float]`), reading/refreshing `MCP_DCR_ENABLED` kill-switch and rate-limit config, circuit-breaker behavior that can disable DCR, authorization code generation (`secrets.token_urlsafe(32)` with 60s TTL), PKCE S256 validation, JWT access token issuance (claims include `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4e8d814288325bf215bd4c2e0bb67)