### PR TITLE
Add finance journal engine migration and queryregistry subdomains

### DIFF
--- a/migrations/v0.9.2.0_journal_engine.sql
+++ b/migrations/v0.9.2.0_journal_engine.sql
@@ -1,0 +1,273 @@
+SET NOCOUNT ON;
+
+IF NOT EXISTS (
+  SELECT 1 FROM system_edt_mappings WHERE element_name = 'DECIMAL_19_5'
+)
+BEGIN
+  INSERT INTO system_edt_mappings (
+    element_name, element_mssql_type, element_postgresql_type, element_mysql_type,
+    element_python_type, element_odbc_type_code, element_max_length, element_notes
+  ) VALUES (
+    'DECIMAL_19_5', 'decimal(19,5)', 'numeric(19,5)', 'decimal(19,5)', 'Decimal', 3, 19,
+    'Fixed-point financial amount. 19 digits total, 5 after decimal. Stored and computed at 5dp, quantized to 4dp before posting per precision policy.'
+  );
+END;
+
+IF EXISTS (
+  SELECT 1
+  FROM sys.indexes
+  WHERE object_id = OBJECT_ID(N'[dbo].[finance_journals]')
+    AND name = N'UQ_finance_journals_name'
+)
+BEGIN
+  DROP INDEX [UQ_finance_journals_name] ON [dbo].[finance_journals];
+END;
+
+IF COL_LENGTH('dbo.finance_journals', 'element_posting_key') IS NULL
+BEGIN
+  ALTER TABLE [dbo].[finance_journals] ADD
+    [element_posting_key]  NVARCHAR(256) NULL,
+    [element_source_type]  NVARCHAR(64) NULL,
+    [element_source_id]    NVARCHAR(256) NULL,
+    [periods_guid]         UNIQUEIDENTIFIER NULL,
+    [ledgers_recid]        BIGINT NULL,
+    [element_posted_by]    UNIQUEIDENTIFIER NULL,
+    [element_posted_on]    DATETIMEOFFSET(7) NULL,
+    [element_reversed_by]  BIGINT NULL,
+    [element_reversal_of]  BIGINT NULL;
+END;
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM sys.indexes
+  WHERE object_id = OBJECT_ID(N'[dbo].[finance_journals]')
+    AND name = N'UQ_finance_journals_posting_key'
+)
+BEGIN
+  CREATE UNIQUE INDEX [UQ_finance_journals_posting_key]
+    ON [dbo].[finance_journals] ([element_posting_key])
+    WHERE [element_posting_key] IS NOT NULL;
+END;
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM sys.foreign_keys
+  WHERE name = N'FK_finance_journals_periods_guid'
+)
+BEGIN
+  ALTER TABLE [dbo].[finance_journals]
+    ADD CONSTRAINT [FK_finance_journals_periods_guid]
+    FOREIGN KEY ([periods_guid]) REFERENCES [dbo].[finance_periods] ([element_guid]);
+END;
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM sys.foreign_keys
+  WHERE name = N'FK_finance_journals_ledgers_recid'
+)
+BEGIN
+  ALTER TABLE [dbo].[finance_journals]
+    ADD CONSTRAINT [FK_finance_journals_ledgers_recid]
+    FOREIGN KEY ([ledgers_recid]) REFERENCES [dbo].[finance_ledgers] ([recid]);
+END;
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM sys.foreign_keys
+  WHERE name = N'FK_finance_journals_reversed_by'
+)
+BEGIN
+  ALTER TABLE [dbo].[finance_journals]
+    ADD CONSTRAINT [FK_finance_journals_reversed_by]
+    FOREIGN KEY ([element_reversed_by]) REFERENCES [dbo].[finance_journals] ([recid]);
+END;
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM sys.foreign_keys
+  WHERE name = N'FK_finance_journals_reversal_of'
+)
+BEGIN
+  ALTER TABLE [dbo].[finance_journals]
+    ADD CONSTRAINT [FK_finance_journals_reversal_of]
+    FOREIGN KEY ([element_reversal_of]) REFERENCES [dbo].[finance_journals] ([recid]);
+END;
+
+IF OBJECT_ID(N'[dbo].[finance_journal_lines]', N'U') IS NULL
+BEGIN
+  CREATE TABLE [dbo].[finance_journal_lines] (
+    [recid]                BIGINT IDENTITY(1,1) NOT NULL,
+    [journals_recid]       BIGINT NOT NULL,
+    [element_line_number]  INT NOT NULL,
+    [accounts_guid]        UNIQUEIDENTIFIER NOT NULL,
+    [element_debit]        DECIMAL(19,5) NOT NULL DEFAULT (0),
+    [element_credit]       DECIMAL(19,5) NOT NULL DEFAULT (0),
+    [element_description]  NVARCHAR(512) NULL,
+    [element_created_on]   DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [element_modified_on]  DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+    CONSTRAINT [PK_finance_journal_lines] PRIMARY KEY ([recid]),
+    CONSTRAINT [FK_journal_lines_journals] FOREIGN KEY ([journals_recid])
+      REFERENCES [dbo].[finance_journals] ([recid]),
+    CONSTRAINT [FK_journal_lines_accounts] FOREIGN KEY ([accounts_guid])
+      REFERENCES [dbo].[finance_accounts] ([element_guid])
+  );
+END;
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM sys.indexes
+  WHERE object_id = OBJECT_ID(N'[dbo].[finance_journal_lines]')
+    AND name = N'IX_journal_lines_journals_recid'
+)
+BEGIN
+  CREATE INDEX [IX_journal_lines_journals_recid]
+    ON [dbo].[finance_journal_lines] ([journals_recid]);
+END;
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM sys.indexes
+  WHERE object_id = OBJECT_ID(N'[dbo].[finance_journal_lines]')
+    AND name = N'UQ_journal_lines_journal_line'
+)
+BEGIN
+  CREATE UNIQUE INDEX [UQ_journal_lines_journal_line]
+    ON [dbo].[finance_journal_lines] ([journals_recid], [element_line_number]);
+END;
+
+IF OBJECT_ID(N'[dbo].[finance_journal_line_dimensions]', N'U') IS NULL
+BEGIN
+  CREATE TABLE [dbo].[finance_journal_line_dimensions] (
+    [recid]              BIGINT IDENTITY(1,1) NOT NULL,
+    [lines_recid]        BIGINT NOT NULL,
+    [dimensions_recid]   BIGINT NOT NULL,
+    CONSTRAINT [PK_finance_journal_line_dimensions] PRIMARY KEY ([recid]),
+    CONSTRAINT [FK_line_dimensions_lines] FOREIGN KEY ([lines_recid])
+      REFERENCES [dbo].[finance_journal_lines] ([recid]),
+    CONSTRAINT [FK_line_dimensions_dimensions] FOREIGN KEY ([dimensions_recid])
+      REFERENCES [dbo].[finance_dimensions] ([recid])
+  );
+END;
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM sys.indexes
+  WHERE object_id = OBJECT_ID(N'[dbo].[finance_journal_line_dimensions]')
+    AND name = N'UQ_line_dimensions_line_dim'
+)
+BEGIN
+  CREATE UNIQUE INDEX [UQ_line_dimensions_line_dim]
+    ON [dbo].[finance_journal_line_dimensions] ([lines_recid], [dimensions_recid]);
+END;
+
+-- ============================================================
+-- Schema reflection metadata for journal engine tables
+-- ============================================================
+
+IF NOT EXISTS (
+  SELECT 1 FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'
+)
+BEGIN
+  INSERT INTO system_schema_tables (element_name, element_schema)
+  VALUES ('finance_journal_lines', 'dbo');
+END;
+
+IF NOT EXISTS (
+  SELECT 1 FROM system_schema_tables WHERE element_name = 'finance_journal_line_dimensions' AND element_schema = 'dbo'
+)
+BEGIN
+  INSERT INTO system_schema_tables (element_name, element_schema)
+  VALUES ('finance_journal_line_dimensions', 'dbo');
+END;
+
+DELETE FROM system_schema_columns
+WHERE tables_recid = (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo');
+
+INSERT INTO system_schema_columns (
+  tables_recid, edt_recid, element_name, element_ordinal, element_nullable,
+  element_default, element_max_length, element_is_primary_key, element_is_identity
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64_IDENTITY'), 'recid', 1, 0, NULL, NULL, 1, 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'journals_recid', 2, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT32'), 'element_line_number', 3, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'UUID'), 'accounts_guid', 4, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DECIMAL_19_5'), 'element_debit', 5, 0, '((0))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DECIMAL_19_5'), 'element_credit', 6, 0, '((0))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_description', 7, 1, NULL, 512, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_created_on', 8, 0, '(sysutcdatetime())', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_modified_on', 9, 0, '(sysutcdatetime())', NULL, 0, 0);
+
+DELETE FROM system_schema_columns
+WHERE tables_recid = (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_line_dimensions' AND element_schema = 'dbo');
+
+INSERT INTO system_schema_columns (
+  tables_recid, edt_recid, element_name, element_ordinal, element_nullable,
+  element_default, element_max_length, element_is_primary_key, element_is_identity
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_line_dimensions' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64_IDENTITY'), 'recid', 1, 0, NULL, NULL, 1, 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_line_dimensions' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'lines_recid', 2, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_line_dimensions' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'dimensions_recid', 3, 0, NULL, NULL, 0, 0);
+
+DELETE FROM system_schema_columns
+WHERE tables_recid = (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo')
+  AND element_name IN (
+    'element_posting_key',
+    'element_source_type',
+    'element_source_id',
+    'periods_guid',
+    'ledgers_recid',
+    'element_posted_by',
+    'element_posted_on',
+    'element_reversed_by',
+    'element_reversal_of'
+  );
+
+INSERT INTO system_schema_columns (
+  tables_recid, edt_recid, element_name, element_ordinal, element_nullable,
+  element_default, element_max_length, element_is_primary_key, element_is_identity
+) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_posting_key', 8, 1, NULL, 256, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_source_type', 9, 1, NULL, 64, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_source_id', 10, 1, NULL, 256, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'UUID'), 'periods_guid', 11, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'ledgers_recid', 12, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'UUID'), 'element_posted_by', 13, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_posted_on', 14, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'element_reversed_by', 15, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'element_reversal_of', 16, 1, NULL, NULL, 0, 0);
+
+DELETE FROM system_schema_indexes
+WHERE tables_recid = (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo')
+  AND element_name IN ('UQ_finance_journals_name', 'UQ_finance_journals_posting_key');
+
+DELETE FROM system_schema_indexes
+WHERE tables_recid = (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo');
+
+DELETE FROM system_schema_indexes
+WHERE tables_recid = (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_line_dimensions' AND element_schema = 'dbo');
+
+INSERT INTO system_schema_indexes (tables_recid, element_name, element_columns, element_is_unique) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), 'UQ_finance_journals_posting_key', 'element_posting_key', 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), 'IX_journal_lines_journals_recid', 'journals_recid', 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), 'UQ_journal_lines_journal_line', 'journals_recid,element_line_number', 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_line_dimensions' AND element_schema = 'dbo'), 'UQ_line_dimensions_line_dim', 'lines_recid,dimensions_recid', 1);
+
+DELETE FROM system_schema_foreign_keys
+WHERE tables_recid = (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo')
+  AND element_column_name IN ('periods_guid', 'ledgers_recid', 'element_reversed_by', 'element_reversal_of');
+
+DELETE FROM system_schema_foreign_keys
+WHERE tables_recid = (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo');
+
+DELETE FROM system_schema_foreign_keys
+WHERE tables_recid = (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_line_dimensions' AND element_schema = 'dbo');
+
+INSERT INTO system_schema_foreign_keys (tables_recid, element_column_name, referenced_tables_recid, element_referenced_column) VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), 'periods_guid', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_periods' AND element_schema = 'dbo'), 'element_guid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), 'ledgers_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_ledgers' AND element_schema = 'dbo'), 'recid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), 'element_reversed_by', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), 'recid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), 'element_reversal_of', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), 'recid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), 'journals_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), 'recid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), 'accounts_guid', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_accounts' AND element_schema = 'dbo'), 'element_guid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_line_dimensions' AND element_schema = 'dbo'), 'lines_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_lines' AND element_schema = 'dbo'), 'recid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journal_line_dimensions' AND element_schema = 'dbo'), 'dimensions_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_dimensions' AND element_schema = 'dbo'), 'recid');

