### PR TITLE
fix(finance-periods): make days_in_period and quarter_number optional for upsert

### DIFF
--- a/rpc/finance/periods/models.py
+++ b/rpc/finance/periods/models.py
@@ -8,8 +8,8 @@ class FinancePeriodsItem1(BaseModel):
   period_name: str
   start_date: str
   end_date: str
-  days_in_period: int
-  quarter_number: int
+  days_in_period: int | None = None
+  quarter_number: int | None = None
   has_closing_week: bool = False
   is_leap_adjustment: bool = False
   anchor_event: str | None = None


### PR DESCRIPTION
### Motivation
- The periods upsert endpoint receives partial payloads from period close/reopen flows that come from a view lacking `days_in_period` and `quarter_number`, causing validation failures; making those fields optional allows targeted upserts without requiring calendar-generator-only fields.

### Description
- Made `days_in_period` and `quarter_number` optional on `FinancePeriodsItem1` (`int | None = None`) in `rpc/finance/periods/models.py` so `urn:finance:periods:upsert:1` accepts partial payloads; verified `rpc/finance/credit_lots/services.py` already implements `_coerce_lot` and `_coerce_event` at all required call sites and `frontend/src/pages/finance/FinanceAccountantPage.tsx` already hides the Reverse button for reversal journals.

### Testing
- Ran a Python smoke test that instantiates `FinancePeriodsUpsert1` without the optional fields and asserts both default to `None`, and exercised `_coerce_lot`/`_coerce_event` to confirm float→`str` coercion; the checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8456c4c448325933b51e91da27d70)