### PR TITLE
Handle Azure Cost Details subscription-epoch 400 with one-time retry

### DIFF
--- a/server/modules/azure_billing_import_module.py
+++ b/server/modules/azure_billing_import_module.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import csv
+from datetime import datetime
 import io
 import logging
+import re
 
 import aiohttp
 from azure.identity.aio import ClientSecretCredential
@@ -30,6 +32,12 @@ from .env_module import EnvModule
 
 
 class AzureBillingImportModule(BaseModule):
+  _START_DATE_AFTER_PATTERN = re.compile(
+    r"Start\s+date\s+must\s+be\s+after\s+"
+    r"(\d{1,2}/\d{1,2}/\d{4}\s+\d{1,2}:\d{2}:\d{2}\s+[AP]M)",
+    re.IGNORECASE,
+  )
+
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.db: DbModule | None = None
@@ -136,6 +144,12 @@ class AzureBillingImportModule(BaseModule):
       return default
     return max(1, min(parsed, 300))
 
+  def _parse_start_date_after_error(self, response_text: str) -> datetime | None:
+    match = self._START_DATE_AFTER_PATTERN.search(response_text)
+    if not match:
+      return None
+    return datetime.strptime(match.group(1), "%m/%d/%Y %I:%M:%S %p")
+
   async def import_cost_details(
     self,
     period_start: str,
@@ -188,17 +202,39 @@ class AzureBillingImportModule(BaseModule):
       }
 
       async with aiohttp.ClientSession() as session:
-        async with session.post(url, headers=headers, json=body) as response:
-          if response.status != 202:
+        corrected_start: str | None = None
+        for attempt in range(2):
+          async with session.post(url, headers=headers, json=body) as response:
+            if response.status == 202:
+              location = response.headers.get("Location")
+              retry_after = self._parse_retry_after(response.headers.get("Retry-After"))
+              if not location:
+                raise RuntimeError("Azure Cost Details report response missing Location header")
+              break
+
             response_text = await response.text()
