### PR TITLE
Add typed response models for users.providers RPC operations

### DIFF
--- a/rpc/users/providers/models.py
+++ b/rpc/users/providers/models.py
@@ -31,3 +31,28 @@ class UsersProvidersCreateFromProvider1(BaseModel):
   provider_email: str
   provider_displayname: str
   provider_profile_image: str | None = None
+
+
+class UsersProvidersSetProviderResult1(BaseModel):
+  provider: str
+  code: str | None = None
+  id_token: str | None = None
+  access_token: str | None = None
+
+
+class UsersProvidersLinkProviderResult1(BaseModel):
+  provider: str
+
+
+class UsersProvidersUnlinkProviderResult1(BaseModel):
+  provider: str
+
+
+class UsersProvidersGetByProviderIdentifierResult1(BaseModel):
+  guid: str | None = None
+  element_soft_deleted_at: str | None = None
+
+
+class UsersProvidersCreateFromProviderResult1(BaseModel):
+  guid: str | None = None
+  element_soft_deleted_at: str | None = None

--- a/rpc/users/providers/services.py
+++ b/rpc/users/providers/services.py
@@ -5,11 +5,16 @@ from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.oauth_module import OauthModule
 from .models import (
-  UsersProvidersSetProvider1,
-  UsersProvidersLinkProvider1,
-  UsersProvidersUnlinkProvider1,
-  UsersProvidersGetByProviderIdentifier1,
   UsersProvidersCreateFromProvider1,
+  UsersProvidersCreateFromProviderResult1,
+  UsersProvidersLinkProvider1,
+  UsersProvidersGetByProviderIdentifier1,
+  UsersProvidersGetByProviderIdentifierResult1,
+  UsersProvidersLinkProviderResult1,
+  UsersProvidersSetProvider1,
+  UsersProvidersSetProviderResult1,
+  UsersProvidersUnlinkProvider1,
+  UsersProvidersUnlinkProviderResult1,
 )
 
 async def users_providers_set_provider_v1(request: Request):
@@ -21,7 +26,7 @@ async def users_providers_set_provider_v1(request: Request):
   provider = payload.provider.lower()
   module: OauthModule = request.app.state.oauth
   await module.on_ready()
