### PR TITLE
Refactor MCP endpoint to FastAPI-native /mcp route

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,8 +4,8 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from server.helpers.logging import configure_root_logging
 from server.lifespan import lifespan
-from server.mcp_server import get_mcp_app, set_gateway_resolver
-from server.routers import oauth_router, rpc_router, web_router
+from server.mcp_server import init_session_manager, set_gateway_resolver
+from server.routers import mcp_router, oauth_router, rpc_router, web_router
 
 configure_root_logging(4)
 
@@ -14,9 +14,8 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 app.include_router(rpc_router.router, prefix="/rpc")
 app.include_router(oauth_router.router)
 set_gateway_resolver(lambda: app.state.mcp_gateway)
-_mcp_app = get_mcp_app()
-if _mcp_app is not None:
-  app.mount("/mcp", _mcp_app)
+init_session_manager()
+app.include_router(mcp_router.router)
 app.include_router(web_router.router)
 
 @app.get("/")

--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -12,11 +12,9 @@ from typing import TYPE_CHECKING, Any
 from fastapi import HTTPException
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
-from starlette.applications import Starlette
-from starlette.middleware import Middleware
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
 from starlette.responses import JSONResponse
-from starlette.routing import Mount
+from starlette.types import Receive, Scope, Send
 
 from queryregistry.finance.credits import set_credits_request
 from queryregistry.finance.credits.models import SetCreditsParams
@@ -75,70 +73,101 @@ def _get_gateway() -> Any:
   return gateway
 
 
-class MCPAuthMiddleware(BaseHTTPMiddleware):
-  """Bearer-token gate: static token OR MCP OAuth JWT."""
+def _auth_challenge_headers() -> dict[str, str]:
+  return {
+    "WWW-Authenticate": f'Bearer resource_metadata="https://{_hostname}/.well-known/oauth-protected-resource"'
+  }
 
-  async def dispatch(self, request: Any, call_next: Any) -> JSONResponse | Any:
-    if not _MCP_TOKEN:
-      return JSONResponse({"error": "MCP not configured"}, status_code=503)
 
-    auth = request.headers.get("authorization", "")
-    if not auth.startswith("Bearer "):
-      return JSONResponse(
-        {"error": "Unauthorized"},
-        status_code=401,
-        headers={
-          "WWW-Authenticate": f'Bearer resource_metadata="https://{_hostname}/.well-known/oauth-protected-resource"'
-        },
-      )
+async def mcp_auth_check(scope: Scope, receive: Receive, send: Send) -> dict[str, Any] | None:
+  """Validate MCP auth from bearer token or JWT; send 401 when invalid."""
+  if not _MCP_TOKEN:
+    response = JSONResponse({"error": "MCP not configured"}, status_code=503)
+    await response(scope, receive, send)
+    return None
 
-    token = auth[7:]
+  request = Request(scope, receive)
+  auth = request.headers.get("authorization", "")
+  if not auth.startswith("Bearer "):
+    response = JSONResponse(
+      {"error": "Unauthorized"},
+      status_code=401,
+      headers=_auth_challenge_headers(),
+    )
+    await response(scope, receive, send)
+    return None
 
-    if token == _MCP_TOKEN:
-      request.state.mcp_auth = {
-        "type": "static",
-        "scopes": {
-          "mcp:schema:read",
-          "mcp:data:read",
-          "mcp:rpc:list",
-          "mcp:schema:write",
-          "mcp:data:write",
-          "mcp:rpc:execute",
-          "mcp:admin",
-        },
-        "user_guid": None,
-        "client_id": None,
-      }
-      token_handle = _AUTH_CONTEXT.set(request.state.mcp_auth)
-      try:
-        return await call_next(request)
-      finally:
-        _AUTH_CONTEXT.reset(token_handle)
+  token = auth[7:]
+  if token == _MCP_TOKEN:
+    return {
+      "type": "static",
+      "scopes": {
+        "mcp:schema:read",
+        "mcp:data:read",
+        "mcp:rpc:list",
+        "mcp:schema:write",
+        "mcp:data:write",
+        "mcp:rpc:execute",
+        "mcp:admin",
+      },
+      "user_guid": None,
+      "client_id": None,
+    }
 
