### PR TITLE
Add system batch job DDL and QueryRegistry subdomain

### DIFF
--- a/migrations/batch_jobs.sql
+++ b/migrations/batch_jobs.sql
@@ -1,0 +1,35 @@
+CREATE TABLE [dbo].[system_batch_jobs] (
+  [recid]                   BIGINT IDENTITY(1,1) NOT NULL,
+  [element_name]            NVARCHAR(128) NOT NULL,
+  [element_description]     NVARCHAR(512) NULL,
+  [element_class]           NVARCHAR(256) NOT NULL,
+  [element_parameters]      NVARCHAR(MAX) NULL,
+  [element_cron]            NVARCHAR(64) NOT NULL,
+  [element_recurrence_type] TINYINT NOT NULL DEFAULT (0),
+  [element_run_count_limit] INT NULL,
+  [element_run_until]       DATETIMEOFFSET(7) NULL,
+  [element_total_runs]      INT NOT NULL DEFAULT (0),
+  [element_is_enabled]      BIT NOT NULL DEFAULT (1),
+  [element_last_run]        DATETIMEOFFSET(7) NULL,
+  [element_next_run]        DATETIMEOFFSET(7) NULL,
+  [element_status]          TINYINT NOT NULL DEFAULT (0),
+  [element_created_on]      DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+  [element_modified_on]     DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+  CONSTRAINT [PK_system_batch_jobs] PRIMARY KEY ([recid])
+);
+CREATE UNIQUE INDEX [UQ_system_batch_jobs_name] ON [dbo].[system_batch_jobs] ([element_name]);
+
+CREATE TABLE [dbo].[system_batch_job_history] (
+  [recid]               BIGINT IDENTITY(1,1) NOT NULL,
+  [jobs_recid]          BIGINT NOT NULL,
+  [element_started_on]  DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+  [element_ended_on]    DATETIMEOFFSET(7) NULL,
+  [element_status]      TINYINT NOT NULL DEFAULT (1),
+  [element_error]       NVARCHAR(MAX) NULL,
+  [element_result]      NVARCHAR(MAX) NULL,
+  [element_created_on]  DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+  CONSTRAINT [PK_system_batch_job_history] PRIMARY KEY ([recid]),
+  CONSTRAINT [FK_batch_job_history_jobs] FOREIGN KEY ([jobs_recid])
+    REFERENCES [dbo].[system_batch_jobs] ([recid])
+);
+CREATE INDEX [IX_batch_job_history_jobs_recid] ON [dbo].[system_batch_job_history] ([jobs_recid]);

