### PR TITLE
Add frontend_pages migration and list_frontend_pages QR operation

### DIFF
--- a/migrations/v0.11.9.0_frontend_pages_registry.sql
+++ b/migrations/v0.11.9.0_frontend_pages_registry.sql
@@ -1,0 +1,150 @@
+-- ==========================================================================
+-- TheOracleRPC v0.11.9.0 Frontend Pages Registry
+-- Date: 2026-04-02
+-- Purpose:
+--   1. Create frontend_pages table for route-to-component mapping
+--   2. Register frontend_pages in system schema reflection tables
+--   3. Seed canonical frontend page route data
+-- ============================================================================
+
+IF OBJECT_ID(N'dbo.frontend_pages', N'U') IS NULL
+BEGIN
+  CREATE TABLE [dbo].[frontend_pages] (
+    [recid] BIGINT IDENTITY(1,1) NOT NULL,
+    [element_path] NVARCHAR(512) NOT NULL,
+    [element_component] NVARCHAR(256) NOT NULL,
+    [element_sequence] INT NOT NULL CONSTRAINT [DF_frontend_pages_element_sequence] DEFAULT ((0)),
+    [element_created_on] DATETIMEOFFSET(7) NOT NULL CONSTRAINT [DF_frontend_pages_element_created_on] DEFAULT (SYSUTCDATETIME()),
+    [element_modified_on] DATETIMEOFFSET(7) NOT NULL CONSTRAINT [DF_frontend_pages_element_modified_on] DEFAULT (SYSUTCDATETIME()),
+    CONSTRAINT [PK_frontend_pages] PRIMARY KEY CLUSTERED ([recid] ASC)
+  );
+END;
+GO
+
+IF NOT EXISTS (
+  SELECT 1
+  FROM sys.indexes
+  WHERE name = N'UQ_frontend_pages_element_path'
+    AND object_id = OBJECT_ID(N'dbo.frontend_pages')
+)
+BEGIN
+  CREATE UNIQUE NONCLUSTERED INDEX [UQ_frontend_pages_element_path]
+    ON [dbo].[frontend_pages] ([element_path] ASC);
+END;
+GO
+
+INSERT INTO dbo.system_schema_tables (element_name, element_schema)
+SELECT 'frontend_pages', 'dbo'
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM dbo.system_schema_tables
+  WHERE element_name = 'frontend_pages' AND element_schema = 'dbo'
+);
+GO
+
+DECLARE @t_frontend_pages BIGINT = (
+  SELECT recid
+  FROM dbo.system_schema_tables
+  WHERE element_name = 'frontend_pages' AND element_schema = 'dbo'
+);
+
+INSERT INTO dbo.system_schema_columns
+  (tables_recid, edt_recid, element_name, element_ordinal, element_nullable, element_default, element_max_length, element_is_primary_key, element_is_identity)
+SELECT @t_frontend_pages, 3, 'recid', 1, 0, NULL, NULL, 1, 1
+WHERE NOT EXISTS (
+  SELECT 1 FROM dbo.system_schema_columns WHERE tables_recid = @t_frontend_pages AND element_name = 'recid'
+);
+
+INSERT INTO dbo.system_schema_columns
+  (tables_recid, edt_recid, element_name, element_ordinal, element_nullable, element_default, element_max_length, element_is_primary_key, element_is_identity)
+SELECT @t_frontend_pages, 8, 'element_path', 2, 0, NULL, 512, 0, 0
+WHERE NOT EXISTS (
+  SELECT 1 FROM dbo.system_schema_columns WHERE tables_recid = @t_frontend_pages AND element_name = 'element_path'
+);
+
+INSERT INTO dbo.system_schema_columns
+  (tables_recid, edt_recid, element_name, element_ordinal, element_nullable, element_default, element_max_length, element_is_primary_key, element_is_identity)
+SELECT @t_frontend_pages, 8, 'element_component', 3, 0, NULL, 256, 0, 0
+WHERE NOT EXISTS (
+  SELECT 1 FROM dbo.system_schema_columns WHERE tables_recid = @t_frontend_pages AND element_name = 'element_component'
+);
+
+INSERT INTO dbo.system_schema_columns
+  (tables_recid, edt_recid, element_name, element_ordinal, element_nullable, element_default, element_max_length, element_is_primary_key, element_is_identity)
+SELECT @t_frontend_pages, 1, 'element_sequence', 4, 0, '((0))', NULL, 0, 0
+WHERE NOT EXISTS (
+  SELECT 1 FROM dbo.system_schema_columns WHERE tables_recid = @t_frontend_pages AND element_name = 'element_sequence'
+);
+
+INSERT INTO dbo.system_schema_columns
+  (tables_recid, edt_recid, element_name, element_ordinal, element_nullable, element_default, element_max_length, element_is_primary_key, element_is_identity)
+SELECT @t_frontend_pages, 7, 'element_created_on', 5, 0, '(sysutcdatetime())', NULL, 0, 0
+WHERE NOT EXISTS (
+  SELECT 1 FROM dbo.system_schema_columns WHERE tables_recid = @t_frontend_pages AND element_name = 'element_created_on'
+);
+
+INSERT INTO dbo.system_schema_columns
+  (tables_recid, edt_recid, element_name, element_ordinal, element_nullable, element_default, element_max_length, element_is_primary_key, element_is_identity)
+SELECT @t_frontend_pages, 7, 'element_modified_on', 6, 0, '(sysutcdatetime())', NULL, 0, 0
+WHERE NOT EXISTS (
+  SELECT 1 FROM dbo.system_schema_columns WHERE tables_recid = @t_frontend_pages AND element_name = 'element_modified_on'
+);
+GO
+
+DECLARE @t_frontend_pages BIGINT = (
+  SELECT recid
+  FROM dbo.system_schema_tables
+  WHERE element_name = 'frontend_pages' AND element_schema = 'dbo'
+);
+
+INSERT INTO dbo.system_schema_indexes (tables_recid, element_name, element_columns, element_is_unique)
+SELECT @t_frontend_pages, 'PK_frontend_pages', 'recid', 1
+WHERE NOT EXISTS (
+  SELECT 1 FROM dbo.system_schema_indexes WHERE tables_recid = @t_frontend_pages AND element_name = 'PK_frontend_pages'
+);
+
+INSERT INTO dbo.system_schema_indexes (tables_recid, element_name, element_columns, element_is_unique)
+SELECT @t_frontend_pages, 'UQ_frontend_pages_element_path', 'element_path', 1
+WHERE NOT EXISTS (
+  SELECT 1 FROM dbo.system_schema_indexes WHERE tables_recid = @t_frontend_pages AND element_name = 'UQ_frontend_pages_element_path'
+);
+GO
+
+INSERT INTO dbo.frontend_pages (element_path, element_component, element_sequence)
+SELECT src.element_path, src.element_component, src.element_sequence
+FROM (VALUES
+  ('/', 'Home', 10),
+  ('/gallery', 'Gallery', 20),
+  ('/loginpage', 'LoginPage', 30),
+  ('/userpage', 'UserPage', 40),
+  ('/products', 'ProductsPage', 50),
+  ('/file-manager', 'FileManager', 60),
+  ('/account-users', 'AccountUsersPage', 100),
+  ('/account-users/:guid', 'AccountUserPanel', 110),
+  ('/account-roles', 'AccountRolesPage', 120),
+  ('/finance-acct', 'finance/FinanceAccountantPage', 200),
+  ('/finance-appr', 'finance/FinanceManagerPage', 210),
+  ('/finance-admin', 'finance/FinanceAdminPage', 220),
+  ('/discord-personas', 'DiscordPersonasPage', 300),
+  ('/discord-guilds', 'DiscordGuildsPage', 310),
+  ('/system-config', 'system/SystemConfigPage', 400),
+  ('/system-models', 'system/SystemModelsPage', 410),
+  ('/system-conversations', 'system/SystemConversationsPage', 420),
+  ('/system-workflows', 'system/SystemWorkflowsPage', 430),
+  ('/service-routes', 'service/ServiceRoutesPage', 500),
+  ('/service-pages', 'service/ServicePagesPage', 510),
+  ('/service-roles', 'service/ServiceRolesPage', 520),
+  ('/service-renewals', 'service/ServiceRenewalsPage', 530),
+  ('/service-visualization', 'service/ServiceVisualizationPage', 540),
+  ('/service-rpcdispatch', 'service/ServiceRpcDispatchPage', 550),
+  ('/service-rpcdispatch-tree', 'service/ServiceRpcDispatchTreePage', 560),
+  ('/profile/:guid', 'PublicProfile', 600),
+  ('/pages/:slug', 'ContentPage', 700),
+  ('/wiki/*', 'WikiPage', 800)
+) AS src(element_path, element_component, element_sequence)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM dbo.frontend_pages fp
+  WHERE fp.element_path = src.element_path
+);
+GO

