### PR TITLE
Add finance reporting views and RPC subdomains for reporting and credit_lots

### DIFF
--- a/migrations/v0.9.4.0_reporting_views.sql
+++ b/migrations/v0.9.4.0_reporting_views.sql
@@ -1,0 +1,183 @@
+SET NOCOUNT ON;
+GO
+
+IF OBJECT_ID(N'[dbo].[vw_finance_trial_balance]', N'V') IS NOT NULL
+BEGIN
+  DROP VIEW [dbo].[vw_finance_trial_balance];
+END;
+GO
+
+CREATE VIEW [dbo].[vw_finance_trial_balance] AS
+SELECT
+  p.element_guid AS period_guid,
+  p.element_year AS fiscal_year,
+  p.element_period_number AS period_number,
+  p.element_period_name AS period_name,
+  a.element_guid AS account_guid,
+  a.element_number AS account_number,
+  a.element_name AS account_name,
+  a.element_type AS account_type,
+  ISNULL(SUM(jl.element_debit), 0) AS total_debit,
+  ISNULL(SUM(jl.element_credit), 0) AS total_credit,
+  ISNULL(SUM(jl.element_debit), 0) - ISNULL(SUM(jl.element_credit), 0) AS net_balance
+FROM finance_journal_lines AS jl
+JOIN finance_journals AS j ON j.recid = jl.journals_recid
+JOIN finance_accounts AS a ON a.element_guid = jl.accounts_guid
+JOIN finance_periods AS p ON p.element_guid = j.periods_guid
+WHERE j.element_status = 1
+GROUP BY
+  p.element_guid,
+  p.element_year,
+  p.element_period_number,
+  p.element_period_name,
+  a.element_guid,
+  a.element_number,
+  a.element_name,
+  a.element_type;
+GO
+
+IF OBJECT_ID(N'[dbo].[vw_finance_journal_summary]', N'V') IS NOT NULL
+BEGIN
+  DROP VIEW [dbo].[vw_finance_journal_summary];
+END;
+GO
+
+CREATE VIEW [dbo].[vw_finance_journal_summary] AS
+SELECT
+  j.recid,
+  j.element_name AS journal_name,
+  j.element_description AS journal_description,
+  j.element_posting_key AS posting_key,
+  j.element_source_type AS source_type,
+  j.element_source_id AS source_id,
+  j.element_status AS journal_status,
+  j.periods_guid,
+  p.element_year AS fiscal_year,
+  p.element_period_name AS period_name,
+  j.element_posted_by AS posted_by,
+  j.element_posted_on AS posted_on,
+  j.element_reversed_by AS reversed_by,
+  j.element_reversal_of AS reversal_of,
+  j.element_created_on AS created_on,
+  ISNULL(line_agg.line_count, 0) AS line_count,
+  ISNULL(line_agg.total_debit, 0) AS total_debit,
+  ISNULL(line_agg.total_credit, 0) AS total_credit
+FROM finance_journals AS j
+LEFT JOIN finance_periods AS p ON p.element_guid = j.periods_guid
+LEFT JOIN (
+  SELECT
+    journals_recid,
+    COUNT(*) AS line_count,
+    SUM(element_debit) AS total_debit,
+    SUM(element_credit) AS total_credit
+  FROM finance_journal_lines
+  GROUP BY journals_recid
+) AS line_agg ON line_agg.journals_recid = j.recid;
+GO
+
+IF OBJECT_ID(N'[dbo].[vw_finance_period_status]', N'V') IS NOT NULL
+BEGIN
+  DROP VIEW [dbo].[vw_finance_period_status];
+END;
+GO
+
+CREATE VIEW [dbo].[vw_finance_period_status] AS
+SELECT
+  p.element_guid AS period_guid,
+  p.element_year AS fiscal_year,
+  p.element_period_number AS period_number,
+  p.element_period_name AS period_name,
+  p.element_start_date AS start_date,
+  p.element_end_date AS end_date,
+  p.element_close_type AS close_type,
+  p.element_status AS period_status,
+  p.element_has_closing_week AS has_closing_week,
+  ISNULL(j_agg.total_journals, 0) AS total_journals,
+  ISNULL(j_agg.unposted_journals, 0) AS unposted_journals,
+  ISNULL(j_agg.posted_journals, 0) AS posted_journals,
+  ISNULL(j_agg.reversed_journals, 0) AS reversed_journals
+FROM finance_periods AS p
+LEFT JOIN (
+  SELECT
+    periods_guid,
+    COUNT(*) AS total_journals,
+    SUM(CASE WHEN element_status = 0 THEN 1 ELSE 0 END) AS unposted_journals,
+    SUM(CASE WHEN element_status = 1 THEN 1 ELSE 0 END) AS posted_journals,
+    SUM(CASE WHEN element_status = 2 THEN 1 ELSE 0 END) AS reversed_journals
+  FROM finance_journals
+  GROUP BY periods_guid
+) AS j_agg ON j_agg.periods_guid = p.element_guid;
+GO
+
+IF OBJECT_ID(N'[dbo].[vw_finance_credit_lot_summary]', N'V') IS NOT NULL
+BEGIN
+  DROP VIEW [dbo].[vw_finance_credit_lot_summary];
+END;
+GO
+
+CREATE VIEW [dbo].[vw_finance_credit_lot_summary] AS
+SELECT
+  cl.recid,
+  cl.users_guid,
+  au.element_display AS user_display_name,
+  cl.element_lot_number AS lot_number,
+  cl.element_source_type AS source_type,
+  cl.element_credits_original AS credits_original,
+  cl.element_credits_remaining AS credits_remaining,
+  cl.element_unit_price AS unit_price,
+  cl.element_total_paid AS total_paid,
+  cl.element_currency AS currency,
+  cl.element_expires_at AS expires_at,
+  cl.element_expired AS expired,
+  cl.element_source_id AS source_id,
+  cl.element_status AS lot_status,
+  cl.element_created_on AS created_on,
+  ISNULL(evt.event_count, 0) AS event_count,
+  ISNULL(evt.total_consumed, 0) AS total_consumed
+FROM finance_credit_lots AS cl
+JOIN account_users AS au ON au.element_guid = cl.users_guid
+LEFT JOIN (
+  SELECT
+    lots_recid,
+    COUNT(*) AS event_count,
+    ISNULL(SUM(CASE WHEN element_event_type = 'Consume' THEN element_credits ELSE 0 END), 0) AS total_consumed
+  FROM finance_credit_lot_events
+  GROUP BY lots_recid
+) AS evt ON evt.lots_recid = cl.recid;
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM system_schema_views WHERE element_name = 'vw_finance_trial_balance' AND element_schema = 'dbo'
+)
+BEGIN
+  INSERT INTO system_schema_views (element_name, element_schema)
+  VALUES ('vw_finance_trial_balance', 'dbo');
+END;
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM system_schema_views WHERE element_name = 'vw_finance_journal_summary' AND element_schema = 'dbo'
+)
+BEGIN
+  INSERT INTO system_schema_views (element_name, element_schema)
+  VALUES ('vw_finance_journal_summary', 'dbo');
+END;
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM system_schema_views WHERE element_name = 'vw_finance_period_status' AND element_schema = 'dbo'
+)
+BEGIN
+  INSERT INTO system_schema_views (element_name, element_schema)
+  VALUES ('vw_finance_period_status', 'dbo');
+END;
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM system_schema_views WHERE element_name = 'vw_finance_credit_lot_summary' AND element_schema = 'dbo'
+)
+BEGIN
+  INSERT INTO system_schema_views (element_name, element_schema)
+  VALUES ('vw_finance_credit_lot_summary', 'dbo');
+END;
+GO

