### PR TITLE
Fix CI workflows ordering and pass AZURE_SQL_CONNECTION_STRING into Docker builds

### DIFF
--- a/.github/workflows/main_elideus-group.yml
+++ b/.github/workflows/main_elideus-group.yml
@@ -40,10 +40,6 @@ jobs:
         cd frontend
         npm ci
 
-    - name: Generate RPC bindings
-      run: |
-        python scripts/generate_rpc_bindings.py
-
     - name: Install MSSQL ODBC Driver
       run: |
         sudo apt-get update
@@ -52,6 +48,12 @@ jobs:
         echo "deb [signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" | sudo tee /etc/apt/sources.list.d/mssql-release.list
         sudo apt-get update
         sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
+
+    - name: Generate bindings and namespaces
+      run: |
+        python scripts/generate_rpc_bindings.py
+        python scripts/generate_db_namespace.py
+        python scripts/generate_nav_pages.py
 
     - name: Run tests
       run: python scripts/run_tests.py
@@ -72,6 +74,8 @@ jobs:
         push: true
         tags: elideus.azurecr.io/${{ secrets.AzureAppService_ContainerUsername_1e20f41167eb4d19983f94f5f4509ac8 }}/elideus-group:${{ github.sha }}
         file: ./Dockerfile
+        build-args: |
+          AZURE_SQL_CONNECTION_STRING=${{ secrets.AZURE_SQL_CONNECTION_STRING }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -35,6 +35,15 @@ jobs:
         cd frontend
         npm ci
 
+    - name: Install MSSQL ODBC Driver
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y curl gnupg2 apt-transport-https ca-certificates unixodbc libodbc2
+        curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /usr/share/keyrings/microsoft-prod.gpg > /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" | sudo tee /etc/apt/sources.list.d/mssql-release.list
+        sudo apt-get update
+        sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
+
     - name: Generate bindings and namespaces
       run: |
         python scripts/generate_rpc_bindings.py

--- a/.github/workflows/test_elideus-group-test.yml
+++ b/.github/workflows/test_elideus-group-test.yml
@@ -40,10 +40,6 @@ jobs:
         cd frontend
         npm ci
 
-    - name: Generate RPC bindings
-      run: |
-        python scripts/generate_rpc_bindings.py
-
     - name: Install MSSQL ODBC Driver
       run: |
         sudo apt-get update
@@ -52,6 +48,12 @@ jobs:
         echo "deb [signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" | sudo tee /etc/apt/sources.list.d/mssql-release.list
         sudo apt-get update
         sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
+
+    - name: Generate bindings and namespaces
+      run: |
+        python scripts/generate_rpc_bindings.py
+        python scripts/generate_db_namespace.py
+        python scripts/generate_nav_pages.py
 
     - name: Run tests
       run: python scripts/run_tests.py
@@ -72,6 +74,8 @@ jobs:
         push: true
         tags: elideus.azurecr.io/${{ secrets.AzureAppService_ContainerUsername_375ace388d15453497189874787dd593 }}/elideus-group-test:${{ github.sha }}
         file: ./Dockerfile
+        build-args: |
+          AZURE_SQL_CONNECTION_STRING=${{ secrets.AZURE_SQL_CONNECTION_STRING_DEV }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN python3 -m venv $VIRTUAL_ENV \
  && $VIRTUAL_ENV/bin/pip install --upgrade pip \
  && $VIRTUAL_ENV/bin/pip install -r requirements.txt
 
+ARG AZURE_SQL_CONNECTION_STRING=""
+ENV AZURE_SQL_CONNECTION_STRING=$AZURE_SQL_CONNECTION_STRING
+
 COPY . .
 
 RUN python3 scripts/generate_rpc_bindings.py


### PR DESCRIPTION
### Motivation

- Generator scripts (`generate_nav_pages.py` and friends) ran before the MSSQL ODBC driver was installed in CI, causing DB-dependent generation to fall back to empty outputs. 
- The `docker build` stage did not receive the `AZURE_SQL_CONNECTION_STRING` from the runner, so build-time generation inside the builder stage could not connect to the database. 
- Deploy workflows only invoked `generate_rpc_bindings.py` and missed `generate_db_namespace.py` and `generate_nav_pages.py`, so generated inputs for the frontend were incomplete.

### Description

- Inserted an `Install MSSQL ODBC Driver` step to run immediately after `Install Node dependencies` in `pr-tests.yml`, and moved the existing ODBC install in deploy workflows so it runs before any generator or test steps. 
- Replaced the single-script generator step in `main_elideus-group.yml` and `test_elideus-group-test.yml` with a `Generate bindings and namespaces` step that runs `python scripts/generate_rpc_bindings.py`, `python scripts/generate_db_namespace.py`, and `python scripts/generate_nav_pages.py`. 
- Added `build-args` to the `docker/build-push-action` steps in both deploy workflows to pass `AZURE_SQL_CONNECTION_STRING` into `docker build`, and updated the builder stage of the `Dockerfile` to declare `ARG AZURE_SQL_CONNECTION_STRING` and export it via `ENV AZURE_SQL_CONNECTION_STRING` before copying sources and running generators. 
- Modified files: `.github/workflows/pr-tests.yml`, `.github/workflows/main_elideus-group.yml`, `.github/workflows/test_elideus-group-test.yml`, and `Dockerfile`.

### Testing

- Ran `git diff --check` and verified there are no whitespace or diff-check issues (success). 
- Attempted to parse the workflows with a quick YAML load but the helper failed due to missing `PyYAML` in the environment (`ModuleNotFoundError: No module named 'yaml'`), so full YAML validation could not be performed here. 
- Verified the modified workflow fragments are syntactically consistent by inspecting the updated files manually in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb9d4494483258599b41647119d6d)