### PR TITLE
Credit lots schema + queryregistry and journal number sequence integration

### DIFF
--- a/migrations/v0.9.3.0_credit_lots.sql
+++ b/migrations/v0.9.3.0_credit_lots.sql
@@ -1,0 +1,381 @@
+SET NOCOUNT ON;
+GO
+
+-- ============================================================
+-- COA accounts required by finance spec (§2, §6, §9, §10)
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '2100')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '2100', 'Deferred Revenue', 1, '7C1FA400-6DF0-4F86-9282-184DA2DDB0E4', 1, 1);
+END;
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '2200')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '2200', 'Accounts Payable', 1, '7C1FA400-6DF0-4F86-9282-184DA2DDB0E4', 1, 1);
+END;
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '2300')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '2300', 'Accrued Expenses', 1, '7C1FA400-6DF0-4F86-9282-184DA2DDB0E4', 1, 1);
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '1300')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '1300', 'Payment Processor Clearing', 0, '31A28AA0-BA53-4370-BCCF-632E8238735E', 1, 1);
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '4010')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '4010', 'Recognized Revenue', 3, '911CE6FF-ED49-4841-B42E-89973FC8D7C9', 1, 1);
+END;
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '4020')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '4020', 'Breakage Revenue', 3, '911CE6FF-ED49-4841-B42E-89973FC8D7C9', 1, 1);
+END;
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '4030')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '4030', 'Contra-Revenue / Refunds', 3, '911CE6FF-ED49-4841-B42E-89973FC8D7C9', 1, 1);
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '3100')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '3100', 'Owner''s Equity', 2, 'D20171F3-DB09-4E41-8ABA-9E1F12DA714B', 1, 1);
+END;
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '3200')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '3200', 'Retained Earnings', 2, 'D20171F3-DB09-4E41-8ABA-9E1F12DA714B', 1, 1);
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '5010')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '5010', 'Merchant Fee Expense', 4, '7C3B3F89-E616-45E1-B1A3-E392F3B5ABDF', 1, 1);
+END;
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '6100')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '6100', 'Owner Usage', 4, '7C3B3F89-E616-45E1-B1A3-E392F3B5ABDF', 1, 1);
+END;
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '6200')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '6200', 'Marketing Expense', 4, '7C3B3F89-E616-45E1-B1A3-E392F3B5ABDF', 1, 1);
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '5600')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '5600', 'Number Sequences', 4, '7C3B3F89-E616-45E1-B1A3-E392F3B5ABDF', 0, 1);
+END;
+GO
+
+DECLARE @seq_parent_guid UNIQUEIDENTIFIER = (SELECT element_guid FROM finance_accounts WHERE element_number = '5600');
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '5610')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '5610', 'Journal Sequences', 4, @seq_parent_guid, 0, 1);
+END;
+
+IF NOT EXISTS (SELECT 1 FROM finance_accounts WHERE element_number = '5620')
+BEGIN
+  INSERT INTO finance_accounts (element_guid, element_number, element_name, element_type, element_parent, is_posting, element_status)
+  VALUES (NEWID(), '5620', 'Lot Sequences', 4, @seq_parent_guid, 0, 1);
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM finance_numbers WHERE element_prefix = 'JRN' AND element_account_number = 'JRN-SEQ')
+BEGIN
+  INSERT INTO finance_numbers (
+    accounts_guid,
+    element_prefix,
+    element_account_number,
+    element_last_number,
+    element_allocation_size,
+    element_reset_policy,
+    element_pattern,
+    element_display_format
+  )
+  VALUES (
+    (SELECT element_guid FROM finance_accounts WHERE element_number = '5610'),
+    'JRN',
+    'JRN-SEQ',
+    0,
+    1,
+    'Never',
+    'JRN-{number:06d}',
+    'JRN-######'
+  );
+END;
+
+IF NOT EXISTS (SELECT 1 FROM finance_numbers WHERE element_prefix = 'LOT' AND element_account_number = 'LOT-SEQ')
+BEGIN
+  INSERT INTO finance_numbers (
+    accounts_guid,
+    element_prefix,
+    element_account_number,
+    element_last_number,
+    element_allocation_size,
+    element_reset_policy,
+    element_pattern,
+    element_display_format
+  )
+  VALUES (
+    (SELECT element_guid FROM finance_accounts WHERE element_number = '5620'),
+    'LOT',
+    'LOT-SEQ',
+    0,
+    1,
+    'Never',
+    'LOT-{number:06d}',
+    'LOT-######'
+  );
+END;
+GO
+
+-- ============================================================
+-- Dimensions required by finance spec (§3)
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM finance_dimensions WHERE element_name = 'ServiceType' AND element_value = 'IMG')
+  INSERT INTO finance_dimensions (element_name, element_value, element_description, element_status)
+  VALUES ('ServiceType', 'IMG', 'Image generation service', 1);
+IF NOT EXISTS (SELECT 1 FROM finance_dimensions WHERE element_name = 'ServiceType' AND element_value = 'VID')
+  INSERT INTO finance_dimensions (element_name, element_value, element_description, element_status)
+  VALUES ('ServiceType', 'VID', 'Video generation service', 1);
+IF NOT EXISTS (SELECT 1 FROM finance_dimensions WHERE element_name = 'ServiceType' AND element_value = 'TTS')
+  INSERT INTO finance_dimensions (element_name, element_value, element_description, element_status)
+  VALUES ('ServiceType', 'TTS', 'Text-to-speech service', 1);
+IF NOT EXISTS (SELECT 1 FROM finance_dimensions WHERE element_name = 'ServiceType' AND element_value = 'CHAT')
+  INSERT INTO finance_dimensions (element_name, element_value, element_description, element_status)
+  VALUES ('ServiceType', 'CHAT', 'Chat/conversation service', 1);
+IF NOT EXISTS (SELECT 1 FROM finance_dimensions WHERE element_name = 'Vendor' AND element_value = 'Azure')
+  INSERT INTO finance_dimensions (element_name, element_value, element_description, element_status)
+  VALUES ('Vendor', 'Azure', 'Microsoft Azure', 1);
+IF NOT EXISTS (SELECT 1 FROM finance_dimensions WHERE element_name = 'Vendor' AND element_value = 'OpenAI')
+  INSERT INTO finance_dimensions (element_name, element_value, element_description, element_status)
+  VALUES ('Vendor', 'OpenAI', 'OpenAI API', 1);
+IF NOT EXISTS (SELECT 1 FROM finance_dimensions WHERE element_name = 'Vendor' AND element_value = 'Luma')
+  INSERT INTO finance_dimensions (element_name, element_value, element_description, element_status)
+  VALUES ('Vendor', 'Luma', 'Luma Labs API', 1);
+IF NOT EXISTS (SELECT 1 FROM finance_dimensions WHERE element_name = 'LotSource' AND element_value = 'purchase')
+  INSERT INTO finance_dimensions (element_name, element_value, element_description, element_status)
+  VALUES ('LotSource', 'purchase', 'Customer credit purchase', 1);
+IF NOT EXISTS (SELECT 1 FROM finance_dimensions WHERE element_name = 'LotSource' AND element_value = 'grant_owner')
+  INSERT INTO finance_dimensions (element_name, element_value, element_description, element_status)
+  VALUES ('LotSource', 'grant_owner', 'Owner/admin credit grant', 1);
+IF NOT EXISTS (SELECT 1 FROM finance_dimensions WHERE element_name = 'LotSource' AND element_value = 'grant_promo')
+  INSERT INTO finance_dimensions (element_name, element_value, element_description, element_status)
+  VALUES ('LotSource', 'grant_promo', 'Promotional credit grant', 1);
+IF NOT EXISTS (SELECT 1 FROM finance_dimensions WHERE element_name = 'LotSource' AND element_value = 'grant_signup')
+  INSERT INTO finance_dimensions (element_name, element_value, element_description, element_status)
+  VALUES ('LotSource', 'grant_signup', 'Signup bonus credits', 1);
+GO
+
+-- ============================================================
+-- Credit lots (FIFO subledger per spec §5)
+-- ============================================================
+IF OBJECT_ID(N'[dbo].[finance_credit_lots]', N'U') IS NULL
+BEGIN
+  CREATE TABLE [dbo].[finance_credit_lots] (
+    [recid]                     BIGINT IDENTITY(1,1) NOT NULL,
+    [users_guid]                UNIQUEIDENTIFIER NOT NULL,
+    [element_lot_number]        NVARCHAR(64) NOT NULL,
+    [element_source_type]       NVARCHAR(64) NOT NULL,
+    [element_credits_original]  INT NOT NULL,
+    [element_credits_remaining] INT NOT NULL,
+    [element_unit_price]        DECIMAL(19,5) NOT NULL DEFAULT (0),
+    [element_total_paid]        DECIMAL(19,5) NOT NULL DEFAULT (0),
+    [element_currency]          NVARCHAR(3) NOT NULL DEFAULT ('USD'),
+    [element_expires_at]        DATETIMEOFFSET(7) NULL,
+    [element_expired]           BIT NOT NULL DEFAULT (0),
+    [element_source_id]         NVARCHAR(256) NULL,
+    [numbers_recid]             BIGINT NULL,
+    [element_status]            TINYINT NOT NULL DEFAULT (1),
+    [element_created_on]        DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [element_modified_on]       DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+    CONSTRAINT [PK_finance_credit_lots] PRIMARY KEY ([recid]),
+    CONSTRAINT [FK_credit_lots_users] FOREIGN KEY ([users_guid])
+      REFERENCES [dbo].[account_users] ([element_guid]),
+    CONSTRAINT [FK_credit_lots_numbers] FOREIGN KEY ([numbers_recid])
+      REFERENCES [dbo].[finance_numbers] ([recid])
+  );
+END;
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.indexes
+  WHERE object_id = OBJECT_ID(N'[dbo].[finance_credit_lots]')
+    AND name = N'UQ_credit_lots_lot_number'
+)
+BEGIN
+  CREATE UNIQUE INDEX [UQ_credit_lots_lot_number] ON [dbo].[finance_credit_lots] ([element_lot_number]);
+END;
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.indexes
+  WHERE object_id = OBJECT_ID(N'[dbo].[finance_credit_lots]')
+    AND name = N'IX_credit_lots_users_guid'
+)
+BEGIN
+  CREATE INDEX [IX_credit_lots_users_guid] ON [dbo].[finance_credit_lots] ([users_guid]);
+END;
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.indexes
+  WHERE object_id = OBJECT_ID(N'[dbo].[finance_credit_lots]')
+    AND name = N'IX_credit_lots_fifo'
+)
+BEGIN
+  CREATE INDEX [IX_credit_lots_fifo] ON [dbo].[finance_credit_lots]
+    ([users_guid], [element_expired], [element_credits_remaining])
+    WHERE [element_expired] = 0 AND [element_credits_remaining] > 0;
+END;
+GO
+
+IF OBJECT_ID(N'[dbo].[finance_credit_lot_events]', N'U') IS NULL
+BEGIN
+  CREATE TABLE [dbo].[finance_credit_lot_events] (
+    [recid]                BIGINT IDENTITY(1,1) NOT NULL,
+    [lots_recid]           BIGINT NOT NULL,
+    [element_event_type]   NVARCHAR(32) NOT NULL,
+    [element_credits]      INT NOT NULL,
+    [element_unit_price]   DECIMAL(19,5) NOT NULL DEFAULT (0),
+    [element_description]  NVARCHAR(512) NULL,
+    [element_actor_guid]   UNIQUEIDENTIFIER NULL,
+    [journals_recid]       BIGINT NULL,
+    [element_created_on]   DATETIMEOFFSET(7) NOT NULL DEFAULT (SYSUTCDATETIME()),
+    CONSTRAINT [PK_finance_credit_lot_events] PRIMARY KEY ([recid]),
+    CONSTRAINT [FK_lot_events_lots] FOREIGN KEY ([lots_recid])
+      REFERENCES [dbo].[finance_credit_lots] ([recid]),
+    CONSTRAINT [FK_lot_events_journals] FOREIGN KEY ([journals_recid])
+      REFERENCES [dbo].[finance_journals] ([recid])
+  );
+END;
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.indexes
+  WHERE object_id = OBJECT_ID(N'[dbo].[finance_credit_lot_events]')
+    AND name = N'IX_lot_events_lots_recid'
+)
+BEGIN
+  CREATE INDEX [IX_lot_events_lots_recid] ON [dbo].[finance_credit_lot_events] ([lots_recid]);
+END;
+GO
+
+-- ============================================================
+-- Schema reflection metadata for credit lots tables
+-- ============================================================
+IF NOT EXISTS (
+  SELECT 1 FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'
+)
+BEGIN
+  INSERT INTO system_schema_tables (element_name, element_schema)
+  VALUES ('finance_credit_lots', 'dbo');
+END;
+
+IF NOT EXISTS (
+  SELECT 1 FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'
+)
+BEGIN
+  INSERT INTO system_schema_tables (element_name, element_schema)
+  VALUES ('finance_credit_lot_events', 'dbo');
+END;
+GO
+
+DELETE FROM system_schema_columns
+WHERE tables_recid IN (
+  (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'),
+  (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo')
+);
+GO
+
+INSERT INTO system_schema_columns (
+  tables_recid,
+  edt_mappings_recid,
+  element_name,
+  element_ordinal,
+  element_nullable,
+  element_default,
+  element_max_length,
+  element_is_primary_key,
+  element_is_identity
+)
+VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64_IDENTITY'), 'recid', 1, 0, NULL, NULL, 1, 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'UUID'), 'users_guid', 2, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_lot_number', 3, 0, NULL, 64, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_source_type', 4, 0, NULL, 64, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT32'), 'element_credits_original', 5, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT32'), 'element_credits_remaining', 6, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DECIMAL_19_5'), 'element_unit_price', 7, 0, '((0))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DECIMAL_19_5'), 'element_total_paid', 8, 0, '((0))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_currency', 9, 0, '(''USD'')', 3, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_expires_at', 10, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'BOOL'), 'element_expired', 11, 0, '((0))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_source_id', 12, 1, NULL, 256, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'numbers_recid', 13, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT8'), 'element_status', 14, 0, '((1))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_created_on', 15, 0, '(sysutcdatetime())', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_modified_on', 16, 0, '(sysutcdatetime())', NULL, 0, 0),
+
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64_IDENTITY'), 'recid', 1, 0, NULL, NULL, 1, 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'lots_recid', 2, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_event_type', 3, 0, NULL, 32, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT32'), 'element_credits', 4, 0, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DECIMAL_19_5'), 'element_unit_price', 5, 0, '((0))', NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'STRING'), 'element_description', 6, 1, NULL, 512, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'UUID'), 'element_actor_guid', 7, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'INT64'), 'journals_recid', 8, 1, NULL, NULL, 0, 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'), (SELECT recid FROM system_edt_mappings WHERE element_name = 'DATETIME_TZ'), 'element_created_on', 9, 0, '(sysutcdatetime())', NULL, 0, 0);
+GO
+
+DELETE FROM system_schema_indexes
+WHERE tables_recid IN (
+  (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'),
+  (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo')
+);
+GO
+
+INSERT INTO system_schema_indexes (tables_recid, element_name, element_columns, element_is_unique)
+VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), 'UQ_credit_lots_lot_number', 'element_lot_number', 1),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), 'IX_credit_lots_users_guid', 'users_guid', 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), 'IX_credit_lots_fifo', 'users_guid,element_expired,element_credits_remaining', 0),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'), 'IX_lot_events_lots_recid', 'lots_recid', 0);
+GO
+
+DELETE FROM system_schema_foreign_keys
+WHERE tables_recid IN (
+  (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'),
+  (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo')
+);
+GO
+
+INSERT INTO system_schema_foreign_keys (tables_recid, element_column_name, referenced_tables_recid, element_referenced_column)
+VALUES
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), 'users_guid', (SELECT recid FROM system_schema_tables WHERE element_name = 'account_users' AND element_schema = 'dbo'), 'element_guid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), 'numbers_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_numbers' AND element_schema = 'dbo'), 'recid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'), 'lots_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lots' AND element_schema = 'dbo'), 'recid'),
+  ((SELECT recid FROM system_schema_tables WHERE element_name = 'finance_credit_lot_events' AND element_schema = 'dbo'), 'journals_recid', (SELECT recid FROM system_schema_tables WHERE element_name = 'finance_journals' AND element_schema = 'dbo'), 'recid');
+GO

--- a/queryregistry/finance/credit_lots/__init__.py
+++ b/queryregistry/finance/credit_lots/__init__.py
@@ -1,0 +1,59 @@
+"""Finance credit lots query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import (
+  CreateEventParams,
+  CreateLotParams,
+  ConsumeCreditsParams,
+  ExpireLotParams,
+  GetLotParams,
+  ListEventsByLotParams,
+  ListLotsByUserParams,
+  SumRemainingByUserParams,
+)
+
+__all__ = [
+  "consume_credits_request",
+  "create_event_request",
+  "create_lot_request",
+  "expire_lot_request",
+  "get_lot_request",
+  "list_events_by_lot_request",
+  "list_lots_by_user_request",
+  "sum_remaining_by_user_request",
+]
+
+
+def list_lots_by_user_request(params: ListLotsByUserParams) -> DBRequest:
+  return DBRequest(op="db:finance:credit_lots:list_lots_by_user:1", payload=params.model_dump())
+
+
+def get_lot_request(params: GetLotParams) -> DBRequest:
+  return DBRequest(op="db:finance:credit_lots:get_lot:1", payload=params.model_dump())
+
+
+def create_lot_request(params: CreateLotParams) -> DBRequest:
+  return DBRequest(op="db:finance:credit_lots:create_lot:1", payload=params.model_dump())
+
+
+def consume_credits_request(params: ConsumeCreditsParams) -> DBRequest:
+  return DBRequest(op="db:finance:credit_lots:consume_credits:1", payload=params.model_dump())
+
+
+def expire_lot_request(params: ExpireLotParams) -> DBRequest:
+  return DBRequest(op="db:finance:credit_lots:expire_lot:1", payload=params.model_dump())
+
+
+def list_events_by_lot_request(params: ListEventsByLotParams) -> DBRequest:
+  return DBRequest(op="db:finance:credit_lots:list_events_by_lot:1", payload=params.model_dump())
+
+
+def create_event_request(params: CreateEventParams) -> DBRequest:
+  return DBRequest(op="db:finance:credit_lots:create_event:1", payload=params.model_dump())
+
+
+def sum_remaining_by_user_request(params: SumRemainingByUserParams) -> DBRequest:
+  return DBRequest(op="db:finance:credit_lots:sum_remaining_by_user:1", payload=params.model_dump())

--- a/queryregistry/finance/credit_lots/handler.py
+++ b/queryregistry/finance/credit_lots/handler.py
@@ -1,0 +1,47 @@
+"""Finance credit lots subdomain handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import (
+  consume_credits_v1,
+  create_event_v1,
+  create_lot_v1,
+  expire_lot_v1,
+  get_lot_v1,
+  list_events_by_lot_v1,
+  list_lots_by_user_v1,
+  sum_remaining_by_user_v1,
+)
+
+__all__ = ["handle_credit_lots_request"]
+
+DISPATCHERS = {
+  ("list_lots_by_user", "1"): list_lots_by_user_v1,
+  ("get_lot", "1"): get_lot_v1,
+  ("create_lot", "1"): create_lot_v1,
+  ("consume_credits", "1"): consume_credits_v1,
+  ("expire_lot", "1"): expire_lot_v1,
+  ("list_events_by_lot", "1"): list_events_by_lot_v1,
+  ("create_event", "1"): create_event_v1,
+  ("sum_remaining_by_user", "1"): sum_remaining_by_user_v1,
+}
+
+
+async def handle_credit_lots_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown finance credit lots operation",
+  )