--- a/queryregistry/system/public/__init__.py
+++ b/queryregistry/system/public/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
   "get_home_links_request",
   "get_navbar_routes_request",
   "get_routes_request",
+  "list_frontend_pages_request",
   "upsert_route_request",
 ]
 
@@ -28,6 +29,10 @@ def get_navbar_routes_request(role_mask: int | None = None) -> DBRequest:
 
 def get_routes_request() -> DBRequest:
   return DBRequest(op="db:system:public:get_routes:1", payload={})
+
+
+def list_frontend_pages_request() -> DBRequest:
+  return DBRequest(op="db:system:public:list_frontend_pages:1", payload={})
 
 
 def upsert_route_request(params: UpsertRouteParams) -> DBRequest:

--- a/queryregistry/system/public/handler.py
+++ b/queryregistry/system/public/handler.py
@@ -12,6 +12,7 @@ from .services import (
   get_home_links_v1,
   get_navbar_routes_v1,
   get_routes_v1,
+  list_frontend_pages_v1,
   upsert_route_v1,
 )
 from ..dispatch import SubdomainDispatcher
@@ -22,6 +23,7 @@ DISPATCHERS: dict[tuple[str, str], SubdomainDispatcher] = {
   ("get_home_links", "1"): get_home_links_v1,
   ("get_navbar_routes", "1"): get_navbar_routes_v1,
   ("get_routes", "1"): get_routes_v1,
+  ("list_frontend_pages", "1"): list_frontend_pages_v1,
   ("upsert_route", "1"): upsert_route_v1,
   ("delete_route", "1"): delete_route_v1,
 }

