### PR TITLE
docs: add MSSQL GO batch separator guidance to migrations/AGENTS.md

### DIFF
--- a/migrations/AGENTS.md
+++ b/migrations/AGENTS.md
@@ -37,3 +37,30 @@ Format: `v{Major}.{Minor}.{Patch}.0_{short_description}.sql`
 - Every migration must include seed data updates for the `system_schema` reflection tables alongside schema changes
 - Do not modify root baseline files — those are regenerated at release time
 - Keep descriptions short, lowercase, underscores in filenames
+
+## MSSQL Batch Separators
+
+**Always use `GO` between statements that depend on each other.** MSSQL executes scripts in batches, and a batch boundary (`GO`) is required between:
+
+- `CREATE TABLE` and any `ALTER TABLE` that references it (FKs, constraints)
+- `CREATE TABLE` and any `INSERT` that targets it
+- `ALTER TABLE` adding columns and any subsequent statements referencing those columns
+- `CREATE INDEX` and any statements that depend on the indexed table existing
+- `INSERT INTO` seed tables that use subselects against tables created earlier in the same script
+
+Without `GO`, SSMS and `sqlcmd` will fail because the parser resolves the entire batch before execution and cannot see objects created within the same batch.
+
+Example:
+```sql
+CREATE TABLE [dbo].[my_table] (
+  [recid] BIGINT IDENTITY(1,1) NOT NULL,
+  CONSTRAINT [PK_my_table] PRIMARY KEY ([recid])
+);
+GO
+
+ALTER TABLE [dbo].[my_table] ADD [element_name] NVARCHAR(128) NOT NULL;
+GO
+
+INSERT INTO [dbo].[my_table] ([element_name]) VALUES ('example');
+GO
+```


### PR DESCRIPTION
### Motivation

- Prevent runtime failures when applying MSSQL migration scripts by documenting when a batch boundary (`GO`) is required between dependent statements. 
- Capture common dependency scenarios for migration authors so `SSMS` and `sqlcmd` parser errors are avoided during deploys.

### Description

- Append a new `## MSSQL Batch Separators` section to `migrations/AGENTS.md` that lists specific cases requiring `GO` and explains the parser rationale. 
- Include a concrete SQL example showing `CREATE TABLE`, `ALTER TABLE`, and `INSERT` separated by `GO` to illustrate the recommended pattern.

### Testing

- No automated unit tests were run because this is a documentation-only change; the repository CI will execute the standard lint/type/test pipeline for this branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7310ef9d08325a689e2b2c73ed9b4)