### PR TITLE
Fix MCP endpoint routing to avoid trailing-slash redirects

### DIFF
--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -331,7 +331,7 @@ def get_mcp_app() -> Starlette | None:
 
   mcp_inner = Starlette(
     routes=[
-      Mount("/mcp", app=session_manager.handle_request),
+      Mount("/", app=session_manager.handle_request),
     ],
   )
 

--- a/server/routers/web_router.py
+++ b/server/routers/web_router.py
@@ -1,8 +1,11 @@
 from fastapi import APIRouter
 from fastapi.responses import FileResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 router = APIRouter()
 
 @router.get("/{full_path:path}")
 async def serve_react_app(full_path: str):
+  if full_path.startswith("mcp"):
+    raise StarletteHTTPException(status_code=404)
   return FileResponse("static/index.html")


### PR DESCRIPTION
### Motivation
- Prevent Starlette trailing-slash redirects that convert a successful MCP `POST /mcp` into a `307` and drop the body and auth headers. 
- Ensure the externally mounted MCP endpoint resolves exactly to `/mcp` (not `/mcp/mcp`) so MCP clients receive the protocol response. 
- Stop the SPA catch-all from intercepting `GET /mcp` probes so the MCP mount can handle GET health/probe requests.

### Description
- Changed the inner MCP Starlette mount in `get_mcp_app` from `Mount("/mcp", ...)` to `Mount("/", ...)` so the outer FastAPI mount at `/mcp` becomes the single external route for MCP (file: `server/mcp_server.py`).
- Updated the SPA catch-all route to raise `starlette.exceptions.HTTPException(404)` when the path starts with `mcp`, preventing React HTML from being served for `/mcp` (file: `server/routers/web_router.py`).
- Verified that the OAuth protected-resource metadata continues to advertise the MCP resource as `/mcp` and required no change (file: `server/routers/oauth_router.py`).

### Testing
- Ran a `TestClient` route probe script against `main.app` with `MCP_AGENT_TOKEN` set and observed that `POST /mcp` no longer yields a 307 redirect (test harness produced `405`/`500` due to lifespan/session-manager initialization, but no trailing-slash redirect was present). (succeeded for redirect removal)
- Confirmed `GET /mcp` returns `404` and is not served the SPA HTML. (succeeded)
- Confirmed `GET /` and `GET /some-page` still return the React SPA HTML. (succeeded)
- Confirmed `GET /.well-known/oauth-protected-resource` returns a `resource` URL of `https://<hostname>/mcp`. (succeeded)
- Note: full MCP streamable behavior for protocol `POST /mcp` requires the session manager lifespan to be initialized; the lightweight `TestClient` harness cannot fully exercise that runtime and produced internal-server errors unrelated to routing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b20d23208325930da4a0d70d049e)