-    try:
-      gateway = _get_gateway()
-      claims = await gateway.validate_access_token(token)
-      logging.info("[MCP Auth] JWT validated: sub=%s client_id=%s scopes=%s", claims.get("sub"), claims.get("client_id"), claims.get("scopes"))
-      request.state.mcp_auth = {
-        "type": "oauth",
-        "scopes": set(str(claims.get("scopes", "")).split()),
-        "user_guid": claims.get("sub"),
-        "client_id": claims.get("client_id"),
-      }
-      token_handle = _AUTH_CONTEXT.set(request.state.mcp_auth)
-      try:
-        return await call_next(request)
-      finally:
-        _AUTH_CONTEXT.reset(token_handle)
-    except Exception as exc:
-      logging.error("[MCP Auth] JWT validation failed: %s", exc, exc_info=True)
-      return JSONResponse(
-        {"error": "Unauthorized"},
-        status_code=401,
-        headers={
-          "WWW-Authenticate": f'Bearer resource_metadata="https://{_hostname}/.well-known/oauth-protected-resource"'
-        },
-      )
+  try:
+    gateway = _get_gateway()
+    claims = await gateway.validate_access_token(token)
+    logging.info("[MCP Auth] JWT validated: sub=%s client_id=%s scopes=%s", claims.get("sub"), claims.get("client_id"), claims.get("scopes"))
+    return {
+      "type": "oauth",
+      "scopes": set(str(claims.get("scopes", "")).split()),
+      "user_guid": claims.get("sub"),
+      "client_id": claims.get("client_id"),
+    }
+  except Exception as exc:
+    logging.error("[MCP Auth] JWT validation failed: %s", exc, exc_info=True)
+    response = JSONResponse(
+      {"error": "Unauthorized"},
+      status_code=401,
+      headers=_auth_challenge_headers(),
+    )
+    await response(scope, receive, send)
+    return None
+
+
+async def mcp_asgi_handler(scope: Scope, receive: Receive, send: Send) -> None:
+  """Authenticate and delegate to the MCP session manager ASGI handler."""
+  if session_manager is None:
+    response = JSONResponse({"error": "MCP not configured"}, status_code=503)
+    await response(scope, receive, send)
+    return
+
+  auth = await mcp_auth_check(scope, receive, send)
+  if auth is None:
+    return
+
+  token_handle = _AUTH_CONTEXT.set(auth)
+  try:
+    await session_manager.handle_request(scope, receive, send)
+  finally:
+    _AUTH_CONTEXT.reset(token_handle)
+
+
+def init_session_manager() -> None:
+  """Create the MCP session manager when MCP is configured."""
+  global session_manager
+  if not _MCP_TOKEN:
+    logging.info("[MCP] skipped (MCP_AGENT_TOKEN not set)")
+    return
+
+  from mcp.server.streamable_http_manager import StreamableHTTPSessionManager as _Manager
+
+  session_manager = _Manager(
+    app=mcp._mcp_server,
+    json_response=True,
+    stateless=True,
+  )
+  logging.info("[MCP] session manager built, waiting for lifespan init")
 
 
 def _check_scope(ctx: Context, required_scope: str) -> dict[str, Any]:
@@ -312,29 +341,3 @@ async def oracle_list_rpc_endpoints(ctx: Context) -> list[str]:
   """List available top-level RPC domains."""
   _check_scope(ctx, "mcp:rpc:list")
   return sorted(RPC_HANDLERS.keys())
-
-
-def get_mcp_app() -> Starlette | None:
-  """Return the MCP ASGI app wrapped with auth middleware, or None if unconfigured."""
-  global session_manager
-  if not _MCP_TOKEN:
-    logging.info("[MCP] skipped (MCP_AGENT_TOKEN not set)")
-    return None
-
-  from mcp.server.streamable_http_manager import StreamableHTTPSessionManager as _Manager
-
-  session_manager = _Manager(
-    app=mcp._mcp_server,
-    json_response=True,
-    stateless=True,
-  )
-
-  app = Starlette(
-    routes=[
-      Mount("/", app=session_manager.handle_request),
-    ],
-    middleware=[Middleware(MCPAuthMiddleware)],
-    redirect_slashes=False,
-  )
-  logging.info("[MCP] app built, waiting for lifespan init")
-  return app

--- a/server/routers/mcp_router.py
+++ b/server/routers/mcp_router.py
@@ -1,0 +1,19 @@
+"""MCP protocol router for delegating /mcp requests to the SDK session manager."""
+
+from fastapi import APIRouter
+from starlette.routing import Route
+from starlette.types import Receive, Scope, Send
+
+from server.mcp_server import mcp_asgi_handler
+
+router = APIRouter()
+
+
+class _MCPRouteHandler:
+  async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+    await mcp_asgi_handler(scope, receive, send)
+
+
+router.routes.append(
+  Route("/mcp", endpoint=_MCPRouteHandler(), methods=["GET", "POST", "DELETE"])
+)


### PR DESCRIPTION
### Motivation
- Eliminate Starlette sub-app mounting and trailing-slash/Mount routing issues by handling MCP traffic as a first-class FastAPI route. 
- Preserve existing auth behavior, tool definitions, and lifespan/task-group requirements while simplifying routing and avoiding nested app semantics. 
- Make the MCP SDK's ASGI `session_manager.handle_request()` callable reachable directly from the FastAPI app without double-wrapping or mount redirects.

### Description
- Replaced middleware-mounted Starlette app with an ASGI-level auth check and direct delegation by adding `mcp_auth_check(...)`, `mcp_asgi_handler(...)`, and `init_session_manager()` in `server/mcp_server.py`, and removed the old `MCPAuthMiddleware`/`get_mcp_app()` plumbing. 
- Introduced `server/routers/mcp_router.py` which registers an exact `Route("/mcp")` for `GET`, `POST`, and `DELETE` and delegates to the shared ASGI handler to avoid trailing-slash redirects. 
- Updated `main.py` to call `init_session_manager()` and `app.include_router(mcp_router.router)` instead of mounting a Starlette sub-app, and kept gateway resolver wiring via `set_gateway_resolver(...)`. 
- Preserved existing MCP tool functions, `_AUTH_CONTEXT` contextvar usage, scope checks (`_check_scope`), credit consumption (`_consume_credit`), and lifespan behavior (`session_manager.run()` remains used by `server/lifespan.py`).

### Testing
- Ran the unified test pipeline via `python scripts/run_tests.py`, which completed successfully with all tests passing (`72 passed, 0 failed`) and no test regressions. 
- Performed a route inspection using a small runtime script (`from main import app` route query) which confirmed `/mcp` is registered with `GET/POST/DELETE` methods. 
- Verified application startup behavior locally (MCP initialization is skipped when `MCP_AGENT_TOKEN` is unset) and that the new ASGI delegation path is present and ready for further integration/QA.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d3e98a148325bba8251933bcfee4)