### PR TITLE
Migrate storage reindex to batch job system

### DIFF
--- a/migrations/v0.9.1.0_batch_jobs.sql
+++ b/migrations/v0.9.1.0_batch_jobs.sql
@@ -109,3 +109,27 @@ INSERT INTO [dbo].[frontend_routes] (
     'Batch Jobs',
     'schedule'
 );
+
+-- ============================================================
+-- Seed: Storage Reindex batch job
+-- ============================================================
+
+INSERT INTO [dbo].[system_batch_jobs] (
+    [element_name],
+    [element_description],
+    [element_class],
+    [element_parameters],
+    [element_cron],
+    [element_recurrence_type],
+    [element_is_enabled],
+    [element_status]
+) VALUES (
+    'Storage Reindex',
+    'Periodically scan Azure Blob Storage and synchronize the users_storage_cache table.',
+    'server.jobs.storage_reindex.run',
+    NULL,
+    '0 */12 * * *',
+    1,
+    1,
+    0
+);

--- a/server/jobs/__init__.py
+++ b/server/jobs/__init__.py
@@ -1,0 +1,1 @@
+"""Batch job callables for the BatchJobModule scheduler."""

--- a/server/jobs/storage_reindex.py
+++ b/server/jobs/storage_reindex.py
@@ -1,0 +1,32 @@
+"""Storage reindex batch job.
+
+Callable path for batch job registration: server.jobs.storage_reindex.run
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+
+
+async def run(app: FastAPI, params: dict[str, Any]) -> dict[str, Any]:
+  """Execute a full storage reindex.
+
+  Params (all optional):
+      user_guid: str — if provided, reindex only this user's files.
+
+  Returns dict with reindex summary.
+  """
+  storage = getattr(app.state, "storage", None)
+  if storage is None:
+    raise RuntimeError("StorageModule is not available")
+  await storage.on_ready()
+
+  user_guid = params.get("user_guid")
+  await storage.reindex(user_guid=user_guid)
+
+  return {
+    "status": "completed",
+    "user_guid": user_guid,
+  }

--- a/server/modules/storage_module.py
+++ b/server/modules/storage_module.py
@@ -1,6 +1,6 @@
 """Storage management module for indexing Azure Blob contents."""
 
-import asyncio, logging, re, base64
+import logging, base64
 from typing import Any
 from datetime import datetime, timezone
 from uuid import UUID
@@ -37,9 +37,8 @@ from .providers.storage.azure_blob_provider import AzureBlobStorageProvider
 class StorageModule(BaseModule):
   """Module responsible for cataloging files stored in Azure Blob Storage.
 
-  The module maintains a background task that periodically triggers a
-  reindex operation. Database helpers are provided for upserting file
-  metadata and querying indexed data.
+  Database helpers are provided for upserting file metadata and querying
+  indexed data.
   """
 
   def __init__(self, app: FastAPI):
@@ -47,19 +46,8 @@ class StorageModule(BaseModule):
     self.env: EnvModule | None = None
     self.db: DbModule | None = None
     self.connection_string: str | None = None
-    self._reindex_task: asyncio.Task | None = None
-    self.reindex_interval = 15 * 60
     self.discord: DiscordBotModule | None = None
     self.provider: AzureBlobStorageProvider | None = None
-
-  @staticmethod
-  def _parse_duration(value: str) -> int:
-    match = re.fullmatch(r"(\d+)([smhdw])", value.strip().lower())
-    if not match:
-      raise ValueError(f"Invalid duration: {value}")
-    num, unit = match.groups()
-    mult = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
-    return int(num) * mult[unit]
 
   async def startup(self):
     self.env = self.app.state.env
@@ -80,42 +68,16 @@ class StorageModule(BaseModule):
     except Exception as e:
       logging.error("[StorageModule] Failed to load AZURE_BLOB_CONNECTION_STRING: %s", e)
       self.provider = None
-
-    try:
-      res = await self.db.run(get_config_request(ConfigKeyParams(key="StorageCacheTime")))
-      value = res.rows[0]["element_value"] if res.rows else "15m"
-      try:
-        self.reindex_interval = self._parse_duration(value)
-      except Exception:
-        logging.error("[StorageModule] Invalid StorageCacheTime '%s'", value)
-    except Exception as e:
-      logging.error("[StorageModule] Failed to load StorageCacheTime: %s", e)
-    self._reindex_task = asyncio.create_task(self._reindex_loop())
     logging.debug("Storage module loaded")
     self.mark_ready()
 
   async def shutdown(self):
-    if self._reindex_task:
-      self._reindex_task.cancel()
-      try:
-        await self._reindex_task
-      except asyncio.CancelledError:
-        pass
-      self._reindex_task = None
     if self.provider:
       try:
         await self.provider.shutdown()
       except Exception as exc:
         logging.error("[StorageModule] Provider shutdown failed: %s", exc)
       self.provider = None
-
-  async def _reindex_loop(self):
-    while True:
-      await asyncio.sleep(self.reindex_interval)
-      try:
-        await self.reindex()
-      except Exception as e:
-        logging.error("[StorageModule] Reindex failed: %s", e)
 
   def _require_provider(self) -> AzureBlobStorageProvider | None:
     if not self.provider:


### PR DESCRIPTION
### Motivation
- Replace the StorageModule's internal asyncio reindex loop with the centralized, auditable BatchJob scheduler so reindexing is schedulable, pausable, and has run history. 
- Keep `reindex()` implementation untouched while moving scheduling responsibility to the `BatchJobModule` contract (`async def run(app, params) -> dict`).

### Description
- Added a `server/jobs` package marker file at `server/jobs/__init__.py` to host batch job callables. 
- Implemented the storage reindex job callable at `server/jobs/storage_reindex.py` as `async def run(app: FastAPI, params: dict) -> dict` which waits for `StorageModule` readiness and calls `storage.reindex(user_guid=...)` returning a summary payload. 
- Removed the internal reindex loop, task lifecycle, interval config lookup, and duration parser from `server/modules/storage_module.py` and cleaned up unused imports so scheduling is now owned by the batch job system. 
- Appended a seed row to `migrations/v0.9.1.0_batch_jobs.sql` to register an enabled recurring `Storage Reindex` job using cron `0 */12 * * *` and class path `server.jobs.storage_reindex.run`.

### Testing
- Ran the unified test harness with `python scripts/run_tests.py`, which completed and reported the automated test suite passed (unit/frontend checks included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b72a38bc788325a9099b3d9cb8f769)