### PR TITLE
docs: overhaul project documentation for v0.9.0.0

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,41 +32,115 @@ Layer responsibility rule: **Modules (business logic) → QueryRegistry (data-ac
 
 ## Security Model
 
-## MCP Server (Schema Discovery)
+## Input Shim Architecture
 
-The application hosts an MCP (Model Context Protocol) server at `/mcp` that
-provides read-only access to the database reflection domain and
-INFORMATION_SCHEMA. This endpoint is designed for LLM agents (Claude, Codex)
-to discover the database schema and query registry structure for prompt
-planning.
+External protocols connect to the platform through **input shims** — thin
+protocol adapters that authenticate callers and dispatch requests through the
+standard RPC handler chain. Input shims contain no business logic. They are
+structurally equivalent to the RPC router — they receive, authenticate,
+dispatch, and return.
+
+Every input surface — React frontend, Discord bot, TheOracleMCP, future social
+integrations — is a different view into the same authoritative backend. See
+**INPUT_SHIMS.md** for the full design, constraints, and per-surface details.
+
+| Surface | Transport | Status |
+|---------|-----------|--------|
+| React frontend | HTTP POST `/rpc` | Production |
+| Discord | WebSocket (discord.py) | Production |
+| TheOracleMCP | Streamable HTTP `/mcp` | Refactoring |
+| Others (Bluesky, TikTok, etc.) | Varies | Planned |
+
+## TheOracleMCP (Agent Input Surface)
+
+The application hosts TheOracleMCP at `/mcp` — a Model Context Protocol server
+that provides LLM agents (Claude, Codex) with access to the platform.
+TheOracleMCP follows the input shim pattern described above.
+
+### Current State (POC)
+
+The current implementation is a proof-of-concept that bypasses the RPC layer.
+MCP tool functions call `dispatch_query_request()` directly against the
+QueryRegistry, which violates the layered architecture. This is being
+refactored to route through `urn:service:reflection:*` RPC operations under
+`ROLE_SERVICE_ADMIN`.
+
+### Target Architecture
+
+MCP tools will be thin wrappers that:
+
+1. Authenticate the caller via OAuth 2.1 JWT (issued through TheOracleMCP's
+   OAuth consent flow with Microsoft/Google/Discord provider login).
+2. Resolve the JWT subject to an internal user GUID and role bitmask via
+   `AuthModule.get_user_roles()`.
+3. Construct an `RPCRequest` with the resolved auth context.
+4. Dispatch through the standard RPC handler chain (`dispatch_rpc_op`).
+5. Return the `RPCResponse` payload to the MCP client.
+
+This makes TheOracleMCP structurally identical to the Discord input shim and
+the React frontend — all three are presentation layers over the same RPC
+boundary.
 
 ### Authentication
 
-The MCP endpoint requires a bearer token matching the `MCP_AGENT_TOKEN`
-environment variable. This token is linked to a dedicated API user account
-in `account_api_tokens`. The MCP server validates the token via ASGI
-middleware — requests without a valid bearer token receive HTTP 401.
+TheOracleMCP authentication uses OAuth 2.1 with PKCE:
 
-### Available Tools
+1. Client discovers auth metadata via `/.well-known/oauth-protected-resource`
+   and `/.well-known/oauth-authorization-server`.
+2. Client initiates authorization code flow with PKCE S256 challenge.
+3. User authenticates through a server-rendered consent page using an identity
+   provider (Microsoft, Google, or Discord).
+4. Server issues a short-lived JWT access token (5 min) and refresh token
+   (7 days).
+5. JWT contains `sub` (user GUID), `client_id`, scopes, and is signed with
+   the application's JWT secret.
+6. The user's role bitmask is resolved server-side at dispatch time — JWT
+   scopes are not the authorization mechanism, the role bitmask is.
 
-All tools are read-only and idempotent.
+A static `MCP_AGENT_TOKEN` environment variable is supported for development
+bootstrapping but grants full access without user identity binding.
+
+### OAuth Infrastructure
+
+| Component | Location |
+|-----------|----------|
+| Discovery endpoints | `server/routers/oauth_router.py` |
+| OAuth consent flow | `server/routers/oauth_router.py` |
+| Token issuance & refresh | `server/modules/mcp_gateway_module.py` |
+| Client/token storage | `identity.mcp_agents` QueryRegistry subdomain |
+| Rate limiting | `McpGatewayModule.SlidingWindowRateLimiter` |
+| DCR circuit breaker | `McpGatewayModule._set_dcr_enabled()` |
+
+### Database Tables
+
+| Table | Purpose |
+|-------|---------|
+| `account_mcp_agents` | Registered MCP clients (client_id, scopes, user binding) |
+| `account_mcp_agent_tokens` | Issued access/refresh tokens per agent |
+| `account_mcp_auth_codes` | Authorization codes (consumed during token exchange) |
+
+### Available Tools (Current POC)
+
+All tools are currently read-only and idempotent. These will be rewired to
+dispatch through `urn:service:reflection:*` RPC operations.
 
 | Tool | Description |
 |------|-------------|
-| `oracle_list_tables` | List all tables from the reflection schema catalog |
+| `oracle_list_tables` | List tables from reflection schema catalog |
 | `oracle_describe_table` | Columns, indexes, and foreign keys for a table |
-| `oracle_list_views` | List all views with definitions |
-| `oracle_get_full_schema` | Complete schema dump |
-| `oracle_get_schema_version` | Current schema version from system_config |
-| `oracle_dump_table` | Export table rows as JSON (with row limit) |
+| `oracle_list_views` | List views with definitions |
+| `oracle_get_full_schema` | Complete schema snapshot |
+| `oracle_get_schema_version` | Schema version from system_config |
+| `oracle_dump_table` | Export table rows as JSON (bounded) |
 | `oracle_query_info_schema` | Query INFORMATION_SCHEMA views (whitelisted) |
-| `oracle_list_domains` | Enumerate query registry domains/subdomains/ops |
+| `oracle_list_domains` | Enumerate QueryRegistry domains and operations |
 | `oracle_list_rpc_endpoints` | List RPC domain handler names |
 
 ### Transport
 
-Streamable HTTP transport mounted at `/mcp` on the existing FastAPI server.
-Runs in-process sharing the same database connection pool.
+Streamable HTTP mounted at `/mcp` via Starlette `Route`. Runs in-process
+sharing the application's database connection pool. Stateless mode with JSON
+responses.
 
 ### Role Bit Assignments
 

--- a/INPUT_SHIMS.md
+++ b/INPUT_SHIMS.md
@@ -1,0 +1,132 @@
+# Input Shim Architecture
+
+This document describes the **input shim pattern** used by TheOracleRPC to
+connect external protocols to the platform's RPC layer.
+
+## Design Principle
+
+An input shim is a thin protocol adapter that:
+
+1. **Receives** requests from an external protocol (HTTP, WebSocket, AT
+   Protocol, MCP, etc.).
+2. **Authenticates** the caller using the protocol's native auth mechanism.
+3. **Resolves** the caller to an internal user GUID and role bitmask.
+4. **Constructs** an `RPCRequest` with the resolved auth context.
+5. **Dispatches** through `dispatch_rpc_op()` — the same entry point used by
+   all callers.
+6. **Returns** the `RPCResponse` payload translated to the protocol's response
+   format.
+
+Input shims contain **no business logic**. They are structurally equivalent to
+the FastAPI RPC router (`server/routers/rpc_router.py`) — receive,
+authenticate, dispatch, return. All validation, authorization, and execution
+happens in the RPC → Module → Provider chain.
+
+## Why This Matters
+
+Every input surface — React frontend, Discord bot, TheOracleMCP, social media
+bridges — is a different view into the same authoritative backend. By routing
+all of them through the RPC boundary:
+
+- Security is enforced uniformly (role bitmask, entitlements, credits).
+- Business logic exists in exactly one place (modules).
+- New input surfaces require only a protocol adapter, not new business logic.
+- Testing covers the real code path regardless of which surface triggered it.
+
+## Implementation Pattern
+
+### Module Structure
+
+Input shims follow the `SocialInputModule` / `SocialInputProvider` pattern:
+
+- A **coordinator module** (`SocialInputModule`) manages provider lifecycle.
+- Each protocol has a **provider** (e.g. `DiscordInputProvider`) that
+  implements the protocol-specific adapter.
+- Providers register with the coordinator at startup and deregister at
+  shutdown.
+
+### Auth Resolution
+
+Each shim resolves its protocol-specific identity to the platform's internal
+auth model:
+
+| Surface | Identity Source | Resolution Path |
+|---------|----------------|-----------------|
+| React frontend | Bearer token in `Authorization` header | `AuthModule.decode_session_token()` → GUID, roles, mask |
+| Discord | Discord user ID from message context | `AuthModule.get_discord_user_security()` → GUID, roles, mask |
+| TheOracleMCP (target) | OAuth 2.1 JWT in `Authorization` header | Decode JWT → `sub` (GUID) → `AuthModule.get_user_roles()` → roles, mask |
+| Social integrations (planned) | Platform-specific identity | Platform ID → linked provider → GUID resolution |
+
+### Dispatch
+
+All shims call `dispatch_rpc_op()` from `rpc/handler.py`:
+
+```python
+response = await dispatch_rpc_op(
+    app,
+    "urn:domain:subsystem:operation:version",
+    payload_dict,
+    discord_ctx=metadata,  # or equivalent context for other shims
+)
+```
+
+The `dispatch_rpc_op` function builds a request object with the auth context
+and delegates to the domain handler. The exact parameter shape may evolve as
+new shims are added, but the contract is the same: the shim provides identity,
+the RPC layer enforces authorization.
+
+## Current Input Surfaces
+
+### React Frontend (Production)
+
+- **Entry:** `POST /rpc` → `rpc_router.py` → `handle_rpc_request()`
+- **Auth:** Bearer token → `_process_rpcrequest()` →
+  `AuthModule.decode_session_token()`
+- **Pattern:** Direct HTTP RPC. The frontend sends
+  `{ op: "urn:...", payload: {...} }`.
+
+### Discord (Production)
+
+- **Entry:** Discord WebSocket → `discord.py` bot →
+  `DiscordInputProvider`
+- **Auth:** Discord user ID → `AuthModule.get_discord_user_security()` →
+  GUID, roles
+- **Pattern:** Bot commands (`!rpc`, `!summarize`, `!persona`, `!register`,
+  `!credits`, `!guildcredits`) translated to RPC calls via
+  `dispatch_rpc_op()`.
+- **Files:** `server/modules/social_input_module.py`,
+  `server/modules/providers/social/discord_input_provider.py`
+
+### TheOracleMCP (Refactoring)
+
+- **Entry:** Streamable HTTP `/mcp` → MCP SDK → tool functions in
+  `mcp_server.py`
+- **Auth (current POC):** Static token or OAuth JWT → scope check in tool
+  functions
+- **Auth (target):** OAuth JWT → decode to GUID →
+  `AuthModule.get_user_roles()` → construct `RPCRequest` →
+  `dispatch_rpc_op()`
+- **Pattern (current):** Tools call `dispatch_query_request()` directly
+  (violates layered architecture).
+- **Pattern (target):** Tools call `dispatch_rpc_op()` with
+  `urn:service:reflection:*` operations under `ROLE_SERVICE_ADMIN`.
+- **Files:** `server/mcp_server.py`, `server/routers/mcp_router.py`,
+  `server/modules/mcp_gateway_module.py`, `server/routers/oauth_router.py`
+
+### Social Integrations (Planned)
+
+- **Targets:** Bluesky, TikTok, and others as platform APIs allow.
+- **Pattern:** Same shim architecture — platform-specific adapter,
+  identity resolution to internal GUID, dispatch through RPC.
+- **Files:** `server/modules/bsky_module.py` (exists, early stage)
+
+## Constraints
+
+- Input shims MUST NOT contain business logic.
+- Input shims MUST NOT call QueryRegistry directly — all data access goes
+  through the RPC → Module → Provider chain.
+- Input shims MUST resolve protocol identity to internal GUID + role bitmask
+  before dispatching.
+- Input shims MUST use `dispatch_rpc_op()` as the sole dispatch entry point.
+- New input surfaces SHOULD follow the `SocialInputModule` / provider pattern
+  for lifecycle management.

--- a/QUERYREGISTRY.md
+++ b/QUERYREGISTRY.md
@@ -48,6 +48,36 @@ Finance currently exposes a status check service.
 
 - `finance.check_status`
 
+### Database reflection and self-description → `reflection`
+
+The reflection domain provides self-describing schema access. It reads from
+the application's own reflection tables (populated by deployment scripts) and
+returns normalized metadata about tables, columns, indexes, views, and schema
+versions.
+
+Reflection subdomains:
+- `reflection.schema` — table, column, index, view, and foreign key metadata
+  (list_tables, list_columns, list_indexes, list_foreign_keys, list_views,
+  get_full_schema)
+- `reflection.data` — schema versioning, table dumps, index rebuilds, batch
+  apply (get_version, update_version, dump_table, rebuild_indexes, apply_batch)
+
+### Discord guild and channel metadata → `discord`
+
+The discord domain stores operational metadata for Discord bot integration.
+
+Discord subdomains:
+- `discord.guilds` — guild registration, metadata, membership tracking
+- `discord.channels` — channel activity tracking
+
+### MCP agent identity → `identity.mcp_agents`
+
+The identity domain includes an `mcp_agents` subdomain for OAuth client
+management used by TheOracleMCP authentication flow.
+
+- `identity.mcp_agents` — agent registration, token issuance, auth code
+  management, user linking, revocation
+
 ## Dispatch contract (authoritative)
 
 All query registry operations MUST follow:
@@ -67,18 +97,21 @@ Examples of currently scaffolded CRUD stubs:
 - `db:system:roles:update:1`
 
 ## Handler entry points
-
 - Root dispatch: `queryregistry/handler.py` → `queryregistry.handler.HANDLERS`
 - Content: `queryregistry/content/handler.py`
 - Identity: `queryregistry/identity/handler.py`
 - System: `queryregistry/system/handler.py`
 - Finance: `queryregistry/finance/handler.py`
+- Reflection: `queryregistry/reflection/handler.py`
+- Discord: `queryregistry/discord/handler.py`
 
 ## Current ownership map
 
 | Domain | Subdomains | Query registry owner | Upstream module owners |
 | --- | --- | --- | --- |
 | `content` | `assets`, `galleries`, `visibility`, `moderation`, `cache` | `queryregistry/content/handler.py` | Content-facing modules that dispatch through the root registry handler |
-| `identity` | `accounts`, `profiles`, `sessions`, `providers`, `audit`, `role_memberships` | `queryregistry/identity/handler.py` | Identity/auth modules, including role membership management flows |
+| `identity` | `accounts`, `profiles`, `sessions`, `providers`, `audit`, `role_memberships`, `mcp_agents` | `queryregistry/identity/handler.py` | Identity/auth modules, including role membership management flows |
 | `system` | `config`, `routes`, `service_pages`, `models`, `personas`, `public_vars`, `integrations`, `roles` | `queryregistry/system/handler.py` | System/auth/admin modules |
 | `finance` | `check_status` | `queryregistry/finance/handler.py` | Finance/status modules routed through the root registry handler |
+| `reflection` | `schema`, `data` | `queryregistry/reflection/handler.py` | TheOracleMCP tools, CLI schema utilities, self-describing database features |
+| `discord` | `guilds`, `channels` | `queryregistry/discord/handler.py` | Discord bot module, social input provider |

--- a/README.md
+++ b/README.md
@@ -1,90 +1,150 @@
-## TheOracleGPT - RPC Version
-Welcome to TheOracleGPT web site repository! We're just getting started, but feel free to follow along!
+## TheOracleRPC
 
-The following links are for the original site that we're rebuilding and check out Patreon for our project blogs!
-* Original TheOracleGPT: https://github.com/elide-us/TheOracle
-* Live (Original) Site: https://elideusgroup.com
-* Patreon: https://patreon.com/Elideus
-* Live (Rebuild) Site: https://elideus-group.azurewebsites.net
+AI-powered content generation platform. Template-driven image generation,
+text-to-speech, video generation, social media distribution, and creative
+workspace management — all behind a typed RPC boundary with OAuth
+authentication and role-based access control.
 
-### TheOracleGPT - Tech Stack
-We'll update this section as we move through the rebuild.
-- Azure Web App (Container/Linux B1)
-- Azure Container Registry
-- GitHub Actions CI/CD Integration
-- Python, Node, React, TypeScript, Docker, Vite, ESLint, Vitest, Pytest
-- OAuth2 Microsoft Identity
-- MSSQL (Azure SQL)
-- Discord Bot TheOracleGPT-dev
+Built on FastAPI, Azure SQL, and React. Deployed to Azure via GitHub Actions.
+Connected to LLM agents via TheOracleMCP.
 
-These items were previously implemented and are on the rebuild roadmap.
-- OpenAI, LumaAI, BlueSky Social
-- OAuth for Google, Discord, Apple
+**Production:** https://elideusgroup.com
+**Test:** https://elideus-group-test.azurewebsites.net
+**Repository:** https://github.com/elide-us/elideus-group
+**Patreon:** https://patreon.com/Elideus
 
-### Technical Details
-- Docker buildx creates a WSGI compliant container that Azure Web App can run.
-- The project contains a startup.sh which will be executed by the environment on activation.
-- The project contains a dev.cmd script that supports `generate`, `start`, `fast`, and `test` subcommands for local development on Windows.
-- Environment variables are configured in .env for local work, but are set up as environment variables on the web app.
-- The database provider can be selected with the `DATABASE_PROVIDER` environment variable. The architecture supports multiple providers; currently only `mssql` is implemented.
-- You must configure Always On and enable SCM Basic Auth Publishing Credentials for GitHub Actions.
-- Deploy the Azure Web App Container Quickstart configuration.
-- Use Deployment Center to configure CI/CD from GitHub Actions post deploy, target build-ready repo.
+### Tech Stack
 
-### Pull Request Testing
-GitHub Actions run both the Node and Python test suites whenever a pull request targets the `main` branch. The workflow is defined in `.github/workflows/pr-tests.yml`.
+| Layer | Technology |
+|-------|------------|
+| Runtime | Python 3.12, FastAPI, Uvicorn |
+| Frontend | React, TypeScript, Vite |
+| Database | Azure SQL (MSSQL), ODBC 18, aioodbc/pyodbc |
+| Infrastructure | Azure Web App (Container/Linux), Azure Container Registry, GitHub Actions CI/CD |
+| Authentication | OAuth 2.0/2.1 — Microsoft Entra, Google, Discord (Apple planned) |
+| AI Services | OpenAI (chat completion, image generation, TTS), LumaAI (video generation) |
+| Social | Discord bot, Bluesky bridge, TikTok (planned) |
+| Agent Access | TheOracleMCP — Model Context Protocol server for LLM tooling |
+| Storage | Azure Blob Storage (with provider abstraction for S3, CDN, local) |
 
-### AI Usage Details
-We are building this site primarily using [Codex](https://chatgpt.com/codex). This is the OpenAI coding agent that integrates directly into your repository. It features agentified access to a full suite of command line build and editing tools.
+### Core Features
 
-### CLI Utilities
-Several helper scripts in the `scripts` directory manage the project database and data entities:
-- `mssql_cli.py` provides similar features for Azure SQL using the `AZURE_SQL_CONNECTION_STRING` environment variable.
-- `run_tests.py` executes various test, generate, and update operations for build automation. It increments the build version directly in the Azure SQL database.
-    - Requires `DATABASE_PROVIDER` and the `AZURE_SQL_CONNECTION_STRING` environment variable for MSSQL.
-- `generate_rpc_bindings.py` generates RPC TypeScript models and client accessors.
-- `generate_db_namespace.py` generates Query Registry TypeScript models and DB namespace helpers at `frontend/src/db/namespace.ts`.
-- `scriptlib.py` handles common RPC namespace generation functions and version helpers.
-- `msdblib.py` handles most of the mssql querying operations.
-Schema dumps now record NVARCHAR field lengths for accurate
-recreation across environments.
+- **Template-driven image generation** — composable prompt templates with
+  selectable style keys, tone, palette, lighting, composition, and subject
+  parameters. Templates are stored server-side; the frontend is a selector
+  over server-provided options.
+- **Text-to-speech** — voice synthesis via OpenAI TTS with configurable voice
+  and model parameters.
+- **Video generation** — LumaAI integration with callback-based async
+  pipeline, automatic download and storage.
+- **Creative workspace** — per-user file storage with upload, download,
+  folder management, gallery publishing, and moderation queue.
+- **Social distribution** — post generated content to Discord channels,
+  Bluesky feeds, and TikTok (planned). Additional platforms (X, Meta) are
+  medium-term targets.
+- **Discord bot** — command-driven interface for chat summarization, persona
+  conversations, user registration, and credit management.
+- **TheOracleMCP** — LLM agents (Claude, Codex) connect via Model Context
+  Protocol for schema discovery, database introspection, and platform
+  interaction.
+- **Credit system** — per-user credit tracking with charge-per-operation for
+  AI service calls.
 
-The `server` package also exposes a `database_cli` module with callable
-management helpers (connect, reconnect, list tables) for API-level automation.
+### Architecture
 
-### ODBC 18 Upgrade Plan
-We are moving to ODBC Driver 18 and Python 3.12 compatible client libraries:
-1. Update `requirements.txt` to newer `aioodbc` and `pyodbc` versions that
-   support Python 3.12 (now pinned to 0.5.0 and 5.1.0).
-2. Ensure the host has **ODBC Driver 18 for SQL Server** installed (Windows,
-   Linux, and container images).
-3. Update `AZURE_SQL_CONNECTION_STRING` to include the Driver 18 name plus
-   encryption defaults (for example: `Driver={ODBC Driver 18 for SQL Server};Encrypt=yes;TrustServerCertificate=no;`).
-4. Validate database operations (connect/list tables/schema tools) against a
-   staging database before running schema dumps.
+TheOracleRPC follows a strict layered architecture with contract enforcement
+at every boundary:
 
-### Seeding Personas
-Personas for the assistant are defined in `scripts/data/assistant_personas.json`. Load them into the database with:
-
-```bash
-python scripts/seed_personas.py
+```
+Clients / Input Surfaces
+    ↓
+RPC Layer (security gate — authentication, authorization, entitlements)
+    ↓
+Modules (application and business logic)
+    ↓
+Providers (storage, database, external APIs)
+    ↓
+Data Sources (structured responses back up the chain)
 ```
 
-When updating personas, modify the JSON file to keep the source data in sync.
+**Clients** are pure presentation layers with zero business logic — the React
+frontend, Discord bot, TheOracleMCP, and any future input surface all send
+typed RPC requests and render responses. See **INPUT_SHIMS.md**.
 
-### Conversation Logging
+**RPC** is the typed public boundary. Every operation is URN-addressed
+(`urn:domain:subsystem:operation:version`). The RPC layer validates bearer
+tokens, checks role bitmasks, and enforces entitlements before dispatching.
 
-Two tables record persona definitions and usage:
+**Modules** are the application. All business logic, workflow orchestration,
+and decision-making lives here. Modules are loaded at startup by the
+`ModuleManager` and communicate through well-defined interfaces.
 
-| Table | Purpose |
-| ----- | ------- |
-| `assistant_personas` | Stores persona names, prompts, token limits, and model references. |
-| `discord_guilds` | Tracks Discord guild metadata (name, join timestamps, membership counts, owner IDs, etc.) for registry lookups. |
-| `assistant_conversations` | Logs each interaction including guild/channel/user IDs, model reference, token counts, input text, output text, and timestamps. |
+**Providers** are the abstraction layer for external services. The same
+interface can be implemented across platforms — Azure SQL vs PostgreSQL for
+databases, Azure Blob vs S3 vs local disk for storage, OpenAI vs other LLMs
+for chat completion. The database provider is the most complex because each
+engine requires unique query syntax and system operations; the QueryRegistry
+(`queryregistry/`) handles this translation. But the provider pattern applies
+equally to storage, AI services, identity providers, and any other external
+dependency.
 
-The OpenAI module records conversation details whenever `!summarize` is executed.
+See **ARCHITECTURE.md** for the full security model, role bit assignments, and
+authentication workflows.
 
-### Discord Output Module
+### Security
 
-- Outbound Discord messages are buffered through an internal asyncio queue that respects the module's chunking and rate-limiting rules. Use `queue_channel_message` and `queue_user_message` helpers to enqueue work.
-- Successful deliveries update per-channel, per-user, and aggregate throughput metrics. Call `get_throughput_snapshot()` to inspect counters and timestamps for monitoring or diagnostics.
+64-bit signed integer bitmask (63 usable bits) for role-based access control.
+OAuth bearer tokens flow through every request. Anonymous access is limited to
+`public.*` and `auth.*` RPC namespaces. All other namespaces require a valid
+session and the appropriate role bits. See **ARCHITECTURE.md** for the role
+table.
+
+### Database
+
+Azure SQL (MSSQL) is the production database provider. The QueryRegistry
+architecture supports multiple providers; currently only MSSQL is implemented.
+
+Conventions: `datetimeoffset(7)` with `SYSUTCDATETIME()` defaults for all
+datetime columns, `bigint IDENTITY(1,1)` primary keys, ten canonical Extended
+Data Types (EDTs), and a self-describing schema via the `reflection`
+QueryRegistry domain. The EDT mapping table lives in the database itself,
+seeded by deployment scripts, enabling future cross-provider support
+(PostgreSQL, MySQL) without application code changes.
+
+### Code Generation
+
+RPC bindings and database namespace helpers are auto-generated from the Python
+source:
+
+- `python scripts/generate_rpc_bindings.py` — TypeScript RPC models and typed client accessors.
+- `python scripts/generate_db_namespace.py` — TypeScript QueryRegistry namespace helpers.
+
+Generated files are marked `DO NOT MODIFY - GENERATED`.
+
+### Build & Deployment
+
+All code changes are authored through Codex and deployed via GitHub Actions
+CI/CD. The unified test harness validates the full stack:
+
+```bash
+python scripts/run_tests.py
+```
+
+This runs RPC binding generation, DB namespace generation, frontend
+lint/type-check/test, and backend pytest in sequence.
+
+Docker multi-stage build: builder stage runs generators and frontend build,
+runtime stage copies artifacts and starts Uvicorn. See **BUILD.md**.
+
+### AI Development Workflow
+
+TheOracleRPC is built using Claude (architecture, planning, Codex prompt
+generation) and Codex (code execution against the repository). All changes go
+through human review. The MCP integration (TheOracleMCP) enables Claude to
+introspect the live database schema and QueryRegistry structure during planning
+sessions.
+
+### Pull Request Testing
+
+GitHub Actions run both Node and Python test suites on PRs targeting `main`.
+Workflow: `.github/workflows/pr-tests.yml`.

--- a/RPC.md
+++ b/RPC.md
@@ -199,6 +199,24 @@ may also be called by users with `ROLE_SYSTEM_ADMIN`.
 | `urn:service:routes:upsert_route:1` | Create or update a route definition. |
 | `urn:service:routes:delete_route:1` | Delete a route definition.           |
 
+### `reflection` (planned)
+
+Schema introspection operations for LLM agents and tooling. Currently served
+directly by TheOracleMCP tools bypassing RPC; will be migrated to proper RPC
+operations under `ROLE_SERVICE_ADMIN`.
+
+| Operation | Description |
+| --- | --- |
+| `urn:service:reflection:list_tables:1` | List tables from the reflection schema catalog. |
+| `urn:service:reflection:describe_table:1` | Return columns, indexes, and foreign keys for a table. |
+| `urn:service:reflection:list_views:1` | List database views with definitions. |
+| `urn:service:reflection:get_full_schema:1` | Return the complete reflection schema snapshot. |
+| `urn:service:reflection:get_schema_version:1` | Return the current schema version. |
+| `urn:service:reflection:dump_table:1` | Export table rows as JSON with a configurable row limit. |
+| `urn:service:reflection:query_info_schema:1` | Query whitelisted INFORMATION_SCHEMA views. |
+| `urn:service:reflection:list_domains:1` | Enumerate QueryRegistry domains, subdomains, and operations. |
+| `urn:service:reflection:list_rpc_endpoints:1` | List available top-level RPC domain handler names. |
+
 ## Account Domain
 
 All Account domain calls require `ROLE_ACCOUNT_ADMIN`.


### PR DESCRIPTION
### Motivation

- Refresh repository documentation to reflect the current TheOracleRPC state and mark the v0.9.0.0 release (MCP integration POC and start of input shim routing refactor).  
- Provide a single authoritative description of the input-shim pattern so all input surfaces (frontend, Discord, MCP, future bridges) route consistently through the RPC boundary.  
- This is a documentation-only change with no functional code modifications.

### Description

- Rewrote `README.md` end-to-end to describe platform purpose, tech stack, architecture, security, database conventions, codegen, and build/test guidance with v0.9.0.0 context.  
- Replaced the old MCP schema-discovery section in `ARCHITECTURE.md` with a new `Input Shim Architecture` section and expanded TheOracleMCP POC → target routing, auth, infra, tools, and transport details.  
- Extended `QUERYREGISTRY.md` to add the `reflection` domain, `discord` domain, and `identity.mcp_agents` subdomain, added handler entry points, and updated the ownership map to include the new domains.  
- Added a planned `service.reflection` subsection to `RPC.md` listing the intended URN operations, and introduced a new top-level `INPUT_SHIMS.md` documenting design principles, auth resolution, dispatch pattern (`dispatch_rpc_op()`), current input surfaces, and constraints.

### Testing

- Ran the unified harness with `python scripts/run_tests.py` which completed successfully.  
- Frontend generation/lint/type-check/test steps completed (TS model/namespace generation and frontend tests ran; frontend tests: 2 passed).  
- Backend pytest executed and passed (72 tests passed); the harness emitted a non-blocking environment warning about a missing ODBC Driver 18 during a build-version DB check but this did not block the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5fd6a8548832599eb38d0dff10aa4)