### PR TITLE
chore(docker): use Node 22 in builder and remove redundant NodeSource install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 # ────────────────────────────────────────────────────────────────────────────────
 # Frontend build
 # ────────────────────────────────────────────────────────────────────────────────
-FROM node:20 AS builder
+FROM node:22 AS builder
 
-# Download and install Node 18
-RUN apt-get update && apt-get install -y curl python3 python3-pip python3-venv
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv
 WORKDIR /app
 
 COPY requirements.txt ./


### PR DESCRIPTION
### Motivation
- Use the official `node:22` builder image and remove the redundant NodeSource reinstall and incorrect comment while preserving Python tooling for builder-stage codegen.

### Description
- Replace `FROM node:20 AS builder` with `FROM node:22 AS builder` and remove the two `RUN` lines that used `curl`/NodeSource, replacing them with a single `RUN apt-get update && apt-get install -y python3 python3-pip python3-venv` in `Dockerfile`.

### Testing
- Ran `git diff -- Dockerfile`, `git show --stat --oneline HEAD`, and `git status --short` to validate the change and confirm the commit, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b60d920dc083258344c5d7b47aa72e)