### PR TITLE
Fix MSSQL OUTPUT JSON bug in finance registry and add FY to period dropdown labels

### DIFF
--- a/frontend/src/pages/finance/FinanceAccountantPage.tsx
+++ b/frontend/src/pages/finance/FinanceAccountantPage.tsx
@@ -89,6 +89,12 @@ type PeriodStatusRow = {
 
 type JournalLineForm = JournalCreateLine1;
 
+
+const getPeriodDisplayLabel = (period: FinancePeriodsItem1): string => {
+	const periodYear = (period as any).year ?? (period as any).fiscal_year ?? (period as any).element_year;
+	return `FY${periodYear ?? "-"} - ${period.period_name}`;
+};
+
 const DEFAULT_JOURNAL_LINE = (lineNumber: number): JournalLineForm => ({
 	line_number: lineNumber,
 	accounts_guid: "",
@@ -282,7 +288,7 @@ const FinanceAccountantPage = (): JSX.Element => {
 								<MenuItem value="">All</MenuItem>
 								{periodsForSelectedYear.map((period) => (
 									<MenuItem key={`${period.guid || period.period_number}`} value={period.guid || ""}>
-										{`FY${period.year} - ${period.period_name}`}
+										{getPeriodDisplayLabel(period)}
 									</MenuItem>
 								))}
 							</TextField>
@@ -668,7 +674,7 @@ const FinanceAccountantPage = (): JSX.Element => {
 							>
 								<MenuItem value="">Select period</MenuItem>
 								{periods.map((period) => (
-									<MenuItem key={`${period.guid || period.period_number}`} value={period.guid || ""}>{`FY${period.year} - ${period.period_name}`}</MenuItem>
+									<MenuItem key={`${period.guid || period.period_number}`} value={period.guid || ""}>{getPeriodDisplayLabel(period)}</MenuItem>
 								))}
 							</TextField>
 						</Stack>

--- a/queryregistry/finance/credit_lots/mssql.py
+++ b/queryregistry/finance/credit_lots/mssql.py
@@ -78,6 +78,27 @@ async def get_lot_v1(args: Mapping[str, Any]) -> DBResponse:
 
 async def create_lot_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
+    SET NOCOUNT ON;
+
+    DECLARE @result TABLE (
+      recid bigint,
+      users_guid uniqueidentifier,
+      element_lot_number nvarchar(64),
+      element_source_type nvarchar(64),
+      element_credits_original int,
+      element_credits_remaining int,
+      element_unit_price decimal(19,5),
+      element_total_paid decimal(19,5),
+      element_currency nvarchar(3),
+      element_expires_at datetimeoffset,
+      element_expired bit,
+      element_source_id nvarchar(256),
+      numbers_recid bigint,
+      element_status tinyint,
+      element_created_on datetimeoffset,
+      element_modified_on datetimeoffset
+    );
+
     INSERT INTO finance_credit_lots (
       users_guid,
       element_lot_number,
@@ -112,6 +133,7 @@ async def create_lot_v1(args: Mapping[str, Any]) -> DBResponse:
       inserted.element_status,
       inserted.element_created_on,
       inserted.element_modified_on
+    INTO @result
     VALUES (
       TRY_CAST(? AS UNIQUEIDENTIFIER),
       ?,
@@ -128,7 +150,9 @@ async def create_lot_v1(args: Mapping[str, Any]) -> DBResponse:
       ?,
       SYSUTCDATETIME(),
       SYSUTCDATETIME()
-    )
+    );
+
+    SELECT * FROM @result
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
   """
   params = (
@@ -196,6 +220,20 @@ async def list_events_by_lot_v1(args: Mapping[str, Any]) -> DBResponse:
 
 async def create_event_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
+    SET NOCOUNT ON;
+
+    DECLARE @result TABLE (
+      recid bigint,
+      lots_recid bigint,
+      element_event_type nvarchar(32),
+      element_credits int,
+      element_unit_price decimal(19,5),
+      element_description nvarchar(512),
+      element_actor_guid uniqueidentifier,
+      journals_recid bigint,
+      element_created_on datetimeoffset
+    );
+
     INSERT INTO finance_credit_lot_events (
       lots_recid,
       element_event_type,
@@ -216,6 +254,7 @@ async def create_event_v1(args: Mapping[str, Any]) -> DBResponse:
       inserted.element_actor_guid,
       inserted.journals_recid,
       inserted.element_created_on
+    INTO @result
     VALUES (
       ?,
       ?,
@@ -225,7 +264,9 @@ async def create_event_v1(args: Mapping[str, Any]) -> DBResponse:
       TRY_CAST(? AS UNIQUEIDENTIFIER),
       ?,
       SYSUTCDATETIME()
-    )
+    );
+
+    SELECT * FROM @result
     FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
   """
   params = (

--- a/queryregistry/finance/journals/mssql.py
+++ b/queryregistry/finance/journals/mssql.py
@@ -81,6 +81,27 @@ async def get_v1(args: Mapping[str, Any]) -> DBResponse:
 
 async def create_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
+    SET NOCOUNT ON;
+
+    DECLARE @result TABLE (
+      recid bigint,
+      element_name nvarchar(max),
+      element_description nvarchar(max),
+      numbers_recid bigint,
+      element_status tinyint,
+      element_created_on datetimeoffset,
+      element_modified_on datetimeoffset,
+      element_posting_key nvarchar(max),
+      element_source_type nvarchar(max),
+      element_source_id nvarchar(max),
+      periods_guid uniqueidentifier,
+      ledgers_recid bigint,
+      element_posted_by uniqueidentifier,
+      element_posted_on datetimeoffset,
+      element_reversed_by bigint,
+      element_reversal_of bigint
+    );
+
     INSERT INTO finance_journals (
       element_name,
       element_description,
@@ -111,8 +132,11 @@ async def create_v1(args: Mapping[str, Any]) -> DBResponse:
       inserted.element_posted_on,
       inserted.element_reversed_by,
       inserted.element_reversal_of
-    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES
+    INTO @result
     VALUES (?, ?, ?, ?, SYSUTCDATETIME(), SYSUTCDATETIME(), ?, ?, ?, TRY_CAST(? AS UNIQUEIDENTIFIER), ?);
+
+    SELECT * FROM @result
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
   """
   params = (
     args["name"],
@@ -130,6 +154,27 @@ async def create_v1(args: Mapping[str, Any]) -> DBResponse:
 
 async def update_status_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
+    SET NOCOUNT ON;
+
+    DECLARE @result TABLE (
+      recid bigint,
+      element_name nvarchar(max),
+      element_description nvarchar(max),
+      numbers_recid bigint,
+      element_status tinyint,
+      element_created_on datetimeoffset,
+      element_modified_on datetimeoffset,
+      element_posting_key nvarchar(max),
+      element_source_type nvarchar(max),
+      element_source_id nvarchar(max),
+      periods_guid uniqueidentifier,
+      ledgers_recid bigint,
+      element_posted_by uniqueidentifier,
+      element_posted_on datetimeoffset,
+      element_reversed_by bigint,
+      element_reversal_of bigint
+    );
+
     UPDATE finance_journals
     SET
       element_status = ?,
@@ -155,8 +200,11 @@ async def update_status_v1(args: Mapping[str, Any]) -> DBResponse:
       inserted.element_posted_on,
       inserted.element_reversed_by,
       inserted.element_reversal_of
-    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES
+    INTO @result
     WHERE recid = ?;
+
+    SELECT * FROM @result
+    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
   """
   params = (
     args["status"],


### PR DESCRIPTION
### Motivation

- SQL Server does not support `FOR JSON` directly on `INSERT ... OUTPUT` or `UPDATE ... OUTPUT`, causing syntax errors when finance registry functions attempted to return JSON directly from `OUTPUT` clauses.
- The codebase needs a consistent SQL Server-safe pattern (`OUTPUT ... INTO @result` + `SELECT ... FOR JSON`) for write-returning queries to avoid runtime failures.
- The period selector UX in the Finance Accountant page should display fiscal year context to avoid ambiguous period labels.

### Description

- Replaced invalid `... OUTPUT ... FOR JSON` usage with the `OUTPUT ... INTO @result` table-variable pattern followed by `SELECT * FROM @result FOR JSON ...` in `queryregistry/finance/journals/mssql.py` for `create_v1` and `update_status_v1`.
- Applied the same `OUTPUT INTO @result` pattern in `queryregistry/finance/credit_lots/mssql.py` for `create_lot_v1` and `create_event_v1`.
- Added `getPeriodDisplayLabel` to `frontend/src/pages/finance/FinanceAccountantPage.tsx` and replaced inline period labels with `getPeriodDisplayLabel(period)` to render `FY{year} - {period_name}`, where the year falls back through `year`, `fiscal_year`, and `element_year`.
- No change was required for `queryregistry/finance/numbers/mssql.py::next_number_v1` because it already used the `OUTPUT INTO @result` pattern.

### Testing

- Ran the unified harness with `python scripts/run_tests.py`, which executed lint/type/test steps and completed with the repository test suite reporting `72 passed, 1 warning` for Python tests and successful type-check/lint phases.
- Ran frontend tests via the harness which executed `vitest` and reported `2 passed (2)` for the focused frontend tests.
- Started the frontend locally with `npx vite --host 0.0.0.0 --port 4173` and captured a screenshot to validate the updated period labels in the Finance Accountant page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b783f1821c83258ea9adedaff0fb1b)