### PR TITLE
Use McpHostname for MCP gateway hostname config

### DIFF
--- a/server/modules/mcp_gateway_module.py
+++ b/server/modules/mcp_gateway_module.py
@@ -135,7 +135,7 @@ class McpGatewayModule(BaseModule):
 
   async def refresh_runtime_config(self):
     self.dcr_enabled = await self.is_dcr_enabled(refresh=True)
-    self.hostname = await self._get_config_value("Hostname", fallback="")
+    self.hostname = await self._get_config_value("McpHostname", fallback="")
     self.register_ip_limit = await self._get_config_int("MCP_RATE_LIMIT_REGISTER_IP", fallback=5)
     self.register_global_limit = await self._get_config_int(
       "MCP_RATE_LIMIT_REGISTER_GLOBAL", fallback=50


### PR DESCRIPTION
### Motivation
- The MCP gateway was reading `Hostname` (which can include the `https://` prefix) and producing double-protocol URLs like `https://https://...`; a new `McpHostname` DB config contains the bare hostname to fix URL construction.

### Description
- Change `McpGatewayModule.refresh_runtime_config` to load `McpHostname` instead of `Hostname` so `self.hostname` holds a bare hostname compatible with existing `f"https://{hostname}/..."` usage (`server/modules/mcp_gateway_module.py`).

### Testing
- Ran the unified harness with `python scripts/run_tests.py` and the test suite completed successfully (all automated tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4fe9bf7348325b2f2f144d2783e0e)