-            raise RuntimeError(
-              "Azure Cost Details report request failed "
-              f"({response.status}): {response_text}",
+            if response.status != 400 or attempt == 1:
+              raise RuntimeError(
+                "Azure Cost Details report request failed "
+                f"({response.status}): {response_text}",
+              )
+
+            corrected_start_dt = self._parse_start_date_after_error(response_text)
+            if not corrected_start_dt:
+              raise RuntimeError(
+                "Azure Cost Details report request failed "
+                f"({response.status}): {response_text}",
+              )
+
+            corrected_start = corrected_start_dt.isoformat(timespec="seconds")
+            logging.info(
+              "[AzureBillingImportModule] Auto-corrected Azure Cost Details start date from %s to %s",
+              body["timePeriod"]["start"],
+              corrected_start,
             )
-          location = response.headers.get("Location")
-          retry_after = self._parse_retry_after(response.headers.get("Retry-After"))
-          if not location:
-            raise RuntimeError("Azure Cost Details report response missing Location header")
+            body["timePeriod"]["start"] = corrected_start
+        else:
+          raise RuntimeError("Azure Cost Details report request failed with unknown retry state")
 
         manifest: dict | None = None
         while True:

--- a/tests/test_azure_billing_import_module.py
+++ b/tests/test_azure_billing_import_module.py
@@ -1,0 +1,154 @@
+import asyncio
+import copy
+from types import SimpleNamespace
+
+import pytest
+
+from server.modules import azure_billing_import_module as azure_mod
+from server.modules.azure_billing_import_module import AzureBillingImportModule
+
+
+class _FakeResponse:
+  def __init__(self, status, *, text_data="", json_data=None, headers=None):
+    self.status = status
+    self._text_data = text_data
+    self._json_data = json_data
+    self.headers = headers or {}
+
+  async def __aenter__(self):
+    return self
+
+  async def __aexit__(self, exc_type, exc, tb):
+    return False
+
+  async def text(self):
+    return self._text_data
+
+  async def json(self, content_type=None):
+    return self._json_data
+
+
+class _FakeClientSession:
+  def __init__(self, post_responses, get_responses, post_bodies):
+    self._post_responses = list(post_responses)
+    self._get_responses = list(get_responses)
+    self._post_bodies = post_bodies
+
+  async def __aenter__(self):
+    return self
+
+  async def __aexit__(self, exc_type, exc, tb):
+    return False
+
+  def post(self, _url, headers=None, json=None):
+    self._post_bodies.append(copy.deepcopy(json))
+    return self._post_responses.pop(0)
+
+  def get(self, _url, headers=None):
+    return self._get_responses.pop(0)
+
+
+class _FakeDb:
+  def __init__(self):
+    self.calls = 0
+
+  async def run(self, _request):
+    self.calls += 1
+    if self.calls == 1:
+      return SimpleNamespace(rows=[{"recid": 77}])
+    return SimpleNamespace(rows=[])
+
+
+def _build_module(monkeypatch, session_factory):
+  module = AzureBillingImportModule.__new__(AzureBillingImportModule)
+  module.app = SimpleNamespace(state=SimpleNamespace())
+  module.db = _FakeDb()
+  module.env = None
+  module._subscription_id = "sub-123"
+  module._tenant_id = None
+  module._client_id = None
+  module._client_secret = None
+  module._credential = None
+  module._credential_tenant_id = None
+  module._credential_client_id = None
+  module._credential_client_secret = None
+
+  async def _fake_token():
+    return "token-abc"
+
+  monkeypatch.setattr(module, "_get_management_token", _fake_token)
+  monkeypatch.setattr(azure_mod.aiohttp, "ClientSession", session_factory)
+
+  async def _no_sleep(_seconds):
+    return None
+
+  monkeypatch.setattr(azure_mod.asyncio, "sleep", _no_sleep)
+  return module
+
+
+def test_import_cost_details_retries_when_start_date_must_be_after(monkeypatch, caplog):
+  post_bodies = []
+  post_responses = [
+    _FakeResponse(
+      400,
+      text_data=(
+        '{"error":"Start   date must be after 1/2/2024 3:04:05 PM"}'
+      ),
+    ),
+    _FakeResponse(
+      202,
+      headers={"Location": "https://poll.example", "Retry-After": "1"},
+    ),
+  ]
+  get_responses = [
+    _FakeResponse(
+      200,
+      json_data={
+        "status": "Completed",
+        "manifest": {"blobs": [{"blobLink": "https://blob.example"}]},
+      },
+      headers={"Retry-After": "1"},
+    ),
+    _FakeResponse(200, text_data="Date,Cost\n2024-01-02,10\n"),
+  ]
+
+  module = _build_module(
+    monkeypatch,
+    lambda: _FakeClientSession(post_responses, get_responses, post_bodies),
+  )
+
+  with caplog.at_level("INFO"):
+    result = asyncio.run(
+      module.import_cost_details(
+        period_start="2024-01-01T00:00:00",
+        period_end="2024-01-31T23:59:59",
+      )
+    )
+
+  assert result["status"] == "completed"
+  assert len(post_bodies) == 2
+  assert post_bodies[0]["timePeriod"]["start"] == "2024-01-01T00:00:00"
+  assert post_bodies[1]["timePeriod"]["start"] == "2024-01-02T15:04:05"
+  assert "Auto-corrected Azure Cost Details start date" in caplog.text
+
+
+def test_import_cost_details_raises_immediately_for_non_matching_400(monkeypatch):
+  post_bodies = []
+  post_responses = [
+    _FakeResponse(400, text_data='{"error":"some other 400"}'),
+  ]
+
+  module = _build_module(
+    monkeypatch,
+    lambda: _FakeClientSession(post_responses, [], post_bodies),
+  )
+
+  with pytest.raises(RuntimeError, match="Azure Cost Details report request failed"):
+    asyncio.run(
+      module.import_cost_details(
+        period_start="2024-01-01T00:00:00",
+        period_end="2024-01-31T23:59:59",
+      )
+    )
+
+  assert len(post_bodies) == 1


### PR DESCRIPTION
### Motivation

- Azure Cost Details API can return a 400 error when the requested start date is earlier than the subscription epoch and returns a message like `Start date must be after {timestamp}`, so imports should automatically correct and retry once to avoid manual intervention.

### Description

- Added a whitespace-lenient, structure-strict regex `_START_DATE_AFTER_PATTERN` and a helper `._parse_start_date_after_error` that uses `datetime.strptime("%m/%d/%Y %I:%M:%S %p")` to extract the Azure timestamp from the 400 payload. 
- Modified `import_cost_details` to catch a `400` on the initial `POST generateCostDetailsReport` and, when the message matches, replace `timePeriod.start` with the parsed timestamp and reissue the same request exactly once, logging an `INFO` with the original and corrected dates. 
- Preserved existing behavior for non-matching `400`s and all other error paths by raising as before if parsing fails or the retry also fails. 
- Added `tests/test_azure_billing_import_module.py` to cover the successful one-time auto-correction path and the immediate-failure path for non-matching 400 responses.

### Testing

- Ran `pytest -q tests/test_azure_billing_import_module.py` which executed the new tests and succeeded with `2 passed`.
- The new tests assert that the module issues the original request, logs the auto-correction, and issues a second request with the corrected `timePeriod.start`, and that non-matching 400 responses raise immediately.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b79f60c384832581ed881a305b8263)