-  result = await module.set_user_default_provider(
+  result: UsersProvidersSetProviderResult1 = await module.set_user_default_provider(
     auth_ctx.user_guid,
     provider,
     code=payload.code,
@@ -30,7 +35,7 @@ async def users_providers_set_provider_v1(request: Request):
   )
   return RPCResponse(
     op=rpc_request.op,
-    payload=result,
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -43,14 +48,18 @@ async def users_providers_link_provider_v1(request: Request):
   provider = payload.provider.lower()
   module: OauthModule = request.app.state.oauth
   await module.on_ready()
-  result = await module.link_user_provider(
+  result: UsersProvidersLinkProviderResult1 = await module.link_user_provider(
     auth_ctx.user_guid,
     provider,
     code=payload.code,
     id_token=payload.id_token,
     access_token=payload.access_token,
   )
-  return RPCResponse(op=rpc_request.op, payload=result, version=rpc_request.version)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result.model_dump(),
+    version=rpc_request.version,
+  )
 
 async def users_providers_unlink_provider_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
@@ -61,12 +70,16 @@ async def users_providers_unlink_provider_v1(request: Request):
   provider = payload.provider.lower()
   module: OauthModule = request.app.state.oauth
   await module.on_ready()
-  result = await module.unlink_user_provider(
+  result: UsersProvidersUnlinkProviderResult1 = await module.unlink_user_provider(
     auth_ctx.user_guid,
     provider,
     new_default=payload.new_default,
   )
-  return RPCResponse(op=rpc_request.op, payload=result, version=rpc_request.version)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result.model_dump(),
+    version=rpc_request.version,
+  )
 
 async def users_providers_get_by_provider_identifier_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
@@ -77,10 +90,14 @@ async def users_providers_get_by_provider_identifier_v1(request: Request):
   provider = payload.provider.lower()
   module: OauthModule = request.app.state.oauth
   await module.on_ready()
-  row = await module.get_user_by_provider_identifier(
+  result: UsersProvidersGetByProviderIdentifierResult1 = await module.get_user_by_provider_identifier(
     provider, payload.provider_identifier
   )
-  return RPCResponse(op=rpc_request.op, payload=row, version=rpc_request.version)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result.model_dump(),
+    version=rpc_request.version,
+  )
 
 async def users_providers_create_from_provider_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
@@ -91,11 +108,15 @@ async def users_providers_create_from_provider_v1(request: Request):
   provider = payload.provider.lower()
   module: OauthModule = request.app.state.oauth
   await module.on_ready()
-  row = await module.create_user_from_provider(
+  result: UsersProvidersCreateFromProviderResult1 = await module.create_user_from_provider(
     provider,
     payload.provider_identifier,
     payload.provider_email,
     payload.provider_displayname,
     payload.provider_profile_image,
   )
-  return RPCResponse(op=rpc_request.op, payload=row, version=rpc_request.version)
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result.model_dump(),
+    version=rpc_request.version,
+  )

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import base64, logging, uuid
 from collections.abc import Mapping
+from typing import TYPE_CHECKING
 import aiohttp
 from datetime import datetime, timezone, timedelta
 
@@ -48,6 +51,15 @@ from queryregistry.identity.sessions import (
 from queryregistry.finance.credits import set_credits_request
 from queryregistry.finance.credits.models import SetCreditsParams
 from queryregistry.system.config import get_config_request
+
+if TYPE_CHECKING:
+  from rpc.users.providers.models import (
+    UsersProvidersCreateFromProviderResult1,
+    UsersProvidersGetByProviderIdentifierResult1,
+    UsersProvidersLinkProviderResult1,
+    UsersProvidersSetProviderResult1,
+    UsersProvidersUnlinkProviderResult1,
+  )
 
 
 class OauthModule(BaseModule):
@@ -177,7 +189,7 @@ class OauthModule(BaseModule):
     code: str | None = None,
     id_token: str | None = None,
     access_token: str | None = None,
-  ) -> dict:
+  ) -> UsersProvidersSetProviderResult1:
     original = {
       "provider": provider,
       "code": code,
@@ -206,7 +218,8 @@ class OauthModule(BaseModule):
         display_name=display_name,
       )
       await self.db.run(update_if_unedited_request(params))
-    return original
+    from rpc.users.providers.models import UsersProvidersSetProviderResult1
+    return UsersProvidersSetProviderResult1(**original)
 
   async def link_user_provider(
     self,
@@ -216,7 +229,7 @@ class OauthModule(BaseModule):
     code: str | None = None,
     id_token: str | None = None,
     access_token: str | None = None,
-  ) -> dict:
+  ) -> UsersProvidersLinkProviderResult1:
     provider_key = provider.lower()
     if provider_key == "google" and not code:
       raise HTTPException(status_code=400, detail="code required")
@@ -243,7 +256,8 @@ class OauthModule(BaseModule):
         provider_identifier=provider_uid,
       ),
     )
-    return {"provider": provider}
+    from rpc.users.providers.models import UsersProvidersLinkProviderResult1
+    return UsersProvidersLinkProviderResult1(provider=provider)
 
   async def unlink_user_provider(
     self,
@@ -251,7 +265,7 @@ class OauthModule(BaseModule):
     provider: str,
     *,
     new_default: str | None = None,
-  ) -> dict:
+  ) -> UsersProvidersUnlinkProviderResult1:
     res_prof = await self.db.run(
       get_profile_request(GuidParams(guid=user_guid))
     )
@@ -276,7 +290,8 @@ class OauthModule(BaseModule):
           RevokeProviderTokensParams(guid=user_guid, provider=provider)
         )
       )
-    return {"provider": provider}
+    from rpc.users.providers.models import UsersProvidersUnlinkProviderResult1
+    return UsersProvidersUnlinkProviderResult1(provider=provider)
 
   async def unlink_last_provider_record(self, guid: str, provider: str) -> None:
     assert self.db
