### PR TITLE
Refactor users product RPC flow to pure dispatch

### DIFF
--- a/rpc/users/products/services.py
+++ b/rpc/users/products/services.py
@@ -4,22 +4,15 @@ from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.finance_module import FinanceModule
 
-from .models import (
-  UsersProductItem1,
-  UsersProductList1,
-  UsersProductPurchase1,
-  UsersProductPurchaseResult1,
-)
+from .models import UsersProductList1, UsersProductPurchase1, UsersProductPurchaseResult1
 
 
 async def users_products_list_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   module: FinanceModule = request.app.state.finance
   await module.on_ready()
-  products = await module.list_products_with_enablement(auth_ctx.user_guid)
-  items = [UsersProductItem1(**product) for product in products]
-  payload = UsersProductList1(products=items)
-  return RPCResponse(op=rpc_request.op, payload=payload.model_dump(), version=rpc_request.version)
+  result: UsersProductList1 = await module.list_products_with_enablement(auth_ctx.user_guid)
+  return RPCResponse(op=rpc_request.op, payload=result.model_dump(), version=rpc_request.version)
 
 
 async def users_products_purchase_v1(request: Request):
@@ -35,5 +28,4 @@ async def users_products_purchase_v1(request: Request):
     )
   except ValueError as exc:
     raise HTTPException(status_code=400, detail=str(exc)) from exc
-  response_payload = UsersProductPurchaseResult1(**result)
-  return RPCResponse(op=rpc_request.op, payload=response_payload.model_dump(), version=rpc_request.version)
+  return RPCResponse(op=rpc_request.op, payload=result.model_dump(), version=rpc_request.version)

--- a/server/modules/finance_module.py
+++ b/server/modules/finance_module.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from fastapi import FastAPI
 
+from rpc.users.products.models import UsersProductItem1, UsersProductList1, UsersProductPurchaseResult1
+
 from . import BaseModule
 from .db_module import DbModule
 from queryregistry.finance.ledgers import (
@@ -1345,11 +1347,11 @@ class FinanceModule(BaseModule):
     res = await self.db.run(list_products_request(ListProductsParams(category=category, status=status)))
     return [self._map_product(dict(row)) for row in res.rows]
 
-  async def list_products_with_enablement(self, users_guid: str) -> list[dict[str, Any]]:
+  async def list_products_with_enablement(self, users_guid: str) -> UsersProductList1:
     products = await self.list_products(status=1)
     user_enablements = await self.get_user_enablements(users_guid)
     user_roles = await self.get_user_roles_mask(users_guid)
-    out: list[dict[str, Any]] = []
+    out: list[UsersProductItem1] = []
     for product in products:
       already_enabled = False
       enablement_key = product.get("enablement_key")
@@ -1357,8 +1359,8 @@ class FinanceModule(BaseModule):
         already_enabled = bool(user_enablements & 1)
       elif enablement_key == "ROLE_DISCORD_BOT":
         already_enabled = bool(user_roles & 0x10)
-      out.append({**product, "already_enabled": already_enabled})
-    return out
+      out.append(UsersProductItem1(**{**product, "already_enabled": already_enabled}))
+    return UsersProductList1(products=out)
 
   async def get_product(self, recid: int | None = None, sku: str | None = None) -> dict[str, Any] | None:
     assert self.db
@@ -1934,7 +1936,7 @@ class FinanceModule(BaseModule):
     sku: str,
     actor_guid: str | None = None,
     periods_guid: str | None = None,
-  ) -> dict[str, Any]:
+  ) -> UsersProductPurchaseResult1:
     product = await self.get_product(sku=sku)
     if not product or int(product.get("status") or 0) != ELEMENT_ACTIVE:
       raise ValueError("Product is not available for purchase")
@@ -1982,13 +1984,13 @@ class FinanceModule(BaseModule):
         amount=amount,
         description=description,
       )
-      return {
-        "product": sku,
-        "credits_granted": int(product.get("credits") or 0),
-        "lot_number": lot["lot_number"],
-        "transaction_token": transaction_token,
-        "journal_lines_added": True,
-      }
+      return UsersProductPurchaseResult1(
+        product=sku,
+        credits_granted=int(product.get("credits") or 0),
+        lot_number=lot["lot_number"],
+        transaction_token=transaction_token,
+        journal_lines_added=True,
+      )
 
     if category == "enablement":
       enablement_key = str(product.get("enablement_key") or "")
@@ -2023,11 +2025,11 @@ class FinanceModule(BaseModule):
           description=f"Enablement purchase: {sku} - {transaction_token}",
         )
 
-      return {
-        "product": sku,
-        "enablement_granted": enablement_key,
-        "transaction_token": transaction_token,
-      }
+      return UsersProductPurchaseResult1(
+        product=sku,
+        enablement_granted=enablement_key,
+        transaction_token=transaction_token,
+      )
 
     raise ValueError(f"Unsupported product category: {category}")
 


### PR DESCRIPTION
### Motivation
- Conform to the repository RPC pattern where modules return Pydantic RPC response models and service functions act as thin dispatchers, keeping business logic and model construction inside modules.

### Description
- Import `UsersProductList1`, `UsersProductItem1`, and `UsersProductPurchaseResult1` into `server/modules/finance_module.py` and use them in-module to construct response models.
- Change `FinanceModule.list_products_with_enablement` to return `UsersProductList1` and build `UsersProductItem1` instances before returning.
- Change `FinanceModule.purchase_product` to return `UsersProductPurchaseResult1` and construct the appropriate model for both `credit_purchase` and `enablement` branches.
- Refactor `rpc/users/products/services.py` to pure dispatch by annotating `result` with the response model types and returning `payload=result.model_dump()` without converting lists/dicts to models in the service layer.

### Testing
- Ran the unified harness with `python scripts/run_tests.py` and it completed successfully with the test suite passing (40 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cee6c6bf6c83258fc8f60dcecc778a)