### PR TITLE
Add PKCE to provider OAuth redirect flow and improve callback error handling

### DIFF
--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -335,6 +335,7 @@ class OauthModule(BaseModule):
     client_secret: str,
     redirect_uri: str,
     provider: str = "google",
+    code_verifier: str | None = None,
   ) -> tuple[str | None, str]:
     """Exchange an authorization code for tokens.
 
@@ -361,6 +362,8 @@ class OauthModule(BaseModule):
       "redirect_uri": redirect_uri,
       "grant_type": "authorization_code",
     }
+    if code_verifier:
+      data["code_verifier"] = code_verifier
     logging.debug(
       "[exchange_code_for_tokens] data=%s",
       {k: v for k, v in data.items() if k != "client_secret"},

--- a/server/routers/oauth_router.py
+++ b/server/routers/oauth_router.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import os
+import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import urlencode
@@ -273,12 +275,17 @@ async def get_oauth_provider_login(request: Request, provider: str, flow: str):
   flow_payload = _decode_flow_state(request, flow)
   hostname = request.app.state.mcp_gateway.hostname
   callback = _callback_uri(hostname, provider)
+  provider_code_verifier = secrets.token_urlsafe(32)
+  provider_code_challenge = base64.urlsafe_b64encode(
+    hashlib.sha256(provider_code_verifier.encode("utf-8")).digest()
+  ).decode("utf-8").rstrip("=")
   state_payload = _sign_flow_state(
     request,
     {
       "provider": provider,
       "flow": flow_payload,
       "nonce": base64.urlsafe_b64encode(os.urandom(12)).decode("utf-8").rstrip("="),
+      "provider_code_verifier": provider_code_verifier,
     },
   )
 
@@ -288,6 +295,8 @@ async def get_oauth_provider_login(request: Request, provider: str, flow: str):
     "redirect_uri": callback,
     "scope": _PROVIDER_SCOPES[provider],
     "state": state_payload,
+    "code_challenge": provider_code_challenge,
+    "code_challenge_method": "S256",
   }
   if provider == "google":
     params["access_type"] = "offline"
@@ -297,8 +306,18 @@ async def get_oauth_provider_login(request: Request, provider: str, flow: str):
 
 
 @router.get("/oauth/callback/{provider}")
-async def get_oauth_provider_callback(request: Request, provider: str, code: str | None = None, state: str | None = None):
+async def get_oauth_provider_callback(
+  request: Request,
+  provider: str,
+  code: str | None = None,
+  state: str | None = None,
+  error: str | None = None,
+  error_description: str | None = None,
+):
   provider = provider.lower()
+  if error:
+    detail = error_description or error
+    raise HTTPException(status_code=400, detail=f"Provider authentication failed: {detail}")
   if not state or not code:
     raise HTTPException(status_code=400, detail="Missing code or state")
   callback_state = _decode_flow_state(request, state)
@@ -310,13 +329,16 @@ async def get_oauth_provider_callback(request: Request, provider: str, code: str
     raise HTTPException(status_code=400, detail="Authorization flow is invalid")
 
   gateway = request.app.state.mcp_gateway
+  hostname = gateway.hostname
   redirect_uri = _callback_uri(hostname, provider)
+  provider_code_verifier = callback_state.get("provider_code_verifier")
   id_token, access_token = await gateway.oauth.exchange_code_for_tokens(
     code=code,
     client_id=_provider_client_id(gateway, provider),
     client_secret=_provider_secret(gateway, provider),
     redirect_uri=redirect_uri,
     provider=provider,
+    code_verifier=provider_code_verifier,
   )
   provider_uid, profile, payload = await gateway.auth.handle_auth_login(provider, id_token, access_token)
   provider_uid = gateway.oauth.normalize_provider_identifier(provider_uid)

--- a/tests/test_oauth_provider_pkce.py
+++ b/tests/test_oauth_provider_pkce.py
@@ -1,0 +1,174 @@
+import asyncio
+import pathlib
+import sys
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi import HTTPException
+from jose import jwt
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+  sys.path.insert(0, str(ROOT))
+
+from server.routers import oauth_router
+from server.modules import oauth_module as oauth_module_mod
+from server.modules.oauth_module import OauthModule
+
+
+def _request_with_gateway(gateway):
+  return SimpleNamespace(
+    app=SimpleNamespace(
+      state=SimpleNamespace(
+        mcp_gateway=gateway,
+        auth=SimpleNamespace(jwt_secret="test-secret"),
+      )
+    ),
+    client=None,
+    headers={},
+  )
+
+
+def test_provider_login_includes_pkce_and_state_verifier():
+  gateway = SimpleNamespace(
+    hostname="example.test",
+    oauth=SimpleNamespace(auth=SimpleNamespace(providers={"microsoft": SimpleNamespace(audience="client-id")})),
+  )
+  request = _request_with_gateway(gateway)
+  flow = oauth_router._sign_flow_state(request, {"client_id": "mcp-client"})
+
+  response = asyncio.run(oauth_router.get_oauth_provider_login(request, "microsoft", flow))
+
+  parsed = urlparse(response.headers["location"])
+  params = parse_qs(parsed.query)
+  assert params["code_challenge_method"] == ["S256"]
+  assert params["code_challenge"] and params["code_challenge"][0]
+
+  state_payload = jwt.decode(params["state"][0], "test-secret", algorithms=["HS256"])
+  assert state_payload["provider"] == "microsoft"
+  assert state_payload.get("provider_code_verifier")
+
+
+def test_provider_callback_uses_verifier_and_handles_provider_error():
+  captured = {}
+
+  class FakeOauth:
+    auth = SimpleNamespace(providers={"microsoft": SimpleNamespace(audience="provider-client-id")})
+    env = SimpleNamespace(get=lambda _key: "provider-secret")
+
+    async def exchange_code_for_tokens(self, **kwargs):
+      captured.update(kwargs)
+      return "id-token", "access-token"
+
+    def normalize_provider_identifier(self, uid):
+      return uid
+
+    async def resolve_user(self, provider, provider_uid, profile, payload):
+      return {"guid": "user-guid", "recid": 7}
+
+  class FakeAuth:
+    async def handle_auth_login(self, provider, id_token, access_token):
+      return "provider-uid", {"email": "user@example.com"}, {}
+
+  class FakeGateway:
+    hostname = "example.test"
+    oauth = FakeOauth()
+    auth = FakeAuth()
+
+    async def check_user_mcp_role(self, _user_guid):
+      return True
+
+    async def get_client(self, _client_id):
+      return {"recid": 3}
+
+    async def link_client_to_user(self, _client_id, _users_recid):
+      return None
+
+    async def create_authorization_code(self, **_kwargs):
+      return "auth-code"
+
+  request = _request_with_gateway(FakeGateway())
+  state = oauth_router._sign_flow_state(
+    request,
+    {
+      "provider": "microsoft",
+      "provider_code_verifier": "verifier-abc",
+      "flow": {
+        "client_id": "client-1",
+        "code_challenge": "challenge",
+        "code_challenge_method": "S256",
+        "redirect_uri": "https://client/callback",
+        "scope": "mcp:data:read",
+        "state": "xyz",
+      },
+    },
+  )
+
+  response = asyncio.run(
+    oauth_router.get_oauth_provider_callback(
+      request,
+      "microsoft",
+      code="provider-code",
+      state=state,
+    )
+  )
+  assert response.headers["location"].startswith("https://client/callback?")
+  assert captured["code_verifier"] == "verifier-abc"
+
+  with pytest.raises(HTTPException) as exc_info:
+    asyncio.run(
+      oauth_router.get_oauth_provider_callback(
+        request,
+        "microsoft",
+        error="invalid_request",
+        error_description="PKCE is required",
+      )
+    )
+  assert exc_info.value.status_code == 400
+  assert "Provider authentication failed: PKCE is required" == exc_info.value.detail
+
+
+def test_exchange_code_for_tokens_includes_code_verifier(monkeypatch):
+  captured = {}
+
+  class FakeResponse:
+    status = 200
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+      return False
+
+    async def json(self):
+      return {"id_token": "id", "access_token": "access"}
+
+  class FakeSession:
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+      return False
+
+    def post(self, _url, data):
+      captured.update(data)
+      return FakeResponse()
+
+  monkeypatch.setattr(oauth_module_mod.aiohttp, "ClientSession", lambda: FakeSession())
+
+  module = OauthModule.__new__(OauthModule)
+  tokens = asyncio.run(
+    OauthModule.exchange_code_for_tokens(
+      module,
+      code="auth-code",
+      client_id="client-id",
+      client_secret="secret",
+      redirect_uri="https://example.test/oauth/callback/microsoft",
+      provider="microsoft",
+      code_verifier="pkce-verifier",
+    )
+  )
+
+  assert tokens == ("id", "access")
+  assert captured["code_verifier"] == "pkce-verifier"


### PR DESCRIPTION
### Motivation
- Microsoft Entra rejects cross-origin authorization code flows without PKCE, and the provider callback did not surface provider-originated `error` responses or preserved the verifier for token exchange.
- The callback handler referenced an undefined `hostname` and needed to forward the provider-side PKCE verifier when exchanging the code.

### Description
- Generate a provider-side PKCE `code_verifier` and `S256` `code_challenge` in `/oauth/provider-login`, include them in the provider redirect params, and store the `provider_code_verifier` inside the signed state. (modified `server/routers/oauth_router.py`)
- Validate and Surface provider errors by accepting `error` and `error_description` in `/oauth/callback/{provider}` and returning a clear `400` when present. (modified `server/routers/oauth_router.py`)
- Fix `hostname` usage in the callback by reading it from `request.app.state.mcp_gateway.hostname` and retrieve `provider_code_verifier` from the decoded state to forward to token exchange. (modified `server/routers/oauth_router.py`)
- Extend `OauthModule.exchange_code_for_tokens` to accept an optional `code_verifier` argument and include it in the token POST body when provided. (modified `server/modules/oauth_module.py`)
- Add focused tests covering PKCE redirect params, signed state verifier presence, callback forwarding of the verifier, provider-error handling, and token exchange payload. (added `tests/test_oauth_provider_pkce.py`)

### Testing
- Ran `pytest -q tests/test_oauth_provider_pkce.py` and the new focused tests passed (`3 passed`).
- Ran the full harness `python scripts/run_tests.py`; automated test suite completed successfully in this environment with the test summary reporting `72 passed` and `1 warning` (non-fatal ODBC driver warning during the build-version step).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b504939eb883259d07ae897de4cfd5)