--- a/queryregistry/finance/handler.py
+++ b/queryregistry/finance/handler.py
@@ -16,6 +16,7 @@ from .journal_lines.handler import handle_journal_lines_request
 from .journals.handler import handle_journals_request
 from .numbers.handler import handle_numbers_request
 from .periods.handler import handle_periods_request
+from .reporting.handler import handle_reporting_request
 from .staging.handler import handle_staging_request
 from .status.handler import handle_status_request
 
@@ -30,6 +31,7 @@ HANDLERS = {
   "journals": handle_journals_request,
   "numbers": handle_numbers_request,
   "periods": handle_periods_request,
+  "reporting": handle_reporting_request,
   "staging": handle_staging_request,
   "status": handle_status_request,
 }

--- a/queryregistry/finance/reporting/__init__.py
+++ b/queryregistry/finance/reporting/__init__.py
@@ -1,0 +1,35 @@
+"""Finance reporting query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+from .models import (
+  CreditLotSummaryParams,
+  JournalSummaryParams,
+  PeriodStatusParams,
+  TrialBalanceParams,
+)
+
+__all__ = [
+  "credit_lot_summary_request",
+  "journal_summary_request",
+  "period_status_request",
+  "trial_balance_request",
+]
+
+
+def trial_balance_request(params: TrialBalanceParams) -> DBRequest:
+  return DBRequest(op="db:finance:reporting:trial_balance:1", payload=params.model_dump())
+
+
+def journal_summary_request(params: JournalSummaryParams) -> DBRequest:
+  return DBRequest(op="db:finance:reporting:journal_summary:1", payload=params.model_dump())
+
+
+def period_status_request(params: PeriodStatusParams) -> DBRequest:
+  return DBRequest(op="db:finance:reporting:period_status:1", payload=params.model_dump())
+
+
+def credit_lot_summary_request(params: CreditLotSummaryParams) -> DBRequest:
+  return DBRequest(op="db:finance:reporting:credit_lot_summary:1", payload=params.model_dump())

--- a/queryregistry/finance/reporting/handler.py
+++ b/queryregistry/finance/reporting/handler.py
@@ -1,0 +1,39 @@
+"""Finance reporting subdomain handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import (
+  credit_lot_summary_v1,
+  journal_summary_v1,
+  period_status_v1,
+  trial_balance_v1,
+)
+
+__all__ = ["handle_reporting_request"]
+
+DISPATCHERS = {
+  ("trial_balance", "1"): trial_balance_v1,
+  ("journal_summary", "1"): journal_summary_v1,
+  ("period_status", "1"): period_status_v1,
+  ("credit_lot_summary", "1"): credit_lot_summary_v1,
+}
+
+
+async def handle_reporting_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown finance reporting operation",
+  )

