### PR TITLE
Add `migrations/AGENTS.md` to document migration versioning and rules

### DIFF
--- a/migrations/AGENTS.md
+++ b/migrations/AGENTS.md
@@ -1,0 +1,39 @@
+# Migrations
+
+Human-run migration scripts that alter the database schema incrementally on top of the current baseline.
+
+## Versioning
+
+The repo root holds the current tagged release baseline:
+
+- `v{Major}.{Minor}.{Patch}.{Build}_YYYYMMDD.sql` — full schema DDL
+- `v{Major}.{Minor}.{Patch}.{Build}_seed_YYYYMMDD.sql` — seed data
+
+Version format: `Major.Minor.Patch.Build`
+
+- **Major** — breaking / incompatible platform changes
+- **Minor** — feature releases
+- **Patch / Schema** — incremental schema changes (migrations increment this)
+- **Build** — automated increment by build system
+
+## Naming
+
+Migration files increment the Patch value from the root baseline. If the root is `v0.9.0.0`, migrations are:
+
+```
+v0.9.1.0_batch_jobs.sql
+v0.9.2.0_journal_lines.sql
+v0.9.3.0_credit_lots.sql
+```
+
+Always increment from the highest existing migration in this folder, not from the root.
+
+Format: `v{Major}.{Minor}.{Patch}.0_{short_description}.sql`
+
+## Rules
+
+- Each file should be idempotent where possible
+- Include all related DDL in one file (tables, views, indexes, constraints, seed data)
+- Every migration must include seed data updates for the `system_schema` reflection tables alongside schema changes
+- Do not modify root baseline files — those are regenerated at release time
+- Keep descriptions short, lowercase, underscores in filenames


### PR DESCRIPTION
### Motivation

- Provide a single place documenting how human-run migration scripts should be versioned and named.
- Clarify expectations for migration contents, idempotency, and seeding responsibilities to avoid inconsistent schema changes.
- Ensure contributors follow a consistent workflow when adding incremental schema changes on top of the repository baseline.

### Description

- Add `migrations/AGENTS.md` describing version format `v{Major}.{Minor}.{Patch}.{Build}`, naming conventions, and example filenames.
- Specify that migrations increment the `Patch` from the highest existing migration and include the required filename format `v{Major}.{Minor}.{Patch}.0_{short_description}.sql`.
- Define rules that migrations should be idempotent, include related DDL and seed updates for `system_schema`, and that root baseline files must not be modified.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b718c13d0483259f94111ec8d846e3)