### PR TITLE
Add service.reflection RPC subdomain and QueryRegistry info schema operation

### DIFF
--- a/queryregistry/reflection/data/__init__.py
+++ b/queryregistry/reflection/data/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from queryregistry.models import DBRequest
 
-from .models import BatchParams, DumpTableParams, UpdateVersionParams
+from .models import BatchParams, DumpTableParams, QueryInfoSchemaParams, UpdateVersionParams
 
 __all__ = [
   "apply_batch_request",
@@ -12,6 +12,7 @@ __all__ = [
   "get_version_request",
   "rebuild_indexes_request",
   "update_version_request",
+  "query_info_schema_request",
 ]
 
 
@@ -33,3 +34,7 @@ def rebuild_indexes_request() -> DBRequest:
 
 def apply_batch_request(params: BatchParams) -> DBRequest:
   return DBRequest(op="db:reflection:data:apply_batch:1", payload=params.model_dump())
+
+
+def query_info_schema_request(params: QueryInfoSchemaParams) -> DBRequest:
+  return DBRequest(op="db:reflection:data:query_info_schema:1", payload=params.model_dump())

--- a/queryregistry/reflection/data/handler.py
+++ b/queryregistry/reflection/data/handler.py
@@ -7,7 +7,7 @@ from typing import Sequence
 from queryregistry.dispatch import dispatch_subdomain_request
 from queryregistry.models import DBRequest, DBResponse
 
-from .services import apply_batch_v1, dump_table_v1, get_version_v1, rebuild_indexes_v1, update_version_v1
+from .services import apply_batch_v1, dump_table_v1, get_version_v1, query_info_schema_v1, rebuild_indexes_v1, update_version_v1
 from ..dispatch import SubdomainDispatcher
 
 __all__ = ["handle_data_request"]
@@ -18,6 +18,7 @@ DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
   ("dump_table", "1"): dump_table_v1,
   ("rebuild_indexes", "1"): rebuild_indexes_v1,
   ("apply_batch", "1"): apply_batch_v1,
+  ("query_info_schema", "1"): query_info_schema_v1,
 }
 
 

--- a/queryregistry/reflection/data/models.py
+++ b/queryregistry/reflection/data/models.py
@@ -10,6 +10,7 @@ __all__ = [
   "BatchParams",
   "DumpTableParams",
   "UpdateVersionParams",
+  "QueryInfoSchemaParams",
   "VersionParams",
   "VersionRecord",
 ]
@@ -44,6 +45,16 @@ class BatchParams(BaseModel):
   model_config = ConfigDict(extra="forbid")
 
   sql: str
