### PR TITLE
Install ODBC drivers in Docker builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,17 @@
 # ────────────────────────────────────────────────────────────────────────────────
 FROM node:22 AS builder
 
-RUN apt-get update && apt-get install -y python3 python3-pip python3-venv
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv \
+    curl gnupg2 ca-certificates apt-transport-https
+
+RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+      | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" \
+      > /etc/apt/sources.list.d/mssql-release.list
+
+RUN apt-get update \
+ && ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc libodbc2 \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 COPY requirements.txt ./


### PR DESCRIPTION
### Motivation
- Ensure the Python generator `generate_nav_pages.py` can connect via `pyodbc` during the multi-stage Docker build so the frontend route registry is generated instead of being skipped.
- The runtime stage already installs ODBC drivers; the builder stage must mirror the driver install so code-generation step in the `node:22 AS builder` stage has required system deps.
- Keep the runtime stage unchanged and avoid altering generator `RUN` lines or other files.

### Description
- Updated `Dockerfile` builder stage to add apt prerequisites: `curl`, `gnupg2`, `ca-certificates`, and `apt-transport-https` before any Python scripts run.
- Added Microsoft package signing key and Debian 12 repo registration in the builder stage and installed `msodbcsql18`, `unixodbc`, and `libodbc2`, then cleaned apt lists.
- Placed the new installation steps before the generator `RUN` lines and modified only `Dockerfile`, leaving the runtime stage and generator ordering intact.

### Testing
- Attempted `docker build --target builder -t test-builder .`, but the build could not be executed in this environment because the Docker CLI is not available (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdf2d186808325a13715d95d897dca)