### PR TITLE
Wire MCP OAuth routes, middleware JWT auth, and tool scope checks

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,15 +4,17 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from server.helpers.logging import configure_root_logging
 from server.lifespan import lifespan
-from server.mcp_server import get_mcp_app
-from server.routers import rpc_router, web_router
+from server.mcp_server import get_mcp_app, set_gateway_resolver
+from server.routers import oauth_router, rpc_router, web_router
 
 configure_root_logging(4)
 
 app = FastAPI(lifespan=lifespan)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 app.include_router(rpc_router.router, prefix="/rpc")
+app.include_router(oauth_router.router)
 app.include_router(web_router.router)
+set_gateway_resolver(lambda: app.state.mcp_gateway)
 _mcp_app = get_mcp_app()
 if _mcp_app is not None:
   app.mount("/mcp", _mcp_app)

--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import contextvars
 import importlib
 import logging
 import os
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException
@@ -16,6 +18,8 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 from starlette.routing import Mount
 
+from queryregistry.finance.credits import set_credits_request
+from queryregistry.finance.credits.models import SetCreditsParams
 from queryregistry.handler import HANDLERS as QR_HANDLERS
 from queryregistry.handler import dispatch_query_request
 from queryregistry.models import DBRequest
@@ -26,6 +30,9 @@ if TYPE_CHECKING:
   from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 
 _MCP_TOKEN = os.environ.get("MCP_AGENT_TOKEN", "")
