### PR TITLE
Fix expire_lot to use rowcount and return updated lot after UPDATE

### DIFF
--- a/server/modules/finance_module.py
+++ b/server/modules/finance_module.py
@@ -847,10 +847,13 @@ class FinanceModule(BaseModule):
       return None
 
     expired_res = await self.db.run(expire_lot_request(ExpireLotParams(recid=recid)))
-    if not expired_res.rows:
+    if expired_res.rowcount == 0:
       return None
 
-    expired = self._map_lot(dict(expired_res.rows[0]))
+    expired_lot = await self.get_lot(recid)
+    if not expired_lot:
+      return None
+    expired = self._map_lot(expired_lot) if isinstance(expired_lot, dict) else expired_lot
     remaining_before = int(lot.get("credits_remaining") or 0)
     if remaining_before > 0:
       await self.db.run(


### PR DESCRIPTION
### Motivation
- `expire_lot` previously checked `expired_res.rows` after running an `UPDATE` that does not return row data, which caused the method to always return `None` even when the update succeeded.

### Description
- Updated `server/modules/finance_module.py` to check `expired_res.rowcount == 0` to detect a no-op UPDATE instead of inspecting `rows`.
- After a successful expire `UPDATE`, re-fetch the lot via `get_lot(recid)` and use that refreshed payload for the return value.
- Preserve existing behavior for creating the expire event and syncing the wallet while defensively handling a missing re-fetched lot.

### Testing
- Compiled the modified module with `python -m compileall server/modules/finance_module.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8600e0e088325a4f24d79294f4e41)