### PR TITLE
Add system batch_jobs RPC surface and dispatcher wiring

### DIFF
--- a/rpc/system/__init__.py
+++ b/rpc/system/__init__.py
@@ -3,6 +3,7 @@
 Requires ROLE_SYSTEM_ADMIN.
 """
 
+from .batch_jobs.handler import handle_batch_jobs_request
 from .config.handler import handle_config_request
 from .conversations.handler import handle_conversations_request
 from .models.handler import handle_models_request
@@ -10,6 +11,7 @@ from .roles.handler import handle_roles_request
 from .storage.handler import handle_storage_request
 
 HANDLERS: dict[str, callable] = {
+  "batch_jobs": handle_batch_jobs_request,
   "config": handle_config_request,
   "conversations": handle_conversations_request,
   "models": handle_models_request,

--- a/rpc/system/batch_jobs/__init__.py
+++ b/rpc/system/batch_jobs/__init__.py
@@ -1,0 +1,17 @@
+from .services import (
+  system_batch_jobs_delete_v1,
+  system_batch_jobs_get_v1,
+  system_batch_jobs_list_history_v1,
+  system_batch_jobs_list_v1,
+  system_batch_jobs_run_now_v1,
+  system_batch_jobs_upsert_v1,
+)
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list", "1"): system_batch_jobs_list_v1,
+  ("get", "1"): system_batch_jobs_get_v1,
+  ("upsert", "1"): system_batch_jobs_upsert_v1,
+  ("delete", "1"): system_batch_jobs_delete_v1,
+  ("list_history", "1"): system_batch_jobs_list_history_v1,
+  ("run_now", "1"): system_batch_jobs_run_now_v1,
+}

--- a/rpc/system/batch_jobs/handler.py
+++ b/rpc/system/batch_jobs/handler.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_batch_jobs_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/system/batch_jobs/models.py
+++ b/rpc/system/batch_jobs/models.py
@@ -1,0 +1,56 @@
+from pydantic import BaseModel
+
+
+class BatchJobItem1(BaseModel):
+  recid: int | None = None
+  name: str
+  description: str | None = None
+  class_path: str
+  parameters: str | None = None
+  cron: str
+  recurrence_type: int = 0
+  run_count_limit: int | None = None
+  run_until: str | None = None
+  total_runs: int = 0
+  is_enabled: bool = True
+  last_run: str | None = None
+  next_run: str | None = None
+  status: int = 0
+
+
+class BatchJobList1(BaseModel):
+  jobs: list[BatchJobItem1]
+
+
+class BatchJobGet1(BaseModel):
+  recid: int
+
+
+class BatchJobUpsert1(BatchJobItem1):
+  pass
+
+
+class BatchJobDelete1(BaseModel):
+  recid: int
+
+
+class BatchJobListHistory1(BaseModel):
+  jobs_recid: int
+
+
+class BatchJobRunNow1(BaseModel):
+  recid: int
+
+
+class BatchJobHistoryItem1(BaseModel):
+  recid: int | None = None
+  jobs_recid: int
+  started_on: str | None = None
+  ended_on: str | None = None
+  status: int = 1
+  error: str | None = None
+  result: str | None = None
+
+
+class BatchJobHistoryList1(BaseModel):
+  history: list[BatchJobHistoryItem1]

--- a/rpc/system/batch_jobs/services.py
+++ b/rpc/system/batch_jobs/services.py
@@ -1,0 +1,77 @@
+from fastapi import HTTPException, Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+
+from .models import (
+  BatchJobDelete1,
+  BatchJobGet1,
+  BatchJobHistoryItem1,
+  BatchJobHistoryList1,
+  BatchJobItem1,
+  BatchJobList1,
+  BatchJobListHistory1,
+  BatchJobRunNow1,
+  BatchJobUpsert1,
+)
+
+
+async def system_batch_jobs_list_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  module = request.app.state.batch_job
+  await module.on_ready()
+  rows = await module.list_jobs()
+  payload = BatchJobList1(jobs=[BatchJobItem1(**row) for row in rows])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def system_batch_jobs_get_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = BatchJobGet1(**(rpc_request.payload or {}))
+  module = request.app.state.batch_job
+  await module.on_ready()
+  row = await module.get_job(input_payload.recid)
+  if not row:
+    raise HTTPException(status_code=404, detail="Batch job not found")
+  payload = BatchJobItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def system_batch_jobs_upsert_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = BatchJobUpsert1(**(rpc_request.payload or {}))
+  module = request.app.state.batch_job
+  await module.on_ready()
+  row = await module.upsert_job(input_payload.model_dump())
+  payload = BatchJobItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def system_batch_jobs_delete_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = BatchJobDelete1(**(rpc_request.payload or {}))
+  module = request.app.state.batch_job
+  await module.on_ready()
+  row = await module.delete_job(input_payload.recid)
+  payload = BatchJobDelete1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def system_batch_jobs_list_history_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = BatchJobListHistory1(**(rpc_request.payload or {}))
+  module = request.app.state.batch_job
+  await module.on_ready()
+  rows = await module.list_history(input_payload.jobs_recid)
+  payload = BatchJobHistoryList1(history=[BatchJobHistoryItem1(**row) for row in rows])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def system_batch_jobs_run_now_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = BatchJobRunNow1(**(rpc_request.payload or {}))
+  module = request.app.state.batch_job
+  await module.on_ready()
+  row = await module.run_now(input_payload.recid)
+  payload = BatchJobItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)


### PR DESCRIPTION
### Motivation

- Expose system batch job management via the `urn:system:batch_jobs:*` RPC namespace and follow the existing 4-file RPC pattern used by other system subdomains.

### Description

- Added `rpc/system/batch_jobs/__init__.py` which defines the `DISPATCHERS` map for `(operation, version)` → handler functions.
- Added `rpc/system/batch_jobs/handler.py` which resolves dispatcher keys and returns a 404 `HTTPException` for unknown operations.
- Added `rpc/system/batch_jobs/models.py` containing Pydantic request/response models such as `BatchJobItem1`, `BatchJobList1`, and `BatchJobHistoryList1`.
- Added `rpc/system/batch_jobs/services.py` implementing service functions (`system_batch_jobs_list_v1`, `system_batch_jobs_get_v1`, `system_batch_jobs_upsert_v1`, `system_batch_jobs_delete_v1`, `system_batch_jobs_list_history_v1`, `system_batch_jobs_run_now_v1`) that call `unbox_request`, await `request.app.state.batch_job.on_ready()`, delegate to the module, and return `RPCResponse`, and registered the new handler in `rpc/system/__init__.py` by adding `"batch_jobs": handle_batch_jobs_request`.

### Testing

- Ran the unified harness with `python scripts/run_tests.py` which completed successfully and regenerated RPC models/TypeScript bindings.
- Test execution summary: the test run completed successfully (unit/JS tests ran) with `72 passed` and no new test failures.
- Observed a non-blocking environment warning about a missing SQL Server ODBC driver during a build-version step, which did not cause test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b71c903dc883258ceeda9ff3643ea0)