--- a/queryregistry/finance/handler.py
+++ b/queryregistry/finance/handler.py
@@ -11,6 +11,8 @@ from queryregistry.models import DBRequest, DBResponse
 from .accounts.handler import handle_accounts_request
 from .credits.handler import handle_credits_request
 from .dimensions.handler import handle_dimensions_request
+from .journal_lines.handler import handle_journal_lines_request
+from .journals.handler import handle_journals_request
 from .numbers.handler import handle_numbers_request
 from .periods.handler import handle_periods_request
 from .staging.handler import handle_staging_request
@@ -22,6 +24,8 @@ HANDLERS = {
   "accounts": handle_accounts_request,
   "credits": handle_credits_request,
   "dimensions": handle_dimensions_request,
+  "journal_lines": handle_journal_lines_request,
+  "journals": handle_journals_request,
   "numbers": handle_numbers_request,
   "periods": handle_periods_request,
   "staging": handle_staging_request,

--- a/queryregistry/finance/journal_lines/__init__.py
+++ b/queryregistry/finance/journal_lines/__init__.py
@@ -1,0 +1,35 @@
+"""Finance journal lines query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import (
+  CreateLineParams,
+  CreateLinesBatchParams,
+  DeleteLinesByJournalParams,
+  ListLinesByJournalParams,
+)
+
+__all__ = [
+  "create_line_request",
+  "create_lines_batch_request",
+  "delete_lines_by_journal_request",
+  "list_lines_by_journal_request",
+]
+
+
+def list_lines_by_journal_request(params: ListLinesByJournalParams) -> DBRequest:
+  return DBRequest(op="db:finance:journal_lines:list_by_journal:1", payload=params.model_dump())
+
+
+def create_line_request(params: CreateLineParams) -> DBRequest:
+  return DBRequest(op="db:finance:journal_lines:create_line:1", payload=params.model_dump())
+
+
+def create_lines_batch_request(params: CreateLinesBatchParams) -> DBRequest:
+  return DBRequest(op="db:finance:journal_lines:create_lines_batch:1", payload=params.model_dump())
+
+
+def delete_lines_by_journal_request(params: DeleteLinesByJournalParams) -> DBRequest:
+  return DBRequest(op="db:finance:journal_lines:delete_by_journal:1", payload=params.model_dump())

--- a/queryregistry/finance/journal_lines/handler.py
+++ b/queryregistry/finance/journal_lines/handler.py
@@ -1,0 +1,34 @@
+"""Finance journal lines subdomain handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import create_line_v1, create_lines_batch_v1, delete_by_journal_v1, list_by_journal_v1
+
+__all__ = ["handle_journal_lines_request"]
+
+DISPATCHERS = {
+  ("list_by_journal", "1"): list_by_journal_v1,
+  ("create_line", "1"): create_line_v1,
+  ("create_lines_batch", "1"): create_lines_batch_v1,
+  ("delete_by_journal", "1"): delete_by_journal_v1,
+}
+
+
+async def handle_journal_lines_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown finance journal lines operation",
+  )