+_hostname = os.environ.get("MCP_HOSTNAME", "localhost")
+_gateway_resolver: Callable[[], Any] | None = None
+_AUTH_CONTEXT: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar("mcp_auth", default=None)
 _ALLOWED_VIEWS = frozenset({
   "TABLES",
   "COLUMNS",
@@ -50,16 +57,118 @@ _TOOL_ANNOTATIONS = ToolAnnotations(
 )
 
 
+def set_gateway_resolver(resolver: Callable[[], Any] | None) -> None:
+  global _gateway_resolver
+  _gateway_resolver = resolver
+
+
+def _get_gateway() -> Any:
+  if _gateway_resolver is None:
+    raise RuntimeError("MCP gateway resolver is not configured")
+  gateway = _gateway_resolver()
+  if gateway is None:
+    raise RuntimeError("MCP gateway is unavailable")
+  global _hostname
+  hostname = getattr(gateway, "hostname", None)
+  if hostname:
+    _hostname = str(hostname)
+  return gateway
+
+
 class MCPAuthMiddleware(BaseHTTPMiddleware):
-  """Simple bearer-token gate for the mounted MCP app."""
+  """Bearer-token gate: static token OR MCP OAuth JWT."""
 
   async def dispatch(self, request: Any, call_next: Any) -> JSONResponse | Any:
     if not _MCP_TOKEN:
       return JSONResponse({"error": "MCP not configured"}, status_code=503)
+
     auth = request.headers.get("authorization", "")
-    if not auth.startswith("Bearer ") or auth[7:] != _MCP_TOKEN:
-      return JSONResponse({"error": "Unauthorized"}, status_code=401)
-    return await call_next(request)
+    if not auth.startswith("Bearer "):
+      return JSONResponse(
+        {"error": "Unauthorized"},
+        status_code=401,
+        headers={
+          "WWW-Authenticate": f'Bearer resource_metadata="https://{_hostname}/.well-known/oauth-protected-resource"'
+        },
+      )
+
+    token = auth[7:]
+
+    if token == _MCP_TOKEN:
+      request.state.mcp_auth = {
+        "type": "static",
+        "scopes": {
+          "mcp:schema:read",
+          "mcp:data:read",
+          "mcp:rpc:list",
+          "mcp:schema:write",
+          "mcp:data:write",
+          "mcp:rpc:execute",
+          "mcp:admin",
+        },
+        "user_guid": None,
+        "client_id": None,
+      }
+      token_handle = _AUTH_CONTEXT.set(request.state.mcp_auth)
+      try:
+        return await call_next(request)
+      finally:
+        _AUTH_CONTEXT.reset(token_handle)
+
+    try:
+      gateway = _get_gateway()
+      claims = await gateway.validate_access_token(token)
+      request.state.mcp_auth = {
+        "type": "oauth",
+        "scopes": set(str(claims.get("scopes", "")).split()),
+        "user_guid": claims.get("sub"),
+        "client_id": claims.get("client_id"),
+      }
+      token_handle = _AUTH_CONTEXT.set(request.state.mcp_auth)
+      try:
+        return await call_next(request)
+      finally:
+        _AUTH_CONTEXT.reset(token_handle)
+    except Exception:
+      return JSONResponse(
+        {"error": "Unauthorized"},
+        status_code=401,
+        headers={
+          "WWW-Authenticate": f'Bearer resource_metadata="https://{_hostname}/.well-known/oauth-protected-resource"'
+        },
+      )
+
+
+def _check_scope(ctx: Context, required_scope: str) -> dict[str, Any]:
+  """Check scope authorization from middleware-injected auth state."""
+  mcp_auth = None
+  request_context = getattr(ctx, "request_context", None)
+  request = getattr(request_context, "request", None) if request_context else None
+  if request is not None:
+    mcp_auth = getattr(request.state, "mcp_auth", None)
+  if mcp_auth is None:
+    mcp_auth = _AUTH_CONTEXT.get()
+  if mcp_auth is None:
+    raise HTTPException(status_code=401, detail="Not authenticated")
+  if required_scope not in mcp_auth["scopes"]:
+    raise HTTPException(status_code=403, detail=f"Scope '{required_scope}' required")
+  return mcp_auth
+
+
+async def _consume_credit(auth: dict[str, Any], *, cost: int) -> None:
+  if cost <= 0 or auth.get("type") != "oauth":
+    return
+  gateway = _get_gateway()
+  client_id = auth.get("client_id")
+  if not client_id:
+    raise HTTPException(status_code=401, detail="OAuth client binding is missing")
+  client = await gateway.get_client(str(client_id))
+  if not client:
+    raise HTTPException(status_code=401, detail="OAuth client is invalid")
+  user_guid, credits = await gateway.resolve_agent_credits(int(client["recid"]))
+  if credits < cost:
+    raise HTTPException(status_code=402, detail="Insufficient credits")
+  await gateway.db.run(set_credits_request(SetCreditsParams(guid=user_guid, credits=credits - cost)))
 
 
 def _quote_ident(identifier: str) -> str:
@@ -72,10 +181,10 @@ def _extract_payload(response: Any) -> Any:
   return response
 
 
-
 @mcp.tool(annotations=_TOOL_ANNOTATIONS)
 async def oracle_list_tables(ctx: Context) -> Any:
   """List tables exposed by the reflection schema registry."""
+  _check_scope(ctx, "mcp:schema:read")
   response = await dispatch_query_request(DBRequest(op="db:reflection:schema:list_tables:1", payload={}))
   return _extract_payload(response)
 
@@ -87,6 +196,7 @@ async def oracle_describe_table(
   table_schema: str = "dbo",
 ) -> dict[str, Any]:
   """Describe a table by returning columns, indexes, and foreign keys."""
+  _check_scope(ctx, "mcp:schema:read")
   payload = {"table_schema": table_schema, "name": table_name}
   columns = await dispatch_query_request(DBRequest(op="db:reflection:schema:list_columns:1", payload=payload))
   indexes = await dispatch_query_request(DBRequest(op="db:reflection:schema:list_indexes:1", payload=payload))
@@ -101,6 +211,7 @@ async def oracle_describe_table(
 @mcp.tool(annotations=_TOOL_ANNOTATIONS)
 async def oracle_list_views(ctx: Context) -> Any:
   """List database views from reflection schema metadata."""
+  _check_scope(ctx, "mcp:schema:read")
   response = await dispatch_query_request(DBRequest(op="db:reflection:schema:list_views:1", payload={}))
   return _extract_payload(response)
 
@@ -108,6 +219,7 @@ async def oracle_list_views(ctx: Context) -> Any:
 @mcp.tool(annotations=_TOOL_ANNOTATIONS)
 async def oracle_get_full_schema(ctx: Context) -> Any:
   """Return the full reflection schema snapshot payload."""
+  _check_scope(ctx, "mcp:schema:read")
   response = await dispatch_query_request(DBRequest(op="db:reflection:schema:get_full_schema:1", payload={}))
   return _extract_payload(response)
 
@@ -115,6 +227,7 @@ async def oracle_get_full_schema(ctx: Context) -> Any:
 @mcp.tool(annotations=_TOOL_ANNOTATIONS)
 async def oracle_get_schema_version(ctx: Context) -> Any:
   """Return the current schema version from reflection data metadata."""
+  _check_scope(ctx, "mcp:data:read")
   response = await dispatch_query_request(DBRequest(op="db:reflection:data:get_version:1", payload={}))
   return _extract_payload(response)
 
@@ -127,6 +240,8 @@ async def oracle_dump_table(
   max_rows: int = 100,
 ) -> dict[str, Any]:
   """Dump table rows from reflection data and return a bounded result set."""
+  auth = _check_scope(ctx, "mcp:data:read")
+  await _consume_credit(auth, cost=1)
   bounded_max_rows = max(0, min(max_rows, 1000))
   response = await dispatch_query_request(
     DBRequest(op="db:reflection:data:dump_table:1", payload={"table_schema": table_schema, "name": table_name})
@@ -150,6 +265,8 @@ async def oracle_query_info_schema(
   filter_value: str | None = None,
 ) -> Any:
   """Query whitelisted INFORMATION_SCHEMA views with optional equality filter."""
+  auth = _check_scope(ctx, "mcp:data:read")
+  await _consume_credit(auth, cost=1)
   if view_name not in _ALLOWED_VIEWS:
     raise HTTPException(status_code=400, detail=f"Unsupported INFORMATION_SCHEMA view: {view_name}")
 
@@ -165,6 +282,7 @@ async def oracle_query_info_schema(
 @mcp.tool(annotations=_TOOL_ANNOTATIONS)
 async def oracle_list_domains(ctx: Context) -> dict[str, Any]:
   """Enumerate query registry domains, subdomains, and operation versions."""
+  _check_scope(ctx, "mcp:rpc:list")
   results: dict[str, Any] = {}
   for domain, domain_handler in QR_HANDLERS.items():
     try:
@@ -190,6 +308,7 @@ async def oracle_list_domains(ctx: Context) -> dict[str, Any]:
 @mcp.tool(annotations=_TOOL_ANNOTATIONS)
 async def oracle_list_rpc_endpoints(ctx: Context) -> list[str]:
   """List available top-level RPC domains."""
+  _check_scope(ctx, "mcp:rpc:list")
   return sorted(RPC_HANDLERS.keys())
 
 

--- a/server/routers/__init__.py
+++ b/server/routers/__init__.py
@@ -1,1 +1,5 @@
+"""Router package exports."""
 
+from . import oauth_router, rpc_router, web_router
+
+__all__ = ["oauth_router", "rpc_router", "web_router"]

--- a/server/routers/oauth_router.py
+++ b/server/routers/oauth_router.py
@@ -1,0 +1,387 @@
+"""OAuth endpoints for MCP dynamic client registration and authorization flows."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from jose import jwt
+
+from server.modules.providers.auth.discord_provider import AUTHORIZE_URL as DISCORD_AUTHORIZE_URL
+
+router = APIRouter()
+
+_SCOPE_DESCRIPTIONS = {
+  "mcp:schema:read": "Read schema metadata (tables, views, column information).",
+  "mcp:data:read": "Read reflected data and information schema payloads.",
+  "mcp:rpc:list": "List available RPC domains and endpoints.",
+}
+
+_PROVIDER_LABELS = {
+  "microsoft": "Microsoft",
+  "google": "Google",
+  "discord": "Discord",
+}
+
+_PROVIDER_AUTHORIZE_URLS = {
+  "microsoft": "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize",
+  "google": "https://accounts.google.com/o/oauth2/v2/auth",
+  "discord": DISCORD_AUTHORIZE_URL,
+}
+
+_PROVIDER_SCOPES = {
+  "microsoft": "openid profile email User.Read",
+  "google": "openid email profile",
+  "discord": "identify email",
+}
+
+_PROVIDER_SECRET_VARS = {
+  "microsoft": "MICROSOFT_AUTH_SECRET",
+  "google": "GOOGLE_AUTH_SECRET",
+  "discord": "DISCORD_AUTH_SECRET",
+}
+
+
+@router.get("/.well-known/oauth-protected-resource")
+async def get_protected_resource_metadata(request: Request):
+  hostname = request.app.state.mcp_gateway.hostname
+  return {
+    "resource": f"https://{hostname}/mcp",
+    "authorization_servers": [f"https://{hostname}"],
+    "scopes_supported": [
+      "mcp:schema:read",
+      "mcp:data:read",
+      "mcp:rpc:list",
+    ],
+    "bearer_methods_supported": ["header"],
+  }
+
+
+@router.get("/.well-known/oauth-authorization-server")
+async def get_authorization_server_metadata(request: Request):
+  hostname = request.app.state.mcp_gateway.hostname
+  return {
+    "issuer": f"https://{hostname}",
+    "authorization_endpoint": f"https://{hostname}/oauth/authorize",
+    "token_endpoint": f"https://{hostname}/oauth/token",
+    "registration_endpoint": f"https://{hostname}/oauth/register",
+    "scopes_supported": [
+      "mcp:schema:read",
+      "mcp:data:read",
+      "mcp:rpc:list",
+    ],
+    "response_types_supported": ["code"],
+    "grant_types_supported": ["authorization_code", "refresh_token"],
+    "token_endpoint_auth_methods_supported": ["none", "client_secret_post"],
+    "code_challenge_methods_supported": ["S256"],
+    "service_documentation": f"https://{hostname}/docs/mcp",
+  }
+
+
+@router.post("/oauth/register")
+async def post_oauth_register(request: Request):
+  gateway = request.app.state.mcp_gateway
+
+  if not await gateway.is_dcr_enabled():
+    raise HTTPException(status_code=403, detail="Dynamic client registration is disabled")
+
+  ip = request.client.host if request.client else "unknown"
+  if not await gateway.check_register_rate(ip):
+    raise HTTPException(status_code=429, detail="Rate limit exceeded")
+
+  body = await request.json()
+  client_name = body.get("client_name")
+  if not client_name:
+    raise HTTPException(status_code=400, detail="client_name is required")
+
+  result = await gateway.register_client(
+    client_name=client_name,
+    redirect_uris=body.get("redirect_uris"),
+    grant_types=body.get("grant_types", "authorization_code"),
+    response_types=body.get("response_types", "code"),
+    scopes=body.get("scope", "mcp:schema:read mcp:data:read mcp:rpc:list"),
+    ip_address=ip,
+    user_agent=request.headers.get("user-agent"),
+  )
+  return JSONResponse(status_code=201, content=result)
+
+
+def _get_signing_secret(request: Request) -> str:
+  secret = getattr(request.app.state.auth, "jwt_secret", None)
+  if not secret:
+    raise HTTPException(status_code=500, detail="OAuth signing key is not configured")
+  return secret
+
+
+def _parse_redirect_uris(raw_value: Any) -> set[str]:
+  if not raw_value:
+    return set()
+  if isinstance(raw_value, list):
+    return {str(item) for item in raw_value if str(item).strip()}
+  raw = str(raw_value).strip()
+  if not raw:
+    return set()
+  try:
+    parsed = json.loads(raw)
+    if isinstance(parsed, list):
+      return {str(item) for item in parsed if str(item).strip()}
+  except json.JSONDecodeError:
+    pass
+  if "," in raw:
+    return {item.strip() for item in raw.split(",") if item.strip()}
+  if " " in raw:
+    return {item.strip() for item in raw.split(" ") if item.strip()}
+  return {raw}
+
+
+def _sign_flow_state(request: Request, payload: dict[str, Any]) -> str:
+  secret = _get_signing_secret(request)
+  exp = datetime.now(timezone.utc) + timedelta(minutes=10)
+  return jwt.encode({**payload, "exp": int(exp.timestamp())}, secret, algorithm="HS256")
+
+
+def _decode_flow_state(request: Request, token: str) -> dict[str, Any]:
+  secret = _get_signing_secret(request)
+  try:
+    return jwt.decode(token, secret, algorithms=["HS256"])
+  except Exception as exc:
+    raise HTTPException(status_code=400, detail="Invalid authorization state") from exc
+
+
+def _provider_client_id(gateway: Any, provider: str) -> str:
+  provider_obj = gateway.oauth.auth.providers.get(provider)
+  audience = getattr(provider_obj, "audience", None) if provider_obj else None
+  if not audience:
+    raise HTTPException(status_code=500, detail=f"{provider.title()} OAuth is not configured")
+  return str(audience)
+
+
+def _provider_secret(gateway: Any, provider: str) -> str:
+  secret_var = _PROVIDER_SECRET_VARS.get(provider)
+  env_module = getattr(gateway.oauth, "env", None)
+  if not secret_var or not env_module:
+    raise HTTPException(status_code=500, detail=f"{provider.title()} OAuth is not configured")
+  secret = env_module.get(secret_var)
+  if not secret:
+    raise HTTPException(status_code=500, detail=f"{provider.title()} OAuth is not configured")
+  return secret
+
+
+def _callback_uri(hostname: str, provider: str) -> str:
+  return f"https://{hostname}/oauth/callback/{provider}"
+
+
+def _render_authorize_page(client_name: str, requested_scopes: list[str], provider_links: dict[str, str]) -> str:
+  scope_items = "".join(
+    f"<li><code>{scope}</code> — {_SCOPE_DESCRIPTIONS.get(scope, 'Requested access')}</li>"
+    for scope in requested_scopes
+  )
+  provider_buttons = "".join(
+    (
+      f"<a class='btn' href='{provider_links[provider]}'>{_PROVIDER_LABELS[provider]}</a>"
+      for provider in ("microsoft", "google", "discord")
+    )
+  )
+  return f"""
+<!doctype html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"utf-8\" />
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+    <title>MCP OAuth Consent</title>
+    <style>
+      body {{ font-family: Arial, sans-serif; background: #0f172a; color: #e2e8f0; margin: 0; padding: 2rem; }}
+      .card {{ max-width: 720px; margin: 0 auto; background: #1e293b; border-radius: 12px; padding: 1.5rem; }}
+      h1 {{ margin-top: 0; color: #f8fafc; }}
+      ul {{ line-height: 1.6; }}
+      code {{ color: #93c5fd; }}
+      .buttons {{ display: flex; gap: 0.75rem; margin-top: 1.5rem; flex-wrap: wrap; }}
+      .btn {{ background: #2563eb; color: white; text-decoration: none; padding: 0.75rem 1rem; border-radius: 8px; font-weight: 600; }}
+    </style>
+  </head>
+  <body>
+    <div class=\"card\">
+      <h1>{client_name} wants to access Oracle RPC</h1>
+      <p>Requested permissions:</p>
+      <ul>{scope_items}</ul>
+      <p>Continue with a login provider:</p>
+      <div class=\"buttons\">{provider_buttons}</div>
+    </div>
+  </body>
+</html>
+"""
+
+
+@router.get("/oauth/authorize", response_class=HTMLResponse)
+async def get_oauth_authorize(
+  request: Request,
+  client_id: str,
+  redirect_uri: str,
+  response_type: str,
+  scope: str = "mcp:schema:read mcp:data:read mcp:rpc:list",
+  state: str | None = None,
+  code_challenge: str | None = None,
+  code_challenge_method: str | None = None,
+):
+  gateway = request.app.state.mcp_gateway
+  client = await gateway.get_client(client_id)
+  if not client or not client.get("element_is_active"):
+    raise HTTPException(status_code=400, detail="Unknown or inactive client")
+
+  registered_uris = _parse_redirect_uris(client.get("element_redirect_uris"))
+  if redirect_uri not in registered_uris:
+    raise HTTPException(status_code=400, detail="redirect_uri is not registered for this client")
+
+  if response_type != "code":
+    raise HTTPException(status_code=400, detail="Unsupported response_type")
+  if code_challenge_method != "S256" or not code_challenge:
+    raise HTTPException(status_code=400, detail="PKCE S256 code_challenge is required")
+
+  requested_scopes = [segment for segment in scope.split() if segment]
+  flow_state = _sign_flow_state(
+    request,
+    {
+      "client_id": client_id,
+      "redirect_uri": redirect_uri,
+      "state": state,
+      "scope": " ".join(requested_scopes),
+      "code_challenge": code_challenge,
+      "code_challenge_method": code_challenge_method,
+    },
+  )
+
+  provider_links: dict[str, str] = {}
+  for provider in ("microsoft", "google", "discord"):
+    login_params = urlencode({"provider": provider, "flow": flow_state})
+    provider_links[provider] = f"/oauth/provider-login?{login_params}"
+
+  return HTMLResponse(_render_authorize_page(str(client.get("element_client_name") or "Client"), requested_scopes, provider_links))
+
+
+@router.get("/oauth/provider-login")
+async def get_oauth_provider_login(request: Request, provider: str, flow: str):
+  provider = provider.lower()
+  if provider not in _PROVIDER_AUTHORIZE_URLS:
+    raise HTTPException(status_code=400, detail="Unsupported provider")
+
+  flow_payload = _decode_flow_state(request, flow)
+  hostname = request.app.state.mcp_gateway.hostname
+  callback = _callback_uri(hostname, provider)
+  state_payload = _sign_flow_state(
+    request,
+    {
+      "provider": provider,
+      "flow": flow_payload,
+      "nonce": base64.urlsafe_b64encode(os.urandom(12)).decode("utf-8").rstrip("="),
+    },
+  )
+
+  params = {
+    "response_type": "code",
+    "client_id": _provider_client_id(request.app.state.mcp_gateway, provider),
+    "redirect_uri": callback,
+    "scope": _PROVIDER_SCOPES[provider],
+    "state": state_payload,
+  }
+  if provider == "google":
+    params["access_type"] = "offline"
+    params["prompt"] = "consent"
+
+  return RedirectResponse(f"{_PROVIDER_AUTHORIZE_URLS[provider]}?{urlencode(params)}", status_code=302)
+
+
+@router.get("/oauth/callback/{provider}")
+async def get_oauth_provider_callback(request: Request, provider: str, code: str | None = None, state: str | None = None):
+  provider = provider.lower()
+  if not state or not code:
+    raise HTTPException(status_code=400, detail="Missing code or state")
+  callback_state = _decode_flow_state(request, state)
+  if callback_state.get("provider") != provider:
+    raise HTTPException(status_code=400, detail="Provider state mismatch")
+
+  flow = callback_state.get("flow")
+  if not isinstance(flow, dict):
+    raise HTTPException(status_code=400, detail="Authorization flow is invalid")
+
+  gateway = request.app.state.mcp_gateway
+  redirect_uri = _callback_uri(hostname, provider)
+  id_token, access_token = await gateway.oauth.exchange_code_for_tokens(
+    code=code,
+    client_id=_provider_client_id(gateway, provider),
+    client_secret=_provider_secret(gateway, provider),
+    redirect_uri=redirect_uri,
+    provider=provider,
+  )
+  provider_uid, profile, payload = await gateway.auth.handle_auth_login(provider, id_token, access_token)
+  provider_uid = gateway.oauth.normalize_provider_identifier(provider_uid)
+  user = await gateway.oauth.resolve_user(provider, provider_uid, profile, payload)
+  user_guid = str(user.get("guid") or "")
+  if not user_guid or not await gateway.check_user_mcp_role(user_guid):
+    raise HTTPException(status_code=403, detail="User is not authorized for MCP access")
+
+  client_id = str(flow.get("client_id") or "")
+  client = await gateway.get_client(client_id)
+  if not client:
+    raise HTTPException(status_code=400, detail="Unknown OAuth client")
+
+  users_recid = user.get("recid")
+  if users_recid is None:
+    raise HTTPException(status_code=400, detail="User account record is missing")
+
+  await gateway.link_client_to_user(client_id, int(users_recid))
+  auth_code = await gateway.create_authorization_code(
+    agents_recid=int(client["recid"]),
+    users_recid=int(users_recid),
+    code_challenge=str(flow.get("code_challenge") or ""),
+    code_method=str(flow.get("code_challenge_method") or "S256"),
+    redirect_uri=str(flow.get("redirect_uri") or ""),
+    scopes=str(flow.get("scope") or ""),
+  )
+
+  final_redirect_uri = str(flow.get("redirect_uri") or "")
+  final_state = flow.get("state")
+  params = {"code": auth_code}
+  if final_state is not None:
+    params["state"] = final_state
+
+  return RedirectResponse(f"{final_redirect_uri}?{urlencode(params)}", status_code=302)
+
+
+@router.post("/oauth/token")
+async def post_oauth_token(request: Request):
+  gateway = request.app.state.mcp_gateway
+
+  ip = request.client.host if request.client else "unknown"
+  if not await gateway.check_token_rate(ip):
+    raise HTTPException(status_code=429, detail="Rate limit exceeded")
+
+  content_type = request.headers.get("content-type", "")
+  if "application/x-www-form-urlencoded" in content_type:
+    form = await request.form()
+    body = dict(form)
+  else:
+    body = await request.json()
+
+  grant_type = body.get("grant_type")
+
+  if grant_type == "authorization_code":
+    result = await gateway.exchange_authorization_code(
+      code=body.get("code"),
+      code_verifier=body.get("code_verifier"),
+      client_id=body.get("client_id"),
+    )
+    return result
+
+  if grant_type == "refresh_token":
+    result = await gateway.refresh_access_token(
+      refresh_token=body.get("refresh_token"),
+    )
+    return result
+
+  raise HTTPException(status_code=400, detail="Unsupported grant_type")


### PR DESCRIPTION
### Motivation
- Expose standard OAuth discovery and Dynamic Client Registration endpoints and wire an authorization flow so external agents can obtain scoped MCP access tokens.
- Allow existing static MCP agent tokens to remain functional while adding OAuth JWT validation and per-tool scope/credit enforcement for meterable usage.
- Ensure the MCP sub-app has access to the runtime gateway/module state (hostname, gateway methods) when validating tokens and charging credits.

### Description
- Added `server/routers/oauth_router.py` implementing RFC 9728 and RFC 8414 discovery endpoints, `POST /oauth/register` (DCR + rate limit + kill-switch), `GET /oauth/authorize` (HTML consent page + provider handoff), provider callback handlers, and `POST /oauth/token` supporting both form and JSON payloads.
- Mounted the oauth router in `main.py` before the SPA catch-all and wired a gateway resolver (`set_gateway_resolver`) so the MCP sub-app can access `app.state.mcp_gateway` at runtime.
- Exported `oauth_router` from `server/routers/__init__.py` so the router is available to `main.py`.
- Reworked `server/mcp_server.py` to accept a gateway resolver, store hostname, add a contextvar-backed auth context, upgrade `MCPAuthMiddleware` to accept either the legacy static `_MCP_TOKEN` or OAuth JWTs validated via `mcp_gateway.validate_access_token`, and include `WWW-Authenticate` responses pointing at the resource metadata endpoint.
- Implemented `_check_scope(ctx, scope)` helper for MCP tools and `_consume_credit(...)` which resolves agent credits and deducts for metered tools; added scope checks and credit consumption to tools such as `oracle_dump_table`, `oracle_query_info_schema`, and other read/list tools.

### Testing
- Compiled updated modules with `python -m compileall main.py server/routers/oauth_router.py server/mcp_server.py server/routers/__init__.py` and the compilation succeeded.
- Ran the unified test harness via `python scripts/run_tests.py`, which completed with the automated test suite passing (69 pytest tests passed and frontend tests passed), and emitted a non-fatal environment warning about a missing ODBC driver during a build/version update step.
- Performed a quick visual verification of the consent page by rendering a static preview and saving `artifacts/oauth-consent-page.png` to confirm the HTML layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4eccc43888325b550d760db6ca0b2)