### PR TITLE
Return typed profile models from ProfileModule and simplify RPC services

### DIFF
--- a/rpc/users/profile/services.py
+++ b/rpc/users/profile/services.py
@@ -27,19 +27,11 @@ async def users_profile_get_profile_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   module: ProfileModule = request.app.state.profile
-  record = await module.get_profile(user_guid)
-  if not record:
-    raise HTTPException(status_code=404, detail="Profile not found")
-  record["guid"] = str(record.get("guid", ""))
-  auth_providers = record.get("auth_providers")
-  if auth_providers is None:
-    record["auth_providers"] = []
-  elif not isinstance(auth_providers, list):
-    raise HTTPException(status_code=500, detail="Invalid auth provider payload")
-  profile_payload = UsersProfileProfile1(**record)
+  await module.on_ready()
+  result: UsersProfileProfile1 = await module.get_profile(user_guid)
   return RPCResponse(
     op=rpc_request.op,
-    payload=profile_payload.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -51,10 +43,12 @@ async def users_profile_set_display_v1(request: Request):
 
   payload = UsersProfileSetDisplay1(**(rpc_request.payload or {}))
   module: ProfileModule = request.app.state.profile
+  await module.on_ready()
   await module.set_display(user_guid, payload.display_name)
+  result: UsersProfileSetDisplay1 = payload
   return RPCResponse(
     op=rpc_request.op,
-    payload=payload.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -66,10 +60,12 @@ async def users_profile_set_optin_v1(request: Request):
 
   payload = UsersProfileSetOptin1(**(rpc_request.payload or {}))
   module: ProfileModule = request.app.state.profile
+  await module.on_ready()
   await module.set_optin(user_guid, payload.display_email)
+  result: UsersProfileSetOptin1 = payload
   return RPCResponse(
     op=rpc_request.op,
-    payload=payload.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -80,11 +76,11 @@ async def users_profile_get_roles_v1(request: Request):
     raise HTTPException(status_code=400, detail="Missing user GUID")
 
   module: ProfileModule = request.app.state.profile
-  roles = await module.get_roles(user_guid)
-  payload = UsersProfileRoles1(roles=roles)
+  await module.on_ready()
+  result: UsersProfileRoles1 = await module.get_roles(user_guid)
   return RPCResponse(
     op=rpc_request.op,
-    payload=payload.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -96,14 +92,15 @@ async def users_profile_set_profile_image_v1(request: Request):
 
   payload = UsersProfileSetProfileImage1(**(rpc_request.payload or {}))
   module: ProfileModule = request.app.state.profile
+  await module.on_ready()
   await module.set_profile_image(
     user_guid,
     payload.provider,
     payload.image_b64,
   )
+  result: UsersProfileSetProfileImage1 = payload
   return RPCResponse(
     op=rpc_request.op,
-    payload=payload.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
-

--- a/server/modules/profile_module.py
+++ b/server/modules/profile_module.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
+from rpc.users.profile.models import UsersProfileProfile1, UsersProfileRoles1
 from . import BaseModule
 from .auth_module import AuthModule
 from .db_module import DbModule
@@ -33,10 +34,31 @@ class ProfileModule(BaseModule):
     self.auth = None
 
 
-  async def get_profile(self, guid: str) -> ProfileRecord | None:
+  async def get_profile(self, guid: str) -> UsersProfileProfile1:
     params = GuidParams(guid=guid)
     res = await self.db.run(get_profile_request(params))
-    return res.rows[0] if res.rows else None
+    if not res.rows:
+      raise HTTPException(status_code=404, detail="Profile not found")
+
+    record: ProfileRecord = res.rows[0]
+    auth_providers = record.get("auth_providers")
+    if auth_providers is None:
+      normalized_auth_providers = []
+    elif isinstance(auth_providers, list):
+      normalized_auth_providers = auth_providers
+    else:
+      raise HTTPException(status_code=500, detail="Invalid auth provider payload")
+
+    return UsersProfileProfile1(
+      guid=str(record.get("guid", "")),
+      display_name=record.get("display_name") or "",
+      email=record.get("email") or "",
+      display_email=bool(record.get("display_email", False)),
+      credits=int(record.get("credits", 0) or 0),
+      profile_image=record.get("profile_image"),
+      default_provider=record.get("default_provider") or "",
+      auth_providers=normalized_auth_providers,
+    )
 
   async def set_display(self, guid: str, display_name: str) -> None:
     params = UpdateProfileParams(guid=guid, display_name=display_name)
@@ -46,10 +68,10 @@ class ProfileModule(BaseModule):
     params = UpdateProfileParams(guid=guid, display_email=display_email)
     await self.db.run(update_profile_request(params))
 
-  async def get_roles(self, guid: str) -> int:
+  async def get_roles(self, guid: str) -> UsersProfileRoles1:
     assert self.auth
     _, mask = await self.auth.get_user_roles(guid)
-    return mask
+    return UsersProfileRoles1(roles=mask)
 
   async def set_profile_image(self, guid: str, provider: str, image_b64: str | None) -> None:
     params = UpdateProfileParams(guid=guid, provider=provider, image_b64=image_b64)


### PR DESCRIPTION
### Motivation
- Move data normalization and response-model construction into the module layer so RPC service functions stay as thin security routers following the module→service contract. 
- Ensure module methods return the canonical RPC response models so downstream tooling and RPC binding extraction get stable typed outputs.

### Description
- Updated `ProfileModule.get_profile` to return `UsersProfileProfile1` and perform normalization (GUID string coercion, `auth_providers` null/list handling, and default/fallback values for nullable fields). 
- Updated `ProfileModule.get_roles` to return `UsersProfileRoles1`. 
- Consolidated error handling in the module using `HTTPException` for `404`/`500` cases. 
- Simplified `rpc/users/profile/services.py` handlers to only validate auth context, `await module.on_ready()`, use typed `result` annotations, and return `payload=result.model_dump()` while removing inline row mutation and model construction.

### Testing
- Ran `python -m py_compile server/modules/profile_module.py rpc/users/profile/services.py` which succeeded. 
- Ran the unified harness `python scripts/run_tests.py`, which exercised the frontend TypeScript type-check and failed due to an existing frontend type error unrelated to these Python changes (`src/pages/ProductsPage.tsx(91,41): Property 'credits' does not exist on type 'void'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cee0b29c648325be2e547726797870)