--- a/queryregistry/system/batch_jobs/__init__.py
+++ b/queryregistry/system/batch_jobs/__init__.py
@@ -1,0 +1,59 @@
+"""System batch jobs query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import (
+  CreateHistoryParams,
+  DeleteJobParams,
+  GetJobParams,
+  ListHistoryParams,
+  ListJobsParams,
+  UpdateHistoryParams,
+  UpdateJobStatusParams,
+  UpsertJobParams,
+)
+
+__all__ = [
+  "create_history_request",
+  "delete_job_request",
+  "get_job_request",
+  "list_history_request",
+  "list_jobs_request",
+  "update_history_request",
+  "update_job_status_request",
+  "upsert_job_request",
+]
+
+
+def list_jobs_request(params: ListJobsParams) -> DBRequest:
+  return DBRequest(op="db:system:batch_jobs:list_jobs:1", payload=params.model_dump())
+
+
+def get_job_request(params: GetJobParams) -> DBRequest:
+  return DBRequest(op="db:system:batch_jobs:get_job:1", payload=params.model_dump())
+
+
+def upsert_job_request(params: UpsertJobParams) -> DBRequest:
+  return DBRequest(op="db:system:batch_jobs:upsert_job:1", payload=params.model_dump())
+
+
+def delete_job_request(params: DeleteJobParams) -> DBRequest:
+  return DBRequest(op="db:system:batch_jobs:delete_job:1", payload=params.model_dump())
+
+
+def list_history_request(params: ListHistoryParams) -> DBRequest:
+  return DBRequest(op="db:system:batch_jobs:list_history:1", payload=params.model_dump())
+
+
+def create_history_request(params: CreateHistoryParams) -> DBRequest:
+  return DBRequest(op="db:system:batch_jobs:create_history:1", payload=params.model_dump())
+
+
+def update_history_request(params: UpdateHistoryParams) -> DBRequest:
+  return DBRequest(op="db:system:batch_jobs:update_history:1", payload=params.model_dump())
+
+
+def update_job_status_request(params: UpdateJobStatusParams) -> DBRequest:
+  return DBRequest(op="db:system:batch_jobs:update_job_status:1", payload=params.model_dump())

--- a/queryregistry/system/batch_jobs/handler.py
+++ b/queryregistry/system/batch_jobs/handler.py
@@ -1,0 +1,47 @@
+"""System batch jobs handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import (
+  create_history_v1,
+  delete_job_v1,
+  get_job_v1,
+  list_history_v1,
+  list_jobs_v1,
+  update_history_v1,
+  update_job_status_v1,
+  upsert_job_v1,
+)
+
+__all__ = ["handle_batch_jobs_request"]
+
+DISPATCHERS = {
+  ("list_jobs", "1"): list_jobs_v1,
+  ("get_job", "1"): get_job_v1,
+  ("upsert_job", "1"): upsert_job_v1,
+  ("delete_job", "1"): delete_job_v1,
+  ("list_history", "1"): list_history_v1,
+  ("create_history", "1"): create_history_v1,
+  ("update_history", "1"): update_history_v1,
+  ("update_job_status", "1"): update_job_status_v1,
+}
+
+
+async def handle_batch_jobs_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown system batch_jobs operation",
+  )

