### PR TITLE
Add optional pre-resolved AuthContext support to dispatch_rpc_op

### DIFF
--- a/rpc/handler.py
+++ b/rpc/handler.py
@@ -20,6 +20,7 @@ async def dispatch_rpc_op(
   payload: dict | None = None,
   *,
   discord_ctx=None,
+  auth_ctx: AuthContext | None = None,
   headers: dict | None = None,
 ) -> RPCResponse:
   rpc_request = RPCRequest(op=op, payload=payload)
@@ -28,7 +29,13 @@ async def dispatch_rpc_op(
     raise HTTPException(status_code=400, detail='Invalid URN prefix')
 
   normalized_ctx = _normalize_discord_ctx(discord_ctx)
-  auth_ctx = await _resolve_auth_context(app, rpc_request, normalized_ctx)
+  if auth_ctx is None:
+    auth_ctx = await _resolve_auth_context(app, rpc_request, normalized_ctx)
+  elif auth_ctx.user_guid:
+    # Pre-resolved auth context from an input shim — stamp onto the request
+    rpc_request.user_guid = auth_ctx.user_guid
+    rpc_request.roles = auth_ctx.roles
+    rpc_request.role_mask = auth_ctx.role_mask
 
   state = SimpleNamespace(rpc_request=rpc_request, auth_ctx=auth_ctx)
   if normalized_ctx:


### PR DESCRIPTION
### Motivation
- Allow external input shims to supply a pre-resolved `AuthContext` (GUID + role mask) into the RPC dispatch chain so protocol-specific auth (e.g. JWT from MCP) can bypass the bearer/Discord resolution path while remaining non-breaking.

### Description
- Updated `rpc/handler.py` to accept an optional `auth_ctx: AuthContext | None` parameter on `dispatch_rpc_op` and only call `_resolve_auth_context` when `auth_ctx` is `None`, and when provided stamp `rpc_request.user_guid`, `rpc_request.roles`, and `rpc_request.role_mask` from the pre-resolved context.

### Testing
- Ran the unified test harness `python scripts/run_tests.py`, which completed successfully (tests passed); the run produced a non-fatal environment warning about a missing ODBC driver but the test suite exit status was success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b630778db8832594bbcf44dc2c03bc)