+
+
+class QueryInfoSchemaParams(BaseModel):
+  """Payload for querying INFORMATION_SCHEMA views."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  view_name: str
+  filter_column: str | None = None
+  filter_value: str | None = None
 
 
 class VersionRecord(TypedDict):

--- a/queryregistry/reflection/data/mssql.py
+++ b/queryregistry/reflection/data/mssql.py
@@ -8,12 +8,15 @@ from typing import Any
 from queryregistry.models import DBResponse
 from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
 
+from .models import QueryInfoSchemaParams
+
 __all__ = [
   "apply_batch_v1",
   "dump_table_v1",
   "get_version_v1",
   "rebuild_indexes_v1",
   "update_version_v1",
+  "query_info_schema_v1",
 ]
 
 
@@ -52,3 +55,16 @@ async def rebuild_indexes_v1(_: Mapping[str, Any]) -> DBResponse:
 async def apply_batch_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = args["sql"]
   return await run_exec(sql)
+
+
+async def query_info_schema_v1(args: Mapping[str, Any]) -> DBResponse:
+  params = QueryInfoSchemaParams.model_validate(args)
+  ident = _quote_ident(params.view_name)
+  sql = f"SELECT * FROM INFORMATION_SCHEMA.{ident}"
+  query_params: tuple[str, ...] = ()
+  if params.filter_column is not None and params.filter_value is not None:
+    col_ident = _quote_ident(params.filter_column)
+    sql += f" WHERE {col_ident} = ?"
+    query_params = (params.filter_value,)
+  sql += " FOR JSON PATH;"
+  return await run_json_many(sql, query_params)

--- a/queryregistry/reflection/data/services.py
+++ b/queryregistry/reflection/data/services.py
@@ -8,7 +8,7 @@ from typing import Any
 from queryregistry.models import DBRequest, DBResponse
 
 from . import mssql
-from .models import BatchParams, DumpTableParams, UpdateVersionParams, VersionParams
+from .models import BatchParams, DumpTableParams, QueryInfoSchemaParams, UpdateVersionParams, VersionParams
 
 __all__ = [
   "apply_batch_v1",
@@ -16,6 +16,7 @@ __all__ = [
   "get_version_v1",
   "rebuild_indexes_v1",
   "update_version_v1",
+  "query_info_schema_v1",
 ]
 
 _Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
@@ -25,6 +26,7 @@ _UPDATE_VERSION_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.update_ver
 _DUMP_TABLE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.dump_table_v1}
 _REBUILD_INDEXES_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.rebuild_indexes_v1}
 _APPLY_BATCH_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.apply_batch_v1}
+_QUERY_INFO_SCHEMA_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.query_info_schema_v1}
 
 
 def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
@@ -60,4 +62,10 @@ async def rebuild_indexes_v1(request: DBRequest, *, provider: str) -> DBResponse
 async def apply_batch_v1(request: DBRequest, *, provider: str) -> DBResponse:
   params = BatchParams.model_validate(request.payload)
   result = await _select_dispatcher(provider, _APPLY_BATCH_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def query_info_schema_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = QueryInfoSchemaParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _QUERY_INFO_SCHEMA_DISPATCHERS)(params.model_dump())
   return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/rpc/service/__init__.py
+++ b/rpc/service/__init__.py
@@ -5,8 +5,10 @@ Requires ROLE_SERVICE_ADMIN.
 
 from .roles.handler import handle_roles_request
 from .routes.handler import handle_routes_request
+from .reflection.handler import handle_reflection_request
 
 HANDLERS: dict[str, callable] = {
   "roles": handle_roles_request,
   "routes": handle_routes_request,
+  "reflection": handle_reflection_request,
 }

--- a/rpc/service/reflection/__init__.py
+++ b/rpc/service/reflection/__init__.py
@@ -1,0 +1,29 @@
+"""Service reflection RPC namespace.
+
+Requires ROLE_SERVICE_ADMIN.
+"""
+
+from .services import (
+  service_reflection_describe_table_v1,
+  service_reflection_dump_table_v1,
+  service_reflection_get_full_schema_v1,
+  service_reflection_get_schema_version_v1,
+  service_reflection_list_domains_v1,
+  service_reflection_list_rpc_endpoints_v1,
+  service_reflection_list_tables_v1,
+  service_reflection_list_views_v1,
+  service_reflection_query_info_schema_v1,
+)
+
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list_tables", "1"): service_reflection_list_tables_v1,
+  ("describe_table", "1"): service_reflection_describe_table_v1,
+  ("list_views", "1"): service_reflection_list_views_v1,
+  ("get_full_schema", "1"): service_reflection_get_full_schema_v1,
+  ("get_schema_version", "1"): service_reflection_get_schema_version_v1,
+  ("dump_table", "1"): service_reflection_dump_table_v1,
+  ("query_info_schema", "1"): service_reflection_query_info_schema_v1,
+  ("list_domains", "1"): service_reflection_list_domains_v1,
+  ("list_rpc_endpoints", "1"): service_reflection_list_rpc_endpoints_v1,
+}

--- a/rpc/service/reflection/handler.py
+++ b/rpc/service/reflection/handler.py
@@ -1,0 +1,18 @@
+"""Service reflection RPC handler.
+
+Dispatches schema introspection operations.
+"""
+
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_reflection_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/service/reflection/models.py
+++ b/rpc/service/reflection/models.py
@@ -1,0 +1,52 @@
+"""Pydantic models for service.reflection RPC operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class DescribeTableRequest1(BaseModel):
+  table_name: str
+  table_schema: str = "dbo"
+
+
+class DumpTableRequest1(BaseModel):
+  table_name: str
+  table_schema: str = "dbo"
+  max_rows: int = Field(default=100, ge=0, le=1000)
+
+
+class QueryInfoSchemaRequest1(BaseModel):
+  view_name: str
+  filter_column: str | None = None
+  filter_value: str | None = None
+
+
+class SchemaVersionResponse1(BaseModel):
+  version: Any
+
+
+class TableListResponse1(BaseModel):
+  tables: list[dict[str, Any]]
+
+
+class DescribeTableResponse1(BaseModel):
+  columns: list[dict[str, Any]]
+  indexes: list[dict[str, Any]]
+  foreign_keys: list[dict[str, Any]]
+
+
+class DumpTableResponse1(BaseModel):
+  rows: list[dict[str, Any]]
+  truncated: bool
+  total_rows: int
+
+
+class DomainsResponse1(BaseModel):
+  domains: dict[str, Any]
+
+
+class RpcEndpointsResponse1(BaseModel):
+  endpoints: list[str]