--- a/queryregistry/system/batch_jobs/models.py
+++ b/queryregistry/system/batch_jobs/models.py
@@ -1,0 +1,112 @@
+"""System batch jobs query registry service models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "BatchJobHistoryRecord",
+  "BatchJobRecord",
+  "CreateHistoryParams",
+  "DeleteJobParams",
+  "GetJobParams",
+  "ListHistoryParams",
+  "ListJobsParams",
+  "UpdateHistoryParams",
+  "UpdateJobStatusParams",
+  "UpsertJobParams",
+]
+
+
+class ListJobsParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+
+class GetJobParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+
+
+class UpsertJobParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int | None = None
+  name: str
+  description: str | None = None
+  class_path: str
+  parameters: str | None = None
+  cron: str
+  recurrence_type: int = 0
+  run_count_limit: int | None = None
+  run_until: str | None = None
+  is_enabled: bool = True
+
+
+class DeleteJobParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+
+
+class ListHistoryParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  jobs_recid: int
+
+
+class CreateHistoryParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  jobs_recid: int
+
+
+class UpdateHistoryParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+  status: int
+  error: str | None = None
+  result: str | None = None
+
+
+class UpdateJobStatusParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+  status: int
+  total_runs: int | None = None
+  last_run: str | None = None
+  next_run: str | None = None
+
+
+class BatchJobRecord(TypedDict):
+  recid: int
+  element_name: str
+  element_description: str | None
+  element_class: str
+  element_parameters: str | None
+  element_cron: str
+  element_recurrence_type: int
+  element_run_count_limit: int | None
+  element_run_until: str | None
+  element_total_runs: int
+  element_is_enabled: bool
+  element_last_run: str | None
+  element_next_run: str | None
+  element_status: int
+  element_created_on: str
+  element_modified_on: str
+
+
+class BatchJobHistoryRecord(TypedDict):
+  recid: int
+  jobs_recid: int
+  element_started_on: str
+  element_ended_on: str | None
+  element_status: int
+  element_error: str | None
+  element_result: str | None
+  element_created_on: str

--- a/queryregistry/system/batch_jobs/mssql.py
+++ b/queryregistry/system/batch_jobs/mssql.py
@@ -1,0 +1,331 @@
+"""MSSQL implementations for system batch jobs query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
+
+__all__ = [
+  "create_history_v1",
+  "delete_job_v1",
+  "get_job_v1",
+  "list_history_v1",
+  "list_jobs_v1",
+  "update_history_v1",
+  "update_job_status_v1",
+  "upsert_job_v1",
+]
+
+
+async def list_jobs_v1(args: Mapping[str, Any]) -> DBResponse:
+  del args
+  sql = """
+    SELECT
+      recid,
+      element_name,
+      element_description,
+      element_class,
+      element_parameters,
+      element_cron,
+      element_recurrence_type,
+      element_run_count_limit,
+      element_run_until,
+      element_total_runs,
+      element_is_enabled,
+      element_last_run,
+      element_next_run,
+      element_status,
+      element_created_on,
+      element_modified_on
+    FROM system_batch_jobs
+    ORDER BY element_name
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql)
+
+
+async def get_job_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      recid,
+      element_name,
+      element_description,
+      element_class,
+      element_parameters,
+      element_cron,
+      element_recurrence_type,
+      element_run_count_limit,
+      element_run_until,
+      element_total_runs,
+      element_is_enabled,
+      element_last_run,
+      element_next_run,
+      element_status,
+      element_created_on,
+      element_modified_on
+    FROM system_batch_jobs
+    WHERE recid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (args["recid"],))
+
+
+async def upsert_job_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    DECLARE @inserted TABLE (
+      recid BIGINT,
+      element_name NVARCHAR(128),
+      element_description NVARCHAR(512),
+      element_class NVARCHAR(256),
+      element_parameters NVARCHAR(MAX),
+      element_cron NVARCHAR(64),
+      element_recurrence_type TINYINT,
+      element_run_count_limit INT,
+      element_run_until DATETIMEOFFSET(7),
+      element_total_runs INT,
+      element_is_enabled BIT,
+      element_last_run DATETIMEOFFSET(7),
+      element_next_run DATETIMEOFFSET(7),
+      element_status TINYINT,
+      element_created_on DATETIMEOFFSET(7),
+      element_modified_on DATETIMEOFFSET(7)
+    );
+
+    IF ? IS NOT NULL AND EXISTS (SELECT 1 FROM system_batch_jobs WHERE recid = ?)
+    BEGIN
+      UPDATE system_batch_jobs
+      SET
+        element_name = ?,
+        element_description = ?,
+        element_class = ?,
+        element_parameters = ?,
+        element_cron = ?,
+        element_recurrence_type = ?,
+        element_run_count_limit = ?,
+        element_run_until = TRY_CAST(? AS DATETIMEOFFSET(7)),
+        element_is_enabled = ?,
+        element_modified_on = SYSUTCDATETIME()
+      WHERE recid = ?;
+
+      SELECT
+        recid,
+        element_name,
+        element_description,
+        element_class,
+        element_parameters,
+        element_cron,
+        element_recurrence_type,
+        element_run_count_limit,
+        element_run_until,
+        element_total_runs,
+        element_is_enabled,
+        element_last_run,
+        element_next_run,
+        element_status,
+        element_created_on,
+        element_modified_on
+      FROM system_batch_jobs
+      WHERE recid = ?
+      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+    END
+    ELSE
+    BEGIN
+      INSERT INTO system_batch_jobs (
+        element_name,
+        element_description,
+        element_class,
+        element_parameters,
+        element_cron,
+        element_recurrence_type,
+        element_run_count_limit,
+        element_run_until,
+        element_is_enabled,
+        element_created_on,
+        element_modified_on
+      )
+      OUTPUT
+        inserted.recid,
+        inserted.element_name,
+        inserted.element_description,
+        inserted.element_class,
+        inserted.element_parameters,
+        inserted.element_cron,
+        inserted.element_recurrence_type,
+        inserted.element_run_count_limit,
+        inserted.element_run_until,
+        inserted.element_total_runs,
+        inserted.element_is_enabled,
+        inserted.element_last_run,
+        inserted.element_next_run,
+        inserted.element_status,
+        inserted.element_created_on,
+        inserted.element_modified_on
+      INTO @inserted
+      VALUES (
+        ?,
+        ?,
+        ?,
+        ?,
+        ?,
+        ?,
+        TRY_CAST(? AS DATETIMEOFFSET(7)),
+        ?,
+        SYSUTCDATETIME(),
+        SYSUTCDATETIME()
+      );
+
+      SELECT
+        recid,
+        element_name,
+        element_description,
+        element_class,
+        element_parameters,
+        element_cron,
+        element_recurrence_type,
+        element_run_count_limit,
+        element_run_until,
+        element_total_runs,
+        element_is_enabled,
+        element_last_run,
+        element_next_run,
+        element_status,
+        element_created_on,
+        element_modified_on
+      FROM @inserted
+      FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+    END
+  """
+  params = (
+    args.get("recid"),
+    args.get("recid"),
+    args["name"],
+    args.get("description"),
+    args["class_path"],
+    args.get("parameters"),
+    args["cron"],
+    args["recurrence_type"],
+    args.get("run_count_limit"),
+    args.get("run_until"),
+    args["is_enabled"],
+    args.get("recid"),
+    args.get("recid"),
+    args["name"],
+    args.get("description"),
+    args["class_path"],
+    args.get("parameters"),
+    args["cron"],
+    args["recurrence_type"],
+    args.get("run_count_limit"),
+    args.get("run_until"),
+    args["is_enabled"],
+  )
+  return await run_json_one(sql, params)
+
+
+async def delete_job_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SET NOCOUNT ON;
+    DELETE FROM system_batch_jobs
+    WHERE recid = ?;
+  """
+  return await run_exec(sql, (args["recid"],))
+
+
+async def list_history_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT TOP (50)
+      recid,
+      jobs_recid,
+      element_started_on,
+      element_ended_on,
+      element_status,
+      element_error,
+      element_result,
+      element_created_on
+    FROM system_batch_job_history
+    WHERE jobs_recid = ?
+    ORDER BY recid DESC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, (args["jobs_recid"],))
+
+
+async def create_history_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    DECLARE @inserted TABLE (
+      recid BIGINT,
+      jobs_recid BIGINT,
+      element_started_on DATETIMEOFFSET(7),
+      element_ended_on DATETIMEOFFSET(7),
+      element_status TINYINT,
+      element_error NVARCHAR(MAX),
+      element_result NVARCHAR(MAX),
+      element_created_on DATETIMEOFFSET(7)
+    );
+
+    INSERT INTO system_batch_job_history (jobs_recid)
+    OUTPUT
+      inserted.recid,
+      inserted.jobs_recid,
+      inserted.element_started_on,
+      inserted.element_ended_on,
+      inserted.element_status,
+      inserted.element_error,
+      inserted.element_result,
+      inserted.element_created_on
+    INTO @inserted
+    VALUES (?);
+
+    SELECT
+      recid,
+      jobs_recid,
+      element_started_on,
+      element_ended_on,
+      element_status,
+      element_error,
+      element_result,
+      element_created_on
+    FROM @inserted
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (args["jobs_recid"],))
+
+
+async def update_history_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SET NOCOUNT ON;
+    UPDATE system_batch_job_history
+    SET
+      element_ended_on = SYSUTCDATETIME(),
+      element_status = ?,
+      element_error = ?,
+      element_result = ?
+    WHERE recid = ?;
+  """
+  params = (args["status"], args.get("error"), args.get("result"), args["recid"])
+  return await run_exec(sql, params)
+
+
+async def update_job_status_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SET NOCOUNT ON;
+    UPDATE system_batch_jobs
+    SET
+      element_status = ?,
+      element_total_runs = COALESCE(?, element_total_runs),
+      element_last_run = TRY_CAST(? AS DATETIMEOFFSET(7)),
+      element_next_run = TRY_CAST(? AS DATETIMEOFFSET(7)),
+      element_modified_on = SYSUTCDATETIME()
+    WHERE recid = ?;
+  """
+  params = (
+    args["status"],
+    args.get("total_runs"),
+    args.get("last_run"),
+    args.get("next_run"),
+    args["recid"],
+  )
+  return await run_exec(sql, params)

--- a/queryregistry/system/batch_jobs/services.py
+++ b/queryregistry/system/batch_jobs/services.py
@@ -1,0 +1,97 @@
+"""System batch jobs query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  CreateHistoryParams,
+  DeleteJobParams,
+  GetJobParams,
+  ListHistoryParams,
+  ListJobsParams,
+  UpdateHistoryParams,
+  UpdateJobStatusParams,
+  UpsertJobParams,
+)
+
+__all__ = [
+  "create_history_v1",
+  "delete_job_v1",
+  "get_job_v1",
+  "list_history_v1",
+  "list_jobs_v1",
+  "update_history_v1",
+  "update_job_status_v1",
+  "upsert_job_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_JOBS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_jobs_v1}
+_GET_JOB_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_job_v1}
+_UPSERT_JOB_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_job_v1}
+_DELETE_JOB_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_job_v1}
+_LIST_HISTORY_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_history_v1}
+_CREATE_HISTORY_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.create_history_v1}
+_UPDATE_HISTORY_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.update_history_v1}
+_UPDATE_JOB_STATUS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.update_job_status_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for system batch jobs registry")
+  return dispatcher
+
+
+async def list_jobs_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListJobsParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_JOBS_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_job_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = GetJobParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_JOB_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def upsert_job_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpsertJobParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPSERT_JOB_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_job_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = DeleteJobParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_JOB_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_history_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListHistoryParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_HISTORY_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def create_history_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = CreateHistoryParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _CREATE_HISTORY_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def update_history_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpdateHistoryParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPDATE_HISTORY_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def update_job_status_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpdateJobStatusParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPDATE_JOB_STATUS_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/queryregistry/system/handler.py
+++ b/queryregistry/system/handler.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 
 from queryregistry.models import DBRequest, DBResponse
 
