### PR TITLE
Add finance journals RPC handlers and switch finance auth to domain-level role check

### DIFF
--- a/RPC.md
+++ b/RPC.md
@@ -301,6 +301,17 @@ Summarize the last 24 hours of messages in the current channel and send the resu
 
 All Finance domain calls require `ROLE_FINANCE_ADMIN`.
 
+### `journals`
+
+| Operation | Description |
+| --- | --- |
+| `urn:finance:journals:list:1` | List journals with optional status/period filters. |
+| `urn:finance:journals:get:1` | Get a single journal by record id. |
+| `urn:finance:journals:get_lines:1` | List lines for a journal record id. |
+| `urn:finance:journals:create:1` | Create a journal with lines and optional immediate posting. |
+| `urn:finance:journals:post:1` | Post a draft journal. |
+| `urn:finance:journals:reverse:1` | Reverse a posted journal. |
+
 ### `staging`
 
 | Operation | Description |

--- a/rpc/finance/__init__.py
+++ b/rpc/finance/__init__.py
@@ -1,5 +1,6 @@
 from .accounts.handler import handle_accounts_request
 from .dimensions.handler import handle_dimensions_request
+from .journals.handler import handle_journals_request
 from .numbers.handler import handle_numbers_request
 from .periods.handler import handle_periods_request
 from .staging.handler import handle_staging_request
@@ -8,25 +9,8 @@ from .staging.handler import handle_staging_request
 HANDLERS: dict[str, callable] = {
   "accounts": handle_accounts_request,
   "dimensions": handle_dimensions_request,
+  "journals": handle_journals_request,
   "numbers": handle_numbers_request,
   "periods": handle_periods_request,
   "staging": handle_staging_request,
-}
-
-
-REQUIRED_ROLES: dict[str, str] = {
-  "accounts": "ROLE_FINANCE_ADMIN",
-  "dimensions": "ROLE_FINANCE_ADMIN",
-  "numbers": "ROLE_FINANCE_ADMIN",
-  "periods": "ROLE_FINANCE_ADMIN",
-  "staging": "ROLE_FINANCE_ADMIN",
-}
-
-
-FORBIDDEN_DETAILS: dict[str, str] = {
-  "accounts": "Forbidden",
-  "dimensions": "Forbidden",
-  "numbers": "Forbidden",
-  "periods": "Forbidden",
-  "staging": "Forbidden",
 }

--- a/rpc/finance/handler.py
+++ b/rpc/finance/handler.py
@@ -4,19 +4,18 @@ from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.auth_module import AuthModule
 
-from . import FORBIDDEN_DETAILS, HANDLERS, REQUIRED_ROLES
+from . import HANDLERS
 
 
 async def handle_finance_request(parts: list[str], request: Request) -> RPCResponse:
+  _, auth_ctx, _ = await unbox_request(request)
+  auth: AuthModule = request.app.state.auth
+  required_mask = auth.roles.get("ROLE_FINANCE_ADMIN", 0)
+  if not await auth.user_has_role(auth_ctx.user_guid, required_mask):
+    raise HTTPException(status_code=403, detail="Forbidden")
+
   subdomain = parts[0]
   handler = HANDLERS.get(subdomain)
   if not handler:
-    raise HTTPException(status_code=404, detail='Unknown RPC subdomain')
-  _, auth_ctx, _ = await unbox_request(request)
-  auth: AuthModule = request.app.state.auth
-  role_name = REQUIRED_ROLES.get(subdomain)
-  required_mask = auth.roles.get(role_name, 0) if role_name else 0
-  if required_mask and not await auth.user_has_role(auth_ctx.user_guid, required_mask):
-    detail = FORBIDDEN_DETAILS.get(subdomain, 'Forbidden')
-    raise HTTPException(status_code=403, detail=detail)
+    raise HTTPException(status_code=404, detail="Unknown RPC subdomain")
   return await handler(parts[1:], request)

--- a/rpc/finance/journals/__init__.py
+++ b/rpc/finance/journals/__init__.py
@@ -1,0 +1,17 @@
+from .services import (
+  finance_journals_create_v1,
+  finance_journals_get_lines_v1,
+  finance_journals_get_v1,
+  finance_journals_list_v1,
+  finance_journals_post_v1,
+  finance_journals_reverse_v1,
+)
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list", "1"): finance_journals_list_v1,
+  ("get", "1"): finance_journals_get_v1,
+  ("get_lines", "1"): finance_journals_get_lines_v1,
+  ("create", "1"): finance_journals_create_v1,
+  ("post", "1"): finance_journals_post_v1,
+  ("reverse", "1"): finance_journals_reverse_v1,
+}