--- a/queryregistry/system/public/mssql.py
+++ b/queryregistry/system/public/mssql.py
@@ -14,6 +14,7 @@ __all__ = [
   "get_home_links",
   "get_navbar_routes",
   "get_routes_v1",
+  "list_frontend_pages_v1",
   "upsert_route_v1",
 ]
 
@@ -76,6 +77,16 @@ async def get_routes_v1(_: Mapping[str, Any]) -> DBResponse:
     FROM frontend_routes
     ORDER BY element_sequence
     FOR JSON PATH;
+  """
+  return await run_json_many(sql)
+
+
+async def list_frontend_pages_v1(_: Mapping[str, Any]) -> DBResponse:
+  sql = """
+    SELECT element_path, element_component, element_sequence
+    FROM frontend_pages
+    ORDER BY element_sequence
+    FOR JSON PATH, INCLUDE_NULL_VALUES;
   """
   return await run_json_many(sql)
 

--- a/queryregistry/system/public/services.py
+++ b/queryregistry/system/public/services.py
@@ -15,6 +15,7 @@ __all__ = [
   "get_home_links_v1",
   "get_navbar_routes_v1",
   "get_routes_v1",
+  "list_frontend_pages_v1",
   "upsert_route_v1",
 ]
 
@@ -23,6 +24,7 @@ _Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
 _HOME_LINKS_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_home_links}
 _NAVBAR_ROUTES_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_navbar_routes}
 _GET_ROUTES_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.get_routes_v1}
+_LIST_FRONTEND_PAGES_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.list_frontend_pages_v1}
 _UPSERT_ROUTE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.upsert_route_v1}
 _DELETE_ROUTE_DISPATCHERS: dict[str, _Dispatcher] = {"mssql": mssql.delete_route_v1}
 
@@ -46,6 +48,11 @@ async def get_navbar_routes_v1(request: DBRequest, *, provider: str) -> DBRespon
 
 async def get_routes_v1(request: DBRequest, *, provider: str) -> DBResponse:
   result = await _select_dispatcher(provider, _GET_ROUTES_DISPATCHERS)(request.payload)
+  return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
+
+
+async def list_frontend_pages_v1(request: DBRequest, *, provider: str) -> DBResponse:
+  result = await _select_dispatcher(provider, _LIST_FRONTEND_PAGES_DISPATCHERS)(request.payload)
   return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
 
 

--- a/server/modules/service_routes_module.py
+++ b/server/modules/service_routes_module.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from queryregistry.system.public import (
   delete_route_request,
   get_routes_request,
+  list_frontend_pages_request,
   upsert_route_request,
 )
 from queryregistry.system.public.models import RoutePathParams, UpsertRouteParams
@@ -61,6 +62,12 @@ class ServiceRoutesModule(BaseModule):
       len(routes),
     )
     return routes
+
+  async def list_frontend_pages(self) -> list[dict]:
+    if not self.db:
+      raise RuntimeError("ServiceRoutesModule not ready")
+    res = await self.db.run(list_frontend_pages_request())
+    return [dict(row) for row in (res.rows or [])]
 
   async def upsert_route(
     self,


### PR DESCRIPTION
### Motivation
- Introduce a data-driven frontend page registry so route→component mappings can be generated from the database instead of being hardcoded in `App.tsx`.
- Provide a QueryRegistry endpoint and module accessor for the generator script to read the canonical page list.

### Description
- Add migration `migrations/v0.11.9.0_frontend_pages_registry.sql` which creates `dbo.frontend_pages`, a unique index on `element_path`, registers the table/columns/indexes in the reflection tables (`system_schema_tables`, `system_schema_columns`, `system_schema_indexes`) using hardcoded EDT IDs, and seeds the canonical set of page rows. 
- Add MSSQL QueryRegistry implementation `list_frontend_pages_v1` in `queryregistry/system/public/mssql.py` that returns `element_path`, `element_component`, and `element_sequence` ordered by sequence via `FOR JSON PATH, INCLUDE_NULL_VALUES`.
- Wire the operation through the QR layer by adding `_LIST_FRONTEND_PAGES_DISPATCHERS`, service function `list_frontend_pages_v1` in `queryregistry/system/public/services.py`, registering `("list_frontend_pages","1")` in `queryregistry/system/public/handler.py`, and adding the request builder `list_frontend_pages_request()` in `queryregistry/system/public/__init__.py`.
- Add `ServiceRoutesModule.list_frontend_pages()` in `server/modules/service_routes_module.py` which runs `list_frontend_pages_request()` via `self.db.run(...)` and returns a `list[dict]`.

### Testing
- Ran the unified harness `python scripts/run_tests.py --test` and all tests passed (40 passed, 1 warning). 
- Executed a quick smoke check for the request builder with `from queryregistry.system.public import list_frontend_pages_request` and verified the request op/payload is `db:system:public:list_frontend_pages:1` and `{}`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdbb84ef448325bfc6f3b208ad9e6a)