### PR TITLE
Load MICROSOFT_AUTH_SECRET during EnvModule startup

### DIFF
--- a/server/modules/env_module.py
+++ b/server/modules/env_module.py
@@ -14,6 +14,7 @@ class EnvModule(BaseModule):
   async def startup(self):
     self._getenv("DISCORD_SECRET", "MISSING_ENV_DISCORD_SECRET")
     self._getenv("DISCORD_AUTH_SECRET", "MISSING_ENV_DISCORD_AUTH_SECRET")
+    self._getenv("MICROSOFT_AUTH_SECRET", "MISSING_ENV_MICROSOFT_AUTH_SECRET")
     self._getenv("JWT_SECRET", "MISSING_ENV_JWT_SECRET")
     self._getenv("GOOGLE_AUTH_SECRET", "MISSING_ENV_GOOGLE_AUTH_SECRET")
     self._getenv("DATABASE_PROVIDER", "MISSING_DATABASE_PROVIDER")


### PR DESCRIPTION
### Motivation
- The Microsoft OAuth secret `MICROSOFT_AUTH_SECRET` was not initialized in `EnvModule.startup()`, which caused `EnvModule.get(...)` to raise during the OAuth token exchange flow.

### Description
- Added `self._getenv("MICROSOFT_AUTH_SECRET", "MISSING_ENV_MICROSOFT_AUTH_SECRET")` to `server/modules/env_module.py` inside `EnvModule.startup()` alongside the other auth secret loads.

### Testing
- Ran the unified harness with `python scripts/run_tests.py`, which completed successfully and the automated test suite passed (72 tests passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b50c111134832594cbce452cf3ac5f)