--- a/rpc/finance/journals/handler.py
+++ b/rpc/finance/journals/handler.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_journals_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/finance/journals/models.py
+++ b/rpc/finance/journals/models.py
@@ -1,0 +1,79 @@
+from pydantic import BaseModel, Field
+
+
+class JournalItem1(BaseModel):
+  recid: int | None = None
+  name: str
+  description: str | None = None
+  posting_key: str | None = None
+  source_type: str | None = None
+  source_id: str | None = None
+  periods_guid: str | None = None
+  ledgers_recid: int | None = None
+  numbers_recid: int | None = None
+  status: int = 0
+  posted_by: str | None = None
+  posted_on: str | None = None
+  reversed_by: int | None = None
+  reversal_of: int | None = None
+
+
+class JournalList1(BaseModel):
+  journals: list[JournalItem1]
+
+
+class JournalGet1(BaseModel):
+  recid: int
+
+
+class JournalLineItem1(BaseModel):
+  recid: int | None = None
+  journals_recid: int
+  line_number: int
+  accounts_guid: str
+  debit: str = "0"
+  credit: str = "0"
+  description: str | None = None
+  dimension_recids: list[int] = Field(default_factory=list)
+
+
+class JournalLineList1(BaseModel):
+  lines: list[JournalLineItem1]
+
+
+class JournalGetLines1(BaseModel):
+  journals_recid: int
+
+
+class JournalCreateLine1(BaseModel):
+  line_number: int
+  accounts_guid: str
+  debit: str = "0"
+  credit: str = "0"
+  description: str | None = None
+  dimension_recids: list[int] = Field(default_factory=list)
+
+
+class JournalCreate1(BaseModel):
+  name: str
+  description: str | None = None
+  posting_key: str | None = None
+  source_type: str | None = None
+  source_id: str | None = None
+  periods_guid: str | None = None
+  ledgers_recid: int | None = None
+  lines: list[JournalCreateLine1]
+  post: bool = False
+
+
+class JournalListFilter1(BaseModel):
+  status: int | None = None
+  periods_guid: str | None = None
+
+
+class JournalPost1(BaseModel):
+  recid: int
+
+
+class JournalReverse1(BaseModel):
+  recid: int

--- a/rpc/finance/journals/services.py
+++ b/rpc/finance/journals/services.py
@@ -1,0 +1,99 @@
+from fastapi import HTTPException, Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+
+from .models import (
+  JournalCreate1,
+  JournalGet1,
+  JournalGetLines1,
+  JournalItem1,
+  JournalLineItem1,
+  JournalLineList1,
+  JournalList1,
+  JournalListFilter1,
+  JournalPost1,
+  JournalReverse1,
+)
+
+
+async def finance_journals_list_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = JournalListFilter1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  rows = await module.list_journals(status=input_payload.status, periods_guid=input_payload.periods_guid)
+  payload = JournalList1(journals=[JournalItem1(**journal) for journal in rows])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_journals_get_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = JournalGet1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.get_journal(input_payload.recid)
+  if not row:
+    raise HTTPException(status_code=404, detail="Journal not found")
+  payload = JournalItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_journals_get_lines_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = JournalGetLines1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  rows = await module.get_journal_lines(input_payload.journals_recid)
+  payload = JournalLineList1(lines=[JournalLineItem1(**line) for line in rows])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_journals_create_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = JournalCreate1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  try:
+    row = await module.create_journal(
+      name=input_payload.name,
+      description=input_payload.description,
+      posting_key=input_payload.posting_key,
+      source_type=input_payload.source_type,
+      source_id=input_payload.source_id,
+      periods_guid=input_payload.periods_guid,
+      ledgers_recid=input_payload.ledgers_recid,
+      lines=[line.model_dump() for line in input_payload.lines],
+      post=input_payload.post,
+      posted_by=auth_ctx.user_guid,
+    )
+  except ValueError as exc:
+    raise HTTPException(status_code=400, detail=str(exc)) from exc
+  payload = JournalItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_journals_post_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = JournalPost1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  try:
+    row = await module.post_journal(input_payload.recid, posted_by=auth_ctx.user_guid)
+  except ValueError as exc:
+    raise HTTPException(status_code=400, detail=str(exc)) from exc
+  payload = JournalItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_journals_reverse_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = JournalReverse1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  try:
+    row = await module.reverse_journal(input_payload.recid, posted_by=auth_ctx.user_guid)
+  except ValueError as exc:
+    raise HTTPException(status_code=400, detail=str(exc)) from exc
+  payload = JournalItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)


### PR DESCRIPTION
### Motivation
- Consolidate finance authorization to a single domain-level `ROLE_FINANCE_ADMIN` check (matching the `system` domain pattern) and remove the incorrect per-subdomain role dicts.
- Expose the journal posting engine operations from the `FinanceModule` via a new `finance:journals` RPC surface so clients can list/get/create/post/reverse journals.

### Description
- Removed `REQUIRED_ROLES` and `FORBIDDEN_DETAILS` and registered the `journals` handler in `rpc/finance/__init__.py`.
- Rewrote `rpc/finance/handler.py` to perform one domain-level `ROLE_FINANCE_ADMIN` check using `auth.user_has_role` before dispatching to subdomains.
- Added the `rpc/finance/journals` subdomain with `__init__.py` (dispatcher table), `handler.py` (operation/version dispatch), `models.py` (Pydantic request/response models), and `services.py` (service functions that call `request.app.state.finance` methods, await `on_ready()`, pass `auth_ctx.user_guid` for mutating ops, and translate `ValueError` to `HTTPException(400)`).
- Documented the new `urn:finance:journals:*:1` URNs in `RPC.md` and regenerated RPC bindings as part of the test/harness run.

### Testing
- Ran the unified harness with `python scripts/run_tests.py`, and frontend lint/type-check and tests plus backend pytest completed successfully.
- The automated test run finished without failures (unit tests/JS checks passed), with a non-fatal environment warning about a missing ODBC driver during a build-version DB update step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7359beb38832595dd04cb3ac8b0ec)