### PR TITLE
Add ErrorDigest and concise exception logging for Discord and console

### DIFF
--- a/server/helpers/error_digest.py
+++ b/server/helpers/error_digest.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import traceback
+from types import TracebackType
+
+OUR_CODE_MARKERS = (
+  '/rpc/',
+  '/server/',
+  '/queryregistry/',
+  '/scripts/',
+  '/tests/',
+)
+
+
+@dataclass(frozen=True)
+class ErrorDigest:
+  exception_type: str
+  message: str
+  origin_function: str
+  origin_file: str
+  origin_line: int
+  our_frames: list[str]
+  full_traceback: str
+
+  @classmethod
+  def from_exception(
+    cls,
+    exc: BaseException,
+    tb: TracebackType | None = None,
+  ) -> 'ErrorDigest':
+    source_tb = tb if tb is not None else exc.__traceback__
+    traceback_lines = traceback.format_exception(type(exc), exc, source_tb)
+    full_traceback = ''.join(traceback_lines)
+
+    extracted = traceback.extract_tb(source_tb) if source_tb else []
+    our_code_frames: list[traceback.FrameSummary] = []
+    for frame in extracted:
+      normalized = frame.filename.replace('\\', '/').lower()
+      if 'main.py' in normalized or any(marker in normalized for marker in OUR_CODE_MARKERS):
+        our_code_frames.append(frame)
+
+    selected_frames = our_code_frames[-3:]
+    if selected_frames:
+      origin = selected_frames[-1]
+    elif extracted:
+      origin = extracted[-1]
+    else:
+      origin = None
+
+    if origin:
+      origin_function = origin.name
+      origin_file = origin.filename
+      origin_line = origin.lineno
+    else:
+      origin_function = '<unknown>'
+      origin_file = '<unknown>'
+      origin_line = 0
+
+    our_frames = [
+      f"{frame.filename}:{frame.lineno} in {frame.name}"
+      for frame in selected_frames
+    ]
+
+    return cls(
+      exception_type=exc.__class__.__name__,
+      message=str(exc),
+      origin_function=origin_function,
+      origin_file=origin_file,
+      origin_line=origin_line,
+      our_frames=our_frames,
+      full_traceback=full_traceback,
+    )
+
+  @property
+  def short(self) -> str:
+    filename = os.path.basename(self.origin_file)
+    message = self.message.strip().replace('\n', ' ')
+    if len(message) > 200:
+      message = f"{message[:197]}..."
+    return (
+      f"[{self.exception_type}] {filename}:{self.origin_line} "
+      f"in {self.origin_function} — {message}"
+    )
+
+  @property
+  def detail(self) -> str:
+    details = [self.short]
+    for frame in self.our_frames:
+      details.append(f"  → {frame}")
+    return '\n'.join(details)

--- a/server/helpers/logging.py
+++ b/server/helpers/logging.py
@@ -1,6 +1,8 @@
 import logging, asyncio, time
 import sys
 
+from server.helpers.error_digest import ErrorDigest
+
 MAX_DISCORD_MESSAGE_LEN = 1900
 
 def split_message(msg: str, limit: int = MAX_DISCORD_MESSAGE_LEN) -> list[str]:
@@ -9,6 +11,18 @@ def split_message(msg: str, limit: int = MAX_DISCORD_MESSAGE_LEN) -> list[str]:
 class ExcludeDiscordFilter(logging.Filter):
   def filter(self, record):
     return not record.name.startswith('discord')
+
+
+class ConsoleDigestFormatter(logging.Formatter):
+  def formatException(self, ei):
+    exc = ei[1]
+    if exc is None:
+      return super().formatException(ei)
+    digest = ErrorDigest.from_exception(exc, ei[2])
+    logger = logging.getLogger()
+    if logger.isEnabledFor(logging.DEBUG):
+      return f"{digest.detail}\n{digest.full_traceback.rstrip()}"
+    return digest.detail
 
 class DiscordHandler(logging.Handler):
   def __init__(self, discord_module, interval: float = 1.0, delay: float = 5.0):
@@ -23,7 +37,18 @@ class DiscordHandler(logging.Handler):
     if record.name.startswith('discord'):
       return
 
-    msg = self.format(record)
+    record_to_format = record
+    if record.exc_info and record.exc_info[1] is not None:
+      digest = ErrorDigest.from_exception(record.exc_info[1], record.exc_info[2])
+      record_to_format = logging.makeLogRecord({
+        **record.__dict__,
+        'msg': digest.short,
+        'args': (),
+        'exc_info': None,
+        'exc_text': None,
+      })
+
+    msg = self.format(record_to_format)
 
     if not msg or msg == "None":
       return
@@ -110,7 +135,7 @@ def configure_root_logging(level: int = 3):
   if logger.handlers:
     logger.handlers.clear()
   handler = logging.StreamHandler(sys.stdout)
-  handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+  handler.setFormatter(ConsoleDigestFormatter('%(levelname)s: %(message)s'))
   logger.addHandler(handler)
   logger.addFilter(ExcludeDiscordFilter())
   for name in ('discord', 'discord.http', 'discord.client', 'discord.gateway'):
@@ -122,4 +147,3 @@ def remove_discord_logging(discord_module):
   for h in list(logger.handlers):
     if isinstance(h, DiscordHandler) and h.discord is discord_module:
       logger.removeHandler(h)
-