--- a/queryregistry/finance/reporting/models.py
+++ b/queryregistry/finance/reporting/models.py
@@ -1,0 +1,116 @@
+"""Finance reporting query registry models."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+  "CreditLotSummaryParams",
+  "CreditLotSummaryRecord",
+  "JournalSummaryParams",
+  "JournalSummaryRecord",
+  "PeriodStatusParams",
+  "PeriodStatusRecord",
+  "TrialBalanceParams",
+  "TrialBalanceRecord",
+]
+
+
+class TrialBalanceParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  fiscal_year: int | None = None
+  period_guid: str | None = None
+
+
+class JournalSummaryParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  journal_status: int | None = None
+  fiscal_year: int | None = None
+  periods_guid: str | None = None
+
+
+class PeriodStatusParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  fiscal_year: int | None = None
+
+
+class CreditLotSummaryParams(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  users_guid: str | None = None
+
+
+class TrialBalanceRecord(TypedDict):
+  period_guid: str
+  fiscal_year: int
+  period_number: int
+  period_name: str
+  account_guid: str
+  account_number: str
+  account_name: str
+  account_type: int
+  total_debit: str
+  total_credit: str
+  net_balance: str
+
+
+class JournalSummaryRecord(TypedDict):
+  recid: int
+  journal_name: str
+  journal_description: str | None
+  posting_key: str | None
+  source_type: str | None
+  source_id: str | None
+  journal_status: int
+  periods_guid: str | None
+  fiscal_year: int | None
+  period_name: str | None
+  posted_by: str | None
+  posted_on: str | None
+  reversed_by: int | None
+  reversal_of: int | None
+  created_on: str
+  line_count: int
+  total_debit: str
+  total_credit: str
+
+
+class PeriodStatusRecord(TypedDict):
+  period_guid: str
+  fiscal_year: int
+  period_number: int
+  period_name: str
+  start_date: str
+  end_date: str
+  close_type: int
+  period_status: int
+  has_closing_week: bool
+  total_journals: int
+  unposted_journals: int
+  posted_journals: int
+  reversed_journals: int
+
+
+class CreditLotSummaryRecord(TypedDict):
+  recid: int
+  users_guid: str
+  user_display_name: str
+  lot_number: str
+  source_type: str
+  credits_original: int
+  credits_remaining: int
+  unit_price: str
+  total_paid: str
+  currency: str
+  expires_at: str | None
+  expired: bool
+  source_id: str | None
+  lot_status: int
+  created_on: str
+  event_count: int
+  total_consumed: int

--- a/queryregistry/finance/reporting/mssql.py
+++ b/queryregistry/finance/reporting/mssql.py
@@ -1,0 +1,116 @@
+"""MSSQL implementations for finance reporting query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_json_many
+
+__all__ = [
+  "credit_lot_summary_v1",
+  "journal_summary_v1",
+  "period_status_v1",
+  "trial_balance_v1",
+]
+
+
+async def trial_balance_v1(args: Mapping[str, Any]) -> DBResponse:
+  where_clauses: list[str] = []
+  params: list[Any] = []
+
+  if args.get("fiscal_year") is not None:
+    where_clauses.append("fiscal_year = ?")
+    params.append(args["fiscal_year"])
+
+  if args.get("period_guid"):
+    where_clauses.append("period_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)")
+    params.append(args["period_guid"])
+
+  where_sql = ""
+  if where_clauses:
+    where_sql = "WHERE " + " AND ".join(where_clauses)
+
+  sql = f"""
+    SELECT *
+    FROM vw_finance_trial_balance
+    {where_sql}
+    ORDER BY account_number
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, params)
+
+
+async def journal_summary_v1(args: Mapping[str, Any]) -> DBResponse:
+  where_clauses: list[str] = []
+  params: list[Any] = []
+
+  if args.get("journal_status") is not None:
+    where_clauses.append("journal_status = ?")
+    params.append(args["journal_status"])
+
+  if args.get("fiscal_year") is not None:
+    where_clauses.append("fiscal_year = ?")
+    params.append(args["fiscal_year"])
+
+  if args.get("periods_guid"):
+    where_clauses.append("periods_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)")
+    params.append(args["periods_guid"])
+
+  where_sql = ""
+  if where_clauses:
+    where_sql = "WHERE " + " AND ".join(where_clauses)
+
+  sql = f"""
+    SELECT *
+    FROM vw_finance_journal_summary
+    {where_sql}
+    ORDER BY recid DESC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, params)
+
+
+async def period_status_v1(args: Mapping[str, Any]) -> DBResponse:
+  where_clauses: list[str] = []
+  params: list[Any] = []
+
+  if args.get("fiscal_year") is not None:
+    where_clauses.append("fiscal_year = ?")
+    params.append(args["fiscal_year"])
+
+  where_sql = ""
+  if where_clauses:
+    where_sql = "WHERE " + " AND ".join(where_clauses)
+
+  sql = f"""
+    SELECT *
+    FROM vw_finance_period_status
+    {where_sql}
+    ORDER BY fiscal_year DESC, period_number DESC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, params)
+
+
+async def credit_lot_summary_v1(args: Mapping[str, Any]) -> DBResponse:
+  where_clauses: list[str] = []
+  params: list[Any] = []
+
+  if args.get("users_guid"):
+    where_clauses.append("users_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)")
+    params.append(args["users_guid"])
+
+  where_sql = ""
+  if where_clauses:
+    where_sql = "WHERE " + " AND ".join(where_clauses)
+
+  sql = f"""
+    SELECT *
+    FROM vw_finance_credit_lot_summary
+    {where_sql}
+    ORDER BY recid DESC
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql, params)

