### PR TITLE
Fix MCP mount precedence over SPA catch-all

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,11 +13,11 @@ app = FastAPI(lifespan=lifespan)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 app.include_router(rpc_router.router, prefix="/rpc")
 app.include_router(oauth_router.router)
-app.include_router(web_router.router)
 set_gateway_resolver(lambda: app.state.mcp_gateway)
 _mcp_app = get_mcp_app()
 if _mcp_app is not None:
   app.mount("/mcp", _mcp_app)
+app.include_router(web_router.router)
 
 @app.get("/")
 async def get_root():

--- a/server/routers/web_router.py
+++ b/server/routers/web_router.py
@@ -1,10 +1,8 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from fastapi.responses import FileResponse
 
 router = APIRouter()
 
 @router.get("/{full_path:path}")
 async def serve_react_app(full_path: str):
-  if full_path.startswith("mcp/") or full_path.startswith(".well-known/"):
-    raise HTTPException(status_code=404)
   return FileResponse("static/index.html")


### PR DESCRIPTION
### Motivation
- The SPA catch-all route was matching `GET /mcp/*` before the mounted MCP sub-app, and raising `HTTPException(404)` inside the router did not allow the mounted `/mcp` app to handle requests.

### Description
- Moved `app.include_router(web_router.router)` to after the MCP gateway resolver and optional `app.mount("/mcp", ...)` registration in `main.py` so mounts take precedence over the SPA catch-all.
- Reverted `server/routers/web_router.py` to always return `static/index.html` for the catch-all and removed the previous `mcp/` and `.well-known/` exclusions since route ordering now handles MCP paths.
- Adjusted startup ordering so that when the MCP sub-app is built it will be mounted before the `/{full_path:path}` catch-all route.

### Testing
- Ran `python -m py_compile main.py server/routers/web_router.py`, which succeeded.
- Executed a TestClient script exercising `GET/POST /mcp/mcp`, `GET /`, `GET /some-page`, and `GET /.well-known/oauth-protected-resource`; with no MCP token present the `/mcp` mount was skipped and the `.well-known` probe hit an environment-dependent `app.state.mcp_gateway` absence, and with `MCP_AGENT_TOKEN=dummy` the `/mcp` mount was created and appears before the `/{full_path:path}` catch-all as expected.
- Inspected `app.router.routes` ordering with and without `MCP_AGENT_TOKEN` to confirm the mount is ordered before the SPA catch-all when MCP is enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b59c818cfc8325bf1fc48142fb3738)