### PR TITLE
Fix finance next-number SQL FOR JSON issue and show FY in period dropdowns

### DIFF
--- a/frontend/src/pages/finance/FinanceAccountantPage.tsx
+++ b/frontend/src/pages/finance/FinanceAccountantPage.tsx
@@ -282,7 +282,7 @@ const FinanceAccountantPage = (): JSX.Element => {
 								<MenuItem value="">All</MenuItem>
 								{periodsForSelectedYear.map((period) => (
 									<MenuItem key={`${period.guid || period.period_number}`} value={period.guid || ""}>
-										{period.period_name}
+										{`FY${period.year} - ${period.period_name}`}
 									</MenuItem>
 								))}
 							</TextField>
@@ -668,7 +668,7 @@ const FinanceAccountantPage = (): JSX.Element => {
 							>
 								<MenuItem value="">Select period</MenuItem>
 								{periods.map((period) => (
-									<MenuItem key={`${period.guid || period.period_number}`} value={period.guid || ""}>{period.period_name}</MenuItem>
+									<MenuItem key={`${period.guid || period.period_number}`} value={period.guid || ""}>{`FY${period.year} - ${period.period_name}`}</MenuItem>
 								))}
 							</TextField>
 						</Stack>

--- a/queryregistry/finance/numbers/mssql.py
+++ b/queryregistry/finance/numbers/mssql.py
@@ -175,6 +175,21 @@ async def delete_v1(args: Mapping[str, Any]) -> DBResponse:
 
 async def next_number_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
+    SET NOCOUNT ON;
+
+    DECLARE @result TABLE (
+      recid bigint,
+      accounts_guid uniqueidentifier,
+      element_prefix nvarchar(10),
+      element_account_number nvarchar(10),
+      element_block_start bigint,
+      element_block_end bigint,
+      element_allocation_size int,
+      element_reset_policy nvarchar(20),
+      element_created_on datetimeoffset,
+      element_modified_on datetimeoffset
+    );
+
     UPDATE finance_numbers
     SET element_last_number = element_last_number + element_allocation_size,
         element_modified_on = SYSUTCDATETIME()
@@ -183,13 +198,16 @@ async def next_number_v1(args: Mapping[str, Any]) -> DBResponse:
       inserted.accounts_guid,
       inserted.element_prefix,
       inserted.element_account_number,
-      (inserted.element_last_number - inserted.element_allocation_size + 1) AS element_block_start,
-      inserted.element_last_number AS element_block_end,
+      (inserted.element_last_number - inserted.element_allocation_size + 1),
+      inserted.element_last_number,
       inserted.element_allocation_size,
       inserted.element_reset_policy,
       inserted.element_created_on,
       inserted.element_modified_on
-    WHERE recid = ?
+    INTO @result
+    WHERE recid = ?;
+
+    SELECT * FROM @result
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
   """
   return await run_json_one(sql, (args["recid"],))


### PR DESCRIPTION
### Motivation

- Prevent SQL Server error 13602 caused by using `FOR JSON` directly on an `UPDATE ... OUTPUT` statement so journal number allocation works reliably.
- Improve UX by making Period selections unambiguous when multiple fiscal years exist by showing the fiscal year with each period label.

### Description

- Rewrote `next_number_v1` in `queryregistry/finance/numbers/mssql.py` to `OUTPUT ... INTO @result` and then `SELECT ... FOR JSON` from the table variable, and added `SET NOCOUNT ON;` so the JSON return is produced without using `FOR JSON` inside the `UPDATE`.
- Prepended fiscal year to period labels in `frontend/src/pages/finance/FinanceAccountantPage.tsx` for the Journals filter dropdown and the Create Journal dialog, rendering labels as ``FY{year} - {period_name}`` using the `year` field from `FinancePeriodsItem1`.
- Edited only the two files: `queryregistry/finance/numbers/mssql.py` and `frontend/src/pages/finance/FinanceAccountantPage.tsx`.

### Testing

- Ran `npm run type-check` in `frontend/` and it completed successfully.
- Built the frontend with `npm run build` and the production build completed successfully.
- Compiled the modified Python file with `python -m compileall queryregistry/finance/numbers/mssql.py` which succeeded, and ran the test harness `python scripts/run_tests.py` where unit tests passed (72 tests passed) but the overall pipeline emitted a DB connection error in this environment due to a missing ODBC driver (`ODBC Driver 18 for SQL Server`), so the environment-specific DB connectivity step could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b77e7eb8fc83258e438b7cef5e7e26)