--- a/tests/test_error_digest.py
+++ b/tests/test_error_digest.py
@@ -1,0 +1,128 @@
+import asyncio
+import logging
+import sys
+
+from server.helpers.error_digest import ErrorDigest
+from server.helpers.logging import ConsoleDigestFormatter, DiscordHandler
+
+
+def _raise_runtime_error_with_long_message():
+  long_message = 'x' * 250
+  raise RuntimeError(long_message)
+
+
+def _raise_value_error():
+  raise ValueError('digest me')
+
+
+def test_error_digest_from_exception_filters_our_frames():
+  try:
+    _raise_value_error()
+  except ValueError as exc:
+    digest = ErrorDigest.from_exception(exc)
+
+  assert digest.exception_type == 'ValueError'
+  assert digest.origin_file.endswith('test_error_digest.py')
+  assert digest.origin_function == '_raise_value_error'
+  assert digest.origin_line > 0
+  assert digest.our_frames
+  assert len(digest.our_frames) <= 3
+  assert any('/tests/' in frame.replace('\\', '/') for frame in digest.our_frames)
+  assert 'Traceback (most recent call last)' in digest.full_traceback
+
+
+def test_error_digest_short_and_detail_formatting():
+  try:
+    _raise_runtime_error_with_long_message()
+  except RuntimeError as exc:
+    digest = ErrorDigest.from_exception(exc)
+
+  short = digest.short
+  detail = digest.detail
+
+  assert short.startswith('[RuntimeError] test_error_digest.py:')
+  assert ' in _raise_runtime_error_with_long_message — ' in short
+  assert short.endswith('...')
+  assert len(short.split(' — ', 1)[1]) <= 200
+  assert detail.startswith(short)
+  assert '  → ' in detail
+
+
+class _DummyChannel:
+  def __init__(self):
+    self.sent_messages = []
+
+  async def send(self, message):
+    self.sent_messages.append(message)
+
+
+class _DummyLoop:
+  def create_task(self, coro):
+    asyncio.run(coro)
+
+
+class _DummyBot:
+  def __init__(self, channel):
+    self._channel = channel
+    self.loop = _DummyLoop()
+
+  def get_channel(self, _):
+    return self._channel
+
+
+class _DummyDiscordModule:
+  def __init__(self, channel):
+    self.syschan = 42
+    self.bot = _DummyBot(channel)
+
+
+def test_discord_handler_emits_digest_short_for_exceptions():
+  channel = _DummyChannel()
+  handler = DiscordHandler(_DummyDiscordModule(channel), interval=0, delay=0)
+  handler.setFormatter(logging.Formatter('[%(levelname)s] %(message)s'))
+
+  logger = logging.getLogger('test.discord.digest')
+
+  try:
+    _raise_value_error()
+  except ValueError:
+    record = logger.makeRecord(
+      logger.name,
+      logging.ERROR,
+      __file__,
+      0,
+      'failed to process request',
+      (),
+      exc_info=sys.exc_info(),
+    )
+
+  handler.emit(record)
+
+  assert channel.sent_messages
+  message = channel.sent_messages[0]
+  assert message.startswith('[ERROR] [ValueError] test_error_digest.py:')
+  assert 'digest me' in message
+  assert 'Traceback (most recent call last)' not in message
+
+
+def test_console_digest_formatter_uses_detail_for_exception_text():
+  formatter = ConsoleDigestFormatter('%(levelname)s: %(message)s')
+  logger = logging.getLogger('test.console.digest')
+
+  try:
+    _raise_value_error()
+  except ValueError:
+    record = logger.makeRecord(
+      logger.name,
+      logging.ERROR,
+      __file__,
+      0,
+      'failed in formatter',
+      (),
+      exc_info=sys.exc_info(),
+    )
+
+  output = formatter.format(record)
+  assert 'ERROR: failed in formatter' in output
+  assert '[ValueError] test_error_digest.py:' in output
+  assert '  → ' in output


### PR DESCRIPTION
### Motivation
- Discord receives full Python tracebacks for `logging.exception()` calls which buries the real error; console output likewise shows verbose traces unless in debug mode.
- Provide a concise single-line summary for external channels while retaining full traceback availability at debug level for developers.

### Description
- Add `server/helpers/error_digest.py` introducing a frozen `ErrorDigest` dataclass with fields `exception_type`, `message`, `origin_function`, `origin_file`, `origin_line`, `our_frames`, and `full_traceback`, plus `from_exception` that filters frames to project paths and keeps the innermost 3 our-code frames.
- Implement `ErrorDigest.short` as a single-line summary with message truncated to 200 chars and `ErrorDigest.detail` as a multi-line summary including our-code frames.
- Update `server/helpers/logging.py` to import `ErrorDigest` and in `DiscordHandler.emit()` replace exception records with a copied `LogRecord` whose `msg` is `digest.short` and `exc_info` is cleared so Discord receives the concise digest instead of the raw traceback.
- Add `ConsoleDigestFormatter` that overrides `formatException` to return `ErrorDigest.detail` and include the full `full_traceback` only when the root logger level is `DEBUG`, and wire it into `configure_root_logging()` so console output is condensed by default.

### Testing
- Added `tests/test_error_digest.py` which asserts frame filtering, `short`/`detail` formats, `DiscordHandler` emission of digest summaries, and `ConsoleDigestFormatter` behavior.
- Ran `pytest -q tests/test_error_digest.py tests/test_logging_azure.py` and the tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b88be5392c8325a7e231ad831ed5f1)