--- a/queryregistry/finance/credit_lots/models.py
+++ b/queryregistry/finance/credit_lots/models.py
@@ -1,0 +1,117 @@
+"""Finance credit lots query registry models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "CreateEventParams",
+  "CreateLotParams",
+  "ConsumeCreditsParams",
+  "CreditLotEventRecord",
+  "CreditLotRecord",
+  "ExpireLotParams",
+  "GetLotParams",
+  "ListEventsByLotParams",
+  "ListLotsByUserParams",
+  "SumRemainingByUserParams",
+]
+
+
+class ListLotsByUserParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  users_guid: str
+
+
+class GetLotParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+
+
+class CreateLotParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  users_guid: str
+  lot_number: str
+  source_type: str
+  credits_original: int
+  credits_remaining: int
+  unit_price: str = "0"
+  total_paid: str = "0"
+  currency: str = "USD"
+  expires_at: str | None = None
+  source_id: str | None = None
+  numbers_recid: int | None = None
+  status: int = 1
+
+
+class ConsumeCreditsParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+  credits_to_consume: int
+
+
+class ExpireLotParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  recid: int
+
+
+class ListEventsByLotParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  lots_recid: int
+
+
+class CreateEventParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  lots_recid: int
+  event_type: str
+  credits: int
+  unit_price: str = "0"
+  description: str | None = None
+  actor_guid: str | None = None
+  journals_recid: int | None = None
+
+
+class SumRemainingByUserParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  users_guid: str
+
+
+class CreditLotRecord(TypedDict):
+  recid: int
+  users_guid: str
+  element_lot_number: str
+  element_source_type: str
+  element_credits_original: int
+  element_credits_remaining: int
+  element_unit_price: str
+  element_total_paid: str
+  element_currency: str
+  element_expires_at: str | None
+  element_expired: bool
+  element_source_id: str | None
+  numbers_recid: int | None
+  element_status: int
+  element_created_on: str
+  element_modified_on: str
+
+
+class CreditLotEventRecord(TypedDict):
+  recid: int
+  lots_recid: int
+  element_event_type: str
+  element_credits: int
+  element_unit_price: str
+  element_description: str | None
+  element_actor_guid: str | None
+  journals_recid: int | None
+  element_created_on: str

--- a/queryregistry/finance/credit_lots/mssql.py
+++ b/queryregistry/finance/credit_lots/mssql.py
@@ -1,0 +1,252 @@
+"""MSSQL implementations for finance credit lots query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_exec, run_json_many, run_json_one
+
+__all__ = [
+  "consume_credits_v1",
+  "create_event_v1",
+  "create_lot_v1",
+  "expire_lot_v1",
+  "get_lot_v1",
+  "list_events_by_lot_v1",
+  "list_lots_by_user_v1",
+  "sum_remaining_by_user_v1",
+]
+
+
+async def list_lots_by_user_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      recid,
+      users_guid,
+      element_lot_number,
+      element_source_type,
+      element_credits_original,
+      element_credits_remaining,
+      element_unit_price,
+      element_total_paid,
+      element_currency,
+      element_expires_at,
+      element_expired,
+      element_source_id,
+      numbers_recid,
+      element_status,
+      element_created_on,
+      element_modified_on
+    FROM finance_credit_lots
+    WHERE users_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)
+      AND element_expired = 0
+      AND element_credits_remaining > 0
+      AND element_status = 1
+    ORDER BY recid ASC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, (args["users_guid"],))
+
+
+async def get_lot_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      recid,
+      users_guid,
+      element_lot_number,
+      element_source_type,
+      element_credits_original,
+      element_credits_remaining,
+      element_unit_price,
+      element_total_paid,
+      element_currency,
+      element_expires_at,
+      element_expired,
+      element_source_id,
+      numbers_recid,
+      element_status,
+      element_created_on,
+      element_modified_on
+    FROM finance_credit_lots
+    WHERE recid = ?
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (args["recid"],))
+
+
+async def create_lot_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    INSERT INTO finance_credit_lots (
+      users_guid,
+      element_lot_number,
+      element_source_type,
+      element_credits_original,
+      element_credits_remaining,
+      element_unit_price,
+      element_total_paid,
+      element_currency,
+      element_expires_at,
+      element_expired,
+      element_source_id,
+      numbers_recid,
+      element_status,
+      element_created_on,
+      element_modified_on
+    )
+    OUTPUT
+      inserted.recid,
+      inserted.users_guid,
+      inserted.element_lot_number,
+      inserted.element_source_type,
+      inserted.element_credits_original,
+      inserted.element_credits_remaining,
+      inserted.element_unit_price,
+      inserted.element_total_paid,
+      inserted.element_currency,
+      inserted.element_expires_at,
+      inserted.element_expired,
+      inserted.element_source_id,
+      inserted.numbers_recid,
+      inserted.element_status,
+      inserted.element_created_on,
+      inserted.element_modified_on
+    VALUES (
+      TRY_CAST(? AS UNIQUEIDENTIFIER),
+      ?,
+      ?,
+      ?,
+      ?,
+      CAST(? AS DECIMAL(19,5)),
+      CAST(? AS DECIMAL(19,5)),
+      ?,
+      TRY_CAST(? AS DATETIMEOFFSET(7)),
+      0,
+      ?,
+      ?,
+      ?,
+      SYSUTCDATETIME(),
+      SYSUTCDATETIME()
+    )
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  params = (
+    args["users_guid"],
+    args["lot_number"],
+    args["source_type"],
+    args["credits_original"],
+    args["credits_remaining"],
+    args["unit_price"],
+    args["total_paid"],
+    args["currency"],
+    args.get("expires_at"),
+    args.get("source_id"),
+    args.get("numbers_recid"),
+    args["status"],
+  )
+  return await run_json_one(sql, params)
+
+
+async def consume_credits_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    UPDATE finance_credit_lots
+    SET
+      element_credits_remaining = element_credits_remaining - ?,
+      element_modified_on = SYSUTCDATETIME()
+    WHERE recid = ?
+      AND element_credits_remaining >= ?;
+  """
+  return await run_exec(
+    sql,
+    (args["credits_to_consume"], args["recid"], args["credits_to_consume"]),
+  )
+
+
+async def expire_lot_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    UPDATE finance_credit_lots
+    SET
+      element_expired = 1,
+      element_modified_on = SYSUTCDATETIME()
+    WHERE recid = ?;
+  """
+  return await run_exec(sql, (args["recid"],))
+
+
+async def list_events_by_lot_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT
+      recid,
+      lots_recid,
+      element_event_type,
+      element_credits,
+      element_unit_price,
+      element_description,
+      element_actor_guid,
+      journals_recid,
+      element_created_on
+    FROM finance_credit_lot_events
+    WHERE lots_recid = ?
+    ORDER BY recid ASC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, (args["lots_recid"],))
+
+
+async def create_event_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    INSERT INTO finance_credit_lot_events (
+      lots_recid,
+      element_event_type,
+      element_credits,
+      element_unit_price,
+      element_description,
+      element_actor_guid,
+      journals_recid,
+      element_created_on
+    )
+    OUTPUT
+      inserted.recid,
+      inserted.lots_recid,
+      inserted.element_event_type,
+      inserted.element_credits,
+      inserted.element_unit_price,
+      inserted.element_description,
+      inserted.element_actor_guid,
+      inserted.journals_recid,
+      inserted.element_created_on
+    VALUES (
+      ?,
+      ?,
+      ?,
+      CAST(? AS DECIMAL(19,5)),
+      ?,
+      TRY_CAST(? AS UNIQUEIDENTIFIER),
+      ?,
+      SYSUTCDATETIME()
+    )
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  params = (
+    args["lots_recid"],
+    args["event_type"],
+    args["credits"],
+    args["unit_price"],
+    args.get("description"),
+    args.get("actor_guid"),
+    args.get("journals_recid"),
+  )
+  return await run_json_one(sql, params)
+
+
+async def sum_remaining_by_user_v1(args: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT ISNULL(SUM(element_credits_remaining), 0) AS total_remaining
+    FROM finance_credit_lots
+    WHERE users_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)
+      AND element_expired = 0
+      AND element_status = 1
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_one(sql, (args["users_guid"],))

