### PR TITLE
Add debug logging for MCP auth JWT validation failures

### DIFF
--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -118,6 +118,7 @@ class MCPAuthMiddleware(BaseHTTPMiddleware):
     try:
       gateway = _get_gateway()
       claims = await gateway.validate_access_token(token)
+      logging.info("[MCP Auth] JWT validated: sub=%s client_id=%s scopes=%s", claims.get("sub"), claims.get("client_id"), claims.get("scopes"))
       request.state.mcp_auth = {
         "type": "oauth",
         "scopes": set(str(claims.get("scopes", "")).split()),
@@ -129,7 +130,8 @@ class MCPAuthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
       finally:
         _AUTH_CONTEXT.reset(token_handle)
-    except Exception:
+    except Exception as exc:
+      logging.error("[MCP Auth] JWT validation failed: %s", exc, exc_info=True)
       return JSONResponse(
         {"error": "Unauthorized"},
         status_code=401,


### PR DESCRIPTION
### Motivation
- The middleware previously swallowed JWT validation errors via a bare `except Exception`, preventing any diagnostic output when OAuth tokens failed and causing silent 401 responses.

### Description
- Added an info log after `gateway.validate_access_token(token)` to record `sub`, `client_id`, and `scopes` when JWT validation succeeds.
- Changed the silent `except Exception` to `except Exception as exc` and added `logging.error(..., exc_info=True)` to surface the exception and traceback before returning 401.
- No other files were modified.

### Testing
- Ran `python -m py_compile server/mcp_server.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b51a24495c8325915bb971cde04404)