@@ -286,7 +301,7 @@ class OauthModule(BaseModule):
 
   async def get_user_by_provider_identifier(
     self, provider: str, provider_identifier: str
-  ):
+  ) -> UsersProvidersGetByProviderIdentifierResult1:
     res = await self.db.run(
       get_by_provider_identifier_request(
         provider=provider,
@@ -294,7 +309,10 @@ class OauthModule(BaseModule):
       ),
     )
     rows = self._normalize_query_payload(res.payload)
-    return rows[0] if rows else None
+    from rpc.users.providers.models import UsersProvidersGetByProviderIdentifierResult1
+    if not rows:
+      return UsersProvidersGetByProviderIdentifierResult1()
+    return UsersProvidersGetByProviderIdentifierResult1(**rows[0])
 
   async def create_user_from_provider(
     self,
@@ -303,7 +321,7 @@ class OauthModule(BaseModule):
     provider_email: str,
     provider_displayname: str,
     provider_profile_image: str | None = None,
-  ):
+  ) -> UsersProvidersCreateFromProviderResult1:
     res = await self.db.run(
       get_user_by_email_request(email=provider_email),
     )
@@ -320,7 +338,10 @@ class OauthModule(BaseModule):
       ),
     )
     rows = self._normalize_query_payload(res.payload)
-    return rows[0] if rows else None
+    from rpc.users.providers.models import UsersProvidersCreateFromProviderResult1
+    if not rows:
+      return UsersProvidersCreateFromProviderResult1()
+    return UsersProvidersCreateFromProviderResult1(**rows[0])
 
   async def register_discord_user(self, discord_id: str) -> dict:
     auth: AuthModule = self.app.state.auth
@@ -355,9 +376,9 @@ class OauthModule(BaseModule):
       provider_email=f"{discord_id}@discord.placeholder",
       provider_displayname=display_name,
     )
-    if not created or not created.get("guid"):
+    if not created.guid:
       raise HTTPException(status_code=500, detail="Unable to create user")
-    new_user_guid = created["guid"]
+    new_user_guid = created.guid
     await self.db.run(set_credits_request(SetCreditsParams(guid=new_user_guid, credits=50)))
     logging.info(
       "[OauthModule] registered discord user",


### PR DESCRIPTION
### Motivation
- Provide explicit Pydantic response models for `users.providers` RPC operations so modules return typed payloads instead of raw dict/row objects.
- Ensure RPC service functions emit the canonical `model_dump()` payloads so the RPC generation pipeline and TypeScript bindings see stable response contracts.

### Description
- Added response models in `rpc/users/providers/models.py`: `UsersProvidersSetProviderResult1`, `UsersProvidersLinkProviderResult1`, `UsersProvidersUnlinkProviderResult1`, `UsersProvidersGetByProviderIdentifierResult1`, and `UsersProvidersCreateFromProviderResult1`.
- Updated `server/modules/oauth_module.py` to return the new RPC models from `set_user_default_provider`, `link_user_provider`, `unlink_user_provider`, `get_user_by_provider_identifier`, and `create_user_from_provider`, and adapted callers to use model attributes (e.g., `created.guid`).
- Refactored `rpc/users/providers/services.py` to `unbox_request`, validate inputs, await `module.on_ready()`, annotate typed `result` variables, and return `RPCResponse(..., payload=result.model_dump(), ...)` for every handler instead of returning raw dicts.
- Resolved an import cycle by adding `from __future__ import annotations`, using `typing.TYPE_CHECKING` for type-only imports, and performing local imports of models inside functions where necessary.

### Testing
- Ran the unified harness `python scripts/run_tests.py` during development which initially failed due to a transient circular import introduced mid-refactor; the import cycle was fixed in subsequent changes.
- Ran targeted pytest for oauth/provider flows with `pytest -q tests/test_content_wiki_subdomain.py tests/test_oauth_provider_pkce.py` and observed all tests pass (`24 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cede6303fc8325982ee328799acfba)