### PR TITLE
Coerce DECIMAL floats to strings in credit lot RPC services

### DIFF
--- a/rpc/finance/credit_lots/services.py
+++ b/rpc/finance/credit_lots/services.py
@@ -20,13 +20,30 @@ from .models import (
 )
 
 
+def _coerce_lot(row: dict) -> dict:
+  """Coerce decimal fields from DB float to str for Pydantic models."""
+  coerced = dict(row)
+  for key in ("unit_price", "total_paid"):
+    if key in coerced:
+      coerced[key] = str(coerced[key])
+  return coerced
+
+
+def _coerce_event(row: dict) -> dict:
+  """Coerce decimal fields from DB float to str for Pydantic models."""
+  coerced = dict(row)
+  if "unit_price" in coerced:
+    coerced["unit_price"] = str(coerced["unit_price"])
+  return coerced
+
+
 async def finance_credit_lots_list_by_user_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   input_payload = CreditLotListByUser1(**(rpc_request.payload or {}))
   module = request.app.state.finance
   await module.on_ready()
   rows = await module.list_lots_by_user(input_payload.users_guid)
-  payload = CreditLotList1(lots=[CreditLotItem1(**lot) for lot in rows])
+  payload = CreditLotList1(lots=[CreditLotItem1(**_coerce_lot(lot)) for lot in rows])
   return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
 
 
@@ -38,7 +55,7 @@ async def finance_credit_lots_get_v1(request: Request):
   row = await module.get_lot(input_payload.recid)
   if not row:
     raise HTTPException(status_code=404, detail="Credit lot not found")
-  payload = CreditLotItem1(**row)
+  payload = CreditLotItem1(**_coerce_lot(row))
   return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
 
 
@@ -60,7 +77,7 @@ async def finance_credit_lots_create_v1(request: Request):
     )
   except ValueError as exc:
     raise HTTPException(status_code=400, detail=str(exc)) from exc
-  payload = CreditLotItem1(**row)
+  payload = CreditLotItem1(**_coerce_lot(row))
   return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
 
 
@@ -93,7 +110,7 @@ async def finance_credit_lots_expire_v1(request: Request):
     row = await module.expire_lot(input_payload.recid, actor_guid=auth_ctx.user_guid)
   except ValueError as exc:
     raise HTTPException(status_code=400, detail=str(exc)) from exc
-  payload = CreditLotItem1(**row)
+  payload = CreditLotItem1(**_coerce_lot(row))
   return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
 
 
@@ -103,7 +120,7 @@ async def finance_credit_lots_list_events_v1(request: Request):
   module = request.app.state.finance
   await module.on_ready()
   rows = await module.list_lot_events(input_payload.lots_recid)
-  payload = CreditLotEventList1(events=[CreditLotEventItem1(**event) for event in rows])
+  payload = CreditLotEventList1(events=[CreditLotEventItem1(**_coerce_event(event)) for event in rows])
   return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
 
 


### PR DESCRIPTION
### Motivation

- MSSQL `DECIMAL` columns can arrive as Python `float`, which causes Pydantic `ValidationError: Input should be a valid string` for models that expect `str`-typed decimal fields. 
- Journal line coercion was already fixed; credit lot responses must be aligned to prevent the same validation failures.

### Description

- Added module-level helpers ` _coerce_lot` and `_coerce_event` in `rpc/finance/credit_lots/services.py` to convert DB decimal fields to strings before model construction. 
- ` _coerce_lot` converts `unit_price` and `total_paid` to `str`. 
- ` _coerce_event` converts `unit_price` to `str`. 
- Updated all construction sites to use the coercion helpers, replacing `CreditLotItem1(**row)` and `CreditLotEventItem1(**event)` with `CreditLotItem1(**_coerce_lot(row))` and `CreditLotEventItem1(**_coerce_event(event))` respectively across the service functions.

### Testing

- Ran `python -m py_compile rpc/finance/credit_lots/services.py`, which succeeded. 
- Ran `pytest tests -k credit_lots`, which deselected all tests (no matching tests in the suite), so no RPC-specific tests executed by that command.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b838e94e5c83259e229bbdc467629a)