### PR TITLE
Fix RPC service module state attribute resolution

### DIFF
--- a/rpc/account/role/services.py
+++ b/rpc/account/role/services.py
@@ -19,7 +19,7 @@ from .models import (
 
 async def account_role_get_roles_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
-  module: RoleAdminModule = request.app.state.module
+  module: RoleAdminModule = request.app.state.role_admin
   roles_raw = await module.list_roles(auth_ctx.role_mask)
   roles = [AccountRoleRoleItem1(**r) for r in roles_raw]
   payload = AccountRoleList1(roles=roles)
@@ -32,7 +32,7 @@ async def account_role_get_roles_v1(request: Request):
 
 async def account_role_get_all_role_members_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
-  module: RoleAdminModule = request.app.state.module
+  module: RoleAdminModule = request.app.state.role_admin
   roles_raw = await module.get_all_role_members(auth_ctx.role_mask)
   roles = [AccountRoleAggregateItem1(**r) for r in roles_raw]
   payload = AccountRoleAggregateList1(roles=roles)
@@ -46,7 +46,7 @@ async def account_role_get_all_role_members_v1(request: Request):
 async def account_role_get_role_members_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   input_payload = AccountRoleGetMembersRequest1(**(rpc_request.payload or {}))
-  module: RoleAdminModule = request.app.state.module
+  module: RoleAdminModule = request.app.state.role_admin
   members_raw, non_raw = await module.get_role_members(input_payload.role)
   members = [AccountRoleUserItem1(**m) for m in members_raw]
   non_members = [AccountRoleUserItem1(**m) for m in non_raw]
@@ -61,7 +61,7 @@ async def account_role_get_role_members_v1(request: Request):
 async def account_role_add_role_member_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleMemberUpdate1(**(rpc_request.payload or {}))
-  module: RoleAdminModule = request.app.state.module
+  module: RoleAdminModule = request.app.state.role_admin
   members_raw, non_raw = await module.add_role_member(
     data.role,
     data.userGuid,
@@ -80,7 +80,7 @@ async def account_role_add_role_member_v1(request: Request):
 async def account_role_remove_role_member_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleMemberUpdate1(**(rpc_request.payload or {}))
-  module: RoleAdminModule = request.app.state.module
+  module: RoleAdminModule = request.app.state.role_admin
   members_raw, non_raw = await module.remove_role_member(
     data.role,
     data.userGuid,
@@ -99,7 +99,7 @@ async def account_role_remove_role_member_v1(request: Request):
 async def account_role_upsert_role_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleUpsertRole1(**(rpc_request.payload or {}))
-  module: RoleAdminModule = request.app.state.module
+  module: RoleAdminModule = request.app.state.role_admin
   await module.upsert_role(
     data.name,
     int(data.mask),
@@ -116,7 +116,7 @@ async def account_role_upsert_role_v1(request: Request):
 async def account_role_delete_role_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleDeleteRole1(**(rpc_request.payload or {}))
-  module: RoleAdminModule = request.app.state.module
+  module: RoleAdminModule = request.app.state.role_admin
   await module.delete_role(data.name, auth_ctx.role_mask)
   return RPCResponse(
     op=rpc_request.op,

--- a/rpc/account/user/services.py
+++ b/rpc/account/user/services.py
@@ -15,7 +15,7 @@ from .models import (
 async def account_user_get_displayname_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountUserGuid1(**(rpc_request.payload or {}))
-  module: UserAdminModule = request.app.state.module
+  module: UserAdminModule = request.app.state.user_admin
   display = await module.get_displayname(data.userGuid)
   res = AccountUserDisplayName1(userGuid=data.userGuid, displayName=display)
   return RPCResponse(
@@ -28,7 +28,7 @@ async def account_user_get_displayname_v1(request: Request):
 async def account_user_get_credits_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountUserGuid1(**(rpc_request.payload or {}))
-  module: UserAdminModule = request.app.state.module
+  module: UserAdminModule = request.app.state.user_admin
   credits = await module.get_credits(data.userGuid)
   res = AccountUserCredits1(userGuid=data.userGuid, credits=credits)
   return RPCResponse(
@@ -41,7 +41,7 @@ async def account_user_get_credits_v1(request: Request):
 async def account_user_set_credits_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountUserSetCredits1(**(rpc_request.payload or {}))
-  module: UserAdminModule = request.app.state.module
+  module: UserAdminModule = request.app.state.user_admin
   await module.set_credits(data.userGuid, data.credits)
   return RPCResponse(
     op=rpc_request.op,
@@ -53,7 +53,7 @@ async def account_user_set_credits_v1(request: Request):
 async def account_user_reset_display_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountUserGuid1(**(rpc_request.payload or {}))
-  module: UserAdminModule = request.app.state.module
+  module: UserAdminModule = request.app.state.user_admin
   await module.reset_display(data.userGuid)
   return RPCResponse(
     op=rpc_request.op,
@@ -65,7 +65,7 @@ async def account_user_reset_display_v1(request: Request):
 async def account_user_create_folder_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountUserCreateFolder1(**(rpc_request.payload or {}))
-  module: StorageModule = request.app.state.module
+  module: StorageModule = request.app.state.storage
   await module.create_user_folder(data.userGuid, data.path)
   return RPCResponse(
     op=rpc_request.op,

--- a/rpc/support/roles/services.py
+++ b/rpc/support/roles/services.py
@@ -14,7 +14,7 @@ from .models import (
 async def support_roles_get_members_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   input_payload = SupportRolesGetMembersRequest1(**(rpc_request.payload or {}))
-  module: RoleAdminModule = request.app.state.module
+  module: RoleAdminModule = request.app.state.role_admin
   members_raw, non_raw = await module.get_role_members(input_payload.role)
   members = [SupportRolesUserItem1(**m) for m in members_raw]
   non_members = [SupportRolesUserItem1(**m) for m in non_raw]
@@ -29,7 +29,7 @@ async def support_roles_get_members_v1(request: Request):
 async def support_roles_add_member_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = SupportRolesRoleMemberUpdate1(**(rpc_request.payload or {}))
-  module: RoleAdminModule = request.app.state.module
+  module: RoleAdminModule = request.app.state.role_admin
   members_raw, non_raw = await module.add_role_member(
     data.role,
     data.userGuid,
@@ -48,7 +48,7 @@ async def support_roles_add_member_v1(request: Request):
 async def support_roles_remove_member_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = SupportRolesRoleMemberUpdate1(**(rpc_request.payload or {}))
-  module: RoleAdminModule = request.app.state.module
+  module: RoleAdminModule = request.app.state.role_admin
   members_raw, non_raw = await module.remove_role_member(
     data.role,
     data.userGuid,

--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -26,7 +26,7 @@ async def users_profile_get_profile_v1(request: Request):
   if user_guid is None:
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
-  module: ProfileModule = request.app.state.module
+  module: ProfileModule = request.app.state.profile
   record = await module.get_profile(user_guid)
   if not record:
     raise HTTPException(status_code=404, detail="Profile not found")
@@ -50,7 +50,7 @@ async def users_profile_set_display_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   payload = UsersProfileSetDisplay1(**(rpc_request.payload or {}))
-  module: ProfileModule = request.app.state.module
+  module: ProfileModule = request.app.state.profile
   await module.set_display(user_guid, payload.display_name)
   return RPCResponse(
     op=rpc_request.op,
@@ -65,7 +65,7 @@ async def users_profile_set_optin_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   payload = UsersProfileSetOptin1(**(rpc_request.payload or {}))
-  module: ProfileModule = request.app.state.module
+  module: ProfileModule = request.app.state.profile
   await module.set_optin(user_guid, payload.display_email)
   return RPCResponse(
     op=rpc_request.op,
@@ -79,7 +79,7 @@ async def users_profile_get_roles_v1(request: Request):
   if user_guid is None:
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
-  module: ProfileModule = request.app.state.module
+  module: ProfileModule = request.app.state.profile
   roles = await module.get_roles(user_guid)
   payload = UsersProfileRoles1(roles=roles)
   return RPCResponse(
@@ -95,7 +95,7 @@ async def users_profile_set_profile_image_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   payload = UsersProfileSetProfileImage1(**(rpc_request.payload or {}))
-  module: ProfileModule = request.app.state.module
+  module: ProfileModule = request.app.state.profile
   await module.set_profile_image(
     user_guid,
     payload.provider,

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -19,7 +19,7 @@ async def users_providers_set_provider_v1(request: Request):
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
   provider = payload.provider.lower()
-  module: OauthModule = request.app.state.module
+  module: OauthModule = request.app.state.oauth
   await module.on_ready()
   result = await module.set_user_default_provider(
     auth_ctx.user_guid,
@@ -41,7 +41,7 @@ async def users_providers_link_provider_v1(request: Request):
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
   provider = payload.provider.lower()
-  module: OauthModule = request.app.state.module
+  module: OauthModule = request.app.state.oauth
   await module.on_ready()
   result = await module.link_user_provider(
     auth_ctx.user_guid,
@@ -59,7 +59,7 @@ async def users_providers_unlink_provider_v1(request: Request):
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
   provider = payload.provider.lower()
-  module: OauthModule = request.app.state.module
+  module: OauthModule = request.app.state.oauth
   await module.on_ready()
   result = await module.unlink_user_provider(
     auth_ctx.user_guid,
@@ -75,7 +75,7 @@ async def users_providers_get_by_provider_identifier_v1(request: Request):
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
   provider = payload.provider.lower()
-  module: OauthModule = request.app.state.module
+  module: OauthModule = request.app.state.oauth
   await module.on_ready()
   row = await module.get_user_by_provider_identifier(
     provider, payload.provider_identifier
@@ -89,7 +89,7 @@ async def users_providers_create_from_provider_v1(request: Request):
   except ValidationError as e:
     raise HTTPException(status_code=400, detail=str(e))
   provider = payload.provider.lower()
-  module: OauthModule = request.app.state.module
+  module: OauthModule = request.app.state.oauth
   await module.on_ready()
   row = await module.create_user_from_provider(
     provider,


### PR DESCRIPTION
### Motivation

- A regression set many RPC service functions to use the generic `request.app.state.module`, causing `AttributeError: 'State' object has no attribute 'module'` at runtime. 
- The change restores the per-file ModuleManager registration names required by the codegen/AST parser contract in `PATTERNS.md` §0.1.

### Description

- Replaced `request.app.state.module` with `request.app.state.profile` in `rpc/users/profile/services.py` for profile-related service functions.
- Replaced `request.app.state.module` with `request.app.state.role_admin` in `rpc/account/role/services.py` and `rpc/support/roles/services.py` for role-admin service functions.
- Updated `rpc/account/user/services.py` to use `request.app.state.user_admin` for `UserAdminModule` calls and `request.app.state.storage` for the `StorageModule` call.
- Replaced `request.app.state.module` with `request.app.state.oauth` in `rpc/users/providers/services.py` for OAuth provider functions (25 replacements across 5 files).

### Testing

- Verified no remaining incorrect references by running the repository search used in the change: `rg -n "request.app.state.module|request.app.state.(profile|role_admin|user_admin|storage|oauth)"` against the modified files.
- Ran the unified test pipeline with `python scripts/run_tests.py --test` and the suite completed successfully (frontend lint/type-check/tests and backend pytest), with frontend tests passing and backend pytest reporting all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ced04e38808325b059b2885e093226)