--- a/queryregistry/finance/reporting/services.py
+++ b/queryregistry/finance/reporting/services.py
@@ -1,0 +1,61 @@
+"""Finance reporting query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+from .models import (
+  CreditLotSummaryParams,
+  JournalSummaryParams,
+  PeriodStatusParams,
+  TrialBalanceParams,
+)
+
+__all__ = [
+  "credit_lot_summary_v1",
+  "journal_summary_v1",
+  "period_status_v1",
+  "trial_balance_v1",
+]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_TRIAL_BALANCE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.trial_balance_v1}
+_JOURNAL_SUMMARY_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.journal_summary_v1}
+_PERIOD_STATUS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.period_status_v1}
+_CREDIT_LOT_SUMMARY_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.credit_lot_summary_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for finance reporting registry")
+  return dispatcher
+
+
+async def trial_balance_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = TrialBalanceParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _TRIAL_BALANCE_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def journal_summary_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = JournalSummaryParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _JOURNAL_SUMMARY_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def period_status_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = PeriodStatusParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _PERIOD_STATUS_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def credit_lot_summary_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  params = CreditLotSummaryParams.model_validate(request.payload)
+  result = await _select_dispatcher(provider, _CREDIT_LOT_SUMMARY_DISPATCHERS)(params.model_dump())
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/rpc/finance/__init__.py
+++ b/rpc/finance/__init__.py
@@ -1,16 +1,20 @@
 from .accounts.handler import handle_accounts_request
+from .credit_lots.handler import handle_credit_lots_request
 from .dimensions.handler import handle_dimensions_request
 from .journals.handler import handle_journals_request
 from .numbers.handler import handle_numbers_request
 from .periods.handler import handle_periods_request
+from .reporting.handler import handle_reporting_request
 from .staging.handler import handle_staging_request
 
 
 HANDLERS: dict[str, callable] = {
   "accounts": handle_accounts_request,
+  "credit_lots": handle_credit_lots_request,
   "dimensions": handle_dimensions_request,
   "journals": handle_journals_request,
   "numbers": handle_numbers_request,
   "periods": handle_periods_request,
+  "reporting": handle_reporting_request,
   "staging": handle_staging_request,
 }

--- a/rpc/finance/credit_lots/__init__.py
+++ b/rpc/finance/credit_lots/__init__.py
@@ -1,0 +1,19 @@
+from .services import (
+  finance_credit_lots_consume_v1,
+  finance_credit_lots_create_v1,
+  finance_credit_lots_expire_v1,
+  finance_credit_lots_get_v1,
+  finance_credit_lots_list_by_user_v1,
+  finance_credit_lots_list_events_v1,
+  finance_credit_lots_wallet_balance_v1,
+)
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("list_by_user", "1"): finance_credit_lots_list_by_user_v1,
+  ("get", "1"): finance_credit_lots_get_v1,
+  ("create", "1"): finance_credit_lots_create_v1,
+  ("consume", "1"): finance_credit_lots_consume_v1,
+  ("expire", "1"): finance_credit_lots_expire_v1,
+  ("list_events", "1"): finance_credit_lots_list_events_v1,
+  ("wallet_balance", "1"): finance_credit_lots_wallet_balance_v1,
+}

--- a/rpc/finance/credit_lots/handler.py
+++ b/rpc/finance/credit_lots/handler.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_credit_lots_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/finance/credit_lots/models.py
+++ b/rpc/finance/credit_lots/models.py
@@ -1,0 +1,86 @@
+from pydantic import BaseModel
+
+
+class CreditLotItem1(BaseModel):
+  recid: int | None = None
+  users_guid: str
+  lot_number: str | None = None
+  source_type: str
+  credits_original: int
+  credits_remaining: int
+  unit_price: str = "0"
+  total_paid: str = "0"
+  currency: str = "USD"
+  expires_at: str | None = None
+  expired: bool = False
+  source_id: str | None = None
+  numbers_recid: int | None = None
+  status: int = 1
+
+
+class CreditLotList1(BaseModel):
+  lots: list[CreditLotItem1]
+
+
+class CreditLotListByUser1(BaseModel):
+  users_guid: str
+
+
+class CreditLotGet1(BaseModel):
+  recid: int
+
+
+class CreditLotCreate1(BaseModel):
+  users_guid: str
+  source_type: str
+  credits: int
+  total_paid: str = "0"
+  currency: str = "USD"
+  expires_at: str | None = None
+  source_id: str | None = None
+
+
+class CreditLotConsume1(BaseModel):
+  users_guid: str
+  credits_needed: int
+  service_type: str | None = None
+  description: str | None = None
+  periods_guid: str | None = None
+
+
+class CreditLotExpire1(BaseModel):
+  recid: int
+
+
+class CreditLotListEvents1(BaseModel):
+  lots_recid: int
+
+
+class CreditLotEventItem1(BaseModel):
+  recid: int | None = None
+  lots_recid: int
+  event_type: str
+  credits: int
+  unit_price: str = "0"
+  description: str | None = None
+  actor_guid: str | None = None
+  journals_recid: int | None = None
+
+
+class CreditLotEventList1(BaseModel):
+  events: list[CreditLotEventItem1]
+
+
+class CreditLotWalletBalance1(BaseModel):
+  users_guid: str
+
+
+class CreditLotWalletResult1(BaseModel):
+  users_guid: str
+  balance: int
+
+
+class CreditLotConsumeResult1(BaseModel):
+  credits_consumed: int
+  lots_affected: int
+  journal_recid: int | None = None

--- a/rpc/finance/credit_lots/services.py
+++ b/rpc/finance/credit_lots/services.py
@@ -1,0 +1,117 @@
+from fastapi import HTTPException, Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+
+from .models import (
+  CreditLotConsume1,
+  CreditLotConsumeResult1,
+  CreditLotCreate1,
+  CreditLotEventItem1,
+  CreditLotEventList1,
+  CreditLotExpire1,
+  CreditLotGet1,
+  CreditLotItem1,
+  CreditLotList1,
+  CreditLotListByUser1,
+  CreditLotListEvents1,
+  CreditLotWalletBalance1,
+  CreditLotWalletResult1,
+)
+
+
+async def finance_credit_lots_list_by_user_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = CreditLotListByUser1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  rows = await module.list_lots_by_user(input_payload.users_guid)
+  payload = CreditLotList1(lots=[CreditLotItem1(**lot) for lot in rows])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_credit_lots_get_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = CreditLotGet1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  row = await module.get_lot(input_payload.recid)
+  if not row:
+    raise HTTPException(status_code=404, detail="Credit lot not found")
+  payload = CreditLotItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_credit_lots_create_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = CreditLotCreate1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  try:
+    row = await module.create_lot(
+      users_guid=input_payload.users_guid,
+      source_type=input_payload.source_type,
+      credits=input_payload.credits,
+      total_paid=input_payload.total_paid,
+      currency=input_payload.currency,
+      expires_at=input_payload.expires_at,
+      source_id=input_payload.source_id,
+      actor_guid=auth_ctx.user_guid,
+    )
+  except ValueError as exc:
+    raise HTTPException(status_code=400, detail=str(exc)) from exc
+  payload = CreditLotItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_credit_lots_consume_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = CreditLotConsume1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  try:
+    result = await module.consume_credits(
+      users_guid=input_payload.users_guid,
+      credits_needed=input_payload.credits_needed,
+      service_type=input_payload.service_type,
+      description=input_payload.description,
+      periods_guid=input_payload.periods_guid,
+      actor_guid=auth_ctx.user_guid,
+    )
+  except ValueError as exc:
+    raise HTTPException(status_code=400, detail=str(exc)) from exc
+  payload = CreditLotConsumeResult1(**result)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_credit_lots_expire_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = CreditLotExpire1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  try:
+    row = await module.expire_lot(input_payload.recid, actor_guid=auth_ctx.user_guid)
+  except ValueError as exc:
+    raise HTTPException(status_code=400, detail=str(exc)) from exc
+  payload = CreditLotItem1(**row)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_credit_lots_list_events_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = CreditLotListEvents1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  rows = await module.list_lot_events(input_payload.lots_recid)
+  payload = CreditLotEventList1(events=[CreditLotEventItem1(**event) for event in rows])
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_credit_lots_wallet_balance_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  input_payload = CreditLotWalletBalance1(**(rpc_request.payload or {}))
+  module = request.app.state.finance
+  await module.on_ready()
+  balance = await module.get_wallet_balance(input_payload.users_guid)
+  payload = CreditLotWalletResult1(users_guid=input_payload.users_guid, balance=balance)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)

--- a/rpc/finance/reporting/__init__.py
+++ b/rpc/finance/reporting/__init__.py
@@ -1,0 +1,13 @@
+from .services import (
+  finance_reporting_credit_lot_summary_v1,
+  finance_reporting_journal_summary_v1,
+  finance_reporting_period_status_v1,
+  finance_reporting_trial_balance_v1,
+)
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("trial_balance", "1"): finance_reporting_trial_balance_v1,
+  ("journal_summary", "1"): finance_reporting_journal_summary_v1,
+  ("period_status", "1"): finance_reporting_period_status_v1,
+  ("credit_lot_summary", "1"): finance_reporting_credit_lot_summary_v1,
+}

--- a/rpc/finance/reporting/handler.py
+++ b/rpc/finance/reporting/handler.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_reporting_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail='Unknown RPC operation')
+  return await handler(request)

--- a/rpc/finance/reporting/models.py
+++ b/rpc/finance/reporting/models.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel
+
+
+class TrialBalanceFilter1(BaseModel):
+  fiscal_year: int | None = None
+  period_guid: str | None = None
+
+
+class JournalSummaryFilter1(BaseModel):
+  journal_status: int | None = None
+  fiscal_year: int | None = None
+  periods_guid: str | None = None
+
+
+class PeriodStatusFilter1(BaseModel):
+  fiscal_year: int | None = None
+
+
+class CreditLotSummaryFilter1(BaseModel):
+  users_guid: str | None = None
+
+
+class TrialBalanceList1(BaseModel):
+  rows: list[dict]
+
+
+class JournalSummaryList1(BaseModel):
+  journals: list[dict]
+
+
+class PeriodStatusList1(BaseModel):
+  periods: list[dict]
+
+
+class CreditLotSummaryList1(BaseModel):
+  lots: list[dict]

--- a/rpc/finance/reporting/services.py
+++ b/rpc/finance/reporting/services.py
@@ -1,0 +1,95 @@
+from fastapi import Request
+
+from queryregistry.finance.reporting import (
+  credit_lot_summary_request,
+  journal_summary_request,
+  period_status_request,
+  trial_balance_request,
+)
+from queryregistry.finance.reporting.models import (
+  CreditLotSummaryParams,
+  JournalSummaryParams,
+  PeriodStatusParams,
+  TrialBalanceParams,
+)
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.db_module import DbModule
+
+from .models import (
+  CreditLotSummaryFilter1,
+  CreditLotSummaryList1,
+  JournalSummaryFilter1,
+  JournalSummaryList1,
+  PeriodStatusFilter1,
+  PeriodStatusList1,
+  TrialBalanceFilter1,
+  TrialBalanceList1,
+)
+
+
+async def finance_reporting_trial_balance_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  payload = TrialBalanceFilter1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  result = await db.run(
+    trial_balance_request(
+      TrialBalanceParams(
+        fiscal_year=payload.fiscal_year,
+        period_guid=payload.period_guid,
+      ),
+    ),
+  )
+  response_payload = TrialBalanceList1(rows=(result.rows or []))
+  return RPCResponse(op=rpc_request.op, payload=response_payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_reporting_journal_summary_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  payload = JournalSummaryFilter1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  result = await db.run(
+    journal_summary_request(
+      JournalSummaryParams(
+        journal_status=payload.journal_status,
+        fiscal_year=payload.fiscal_year,
+        periods_guid=payload.periods_guid,
+      ),
+    ),
+  )
+  response_payload = JournalSummaryList1(journals=(result.rows or []))
+  return RPCResponse(op=rpc_request.op, payload=response_payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_reporting_period_status_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  payload = PeriodStatusFilter1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  result = await db.run(
+    period_status_request(
+      PeriodStatusParams(
+        fiscal_year=payload.fiscal_year,
+      ),
+    ),
+  )
+  response_payload = PeriodStatusList1(periods=(result.rows or []))
+  return RPCResponse(op=rpc_request.op, payload=response_payload.model_dump(), version=rpc_request.version)
+
+
+async def finance_reporting_credit_lot_summary_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  payload = CreditLotSummaryFilter1(**(rpc_request.payload or {}))
+  db: DbModule = request.app.state.db
+  await db.on_ready()
+  result = await db.run(
+    credit_lot_summary_request(
+      CreditLotSummaryParams(
+        users_guid=payload.users_guid,
+      ),
+    ),
+  )
+  response_payload = CreditLotSummaryList1(lots=(result.rows or []))
+  return RPCResponse(op=rpc_request.op, payload=response_payload.model_dump(), version=rpc_request.version)


### PR DESCRIPTION
### Motivation
- Provide SQL reporting views required by the finance spec for trial balance, journal summaries, period status, and credit lot summaries so the accountant UI can query canonical reports. 
- Expose read-only reporting queries through the QueryRegistry and RPC layer so the frontend can request filtered reports via `db:finance:reporting:*:1` and RPC `finance.reporting` endpoints. 
- Add a dedicated RPC surface for credit lot management so the UI can list, create, consume, expire, and inspect credit lots via `rpc.finance.credit_lots` operations.

### Description
- Added migration `migrations/v0.9.4.0_reporting_views.sql` which creates views: `vw_finance_trial_balance`, `vw_finance_journal_summary`, `vw_finance_period_status`, and `vw_finance_credit_lot_summary`, and registers them in `system_schema_views`, using `GO` batch separators for SSMS/sqlcmd compatibility.
- Implemented the QueryRegistry subdomain `queryregistry/finance/reporting/` including typed params and output TypedDicts in `models.py`, request builders in `__init__.py`, MSSQL provider implementations with dynamic WHERE clause construction in `mssql.py`, service dispatchers in `services.py`, and the subdomain handler in `handler.py`.
- Added RPC endpoints under `rpc/finance/reporting/` that accept filters, call the QueryRegistry requests via `DbModule`, and return shaped results; added `rpc/finance/credit_lots/` subdomain with Pydantic RPC models and service handlers mapping to existing `FinanceModule` methods for listing, getting, creating, consuming, expiring lots, listing events, and wallet balance.
- Wired the new subdomains into existing dispatch maps by updating `queryregistry/finance/handler.py` and `rpc/finance/__init__.py` to include `reporting` and `credit_lots` handlers.

### Testing
- Ran `python -m compileall queryregistry/finance/reporting rpc/finance/credit_lots rpc/finance/reporting` and it succeeded with no syntax errors. 
- Ran the unified test harness `python scripts/run_tests.py`, which completed successfully: Python unit tests passed (`72 passed`) and frontend tests passed (`2 passed`), and the TypeScript RPC/model generation step ran as part of the harness. 
- Observed an automated DB connectivity error while attempting a build-time DB operation (ODBC driver not found), which did not prevent the test suite from passing but indicates the environment could not reach an external SQL backend during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7605b3e648325bdfcca4531ebcb90)