--- a/queryregistry/finance/journal_lines/models.py
+++ b/queryregistry/finance/journal_lines/models.py
@@ -1,0 +1,66 @@
+"""Finance journal lines query registry models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+  "CreateLineParams",
+  "CreateLinesBatchParams",
+  "DeleteLinesByJournalParams",
+  "JournalLineDimensionRecord",
+  "JournalLineRecord",
+  "ListLinesByJournalParams",
+]
+
+
+class ListLinesByJournalParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  journals_recid: int
+
+
+class CreateLineParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  journals_recid: int
+  line_number: int
+  accounts_guid: str
+  debit: str = "0"
+  credit: str = "0"
+  description: str | None = None
+  dimension_recids: list[int] = Field(default_factory=list)
+
+
+class CreateLinesBatchParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  journals_recid: int
+  lines: list[CreateLineParams]
+
+
+class DeleteLinesByJournalParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  journals_recid: int
+
+
+class JournalLineRecord(TypedDict):
+  recid: int
+  journals_recid: int
+  element_line_number: int
+  accounts_guid: str
+  element_debit: str
+  element_credit: str
+  element_description: str | None
+  element_created_on: str
+  element_modified_on: str
+  dimension_recids: list[int]
+
+
+class JournalLineDimensionRecord(TypedDict):
+  recid: int
+  lines_recid: int
+  dimensions_recid: int

--- a/queryregistry/finance/journal_lines/mssql.py
+++ b/queryregistry/finance/journal_lines/mssql.py
@@ -1,0 +1,151 @@
+"""MSSQL implementations for finance journal lines query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one, transaction
+
+__all__ = ["create_line_v1", "create_lines_batch_v1", "delete_by_journal_v1", "list_by_journal_v1"]
+
+
+async def list_by_journal_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      line.recid,
+      line.journals_recid,
+      line.element_line_number,
+      line.accounts_guid,
+      line.element_debit,
+      line.element_credit,
+      line.element_description,
+      line.element_created_on,
+      line.element_modified_on,
+      COALESCE(
+        (
+          SELECT
+            JSON_QUERY(
+              CONCAT(
+                '[',
+                STRING_AGG(CAST(link.dimensions_recid AS NVARCHAR(20)), ',') WITHIN GROUP (ORDER BY link.dimensions_recid),
+                ']'
+              )
+            )
+          FROM finance_journal_line_dimensions AS link
+          WHERE link.lines_recid = line.recid
+        ),
+        JSON_QUERY('[]')
+      ) AS dimension_recids
+    FROM finance_journal_lines AS line
+    WHERE line.journals_recid = ?
+    ORDER BY line.element_line_number
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, (args["journals_recid"],))
+
+
+async def create_line_v1(args: Mapping[str, Any]) -> DBResponse:
+  async with transaction() as cur:
+    await cur.execute(
+      """
+      INSERT INTO finance_journal_lines (
+        journals_recid,
+        element_line_number,
+        accounts_guid,
+        element_debit,
+        element_credit,
+        element_description,
+        element_created_on,
+        element_modified_on
+      ) VALUES (
+        ?,
+        ?,
+        TRY_CAST(? AS UNIQUEIDENTIFIER),
+        CAST(? AS DECIMAL(19,5)),
+        CAST(? AS DECIMAL(19,5)),
+        ?,
+        SYSUTCDATETIME(),
+        SYSUTCDATETIME()
+      );
+      """,
+      (
+        args["journals_recid"],
+        args["line_number"],
+        args["accounts_guid"],
+        args["debit"],
+        args["credit"],
+        args.get("description"),
+      ),
+    )
+    await cur.execute("SELECT CAST(SCOPE_IDENTITY() AS BIGINT) AS recid;")
+    identity_row = await cur.fetchone()
+    line_recid = int(identity_row[0])
+
+    for dimension_recid in args.get("dimension_recids", []):
+      await cur.execute(
+        """
+        INSERT INTO finance_journal_line_dimensions (lines_recid, dimensions_recid)
+        VALUES (?, ?);
+        """,
+        (line_recid, dimension_recid),
+      )
+
+  return await run_json_one(
+    """
+    SELECT
+      line.recid,
+      line.journals_recid,
+      line.element_line_number,
+      line.accounts_guid,
+      line.element_debit,
+      line.element_credit,
+      line.element_description,
+      line.element_created_on,
+      line.element_modified_on,
+      COALESCE(
+        (
+          SELECT
+            JSON_QUERY(
+              CONCAT(
+                '[',
+                STRING_AGG(CAST(link.dimensions_recid AS NVARCHAR(20)), ',') WITHIN GROUP (ORDER BY link.dimensions_recid),
+                ']'
+              )
+            )
+          FROM finance_journal_line_dimensions AS link
+          WHERE link.lines_recid = line.recid
+        ),
+        JSON_QUERY('[]')
+      ) AS dimension_recids
+    FROM finance_journal_lines AS line
+    WHERE line.recid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+    """,
+    (line_recid,),
+  )
+
+
+async def create_lines_batch_v1(args: Mapping[str, Any]) -> DBResponse:
+  created_count = 0
+  for line in args.get("lines", []):
+    line_payload = dict(line)
+    line_payload["journals_recid"] = args["journals_recid"]
+    await create_line_v1(line_payload)
+    created_count += 1
+
+  return DBResponse(payload={"created": created_count}, rowcount=created_count)
+
+
+async def delete_by_journal_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    DELETE FROM finance_journal_line_dimensions
+    WHERE lines_recid IN (
+      SELECT recid FROM finance_journal_lines WHERE journals_recid = ?
+    );
+
+    DELETE FROM finance_journal_lines
+    WHERE journals_recid = ?;
+  """
+  return await run_exec(sql, (args["journals_recid"], args["journals_recid"]))

--- a/queryregistry/finance/journal_lines/services.py
+++ b/queryregistry/finance/journal_lines/services.py
@@ -1,0 +1,56 @@
+"""Finance journal lines query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  CreateLineParams,
+  CreateLinesBatchParams,
+  DeleteLinesByJournalParams,
+  ListLinesByJournalParams,
+)
+
+__all__ = ["create_line_v1", "create_lines_batch_v1", "delete_by_journal_v1", "list_by_journal_v1"]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_BY_JOURNAL_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_by_journal_v1}
+_CREATE_LINE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.create_line_v1}
+_CREATE_LINES_BATCH_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.create_lines_batch_v1}
+_DELETE_BY_JOURNAL_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_by_journal_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for finance journal lines registry")
+  return dispatcher
+
+
+async def list_by_journal_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListLinesByJournalParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_BY_JOURNAL_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def create_line_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = CreateLineParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _CREATE_LINE_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def create_lines_batch_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = CreateLinesBatchParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _CREATE_LINES_BATCH_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def delete_by_journal_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = DeleteLinesByJournalParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _DELETE_BY_JOURNAL_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/queryregistry/finance/journals/__init__.py
+++ b/queryregistry/finance/journals/__init__.py
@@ -1,0 +1,41 @@
+"""Finance journals query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import (
+  CreateJournalParams,
+  GetByPostingKeyParams,
+  GetJournalParams,
+  ListJournalsParams,
+  UpdateJournalStatusParams,
+)
+
+__all__ = [
+  "create_journal_request",
+  "get_by_posting_key_request",
+  "get_journal_request",
+  "list_journals_request",
+  "update_journal_status_request",
+]
+
+
+def list_journals_request(params: ListJournalsParams) -> DBRequest:
+  return DBRequest(op="db:finance:journals:list:1", payload=params.model_dump())
+
+
+def get_journal_request(params: GetJournalParams) -> DBRequest:
+  return DBRequest(op="db:finance:journals:get:1", payload=params.model_dump())
+
+
+def create_journal_request(params: CreateJournalParams) -> DBRequest:
+  return DBRequest(op="db:finance:journals:create:1", payload=params.model_dump())
+
+
+def update_journal_status_request(params: UpdateJournalStatusParams) -> DBRequest:
+  return DBRequest(op="db:finance:journals:update_status:1", payload=params.model_dump())
+
+
+def get_by_posting_key_request(params: GetByPostingKeyParams) -> DBRequest:
+  return DBRequest(op="db:finance:journals:get_by_posting_key:1", payload=params.model_dump())

--- a/queryregistry/finance/journals/handler.py
+++ b/queryregistry/finance/journals/handler.py
@@ -1,0 +1,35 @@
+"""Finance journals subdomain handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import create_v1, get_by_posting_key_v1, get_v1, list_v1, update_status_v1
+
+__all__ = ["handle_journals_request"]
+
+DISPATCHERS = {
+  ("list", "1"): list_v1,
+  ("get", "1"): get_v1,
+  ("create", "1"): create_v1,
+  ("update_status", "1"): update_status_v1,
+  ("get_by_posting_key", "1"): get_by_posting_key_v1,
+}
+
+
+async def handle_journals_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown finance journals operation",
+  )

