### PR TITLE
Add reflection EDT QueryRegistry subdomain and rpcdispatch module accessor

### DIFF
--- a/queryregistry/reflection/edt/__init__.py
+++ b/queryregistry/reflection/edt/__init__.py
@@ -1,0 +1,11 @@
+"""Reflection EDT query registry request builders."""
+
+from __future__ import annotations
+
+from queryregistry.models import DBRequest
+
+__all__ = ["list_edt_mappings_request"]
+
+
+def list_edt_mappings_request() -> DBRequest:
+  return DBRequest(op="db:reflection:edt:list:1", payload={})

--- a/queryregistry/reflection/edt/handler.py
+++ b/queryregistry/reflection/edt/handler.py
@@ -1,0 +1,32 @@
+"""Reflection EDT handler implementations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from queryregistry.dispatch import dispatch_subdomain_request
+from queryregistry.models import DBRequest, DBResponse
+
+from .services import list_edt_v1
+from ..dispatch import SubdomainDispatcher
+
+__all__ = ["handle_edt_request"]
+
+DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
+  ("list", "1"): list_edt_v1,
+}
+
+
+async def handle_edt_request(
+  path: Sequence[str],
+  request: DBRequest,
+  *,
+  provider: str,
+) -> DBResponse:
+  return await dispatch_subdomain_request(
+    path,
+    request,
+    provider=provider,
+    dispatchers=DISPATCHERS,
+    detail="Unknown reflection edt operation",
+  )

--- a/queryregistry/reflection/edt/models.py
+++ b/queryregistry/reflection/edt/models.py
@@ -1,0 +1,1 @@
+"""Pydantic models for reflection EDT query parameters."""

--- a/queryregistry/reflection/edt/mssql.py
+++ b/queryregistry/reflection/edt/mssql.py
@@ -1,0 +1,21 @@
+"""MSSQL implementations for reflection EDT query registry services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from queryregistry.models import DBResponse
+from queryregistry.providers.mssql import run_json_many
+
+__all__ = ["list_edt_v1"]
+
+
+async def list_edt_v1(_: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT recid, element_name
+    FROM system_edt_mappings
+    ORDER BY recid
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
+  """
+  return await run_json_many(sql)

--- a/queryregistry/reflection/edt/services.py
+++ b/queryregistry/reflection/edt/services.py
@@ -1,0 +1,28 @@
+"""Reflection EDT query registry service dispatchers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from queryregistry.models import DBRequest, DBResponse
+
+from . import mssql
+
+__all__ = ["list_edt_v1"]
+
+_Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+
+_LIST_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_edt_v1}
+
+
+def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
+  dispatcher = dispatchers.get(provider)
+  if dispatcher is None:
+    raise KeyError(f"Unsupported provider '{provider}' for reflection edt registry")
+  return dispatcher
+
+
+async def list_edt_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  result = await _select_dispatcher(provider, _LIST_DISPATCHERS)(request.payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)

--- a/queryregistry/reflection/handler.py
+++ b/queryregistry/reflection/handler.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 from queryregistry.models import DBRequest, DBResponse
 
 from .data.handler import handle_data_request
+from .edt.handler import handle_edt_request
 from .schema.handler import handle_schema_request
 
 __all__ = ["handle_reflection_request"]
@@ -16,6 +17,7 @@ __all__ = ["handle_reflection_request"]
 HANDLERS = {
   "schema": handle_schema_request,
   "data": handle_data_request,
+  "edt": handle_edt_request,
 }
 
 

--- a/server/modules/rpcdispatch_module.py
+++ b/server/modules/rpcdispatch_module.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 
 from queryregistry.reflection.data import dump_table_request, get_version_request, query_info_schema_request
 from queryregistry.reflection.data.models import DumpTableParams, QueryInfoSchemaParams
+from queryregistry.reflection.edt import list_edt_mappings_request
 from queryregistry.reflection.schema import (
   get_full_schema_request,
   list_columns_request,
@@ -192,6 +193,12 @@ class RpcdispatchModule(BaseModule):
     if self.db is None:
       raise RuntimeError("rpcdispatch module requires db module")
     result = await self.db.run(list_model_fields_request())
+    return [dict(row) for row in (result.rows or [])]
+
+  async def list_edt_mappings(self) -> list[dict[str, Any]]:
+    if self.db is None:
+      raise RuntimeError("rpcdispatch module requires db module")
+    result = await self.db.run(list_edt_mappings_request())
     return [dict(row) for row in (result.rows or [])]
 
   async def list_tables(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
### Motivation

- Expose database-driven EDT mappings so clients can fetch EDT `recid → element_name` dynamically instead of relying on hand-maintained frontend dictionaries.
- Provide a canonical QR subdomain for `system_edt_mappings` following existing QueryRegistry dispatch patterns so modules can call the DB operation `db:reflection:edt:list:1`.

### Description

- Added a new QueryRegistry subdomain package at `queryregistry/reflection/edt/` with the standard files: request builder (`list_edt_mappings_request()`), `models.py` placeholder, `handler.py`, `services.py`, and `mssql.py` implementing the SQL.
- Implemented the MSSQL provider function `list_edt_v1` which runs the query:
  `SELECT recid, element_name FROM system_edt_mappings ORDER BY recid FOR JSON PATH, INCLUDE_NULL_VALUES;` and returns a `DBResponse`.
- Registered the new `edt` subdomain in `queryregistry/reflection/handler.py` and added a module-level accessor `list_edt_mappings()` to `RpcdispatchModule` with an import of `list_edt_mappings_request` in `server/modules/rpcdispatch_module.py`.
- Followed existing QR/service/handler patterns and did not add any RPC-layer code or modify other QR operations.

### Testing

- Ran the unified test harness `python scripts/run_tests.py --test` and the run completed successfully with the test suite passing (40 passed, 1 warning).
- Codegen and frontend generation steps executed as part of the harness with no failures reported during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdad2cb2e4832584312e1f98aa607b)