### PR TITLE
docs: add mechanical automation contracts for RPC AST parsing

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -1,0 +1,49 @@
+# RPC Patterns
+
+Canonical patterns for RPC domain handlers, subdomain dispatchers, and service implementations.
+
+## 0. Mechanical Automation Contracts
+
+The code generation pipeline uses AST analysis to crawl RPC service functions and extract metadata. The following naming contracts are mechanically parsed — the pipeline matches on exact token names in the syntax tree.
+
+### 0.1 Service Function Module Variable
+
+Every RPC service function resolves its module using this exact pattern:
+
+```python
+module: SystemConfigModule = request.app.state.system_config
+await module.on_ready()
+result = await module.get_configs(auth_ctx.user_guid, auth_ctx.roles)
+```
+
+The local variable is always named `module`. The type annotation (e.g., `SystemConfigModule`) carries the specificity. The right side of the assignment (e.g., `request.app.state.system_config`) is the ModuleManager registration name.
+
+The seed script `scripts/seed_rpcdispatch.py` function `parse_service_module_metadata` extracts:
+- `element_module_attr` from the `request.app.state.{attr}` expression
+- `element_method_name` from the `module.{method}` call expression
+
+These values populate the `reflection_rpc_functions` table and drive code generation. Refer to `scripts/seed_rpcdispatch.py` for the AST crawler implementation.
+
+### 0.2 DISPATCHERS Dict
+
+Every RPC subdomain `__init__.py` exports a `DISPATCHERS` dict keyed by `(operation, version)` tuples:
+
+```python
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("get_configs", "1"): system_config_get_configs_v1,
+}
+```
+
+The seed script `scripts/seed_rpcdispatch.py` function `parse_dict_keys` and the binding generator `scripts/common.py` function `parse_dispatchers` both parse this dict by name using AST analysis. The dict must be named `DISPATCHERS`.
+
+### 0.3 HANDLERS Dict
+
+Every RPC domain `__init__.py` exports a `HANDLERS` dict mapping subdomain names to handler functions:
+
+```python
+HANDLERS: dict[str, callable] = {
+  "config": handle_config_request,
+}
+```
+
+The seed script uses `parse_dict_keys` to discover subdomains from this dict. The dict must be named `HANDLERS`.

--- a/rpc/AGENTS.md
+++ b/rpc/AGENTS.md
@@ -43,6 +43,24 @@ and payload models.
 
 ---
 
+## Mechanical Automation Contracts
+
+The code generation pipeline (`scripts/seed_rpcdispatch.py`) uses AST analysis to extract metadata from service functions. The following naming contracts are required for the pipeline to function.
+
+Service functions resolve their module using this pattern:
+
+```python
+module: RoleAdminModule = request.app.state.role_admin
+await module.on_ready()
+result = await module.list_roles(auth_ctx.role_mask)
+```
+
+The local variable is always `module`. The type annotation carries the specificity. The `request.app.state.{attr}` expression provides the ModuleManager registration name. The `module.{method}` call provides the method name. Both values are extracted by the AST crawler and stored in `reflection_rpc_functions`.
+
+The `DISPATCHERS` dict in each subdomain `__init__.py` and the `HANDLERS` dict in each domain `__init__.py` are also parsed by name using AST analysis. These dicts must use exactly those names.
+
+Refer to `scripts/seed_rpcdispatch.py` (`parse_service_module_metadata`, `parse_dict_keys`) and `scripts/common.py` (`parse_dispatchers`) for the crawler implementations.
+
 ## Anti-Patterns To Avoid
 
 - Do **not** embed database access in RPC services—delegate to modules instead.


### PR DESCRIPTION
### Motivation

- Provide explicit, machine-oriented documentation for naming contracts the code-generation AST crawler expects so authoring mistakes do not break binding generation. 
- Surface the exact token-level requirements for service-local `module` variables and the required `DISPATCHERS`/`HANDLERS` dict names used by `scripts/seed_rpcdispatch.py` and `scripts/common.py`.

### Description

- Add a new `PATTERNS.md` file containing a top-level `0. Mechanical Automation Contracts` section that documents the `module` local-variable pattern and the `DISPATCHERS`/`HANDLERS` naming contracts. 
- Insert a matching `Mechanical Automation Contracts` section into `rpc/AGENTS.md` after `Payload Contracts` and before `Anti-Patterns To Avoid` that references `parse_service_module_metadata`, `parse_dict_keys`, and `parse_dispatchers` for the AST crawler behavior. 
- Clarify that `request.app.state.{attr}` yields the ModuleManager registration name and `module.{method}` yields the method name used to populate `reflection_rpc_functions`. 
- This change is documentation-only and does not modify application source code or runtime behavior. 

### Testing

- Ran repository checks: `git status --short` which completed successfully. 
- Verified the produced diff with `git diff -- PATTERNS.md rpc/AGENTS.md` which completed successfully. 
- No unit test suite (`python scripts/run_tests.py` / `pytest`) was executed as part of this documentation change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc5319f77c8325ac45a2ff2307f45b)