### PR TITLE
Exclude MCP and .well-known routes from SPA catch-all

### DIFF
--- a/server/routers/web_router.py
+++ b/server/routers/web_router.py
@@ -1,8 +1,10 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
 
 router = APIRouter()
 
 @router.get("/{full_path:path}")
 async def serve_react_app(full_path: str):
+  if full_path.startswith("mcp/") or full_path.startswith(".well-known/"):
+    raise HTTPException(status_code=404)
   return FileResponse("static/index.html")


### PR DESCRIPTION
### Motivation
- Prevent the web router's SPA fallback from intercepting `GET /mcp/*` and `GET /.well-known/*` so the mounted MCP sub-app and OAuth metadata endpoints can be handled correctly.

### Description
- Modify `server/routers/web_router.py` to import `HTTPException` and return `404` from the SPA catch-all when `full_path` starts with `mcp/` or `.well-known/`, preserving `index.html` fallback for other routes.

### Testing
- Ran `python -m py_compile server/routers/web_router.py` which succeeded.
- Ran the unified test pipeline with `python scripts/run_tests.py`, which completed successfully (test suite passed; note: unrelated ODBC driver warning during DB-version update step).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5969475a48325a19f8d56f8b6fb8e)