### PR TITLE
Fix circular import caused by eager router package imports

### DIFF
--- a/server/routers/__init__.py
+++ b/server/routers/__init__.py
@@ -1,5 +1,1 @@
-"""Router package exports."""
 
-from . import oauth_router, rpc_router, web_router
-
-__all__ = ["oauth_router", "rpc_router", "web_router"]


### PR DESCRIPTION
### Motivation
- Prevent startup ImportError from a circular import chain by stopping `server.routers` from eagerly importing sub-routers while `rpc` is still initializing.

### Description
- Replace `server/routers/__init__.py` with an empty package marker, removing the `from . import oauth_router, rpc_router, web_router` line and the `__all__` re-exports.

### Testing
- Ran `python -c "import server.routers; print('ok')"` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4f4d41e1083258ee37641c1a58964)