### PR TITLE
Fix MCP endpoint to accept POST /mcp without trailing slash

### DIFF
--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -329,13 +329,12 @@ def get_mcp_app() -> Starlette | None:
     stateless=True,
   )
 
-  mcp_inner = Starlette(
+  app = Starlette(
     routes=[
       Mount("/", app=session_manager.handle_request),
     ],
+    middleware=[Middleware(MCPAuthMiddleware)],
+    redirect_slashes=False,
   )
-
-  app = Starlette(middleware=[Middleware(MCPAuthMiddleware)])
-  app.mount("/", mcp_inner)
   logging.info("[MCP] app built, waiting for lifespan init")
   return app


### PR DESCRIPTION
### Motivation
- The MCP endpoint must accept requests to `/mcp` without a trailing slash because some connectors strip trailing slashes and the previous nested `Mount("/")` setup caused 405 responses for `POST /mcp`.

### Description
- Collapsed the nested Starlette apps in `get_mcp_app` into a single `Starlette` instance that mounts `Mount("/", app=session_manager.handle_request)`, applies `MCPAuthMiddleware` directly, and sets `redirect_slashes=False` to disable trailing-slash redirects.

### Testing
- Ran `python -m py_compile server/mcp_server.py` which succeeded (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b9d686a483259215144ddd20ccca)