### PR TITLE
Fix get_token_v1 JSON parse error by selecting latest non-revoked token

### DIFF
--- a/queryregistry/identity/mcp_agents/mssql.py
+++ b/queryregistry/identity/mcp_agents/mssql.py
@@ -313,7 +313,7 @@ async def create_token_v1(args: dict[str, Any]) -> DBResponse:
 async def get_token_v1(args: dict[str, Any]) -> DBResponse:
   params = RefreshTokenParams.model_validate(args)
   sql = """
-    SELECT
+    SELECT TOP 1
       t.recid,
       t.agents_recid,
       t.element_refresh_token,
@@ -328,6 +328,8 @@ async def get_token_v1(args: dict[str, Any]) -> DBResponse:
     JOIN account_mcp_agents a ON a.recid = t.agents_recid
     LEFT JOIN account_users au ON au.recid = a.users_recid
     WHERE t.element_refresh_token = ?
+      AND t.element_revoked_at IS NULL
+    ORDER BY t.recid DESC
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
   """
   return await run_json_one(sql, (params.refresh_token,))


### PR DESCRIPTION
### Motivation
- The `get_token_v1` SQL could return multiple rows for the same refresh token which makes MSSQL emit comma-separated JSON objects (no enclosing array) and causes `json.loads()` to fail.

### Description
- Updated `get_token_v1` in `queryregistry/identity/mcp_agents/mssql.py` to `SELECT TOP 1` with `ORDER BY t.recid DESC` so the query always returns a single, most-recent row.
- Added `AND t.element_revoked_at IS NULL` to exclude already-revoked tokens from refresh lookups.
- This change is confined to the single SQL string in `get_token_v1` and no other files were modified.

### Testing
- Ran `python scripts/run_tests.py` which completed successfully with the test suite passing (`72 passed`); a non-fatal ODBC driver warning was observed but did not affect test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5eb80c9c483259d46b45db09dfbda)