--- a/rpc/service/reflection/services.py
+++ b/rpc/service/reflection/services.py
@@ -1,0 +1,164 @@
+"""Service functions for service.reflection RPC operations."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+from queryregistry.handler import HANDLERS as QR_HANDLERS
+from queryregistry.models import DBRequest
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.db_module import DbModule
+
+from .models import (
+  DescribeTableRequest1,
+  DescribeTableResponse1,
+  DomainsResponse1,
+  DumpTableRequest1,
+  DumpTableResponse1,
+  QueryInfoSchemaRequest1,
+  RpcEndpointsResponse1,
+  SchemaVersionResponse1,
+  TableListResponse1,
+)
+
+_ALLOWED_VIEWS = frozenset({
+  "TABLES",
+  "COLUMNS",
+  "KEY_COLUMN_USAGE",
+  "TABLE_CONSTRAINTS",
+  "REFERENTIAL_CONSTRAINTS",
+  "CHECK_CONSTRAINTS",
+  "VIEWS",
+  "ROUTINES",
+  "PARAMETERS",
+  "SCHEMATA",
+  "DOMAINS",
+})
+
+
+def _extract_payload(response: Any) -> Any:
+  if hasattr(response, "payload"):
+    return response.payload
+  return response
+
+
+async def service_reflection_list_tables_v1(request: Request) -> RPCResponse:
+  rpc_request, _, _ = await unbox_request(request)
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  response = await db.run(DBRequest(op="db:reflection:schema:list_tables:1", payload={}))
+  payload = TableListResponse1(tables=_extract_payload(response) or [])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def service_reflection_describe_table_v1(request: Request) -> RPCResponse:
+  rpc_request, _, _ = await unbox_request(request)
+  data = DescribeTableRequest1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  qr_payload = {"table_schema": data.table_schema, "name": data.table_name}
+  columns = await db.run(DBRequest(op="db:reflection:schema:list_columns:1", payload=qr_payload))
+  indexes = await db.run(DBRequest(op="db:reflection:schema:list_indexes:1", payload=qr_payload))
+  foreign_keys = await db.run(DBRequest(op="db:reflection:schema:list_foreign_keys:1", payload=qr_payload))
+  payload = DescribeTableResponse1(
+    columns=_extract_payload(columns) or [],
+    indexes=_extract_payload(indexes) or [],
+    foreign_keys=_extract_payload(foreign_keys) or [],
+  )
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def service_reflection_list_views_v1(request: Request) -> RPCResponse:
+  rpc_request, _, _ = await unbox_request(request)
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  response = await db.run(DBRequest(op="db:reflection:schema:list_views:1", payload={}))
+  payload = TableListResponse1(tables=_extract_payload(response) or [])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def service_reflection_get_full_schema_v1(request: Request) -> RPCResponse:
+  rpc_request, _, _ = await unbox_request(request)
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  response = await db.run(DBRequest(op="db:reflection:schema:get_full_schema:1", payload={}))
+  return RPCResponse(op=rpc_request.op, payload=_extract_payload(response), version=rpc_request.version)
+
+
+async def service_reflection_get_schema_version_v1(request: Request) -> RPCResponse:
+  rpc_request, _, _ = await unbox_request(request)
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  response = await db.run(DBRequest(op="db:reflection:data:get_version:1", payload={}))
+  data = _extract_payload(response) or {}
+  payload = SchemaVersionResponse1(version=data.get("element_value", data))
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def service_reflection_dump_table_v1(request: Request) -> RPCResponse:
+  rpc_request, _, _ = await unbox_request(request)
+  data = DumpTableRequest1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  response = await db.run(
+    DBRequest(op="db:reflection:data:dump_table:1", payload={"table_schema": data.table_schema, "name": data.table_name})
+  )
+  rows = _extract_payload(response) or []
+  if not isinstance(rows, list):
+    rows = [rows]
+  total_rows = len(rows)
+  bounded = rows[:data.max_rows]
+  payload = DumpTableResponse1(rows=bounded, truncated=total_rows > data.max_rows, total_rows=total_rows)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def service_reflection_query_info_schema_v1(request: Request) -> RPCResponse:
+  rpc_request, _, _ = await unbox_request(request)
+  data = QueryInfoSchemaRequest1(**(rpc_request.payload or {}))
+  if data.view_name not in _ALLOWED_VIEWS:
+    raise HTTPException(status_code=400, detail=f"Unsupported INFORMATION_SCHEMA view: {data.view_name}")
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  qr_payload: dict[str, Any] = {"view_name": data.view_name}
+  if data.filter_column is not None and data.filter_value is not None:
+    qr_payload["filter_column"] = data.filter_column
+    qr_payload["filter_value"] = data.filter_value
+  response = await db.run(DBRequest(op="db:reflection:data:query_info_schema:1", payload=qr_payload))
+  rows = _extract_payload(response) or []
+  return RPCResponse(op=rpc_request.op, payload=rows, version=rpc_request.version)
+
+
+async def service_reflection_list_domains_v1(request: Request) -> RPCResponse:
+  rpc_request, _, _ = await unbox_request(request)
+  results: dict[str, Any] = {}
+  for domain, domain_handler in QR_HANDLERS.items():
+    try:
+      domain_module = importlib.import_module(domain_handler.__module__)
+      subdomain_handlers = getattr(domain_module, "HANDLERS")
+      if not isinstance(subdomain_handlers, dict):
+        raise TypeError("HANDLERS is not a dict")
+      domain_entry: dict[str, Any] = {}
+      for subdomain, subdomain_handler in subdomain_handlers.items():
+        subdomain_module = importlib.import_module(subdomain_handler.__module__)
+        dispatchers = getattr(subdomain_module, "DISPATCHERS")
+        if not isinstance(dispatchers, dict):
+          raise TypeError("DISPATCHERS is not a dict")
+        operations = [f"{operation}:{version}" for operation, version in dispatchers.keys()]
+        domain_entry[str(subdomain)] = sorted(operations)
+      results[domain] = domain_entry
+    except Exception as exc:
+      results[domain] = {"error": str(exc)}
+  payload = DomainsResponse1(domains=results)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def service_reflection_list_rpc_endpoints_v1(request: Request) -> RPCResponse:
+  rpc_request, _, _ = await unbox_request(request)
+  from rpc import HANDLERS
+
+  payload = RpcEndpointsResponse1(endpoints=sorted(HANDLERS.keys()))
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)


### PR DESCRIPTION
### Motivation

- Expose database introspection operations through the RPC `service.reflection` subdomain and enforce `ROLE_SERVICE_ADMIN` at the correct RPC layer.
- Replace direct QueryRegistry calls in MCP tools with proper RPC operations routed through the application `DbModule` and QueryRegistry.
- Add a safe, canonical QueryRegistry operation for querying `INFORMATION_SCHEMA` views instead of constructing raw SQL in the RPC/service layer.

### Description

- Added a new `rpc/service/reflection` subdomain with `DISPATCHERS`, a thin handler, pydantic request/response models, and service functions that validate payloads, call `DbModule` QueryRegistry operations, and return typed `RPCResponse`s.
- Registered the `reflection` subdomain in `rpc/service/__init__.py` so `urn:service:reflection:*` routes through the existing service domain auth gate.
- Introduced a new QueryRegistry operation `db:reflection:data:query_info_schema:1` with `QueryInfoSchemaParams`, a MSSQL provider implementation that quotes identifiers and parameterizes filters, a service dispatcher, and a request builder export, and registered it in the reflection data `DISPATCHERS` map.
- Implemented `list_domains` and `list_rpc_endpoints` service functions by introspecting the QueryRegistry and RPC handler registries, and added a lazy import for the RPC `HANDLERS` in `service_reflection_list_rpc_endpoints_v1` to avoid an import cycle.

### Testing

- Ran the unified harness with `python scripts/run_tests.py` and the test suite completed successfully (all tests passed).
- Ran the focused unit test `pytest -q tests/test_rpc_handler_dispatch.py` to verify handler import/dispatch behavior and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b633679f90832581b1d49987727cdd)