### PR TITLE
docs: document generated frontend artifact exclusion policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,7 +136,11 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Generated RPC bindings
+# Generated frontend artifacts — never committed, always regenerated at build time.
+# The TypeScript compiler validates generated bindings against backend contracts on
+# every build. Incorrect bindings fail the type-check and block the build. This is
+# an intentional architectural constraint that prevents drift. See PATTERNS.md §6.
 frontend/src/rpc/
 frontend/src/shared/RpcModels.tsx
 frontend/src/db/namespace.ts
+frontend/src/routes/registry.ts

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -564,7 +564,24 @@ flowchart LR
 ```
  
 Generated files carry a `DO NOT MODIFY - GENERATED` banner.
- 
+
+### 6.2.1 Generated Files Are Never Committed
+
+All generated frontend artifacts are excluded from source control via `.gitignore` and are regenerated fresh on every build — locally, in CI, and in the Docker builder stage. This is an intentional architectural constraint.
+
+The TypeScript compiler is the verification gate. If any generator produces bindings that do not match the backend contracts, the frontend type-check fails and the build is blocked. This makes it structurally impossible to ship incorrect bindings and eliminates drift between backend RPC definitions and frontend types.
+
+Generated artifacts:
+
+| File | Generator | Source |
+|---|---|---|
+| `frontend/src/rpc/**/*.ts` | `generate_rpc_bindings.py` | `rpc/**/models.py`, `rpc/**/__init__.py`, `rpc/**/services.py` |
+| `frontend/src/shared/RpcModels.tsx` | `generate_rpc_bindings.py` | All Pydantic models across `rpc/` |
+| `frontend/src/db/namespace.ts` | `generate_db_namespace.py` | `queryregistry/` subdomain models and request builders |
+| `frontend/src/routes/registry.ts` | `generate_nav_pages.py` | `frontend_pages` database table |
+
+These files carry a `DO NOT MODIFY - GENERATED` banner. Never edit them manually — change the source and regenerate.
+
 ### 6.3 Reflection Seeding
  
 At the end of the binding generation run, `generate_rpc_bindings.py` calls `seed_rpcdispatch.py` to populate the `reflection_rpc_*` tables in the connected database. If no database connection is available (e.g., Codex CI builds without ODBC), the seed step is skipped gracefully and runs on the next build in an environment with database access.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -48,3 +48,12 @@ Adjacent guidance:
 - When RPC contracts change, regenerate bindings from Python RPC definitions using
   `python scripts/generate_rpc_bindings.py`.
 - Keep TypeScript types aligned with backend models via regeneration, not manual patching.
+
+### Generated artifacts are excluded from source control
+
+All files in `src/rpc/`, `src/shared/RpcModels.tsx`, `src/db/namespace.ts`, and
+`src/routes/registry.ts` are generated at build time and excluded from the repository
+via `.gitignore`. They are never committed. The TypeScript compiler validates them on
+every build — if a generated binding is incorrect, the build fails. This is a deliberate
+architectural decision that prevents drift between backend contracts and frontend types.
+See PATTERNS.md §6.2.1 for the full rationale and artifact inventory.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -21,6 +21,9 @@ operational tooling.
   change.
 - Generated files include a banner from `HEADER_COMMENT`. Never edit the outputs
   manually—regenerate instead.
+- Generated frontend artifacts (`frontend/src/rpc/`, `frontend/src/shared/RpcModels.tsx`,
+  `frontend/src/db/namespace.ts`, `frontend/src/routes/registry.ts`) are excluded from
+  source control and regenerated on every build. Never commit them. See PATTERNS.md §6.2.1.
 
 ---
 


### PR DESCRIPTION
### Motivation

- The repository lacked explicit documentation and a `.gitignore` entry for a generated frontend route registry, causing ambiguity about which frontend artifacts must never be committed.
- The change clarifies the architectural intent that generated TypeScript artifacts are regenerated at build time and validated by the TypeScript compiler to prevent contract drift.

### Description

- Updated the root `.gitignore` block to broaden the architectural comment and add `frontend/src/routes/registry.ts` to the ignored generated-artifacts list.
- Inserted `### 6.2.1 Generated Files Are Never Committed` into `PATTERNS.md` with the rationale and an inventory table of generated frontend artifacts and their generators.
- Replaced the `## RPC and typing workflow` section in `frontend/AGENTS.md` with strengthened guidance and an explicit note that generated artifacts are excluded from source control and validated on every build.
- Appended a generated-output exclusion note to the `RPC Code Generation` section of `scripts/AGENTS.md` referencing `PATTERNS.md §6.2.1` and listing the generated frontend targets.

### Testing

- Ran the unified harness `python scripts/run_tests.py --test`, which executed the generation steps, frontend lint/type-check/tests, and backend tests and completed successfully.
- The generation step produced TypeScript artifacts (models/clients) and wrote an empty route registry when DB connectivity was not available, and the frontend type-check and tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cec481db4c8325a044c7555a08f1ef)