### PR TITLE
Add service.reflection EDT endpoint and dynamic EDT/domain frontend wiring

### DIFF
--- a/frontend/src/pages/service/ServiceRpcDispatchPage.tsx
+++ b/frontend/src/pages/service/ServiceRpcDispatchPage.tsx
@@ -34,20 +34,7 @@ import {
     fetchListModels,
     fetchListSubdomains,
 } from '../../rpc/service/rpcdispatch/index';
-
-const EDT_NAME_BY_RECID: Record<number, string> = {
-    1: 'INT32',
-    2: 'INT64',
-    3: 'INT64_IDENTITY',
-    4: 'UUID',
-    5: 'BOOL',
-    7: 'DATETIME_TZ',
-    8: 'STRING',
-    9: 'TEXT',
-    11: 'INT8',
-    12: 'DATE',
-    13: 'DECIMAL_19_5',
-};
+import { fetchListEdtMappings } from '../../rpc/service/reflection';
 
 const boolChip = (value: boolean): JSX.Element =>
     value ? <Chip label="Yes" color="success" size="small" /> : <Chip label="No" size="small" />;
@@ -71,6 +58,7 @@ const ServiceRpcDispatchPage = (): JSX.Element => {
     const [functions, setFunctions] = useState<ServiceRpcdispatchFunctionItem1[]>([]);
     const [models, setModels] = useState<ServiceRpcdispatchModelItem1[]>([]);
     const [fields, setFields] = useState<ServiceRpcdispatchModelFieldItem1[]>([]);
+    const [edtMappings, setEdtMappings] = useState<Record<number, string>>({});
 
     const [loading, setLoading] = useState(false);
 
@@ -139,7 +127,19 @@ const ServiceRpcDispatchPage = (): JSX.Element => {
     const loadAll = useCallback(async (): Promise<void> => {
         setLoading(true);
         try {
-            await Promise.all([loadDomains(), loadSubdomains(), loadFunctions(), loadModels(), loadModelFields()]);
+            const [, , , , , edtRes] = await Promise.all([
+                loadDomains(),
+                loadSubdomains(),
+                loadFunctions(),
+                loadModels(),
+                loadModelFields(),
+                fetchListEdtMappings() as Promise<{ mappings: { recid: number; element_name: string }[] }>,
+            ]);
+            const edtMap: Record<number, string> = {};
+            for (const row of edtRes.mappings ?? []) {
+                edtMap[row.recid] = row.element_name;
+            }
+            setEdtMappings(edtMap);
         } finally {
             setLoading(false);
         }
@@ -359,7 +359,7 @@ const ServiceRpcDispatchPage = (): JSX.Element => {
                                         <TableCell>{modelGuidMap.get(row.models_guid) ?? `#${row.models_guid}`}</TableCell>
                                         <TableCell>
                                             {row.element_edt_recid
-                                                ? EDT_NAME_BY_RECID[row.element_edt_recid] ?? `#${row.element_edt_recid}`
+                                                ? edtMappings[row.element_edt_recid] ?? `#${row.element_edt_recid}`
                                                 : '—'}
                                         </TableCell>
                                         <TableCell>{boolChip(row.element_is_nullable)}</TableCell>

--- a/frontend/src/pages/service/ServiceRpcDispatchTreePage.tsx
+++ b/frontend/src/pages/service/ServiceRpcDispatchTreePage.tsx
@@ -23,24 +23,13 @@ import {
     fetchListModels,
     fetchListSubdomains,
 } from '../../rpc/service/rpcdispatch/index';
+import { fetchListEdtMappings } from '../../rpc/service/reflection';
 
-const EDT_NAMES: Record<number, string> = {
-    1: 'INT32',
-    2: 'INT64',
-    3: 'INT64_IDENTITY',
-    4: 'UUID',
-    5: 'BOOL',
-    7: 'DATETIME_TZ',
-    8: 'STRING',
-    9: 'TEXT',
-    11: 'INT8',
-    12: 'DATE',
-    13: 'DECIMAL_19_5',
-    14: 'DECIMAL_28_12',
-    15: 'JSON',
-};
-
-function describeFieldType(field: ServiceRpcdispatchModelFieldItem1, modelMap: Map<string, string>): string {
+function describeFieldType(
+    field: ServiceRpcdispatchModelFieldItem1,
+    modelMap: Map<string, string>,
+    edtMappings: Record<number, string>,
+): string {
     const parts: string[] = [];
 
     if (field.element_ref_model_guid) {
@@ -53,7 +42,7 @@ function describeFieldType(field: ServiceRpcdispatchModelFieldItem1, modelMap: M
     } else if (field.element_is_dict) {
         parts.push(field.element_is_list ? 'list[dict]' : 'JSON');
     } else if (field.element_edt_recid) {
-        const edtName = EDT_NAMES[field.element_edt_recid] ?? `EDT#${field.element_edt_recid}`;
+        const edtName = edtMappings[field.element_edt_recid] ?? `EDT#${field.element_edt_recid}`;
         if (field.element_is_list) {
             parts.push(`list[${edtName}]`);
         } else {
@@ -88,6 +77,7 @@ const ServiceRpcDispatchTreePage = (): JSX.Element => {
     const [functions, setFunctions] = useState<ServiceRpcdispatchFunctionItem1[]>([]);
     const [models, setModels] = useState<ServiceRpcdispatchModelItem1[]>([]);
     const [fields, setFields] = useState<ServiceRpcdispatchModelFieldItem1[]>([]);
+    const [edtMappings, setEdtMappings] = useState<Record<number, string>>({});
 
     const [expandedItems, setExpandedItems] = useState<string[]>([]);
 
@@ -101,12 +91,13 @@ const ServiceRpcDispatchTreePage = (): JSX.Element => {
     const loadAll = useCallback(async (): Promise<void> => {
         setLoading(true);
         try {
-            const [domainRes, subdomainRes, functionRes, modelRes, fieldRes] = await Promise.all([
+            const [domainRes, subdomainRes, functionRes, modelRes, fieldRes, edtRes] = await Promise.all([
                 fetchListDomains() as Promise<ServiceRpcdispatchDomainList1 & { domains: ServiceRpcdispatchDomainItem1[] }>,
                 fetchListSubdomains() as Promise<ServiceRpcdispatchSubdomainList1 & { subdomains: ServiceRpcdispatchSubdomainItem1[] }>,
                 fetchListFunctions() as Promise<ServiceRpcdispatchFunctionList1 & { functions: ServiceRpcdispatchFunctionItem1[] }>,
                 fetchListModels() as Promise<ServiceRpcdispatchModelList1 & { models: ServiceRpcdispatchModelItem1[] }>,
                 fetchListModelFields() as Promise<ServiceRpcdispatchModelFieldList1 & { fields: ServiceRpcdispatchModelFieldItem1[] }>,
+                fetchListEdtMappings() as Promise<{ mappings: { recid: number; element_name: string }[] }>,
             ]);
 
             const nextDomains = (domainRes.domains || []) as ServiceRpcdispatchDomainItem1[];
@@ -119,6 +110,11 @@ const ServiceRpcDispatchTreePage = (): JSX.Element => {
             setFunctions(nextFunctions);
             setModels(nextModels);
             setFields(nextFields);
+            const edtMap: Record<number, string> = {};
+            for (const row of edtRes.mappings ?? []) {
+                edtMap[row.recid] = row.element_name;
+            }
+            setEdtMappings(edtMap);
             setForbidden(false);
             setExpandedItems(nextDomains.map((domain) => `domain-${domain.recid}`));
         } catch (error: any) {
@@ -321,7 +317,7 @@ const ServiceRpcDispatchTreePage = (): JSX.Element => {
                                                                         sx={treeItemSx}
                                                                         label={
                                                                             <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-                                                                                <Typography variant="body2">{field.element_name}: {describeFieldType(field, modelNameByGuid)}</Typography>
+                                                                                <Typography variant="body2">{field.element_name}: {describeFieldType(field, modelNameByGuid, edtMappings)}</Typography>
                                                                                 {field.element_is_nullable && <Chip size="small" label="?" />}
                                                                                 {field.element_is_list && <Chip size="small" label="[]" />}
                                                                                 {field.element_is_dict && <Chip size="small" label="{}" />}
@@ -348,7 +344,7 @@ const ServiceRpcDispatchTreePage = (): JSX.Element => {
                                                                         sx={treeItemSx}
                                                                         label={
                                                                             <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-                                                                                <Typography variant="body2">{field.element_name}: {describeFieldType(field, modelNameByGuid)}</Typography>
+                                                                                <Typography variant="body2">{field.element_name}: {describeFieldType(field, modelNameByGuid, edtMappings)}</Typography>
                                                                                 {field.element_is_nullable && <Chip size="small" label="?" />}
                                                                                 {field.element_is_list && <Chip size="small" label="[]" />}
                                                                                 {field.element_is_dict && <Chip size="small" label="{}" />}

--- a/frontend/src/pages/service/ServiceVisualizationPage.tsx
+++ b/frontend/src/pages/service/ServiceVisualizationPage.tsx
@@ -21,24 +21,33 @@ interface DomainColor {
     glow: string;
 }
 
-const DOMAIN_COLORS: Record<string, DomainColor> = {
-    account: { fill: '#4CAF50', stroke: '#81C784', glow: 'rgba(76,175,80,0.5)' },
-    users: { fill: '#388E3C', stroke: '#66BB6A', glow: 'rgba(56,142,60,0.4)' },
-    sessions: { fill: '#2E7D32', stroke: '#4CAF50', glow: 'rgba(46,125,50,0.35)' },
-    auth: { fill: '#1B5E20', stroke: '#43A047', glow: 'rgba(27,94,32,0.35)' },
-    finance: { fill: '#BF8C2C', stroke: '#D4A845', glow: 'rgba(191,140,44,0.5)' },
-    system: { fill: '#1565C0', stroke: '#42A5F5', glow: 'rgba(21,101,192,0.4)' },
-    assistant: { fill: '#00838F', stroke: '#26C6DA', glow: 'rgba(0,131,143,0.4)' },
-    discord: { fill: '#5865F2', stroke: '#7983F5', glow: 'rgba(88,101,242,0.4)' },
-    frontend: { fill: '#6A1B9A', stroke: '#AB47BC', glow: 'rgba(106,27,154,0.4)' },
-    service: { fill: '#6A1B9A', stroke: '#AB47BC', glow: 'rgba(106,27,154,0.4)' },
-    storage: { fill: '#546E7A', stroke: '#90A4AE', glow: 'rgba(84,110,122,0.3)' },
-    builder: { fill: '#546E7A', stroke: '#90A4AE', glow: 'rgba(84,110,122,0.3)' },
-};
+const PALETTE: DomainColor[] = [
+    { fill: '#4CAF50', stroke: '#81C784', glow: 'rgba(76,175,80,0.5)' },
+    { fill: '#BF8C2C', stroke: '#D4A845', glow: 'rgba(191,140,44,0.5)' },
+    { fill: '#1565C0', stroke: '#42A5F5', glow: 'rgba(21,101,192,0.4)' },
+    { fill: '#00838F', stroke: '#26C6DA', glow: 'rgba(0,131,143,0.4)' },
+    { fill: '#5865F2', stroke: '#7983F5', glow: 'rgba(88,101,242,0.4)' },
+    { fill: '#6A1B9A', stroke: '#AB47BC', glow: 'rgba(106,27,154,0.4)' },
+    { fill: '#546E7A', stroke: '#90A4AE', glow: 'rgba(84,110,122,0.3)' },
+    { fill: '#C62828', stroke: '#EF5350', glow: 'rgba(198,40,40,0.4)' },
+    { fill: '#2E7D32', stroke: '#66BB6A', glow: 'rgba(46,125,50,0.4)' },
+    { fill: '#E65100', stroke: '#FF9800', glow: 'rgba(230,81,0,0.4)' },
+    { fill: '#1B5E20', stroke: '#43A047', glow: 'rgba(27,94,32,0.35)' },
+    { fill: '#4527A0', stroke: '#7E57C2', glow: 'rgba(69,39,160,0.4)' },
+    { fill: '#00695C', stroke: '#26A69A', glow: 'rgba(0,105,92,0.4)' },
+    { fill: '#AD1457', stroke: '#EC407A', glow: 'rgba(173,20,87,0.4)' },
+    { fill: '#37474F', stroke: '#78909C', glow: 'rgba(55,71,79,0.3)' },
+    { fill: '#827717', stroke: '#C0CA33', glow: 'rgba(130,119,23,0.4)' },
+];
 
-function getDomain(name: string): DomainColor {
+function buildDomainColorMap(tables: TableDef[]): Map<string, DomainColor> {
+    const domains = [...new Set(tables.map((table) => table.name.split('_')[0]))].sort();
+    return new Map(domains.map((domain, i) => [domain, PALETTE[i % PALETTE.length]]));
+}
+
+function getDomain(name: string, domainColorMap: Map<string, DomainColor>): DomainColor {
     const prefix = name.split('_')[0];
-    return DOMAIN_COLORS[prefix] ?? DOMAIN_COLORS.system;
+    return domainColorMap.get(prefix) ?? PALETTE[0];
 }
 
 interface GraphNode extends TableDef {
@@ -54,7 +63,11 @@ interface GraphNode extends TableDef {
     incoming: { source: number; col: string }[];
 }
 
-function buildGraph(tables: TableDef[], fks: FKDef[]): { nodes: GraphNode[]; edges: FKDef[] } {
+function buildGraph(
+    tables: TableDef[],
+    fks: FKDef[],
+    domainColorMap: Map<string, DomainColor>,
+): { nodes: GraphNode[]; edges: FKDef[] } {
     const refCount: Record<number, number> = {};
     tables.forEach((table) => {
         refCount[table.recid] = 0;
@@ -96,7 +109,7 @@ function buildGraph(tables: TableDef[], fks: FKDef[]): { nodes: GraphNode[]; edg
             y: cy + Math.sin(angle) * spread,
             vx: 0,
             vy: 0,
-            domain: getDomain(table.name),
+            domain: getDomain(table.name, domainColorMap),
             outgoing: outgoing[table.recid],
             incoming: incoming[table.recid],
         };
@@ -171,16 +184,6 @@ function simulate(nodes: GraphNode[], edges: FKDef[], iterations = 250): void {
     }
 }
 
-const LEGEND = [
-    { label: 'Account / Identity', color: DOMAIN_COLORS.account },
-    { label: 'Finance', color: DOMAIN_COLORS.finance },
-    { label: 'System', color: DOMAIN_COLORS.system },
-    { label: 'Assistant', color: DOMAIN_COLORS.assistant },
-    { label: 'Discord', color: DOMAIN_COLORS.discord },
-    { label: 'Frontend / Service', color: DOMAIN_COLORS.frontend },
-    { label: 'Storage / Builder', color: DOMAIN_COLORS.storage },
-];
-
 const ServiceVisualizationPage = (): JSX.Element => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const [hovered, setHovered] = useState<GraphNode | null>(null);
@@ -190,6 +193,7 @@ const ServiceVisualizationPage = (): JSX.Element => {
     const [loading, setLoading] = useState(true);
     const [tableCount, setTableCount] = useState(0);
     const [edgeCount, setEdgeCount] = useState(0);
+    const [domainColorMap, setDomainColorMap] = useState<Map<string, DomainColor>>(new Map());
     const graphRef = useRef<{ nodes: GraphNode[]; edges: FKDef[] } | null>(null);
     const panStart = useRef<{ mx: number; my: number; panX: number; panY: number } | null>(null);
     const dragOffset = useRef({ x: 0, y: 0 });
@@ -210,7 +214,9 @@ const ServiceVisualizationPage = (): JSX.Element => {
                     col: fk.element_column_name,
                 }));
 
-                const graph = buildGraph(tables, fks);
+                const colorMap = buildDomainColorMap(tables);
+                setDomainColorMap(colorMap);
+                const graph = buildGraph(tables, fks, colorMap);
                 simulate(graph.nodes, graph.edges);
                 graphRef.current = graph;
                 setTableCount(tables.length);
@@ -498,6 +504,10 @@ const ServiceVisualizationPage = (): JSX.Element => {
             byRecid[node.recid] = node;
         });
     }
+    const legend = Array.from(domainColorMap.entries()).map(([domain, color]) => ({
+        label: domain.charAt(0).toUpperCase() + domain.slice(1),
+        color,
+    }));
 
     if (loading) {
         return (
@@ -534,7 +544,7 @@ const ServiceVisualizationPage = (): JSX.Element => {
                     {tableCount} tables &middot; {edgeCount} relationships
                 </Typography>
                 <Box sx={{ ml: 'auto', display: 'flex', gap: 1.5, flexWrap: 'wrap' }}>
-                    {LEGEND.map((item) => (
+                    {legend.map((item) => (
                         <Box
                             key={item.label}
                             sx={{

--- a/rpc/service/reflection/__init__.py
+++ b/rpc/service/reflection/__init__.py
@@ -9,6 +9,7 @@ from .services import (
   service_reflection_get_full_schema_v1,
   service_reflection_get_schema_version_v1,
   service_reflection_list_domains_v1,
+  service_reflection_list_edt_mappings_v1,
   service_reflection_list_rpc_endpoints_v1,
   service_reflection_list_tables_v1,
   service_reflection_list_views_v1,
@@ -25,5 +26,6 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("dump_table", "1"): service_reflection_dump_table_v1,
   ("query_info_schema", "1"): service_reflection_query_info_schema_v1,
   ("list_domains", "1"): service_reflection_list_domains_v1,
+  ("list_edt_mappings", "1"): service_reflection_list_edt_mappings_v1,
   ("list_rpc_endpoints", "1"): service_reflection_list_rpc_endpoints_v1,
 }

--- a/rpc/service/reflection/models.py
+++ b/rpc/service/reflection/models.py
@@ -50,3 +50,7 @@ class DomainsResponse1(BaseModel):
 
 class RpcEndpointsResponse1(BaseModel):
   endpoints: list[str]
+
+
+class EdtMappingsResponse1(BaseModel):
+  mappings: list[dict[str, Any]]

--- a/rpc/service/reflection/services.py
+++ b/rpc/service/reflection/services.py
@@ -11,6 +11,7 @@ from .models import (
   DescribeTableRequest1,
   DescribeTableResponse1,
   DomainsResponse1,
+  EdtMappingsResponse1,
   DumpTableRequest1,
   DumpTableResponse1,
   QueryInfoSchemaRequest1,
@@ -123,4 +124,13 @@ async def service_reflection_list_rpc_endpoints_v1(request: Request) -> RPCRespo
   await module.on_ready()
   endpoints = await module.list_rpc_endpoints()
   payload = RpcEndpointsResponse1(endpoints=endpoints)
+  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+
+
+async def service_reflection_list_edt_mappings_v1(request: Request) -> RPCResponse:
+  rpc_request, _, _ = await unbox_request(request)
+  module = request.app.state.rpcdispatch
+  await module.on_ready()
+  mappings = await module.list_edt_mappings()
+  payload = EdtMappingsResponse1(mappings=mappings)
   return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)


### PR DESCRIPTION
### Motivation

- Expose EDT (element data type) mappings from the backend to the frontend so the UI can render EDT names dynamically instead of relying on brittle hardcoded dicts.  
- Replace the static domain color table and legend with a deterministic palette assignment so new DB domains automatically receive colors.

### Description

- Added a new response model `EdtMappingsResponse1` in `rpc/service/reflection/models.py`.  
- Implemented `service_reflection_list_edt_mappings_v1` in `rpc/service/reflection/services.py` that unboxes the RPC request, awaits `request.app.state.rpcdispatch.on_ready()`, calls `module.list_edt_mappings()`, and returns the result wrapped in `EdtMappingsResponse1` with zero business logic or data reshaping.  
- Registered the new dispatcher entry `("list_edt_mappings", "1")` in `rpc/service/reflection/__init__.py`.  
- Regenerated frontend bindings with the generator so `fetchListEdtMappings` and `EdtMappingsResponse1` are available to the UI via `frontend/src/rpc/service/reflection` and `frontend/src/shared/RpcModels.tsx`.  
- Frontend changes: `ServiceRpcDispatchPage.tsx` and `ServiceRpcDispatchTreePage.tsx` now import `fetchListEdtMappings`, fetch EDT mappings in their parallel `Promise.all` loaders, build a `Record<number,string>` lookup, remove hardcoded EDT maps, and use the dynamic map when rendering field types.  
- Visualization changes: `ServiceVisualizationPage.tsx` replaces `DOMAIN_COLORS`/`LEGEND` with a 16-color `PALETTE`, computes a deterministic `domain -> DomainColor` map via `buildDomainColorMap`, uses that map when building graph nodes, and derives the legend from the map for rendering.

### Testing

- Ran `python scripts/generate_rpc_bindings.py` successfully to emit updated TypeScript models and `fetchListEdtMappings`.  
- Ran the unified test/generation harness `python scripts/run_tests.py --test` and the frontend test suite; the run completed successfully.  
- Verified via code search that the old static EDT constants (`EDT_NAME_BY_RECID`, `EDT_NAMES`) and `DOMAIN_COLORS`/`LEGEND` usages were removed and replaced with dynamic mappings.  
- Confirmed `frontend/src/shared/edtNames.ts` does not exist (no static fallback file present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cec0af4ba48325917ecf267e92345e)