--- a/queryregistry/finance/journals/models.py
+++ b/queryregistry/finance/journals/models.py
@@ -1,0 +1,79 @@
+"""Finance journals query registry models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "CreateJournalParams",
+  "GetByPostingKeyParams",
+  "GetJournalParams",
+  "JournalRecord",
+  "ListJournalsParams",
+  "UpdateJournalStatusParams",
+]
+
+
+class ListJournalsParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  status: int | None = None
+  periods_guid: str | None = None
+
+
+class GetJournalParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+
+
+class CreateJournalParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  name: str
+  description: str | None = None
+  posting_key: str | None = None
+  source_type: str | None = None
+  source_id: str | None = None
+  periods_guid: str | None = None
+  ledgers_recid: int | None = None
+  numbers_recid: int | None = None
+  status: int = 0
+
+
+class UpdateJournalStatusParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+  status: int
+  posted_by: str | None = None
+  posted_on: str | None = None
+  reversed_by: int | None = None
+  reversal_of: int | None = None
+
+
+class GetByPostingKeyParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  posting_key: str
+
+
+class JournalRecord(TypedDict):
+  recid: int
+  element_name: str
+  element_description: str | None
+  numbers_recid: int | None
+  element_status: int
+  element_created_on: str
+  element_modified_on: str
+  element_posting_key: str | None
+  element_source_type: str | None
+  element_source_id: str | None
+  periods_guid: str | None
+  ledgers_recid: int | None
+  element_posted_by: str | None
+  element_posted_on: str | None
+  element_reversed_by: int | None
+  element_reversal_of: int | None

--- a/queryregistry/finance/journals/mssql.py
+++ b/queryregistry/finance/journals/mssql.py
@@ -1,0 +1,195 @@
+"""MSSQL implementations for finance journals query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_json_many, run_json_one
+
+__all__ = ["create_v1", "get_by_posting_key_v1", "get_v1", "list_v1", "update_status_v1"]
+
+
+async def list_v1(args: Mapping[str, Any]) -> DBResponse:
+  where_clauses: list[str] = []
+  params: list[Any] = []
+
+  if args.get("status") is not None:
+    where_clauses.append("element_status = ?")
+    params.append(args["status"])
+
+  if args.get("periods_guid"):
+    where_clauses.append("periods_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)")
+    params.append(args["periods_guid"])
+
+  where_sql = ""
+  if where_clauses:
+    where_sql = "WHERE " + " AND ".join(where_clauses)
+
+  sql = f"""
+    SELECT
+      recid,
+      element_name,
+      element_description,
+      numbers_recid,
+      element_status,
+      element_created_on,
+      element_modified_on,
+      element_posting_key,
+      element_source_type,
+      element_source_id,
+      periods_guid,
+      ledgers_recid,
+      element_posted_by,
+      element_posted_on,
+      element_reversed_by,
+      element_reversal_of
+    FROM finance_journals
+    {where_sql}
+    ORDER BY recid DESC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, params)
+
+
+async def get_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      recid,
+      element_name,
+      element_description,
+      numbers_recid,
+      element_status,
+      element_created_on,
+      element_modified_on,
+      element_posting_key,
+      element_source_type,
+      element_source_id,
+      periods_guid,
+      ledgers_recid,
+      element_posted_by,
+      element_posted_on,
+      element_reversed_by,
+      element_reversal_of
+    FROM finance_journals
+    WHERE recid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (args["recid"],))
+
+
+async def create_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    INSERT INTO finance_journals (
+      element_name,
+      element_description,
+      numbers_recid,
+      element_status,
+      element_created_on,
+      element_modified_on,
+      element_posting_key,
+      element_source_type,
+      element_source_id,
+      periods_guid,
+      ledgers_recid
+    )
+    OUTPUT
+      inserted.recid,
+      inserted.element_name,
+      inserted.element_description,
+      inserted.numbers_recid,
+      inserted.element_status,
+      inserted.element_created_on,
+      inserted.element_modified_on,
+      inserted.element_posting_key,
+      inserted.element_source_type,
+      inserted.element_source_id,
+      inserted.periods_guid,
+      inserted.ledgers_recid,
+      inserted.element_posted_by,
+      inserted.element_posted_on,
+      inserted.element_reversed_by,
+      inserted.element_reversal_of
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES
+    VALUES (?, ?, ?, ?, SYSUTCDATETIME(), SYSUTCDATETIME(), ?, ?, ?, TRY_CAST(? AS UNIQUEIDENTIFIER), ?);
+  """
+  params = (
+    args["name"],
+    args.get("description"),
+    args.get("numbers_recid"),
+    args["status"],
+    args.get("posting_key"),
+    args.get("source_type"),
+    args.get("source_id"),
+    args.get("periods_guid"),
+    args.get("ledgers_recid"),
+  )
+  return await run_json_one(sql, params)
+
+
+async def update_status_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    UPDATE finance_journals
+    SET
+      element_status = ?,
+      element_posted_by = TRY_CAST(? AS UNIQUEIDENTIFIER),
+      element_posted_on = TRY_CAST(? AS DATETIMEOFFSET(7)),
+      element_reversed_by = ?,
+      element_reversal_of = ?,
+      element_modified_on = SYSUTCDATETIME()
+    OUTPUT
+      inserted.recid,
+      inserted.element_name,
+      inserted.element_description,
+      inserted.numbers_recid,
+      inserted.element_status,
+      inserted.element_created_on,
+      inserted.element_modified_on,
+      inserted.element_posting_key,
+      inserted.element_source_type,
+      inserted.element_source_id,
+      inserted.periods_guid,
+      inserted.ledgers_recid,
+      inserted.element_posted_by,
+      inserted.element_posted_on,
+      inserted.element_reversed_by,
+      inserted.element_reversal_of
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES
+    WHERE recid = ?;
+  """
+  params = (
+    args["status"],
+    args.get("posted_by"),
+    args.get("posted_on"),
+    args.get("reversed_by"),
+    args.get("reversal_of"),
+    args["recid"],
+  )
+  return await run_json_one(sql, params)
+
+
+async def get_by_posting_key_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      recid,
+      element_name,
+      element_description,
+      numbers_recid,
+      element_status,
+      element_created_on,
+      element_modified_on,
+      element_posting_key,
+      element_source_type,
+      element_source_id,
+      periods_guid,
+      ledgers_recid,
+      element_posted_by,
+      element_posted_on,
+      element_reversed_by,
+      element_reversal_of
+    FROM finance_journals
+    WHERE element_posting_key = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (args["posting_key"],))

--- a/queryregistry/finance/journals/services.py
+++ b/queryregistry/finance/journals/services.py
@@ -1,0 +1,64 @@
+"""Finance journals query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  CreateJournalParams,
+  GetByPostingKeyParams,
+  GetJournalParams,
+  ListJournalsParams,
+  UpdateJournalStatusParams,
+)
+
+__all__ = ["create_v1", "get_by_posting_key_v1", "get_v1", "list_v1", "update_status_v1"]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_v1}
+_GET_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_v1}
+_CREATE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.create_v1}
+_UPDATE_STATUS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.update_status_v1}
+_GET_BY_POSTING_KEY_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_by_posting_key_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for finance journals registry")
+  return dispatcher
+
+
+async def list_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListJournalsParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = GetJournalParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def create_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = CreateJournalParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _CREATE_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def update_status_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = UpdateJournalStatusParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _UPDATE_STATUS_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_by_posting_key_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = GetByPostingKeyParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_BY_POSTING_KEY_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)


