### PR TITLE
Fix oracle_query_info_schema returning DBResponse object

### DIFF
--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -307,7 +307,8 @@ async def oracle_query_info_schema(
     sql += f" WHERE {_quote_ident(filter_column)} = ?"
     params = (filter_value,)
   sql += " FOR JSON PATH;"
-  return await run_json_many(sql, params)
+  response = await run_json_many(sql, params)
+  return response.rows if hasattr(response, "rows") else response
 
 
 @mcp.tool(annotations=_TOOL_ANNOTATIONS)


### PR DESCRIPTION
### Motivation
- The `oracle_query_info_schema` tool was returning the raw `DBResponse` object returned by `run_json_many`, which serialized to a non-useful object string instead of the underlying data rows.

### Description
- Change `server/mcp_server.py` so `oracle_query_info_schema` stores `response = await run_json_many(sql, params)` and returns `response.rows` when available, falling back to the raw `response` otherwise.

### Testing
- Ran `python -m compileall server/mcp_server.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e52db088832588b87b6a8a3062f4)