### PR TITLE
Coerce debit/credit to str in finance journal lines RPC

### DIFF
--- a/rpc/finance/journals/services.py
+++ b/rpc/finance/journals/services.py
@@ -17,6 +17,15 @@ from .models import (
 )
 
 
+def _coerce_line(line: dict) -> dict:
+  coerced = dict(line)
+  if "debit" in coerced:
+    coerced["debit"] = str(coerced["debit"])
+  if "credit" in coerced:
+    coerced["credit"] = str(coerced["credit"])
+  return coerced
+
+
 async def finance_journals_list_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   input_payload = JournalListFilter1(**(rpc_request.payload or {}))
@@ -45,7 +54,7 @@ async def finance_journals_get_lines_v1(request: Request):
   module = request.app.state.finance
   await module.on_ready()
   rows = await module.get_journal_lines(input_payload.journals_recid)
-  payload = JournalLineList1(lines=[JournalLineItem1(**line) for line in rows])
+  payload = JournalLineList1(lines=[JournalLineItem1(**_coerce_line(line)) for line in rows])
   return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
 
 


### PR DESCRIPTION
### Motivation
- The DB returns `debit`/`credit` as floats while the `JournalLineItem1` model expects `str`, causing Pydantic validation failures and an empty detail dialog when viewing journal lines.

### Description
- Add a module-level helper `def _coerce_line(line: dict) -> dict` in `rpc/finance/journals/services.py` that copies the input line and converts `debit` and `credit` to `str` when present.
- Update `finance_journals_get_lines_v1` to construct `JournalLineItem1` from the coerced line dicts via `JournalLineItem1(**_coerce_line(line))` to avoid type mismatches.

### Testing
- Ran `python -m compileall rpc/finance/journals/services.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b79b8454588325bcda5c3ca6c3e950)