### PR DESCRIPTION
### Motivation

- Introduce the journal posting engine objects and DECIMAL precision mapping to support financial journal headers, lines, and dimension links required by the ledger engine design. 
- Provide canonical data-access endpoints in the queryregistry so services can list/create/update journals and manage journal lines (including batch creates and dimension links). 

### Description

- Add migration `migrations/v0.9.2.0_journal_engine.sql` which inserts the `DECIMAL_19_5` EDT, alters `finance_journals` to add posting/idempotency/reversal columns and FKs, creates `finance_journal_lines` and `finance_journal_line_dimensions` with indexes and FKs, and writes schema reflection metadata for the new/altered tables, columns, indexes, and foreign keys. 
- Add `queryregistry/finance/journals/` with request builders (`__init__.py`), typed models (`models.py`), MSSQL implementations (`mssql.py`), service dispatchers (`services.py`), and handler (`handler.py`) for ops `db:finance:journals:<verb>:1` (list/get/create/update_status/get_by_posting_key). 
- Add `queryregistry/finance/journal_lines/` with request builders (`__init__.py`), typed models (`models.py`), MSSQL implementations (`mssql.py`) that insert lines and link dimensions and return JSON arrays of linked dimension recids, service dispatchers (`services.py`), and handler (`handler.py`) for ops `db:finance:journal_lines:<verb>:1` (list_by_journal/create_line/create_lines_batch/delete_by_journal). 
- Wire both new subdomains into the finance domain handler by registering `journals` and `journal_lines` in `queryregistry/finance/handler.py`.

### Testing

- Compiled the new registry modules with `python -m compileall queryregistry/finance` and the files compiled successfully. 
- Ran the unified test harness via `python scripts/run_tests.py`, which completed with the full test suite (72 tests) passing; there was a non-fatal environment warning about the missing ODBC driver during an attempted DB connection but the test run itself completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b72ba14b288325babd5848340979a8)