--- a/queryregistry/finance/credit_lots/services.py
+++ b/queryregistry/finance/credit_lots/services.py
@@ -1,0 +1,97 @@
+"""Finance credit lots query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  CreateEventParams,
+  CreateLotParams,
+  ConsumeCreditsParams,
+  ExpireLotParams,
+  GetLotParams,
+  ListEventsByLotParams,
+  ListLotsByUserParams,
+  SumRemainingByUserParams,
+)
+
+__all__ = [
+  "consume_credits_v1",
+  "create_event_v1",
+  "create_lot_v1",
+  "expire_lot_v1",
+  "get_lot_v1",
+  "list_events_by_lot_v1",
+  "list_lots_by_user_v1",
+  "sum_remaining_by_user_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_LOTS_BY_USER_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_lots_by_user_v1}
+_GET_LOT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_lot_v1}
+_CREATE_LOT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.create_lot_v1}
+_CONSUME_CREDITS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.consume_credits_v1}
+_EXPIRE_LOT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.expire_lot_v1}
+_LIST_EVENTS_BY_LOT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_events_by_lot_v1}
+_CREATE_EVENT_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.create_event_v1}
+_SUM_REMAINING_BY_USER_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.sum_remaining_by_user_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for finance credit lots registry")
+  return dispatcher
+
+
+async def list_lots_by_user_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListLotsByUserParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_LOTS_BY_USER_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def get_lot_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = GetLotParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _GET_LOT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def create_lot_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = CreateLotParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _CREATE_LOT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def consume_credits_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ConsumeCreditsParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _CONSUME_CREDITS_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def expire_lot_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ExpireLotParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _EXPIRE_LOT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_events_by_lot_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = ListEventsByLotParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _LIST_EVENTS_BY_LOT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def create_event_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = CreateEventParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _CREATE_EVENT_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def sum_remaining_by_user_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = SumRemainingByUserParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _SUM_REMAINING_BY_USER_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/queryregistry/finance/handler.py
+++ b/queryregistry/finance/handler.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 from queryregistry.models import DBRequest, DBResponse
 
 from .accounts.handler import handle_accounts_request
+from .credit_lots.handler import handle_credit_lots_request
 from .credits.handler import handle_credits_request
 from .dimensions.handler import handle_dimensions_request
 from .journal_lines.handler import handle_journal_lines_request
@@ -22,6 +23,7 @@ __all__ = ["handle_finance_request"]
 
 HANDLERS = {
   "accounts": handle_accounts_request,
+  "credit_lots": handle_credit_lots_request,
   "credits": handle_credits_request,
   "dimensions": handle_dimensions_request,
   "journal_lines": handle_journal_lines_request,

--- a/queryregistry/finance/numbers/mssql.py
+++ b/queryregistry/finance/numbers/mssql.py
@@ -44,6 +44,7 @@ async def get_by_prefix_and_account_v1(args: Mapping[str, Any]) -> DBResponse:
       recid,
       element_prefix,
       element_account_number,
+      element_pattern,
       element_display_format
     FROM finance_numbers
     WHERE element_prefix = ?

--- a/server/modules/finance_module.py
+++ b/server/modules/finance_module.py
@@ -463,6 +463,38 @@ class FinanceModule(BaseModule):
     await self.db.run(delete_lines_by_journal_request(DeleteLinesByJournalParams(journals_recid=journals_recid)))
     return {"journals_recid": journals_recid}
 
+  async def _next_formatted_number(self, prefix: str, account_number: str) -> tuple[str, int]:
+    """Get next number from a sequence and format it using the configured pattern."""
+    assert self.db
+    lookup_res = await self.db.run(
+      get_by_prefix_account_number_request(
+        GetByPrefixAndAccountNumberParams(prefix=prefix, account_number=account_number)
+      )
+    )
+    if not lookup_res.rows:
+      raise ValueError(f"Number sequence not found: prefix={prefix} account_number={account_number}")
+
+    seq_row = dict(lookup_res.rows[0])
+    numbers_recid = int(seq_row["recid"])
+
+    next_res = await self.db.run(next_number_request(NextNumberParams(recid=numbers_recid)))
+    if not next_res.rows:
+      raise ValueError(f"Failed to get next number from sequence {numbers_recid}")
+
+    result = dict(next_res.rows[0])
+    next_val = int(result.get("element_block_start", result.get("element_last_number", 0)))
+    pattern = seq_row.get("element_pattern") or seq_row.get("element_display_format")
+
+    if pattern and "{number" in pattern:
+      formatted = pattern.format(number=next_val)
+    elif pattern:
+      formatted = f"{pattern}{next_val}"
+    else:
+      prefix_str = seq_row.get("element_prefix") or ""
+      formatted = f"{prefix_str}{next_val:06d}"
+
+    return formatted, numbers_recid
+
   async def create_journal(
     self,
     *,
@@ -484,6 +516,12 @@ class FinanceModule(BaseModule):
       if existing.rows:
         logging.debug("[FinanceModule] create_journal idempotency hit for posting_key=%s", posting_key)
         return self._map_journal(dict(existing.rows[0]))
+
+    journal_number = None
+    journal_numbers_recid = None
+    if not posting_key:
+      journal_number, journal_numbers_recid = await self._next_formatted_number("JRN", "JRN-SEQ")
+      posting_key = journal_number
 
     if periods_guid and post:
       period = await self.get_period(periods_guid)
@@ -520,13 +558,14 @@ class FinanceModule(BaseModule):
     create_res = await self.db.run(
       create_journal_request(
         CreateJournalParams(
-          name=name,
+          name=journal_number or name,
           description=description,
           posting_key=posting_key,
           source_type=source_type,
           source_id=source_id,
           periods_guid=periods_guid,
           ledgers_recid=ledgers_recid,
+          numbers_recid=journal_numbers_recid,
           status=0,
         )
       )


### PR DESCRIPTION
### Motivation
- Provide a FIFO subledger for customer credits and the metadata required by the finance spec by adding credit-lot tables and seed data. 
- Anchor and seed number sequences for journals and lots so journals and lots can use deterministic sequential references. 
- Ensure journals use the canonical `finance_numbers` sequences when callers do not supply a posting key, removing free-text journal reference usage.

### Description
- Add an idempotent MSSQL migration `migrations/v0.9.3.0_credit_lots.sql` that seeds missing COA accounts, creates a `Number Sequences` anchor (5600) and child anchors (5610/5620), inserts `JRN-SEQ` and `LOT-SEQ` into `finance_numbers`, seeds required `finance_dimensions`, creates `finance_credit_lots` and `finance_credit_lot_events` with indexes/foreign keys, and registers both tables and their columns/indexes/foreign keys in the `system_schema_*` reflection tables (uses `GO` batch separators where required). 
- Add a new canonical QueryRegistry subdomain at `queryregistry/finance/credit_lots/` including request builders (`__init__.py`), typed Pydantic models (`models.py`), MSSQL adapters (`mssql.py`), service dispatchers (`services.py`), and a handler (`handler.py`) implementing list/get/create/consume/expire/event/sum operations and their MSSQL implementations. 
- Wire the new subdomain into finance dispatch by registering `"credit_lots"` in `queryregistry/finance/handler.py`. 
- Extend `queryregistry/finance/numbers/mssql.py` to return `element_pattern` from `get_by_prefix_and_account_v1` so formatted patterns can be applied when generating numbers. 
- Modify `server/modules/finance_module.py` to add `_next_formatted_number(prefix, account_number)` which looks up a `finance_numbers` entry, calls the `next_number` op, formats the returned next block start using the stored pattern/display format/prefix, and returns `(formatted_string, numbers_recid)`; update `create_journal()` to auto-generate a `JRN` posting key (and persist the `numbers_recid`) when `posting_key` is not provided while preserving the method signature. 

### Testing
- Ran the unified harness `python scripts/run_tests.py`; tests completed successfully (unit/test harness completed; repo tests executed and passed). The test run completed but the final build-version DB update step could not run in this environment due to a missing local ODBC driver (`ODBC Driver 18 for SQL Server`). 
- Compiled new/modified modules for syntax checks with `python -m compileall` on `queryregistry/finance/credit_lots`, `queryregistry/finance/handler.py`, `queryregistry/finance/numbers/mssql.py`, and `server/modules/finance_module.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73a816f9c8325a742f55a675eaa5d)