### PR TITLE
Include reversed journals in trial balance and disable reverse action for reversal journals

### DIFF
--- a/frontend/src/pages/finance/FinanceAccountantPage.tsx
+++ b/frontend/src/pages/finance/FinanceAccountantPage.tsx
@@ -374,8 +374,8 @@ const FinanceAccountantPage = (): JSX.Element => {
 												Post
 											</Button>
 										)}
-										{row.journal_status === 1 && (
-											<Button
+									{row.journal_status === 1 && row.source_type !== "reversal" && (
+										<Button
 												size="small"
 												color="error"
 												onClick={async () => {

--- a/migrations/v0.9.4.1_fix_trial_balance.sql
+++ b/migrations/v0.9.4.1_fix_trial_balance.sql
@@ -1,0 +1,66 @@
+SET NOCOUNT ON;
+GO
+
+-- Fix trial balance to include reversed journals.
+-- Both Posted (1) and Reversed (2) journals have valid ledger entries.
+IF OBJECT_ID(N'[dbo].[vw_finance_trial_balance]', N'V') IS NOT NULL
+BEGIN
+  DROP VIEW [dbo].[vw_finance_trial_balance];
+END;
+GO
+
+CREATE VIEW [dbo].[vw_finance_trial_balance] AS
+SELECT
+  p.element_guid AS period_guid,
+  p.element_year AS fiscal_year,
+  p.element_period_number AS period_number,
+  p.element_period_name AS period_name,
+  a.element_guid AS account_guid,
+  a.element_number AS account_number,
+  a.element_name AS account_name,
+  a.element_type AS account_type,
+  ISNULL(SUM(jl.element_debit), 0) AS total_debit,
+  ISNULL(SUM(jl.element_credit), 0) AS total_credit,
+  ISNULL(SUM(jl.element_debit), 0) - ISNULL(SUM(jl.element_credit), 0) AS net_balance
+FROM finance_journal_lines AS jl
+JOIN finance_journals AS j ON j.recid = jl.journals_recid
+JOIN finance_accounts AS a ON a.element_guid = jl.accounts_guid
+JOIN finance_periods AS p ON p.element_guid = j.periods_guid
+WHERE j.element_status IN (1, 2)
+GROUP BY
+  p.element_guid,
+  p.element_year,
+  p.element_period_number,
+  p.element_period_name,
+  a.element_guid,
+  a.element_number,
+  a.element_name,
+  a.element_type;
+GO
+
+IF EXISTS (
+  SELECT 1
+  FROM system_schema_views
+  WHERE element_name = 'vw_finance_trial_balance' AND element_schema = 'dbo'
+)
+BEGIN
+  UPDATE s
+  SET s.element_definition = m.definition
+  FROM system_schema_views AS s
+  CROSS JOIN (
+    SELECT sm.definition
+    FROM sys.views AS v
+    JOIN sys.sql_modules AS sm ON sm.object_id = v.object_id
+    WHERE v.name = 'vw_finance_trial_balance' AND SCHEMA_NAME(v.schema_id) = 'dbo'
+  ) AS m
+  WHERE s.element_name = 'vw_finance_trial_balance' AND s.element_schema = 'dbo';
+END
+ELSE
+BEGIN
+  INSERT INTO system_schema_views (element_name, element_schema, element_definition)
+  SELECT 'vw_finance_trial_balance', 'dbo', sm.definition
+  FROM sys.views AS v
+  JOIN sys.sql_modules AS sm ON sm.object_id = v.object_id
+  WHERE v.name = 'vw_finance_trial_balance' AND SCHEMA_NAME(v.schema_id) = 'dbo';
+END;
+GO


### PR DESCRIPTION
### Motivation
- Trial balance omitted journals with `element_status = 2` (reversed), which caused original entries to disappear after reversal and produced incorrect balances. 
- Reversal journals (with `source_type === "reversal"`) were showing a `Reverse` action in the UI, allowing invalid double-reversals.

### Description
- Added migration `migrations/v0.9.4.1_fix_trial_balance.sql` that drops and recreates `vw_finance_trial_balance` and changes the filter to `WHERE j.element_status IN (1, 2)` so both posted and reversed journals contribute to aggregates. 
- The migration also updates (or inserts) the `system_schema_views.element_definition` entry for `vw_finance_trial_balance` after recreating the view. 
- Updated `frontend/src/pages/finance/FinanceAccountantPage.tsx` so the `Reverse` button is only rendered when `row.journal_status === 1 && row.source_type !== "reversal"` to prevent reversing reversal journals.

### Testing
- Ran frontend lint with `cd frontend && npm run lint` and it completed successfully. 
- Ran TypeScript checks with `cd frontend && npm run type-check` and they passed. 
- Produced a production build with `cd frontend && npm run build` and the build succeeded, and a preview was exercised and a UI screenshot was captured to validate the changed button visibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b82de91690832585150052cead6664)