+from .batch_jobs.handler import handle_batch_jobs_request
 from .config.handler import handle_config_request
 from .conversations.handler import handle_conversations_request
 from .configuration.handler import handle_configuration_request
@@ -23,6 +24,7 @@ from .service_pages.handler import handle_service_pages_request
 __all__ = ["handle_system_request"]
 
 HANDLERS = {
+  "batch_jobs": handle_batch_jobs_request,
   "configuration": handle_configuration_request,
   "config": handle_config_request,
   "conversations": handle_conversations_request,


### PR DESCRIPTION
### Motivation
- Introduce database schema and data-access layer to support system batch jobs (scheduled tasks executed by Python classes) so admins can define and manage recurring jobs and their run history.
- Provide a canonical QueryRegistry subdomain for system-level CRUD and history operations to keep DB access consistent with the rest of the project.

### Description
- Added migration `migrations/batch_jobs.sql` creating `system_batch_jobs` and `system_batch_job_history` tables with PK/FK constraints and indexes, matching requested columns and defaults.
- Added a new QueryRegistry subdomain at `queryregistry/system/batch_jobs/` with the standard five-file pattern: request builders (`__init__.py`), typed Pydantic models and TypedDict records (`models.py`), MSSQL provider implementations (`mssql.py`), service dispatchers (`services.py`), and subdomain handler (`handler.py`).
- MSSQL implementations use `run_json_many`/`run_json_one`/`run_exec` and implement the identity-safe upsert flow (IF EXISTS / INSERT ... OUTPUT into table variable) as specified; history insert/update and job status update operations are included.
- Registered the new subdomain in `queryregistry/system/handler.py` by importing the handler and adding a `"batch_jobs"` entry to `HANDLERS`.

### Testing
- Ran the unified test harness via `python scripts/run_tests.py`, which completed successfully with the test suite passing (72 tests passed).
- The harness produced a non-fatal environment warning when attempting a DB version update due to a missing local ODBC driver (`ODBC Driver 18 for SQL Server`), so no live DB migration was executed in this environment; unit/test suite results remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7111c90308325b9fe26996fac9c8f)