### PR TITLE
Move users.pages/wiki response mapping and auth checks into content modules

### DIFF
--- a/rpc/users/pages/models.py
+++ b/rpc/users/pages/models.py
@@ -1,6 +1,11 @@
 from typing import Optional
 
 from pydantic import BaseModel
+from server.models import ContentAccess as ServerContentAccess
+
+
+class ContentAccess(ServerContentAccess):
+  pass
 
 
 class UsersPagesCreateVersion1(BaseModel):
@@ -28,6 +33,7 @@ class UsersPagesVersionItem1(BaseModel):
 
 class UsersPagesVersionList1(BaseModel):
   versions: list[UsersPagesVersionItem1]
+  access: ContentAccess
 
 
 class UsersPagesVersionContent1(BaseModel):
@@ -37,3 +43,4 @@ class UsersPagesVersionContent1(BaseModel):
   element_summary: Optional[str] = None
   element_created_by: str
   element_created_on: Optional[str] = None
+  access: ContentAccess

--- a/rpc/users/pages/services.py
+++ b/rpc/users/pages/services.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from fastapi import HTTPException, Request
+from fastapi import Request
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
@@ -12,7 +12,6 @@ from .models import (
   UsersPagesGetVersion1,
   UsersPagesListVersions1,
   UsersPagesVersionContent1,
-  UsersPagesVersionItem1,
   UsersPagesVersionList1,
 )
 
@@ -20,51 +19,17 @@ if TYPE_CHECKING:
   from server.modules.content_pages_module import ContentPagesModule
 
 
-def _ensure_authenticated(user_guid: str | None):
-  if not user_guid:
-    raise HTTPException(status_code=401, detail="Authentication required")
-
-
-async def _resolve_editable_page(request: Request, slug: str, user_guid: str, role_mask: int):
-  module: ContentPagesModule = request.app.state.content_pages
-  page = await module.get_page_by_slug(slug)
-  if not page:
-    raise HTTPException(status_code=404, detail="Page not found")
-
-  role_module = request.app.state.role
-  access = role_module.check_content_access(
-    user_guid=user_guid,
-    role_mask=role_mask,
-    owner_guid=page.get("element_created_by"),
-  )
-  if not access.can_edit:
-    raise HTTPException(status_code=403, detail="Forbidden")
-
-  return page
-
-
 async def users_pages_create_version_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
-  _ensure_authenticated(auth_ctx.user_guid)
-
   payload = UsersPagesCreateVersion1(**(rpc_request.payload or {}))
-  page = await _resolve_editable_page(request, payload.slug, auth_ctx.user_guid, auth_ctx.role_mask)
-
   module: ContentPagesModule = request.app.state.content_pages
-  version = await module.create_version(
-    pages_recid=page["recid"],
+  await module.on_ready()
+  result: UsersPagesVersionContent1 = await module.create_version(
+    slug=payload.slug,
     content=payload.content,
-    created_by=auth_ctx.user_guid,
+    user_guid=auth_ctx.user_guid,
+    role_mask=auth_ctx.role_mask,
     summary=payload.summary,
-  )
-
-  result = UsersPagesVersionContent1(
-    recid=version["recid"],
-    element_version=version["element_version"],
-    element_content=version["element_content"],
-    element_summary=version.get("element_summary"),
-    element_created_by=version["element_created_by"],
-    element_created_on=version.get("element_created_on"),
   )
 
   return RPCResponse(
@@ -76,25 +41,13 @@ async def users_pages_create_version_v1(request: Request):
 
 async def users_pages_list_versions_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
-  _ensure_authenticated(auth_ctx.user_guid)
-
   payload = UsersPagesListVersions1(**(rpc_request.payload or {}))
-  page = await _resolve_editable_page(request, payload.slug, auth_ctx.user_guid, auth_ctx.role_mask)
-
   module: ContentPagesModule = request.app.state.content_pages
-  versions = await module.list_versions(page["recid"])
-
-  result = UsersPagesVersionList1(
-    versions=[
-      UsersPagesVersionItem1(
-        recid=version["recid"],
-        element_version=version["element_version"],
-        element_summary=version.get("element_summary"),
-        element_created_by=version["element_created_by"],
-        element_created_on=version.get("element_created_on"),
-      )
-      for version in versions
-    ]
+  await module.on_ready()
+  result: UsersPagesVersionList1 = await module.list_versions(
+    slug=payload.slug,
+    user_guid=auth_ctx.user_guid,
+    role_mask=auth_ctx.role_mask,
   )
 
   return RPCResponse(
@@ -106,23 +59,14 @@ async def users_pages_list_versions_v1(request: Request):
 
 async def users_pages_get_version_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
-  _ensure_authenticated(auth_ctx.user_guid)
-
   payload = UsersPagesGetVersion1(**(rpc_request.payload or {}))
-  page = await _resolve_editable_page(request, payload.slug, auth_ctx.user_guid, auth_ctx.role_mask)
-
   module: ContentPagesModule = request.app.state.content_pages
-  version = await module.get_version(pages_recid=page["recid"], version=payload.version)
-  if not version:
-    raise HTTPException(status_code=404, detail="Version not found")
-
-  result = UsersPagesVersionContent1(
-    recid=version["recid"],
-    element_version=version["element_version"],
-    element_content=version["element_content"],
-    element_summary=version.get("element_summary"),
-    element_created_by=version["element_created_by"],
-    element_created_on=version.get("element_created_on"),
+  await module.on_ready()
+  result: UsersPagesVersionContent1 = await module.get_version(
+    slug=payload.slug,
+    version=payload.version,
+    user_guid=auth_ctx.user_guid,
+    role_mask=auth_ctx.role_mask,
   )
 
   return RPCResponse(

--- a/rpc/users/wiki/models.py
+++ b/rpc/users/wiki/models.py
@@ -1,6 +1,11 @@
 from typing import Optional
 
 from pydantic import BaseModel
+from server.models import ContentAccess as ServerContentAccess
+
+
+class ContentAccess(ServerContentAccess):
+  pass
 
 
 class UsersWikiCreateVersion1(BaseModel):
@@ -36,6 +41,7 @@ class UsersWikiVersionItem1(BaseModel):
 
 class UsersWikiVersionList1(BaseModel):
   versions: list[UsersWikiVersionItem1]
+  access: ContentAccess
 
 
 class UsersWikiVersionContent1(BaseModel):
@@ -45,3 +51,4 @@ class UsersWikiVersionContent1(BaseModel):
   element_edit_summary: Optional[str] = None
   element_created_by: str
   element_created_on: Optional[str] = None
+  access: ContentAccess

--- a/rpc/users/wiki/services.py
+++ b/rpc/users/wiki/services.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from fastapi import HTTPException, Request
+from fastapi import Request
 
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
@@ -13,7 +13,6 @@ from .models import (
   UsersWikiGetVersion1,
   UsersWikiListVersions1,
   UsersWikiVersionContent1,
-  UsersWikiVersionItem1,
   UsersWikiVersionList1,
 )
 
@@ -21,51 +20,17 @@ if TYPE_CHECKING:
   from server.modules.content_wiki_module import ContentWikiModule
 
 
-def _ensure_authenticated(user_guid: str | None):
-  if not user_guid:
-    raise HTTPException(status_code=401, detail="Authentication required")
-
-
-async def _resolve_editable_page(request: Request, slug: str, user_guid: str, role_mask: int):
-  module: ContentWikiModule = request.app.state.content_wiki
-  page = await module.get_page_by_slug(slug)
-  if not page:
-    raise HTTPException(status_code=404, detail="Page not found")
-
-  role_module = request.app.state.role
-  access = role_module.check_content_access(
-    user_guid=user_guid,
-    role_mask=role_mask,
-    owner_guid=page.get("element_created_by"),
-  )
-  if not access.can_edit:
-    raise HTTPException(status_code=403, detail="Forbidden")
-
-  return page
-
-
 async def users_wiki_create_version_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
-  _ensure_authenticated(auth_ctx.user_guid)
-
   payload = UsersWikiCreateVersion1(**(rpc_request.payload or {}))
-  page = await _resolve_editable_page(request, payload.slug, auth_ctx.user_guid, auth_ctx.role_mask)
-
   module: ContentWikiModule = request.app.state.content_wiki
-  version = await module.create_version(
-    wiki_recid=page["recid"],
+  await module.on_ready()
+  result: UsersWikiVersionContent1 = await module.create_version(
+    slug=payload.slug,
     content=payload.content,
-    created_by=auth_ctx.user_guid,
+    user_guid=auth_ctx.user_guid,
+    role_mask=auth_ctx.role_mask,
     edit_summary=payload.edit_summary,
-  )
-
-  result = UsersWikiVersionContent1(
-    recid=version["recid"],
-    element_version=version["element_version"],
-    element_content=version["element_content"],
-    element_edit_summary=version.get("element_edit_summary"),
-    element_created_by=version["element_created_by"],
-    element_created_on=version.get("element_created_on"),
   )
 
   return RPCResponse(op=rpc_request.op, payload=result.model_dump(), version=rpc_request.version)
@@ -73,31 +38,17 @@ async def users_wiki_create_version_v1(request: Request):
 
 async def users_wiki_create_page_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
-  _ensure_authenticated(auth_ctx.user_guid)
-
   payload = UsersWikiCreatePage1(**(rpc_request.payload or {}))
-
   module: ContentWikiModule = request.app.state.content_wiki
-  existing = await module.get_page_by_slug(payload.slug)
-  if existing:
-    raise HTTPException(status_code=409, detail="Page already exists")
-
-  page = await module.create_page(
+  await module.on_ready()
+  result: UsersWikiVersionContent1 = await module.create_page(
     slug=payload.slug,
     title=payload.title,
     content=payload.content,
-    created_by=auth_ctx.user_guid,
+    user_guid=auth_ctx.user_guid,
+    role_mask=auth_ctx.role_mask,
     parent_slug=payload.parent_slug,
     edit_summary=payload.edit_summary,
-  )
-
-  result = UsersWikiVersionContent1(
-    recid=page.get("recid", 0),
-    element_version=page.get("element_version", 1),
-    element_content=page.get("element_content", ""),
-    element_edit_summary=page.get("element_edit_summary"),
-    element_created_by=page.get("element_created_by", ""),
-    element_created_on=page.get("element_created_on"),
   )
 
   return RPCResponse(op=rpc_request.op, payload=result.model_dump(), version=rpc_request.version)
@@ -105,25 +56,13 @@ async def users_wiki_create_page_v1(request: Request):
 
 async def users_wiki_list_versions_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
-  _ensure_authenticated(auth_ctx.user_guid)
-
   payload = UsersWikiListVersions1(**(rpc_request.payload or {}))
-  page = await _resolve_editable_page(request, payload.slug, auth_ctx.user_guid, auth_ctx.role_mask)
-
   module: ContentWikiModule = request.app.state.content_wiki
-  versions = await module.list_versions(page["recid"])
-
-  result = UsersWikiVersionList1(
-    versions=[
-      UsersWikiVersionItem1(
-        recid=version["recid"],
-        element_version=version["element_version"],
-        element_edit_summary=version.get("element_edit_summary"),
-        element_created_by=version["element_created_by"],
-        element_created_on=version.get("element_created_on"),
-      )
-      for version in versions
-    ]
+  await module.on_ready()
+  result: UsersWikiVersionList1 = await module.list_versions(
+    slug=payload.slug,
+    user_guid=auth_ctx.user_guid,
+    role_mask=auth_ctx.role_mask,
   )
 
   return RPCResponse(op=rpc_request.op, payload=result.model_dump(), version=rpc_request.version)
@@ -131,23 +70,14 @@ async def users_wiki_list_versions_v1(request: Request):
 
 async def users_wiki_get_version_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
-  _ensure_authenticated(auth_ctx.user_guid)
-
   payload = UsersWikiGetVersion1(**(rpc_request.payload or {}))
-  page = await _resolve_editable_page(request, payload.slug, auth_ctx.user_guid, auth_ctx.role_mask)
-
   module: ContentWikiModule = request.app.state.content_wiki
-  version = await module.get_version(wiki_recid=page["recid"], version=payload.version)
-  if not version:
-    raise HTTPException(status_code=404, detail="Version not found")
-
-  result = UsersWikiVersionContent1(
-    recid=version["recid"],
-    element_version=version["element_version"],
-    element_content=version["element_content"],
-    element_edit_summary=version.get("element_edit_summary"),
-    element_created_by=version["element_created_by"],
-    element_created_on=version.get("element_created_on"),
+  await module.on_ready()
+  result: UsersWikiVersionContent1 = await module.get_version(
+    slug=payload.slug,
+    version=payload.version,
+    user_guid=auth_ctx.user_guid,
+    role_mask=auth_ctx.role_mask,
   )
 
   return RPCResponse(op=rpc_request.op, payload=result.model_dump(), version=rpc_request.version)

--- a/server/modules/content_pages_module.py
+++ b/server/modules/content_pages_module.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 from . import BaseModule
 from .db_module import DbModule
+from server.models import ContentAccess
 from queryregistry.content.pages import (
   create_page_request,
   create_version_request,
@@ -28,6 +30,10 @@ from queryregistry.content.pages.models import (
   ListVersionsParams,
   UpdatePageParams,
 )
+
+if TYPE_CHECKING:
+  from rpc.users.pages.models import UsersPagesVersionContent1, UsersPagesVersionList1, UsersPagesVersionItem1
+  from .role_module import RoleModule
 
 
 class ContentPagesModule(BaseModule):
@@ -129,42 +135,114 @@ class ContentPagesModule(BaseModule):
 
   async def create_version(
     self,
-    pages_recid: int,
+    slug: str,
     content: str,
-    created_by: str,
+    user_guid: str | None,
+    role_mask: int,
     *,
     summary: str | None = None,
-  ) -> dict[str, Any]:
+  ) -> UsersPagesVersionContent1:
+    page, access = await self._resolve_editable_page(slug=slug, user_guid=user_guid, role_mask=role_mask)
     assert self.db
     res = await self.db.run(
       create_version_request(
         CreateVersionParams(
-          pages_recid=pages_recid,
+          pages_recid=page["recid"],
           content=content,
-          created_by=created_by,
+          created_by=user_guid,
           summary=summary,
         )
       )
     )
-    return dict(res.rows[0])
+    version = dict(res.rows[0])
+    from rpc.users.pages.models import UsersPagesVersionContent1
 
-  async def list_versions(self, pages_recid: int) -> list[dict[str, Any]]:
+    return UsersPagesVersionContent1(
+      recid=version["recid"],
+      element_version=version["element_version"],
+      element_content=version["element_content"],
+      element_summary=version.get("element_summary"),
+      element_created_by=version["element_created_by"],
+      element_created_on=version.get("element_created_on"),
+      access=access,
+    )
+
+  async def list_versions(
+    self,
+    slug: str,
+    user_guid: str | None,
+    role_mask: int,
+  ) -> UsersPagesVersionList1:
+    page, access = await self._resolve_editable_page(slug=slug, user_guid=user_guid, role_mask=role_mask)
     assert self.db
-    res = await self.db.run(list_versions_request(ListVersionsParams(pages_recid=pages_recid)))
-    return [dict(row) for row in res.rows]
+    res = await self.db.run(list_versions_request(ListVersionsParams(pages_recid=page["recid"])))
+    versions = [dict(row) for row in res.rows]
+    from rpc.users.pages.models import UsersPagesVersionItem1, UsersPagesVersionList1
+
+    return UsersPagesVersionList1(
+      versions=[
+        UsersPagesVersionItem1(
+          recid=version["recid"],
+          element_version=version["element_version"],
+          element_summary=version.get("element_summary"),
+          element_created_by=version["element_created_by"],
+          element_created_on=version.get("element_created_on"),
+        )
+        for version in versions
+      ],
+      access=access,
+    )
 
   async def get_version(
     self,
-    *,
-    recid: int | None = None,
-    pages_recid: int | None = None,
-    version: int | None = None,
-  ) -> dict[str, Any] | None:
+    slug: str,
+    version: int,
+    user_guid: str | None,
+    role_mask: int,
+  ) -> UsersPagesVersionContent1:
+    page, access = await self._resolve_editable_page(slug=slug, user_guid=user_guid, role_mask=role_mask)
     assert self.db
     res = await self.db.run(
-      get_version_request(GetVersionParams(recid=recid, pages_recid=pages_recid, version=version))
+      get_version_request(GetVersionParams(recid=None, pages_recid=page["recid"], version=version))
     )
-    return dict(res.rows[0]) if res.rows else None
+    if not res.rows:
+      raise HTTPException(status_code=404, detail="Version not found")
+    version_row = dict(res.rows[0])
+    from rpc.users.pages.models import UsersPagesVersionContent1
+
+    return UsersPagesVersionContent1(
+      recid=version_row["recid"],
+      element_version=version_row["element_version"],
+      element_content=version_row["element_content"],
+      element_summary=version_row.get("element_summary"),
+      element_created_by=version_row["element_created_by"],
+      element_created_on=version_row.get("element_created_on"),
+      access=access,
+    )
 
   async def review_content(self, payload: dict[str, Any]) -> dict[str, Any]:
     raise NotImplementedError("Content review is not yet implemented")
+
+  async def _resolve_editable_page(
+    self,
+    *,
+    slug: str,
+    user_guid: str | None,
+    role_mask: int,
+  ) -> tuple[dict[str, Any], ContentAccess]:
+    if user_guid is None:
+      raise HTTPException(status_code=401, detail="Authentication required")
+
+    page = await self.get_page_by_slug(slug)
+    if not page:
+      raise HTTPException(status_code=404, detail="Page not found")
+
+    role_module: RoleModule = self.app.state.role
+    access = role_module.check_content_access(
+      user_guid=user_guid,
+      role_mask=role_mask,
+      owner_guid=page.get("element_created_by"),
+    )
+    if not access.can_edit:
+      raise HTTPException(status_code=403, detail="Forbidden")
+    return page, access

--- a/server/modules/content_wiki_module.py
+++ b/server/modules/content_wiki_module.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
+from server.models import ContentAccess
 from queryregistry.content.wiki import (
   create_version_request,
   create_wiki_request,
@@ -33,6 +35,10 @@ from queryregistry.content.wiki.models import (
 
 from . import BaseModule
 from .db_module import DbModule
+
+if TYPE_CHECKING:
+  from rpc.users.wiki.models import UsersWikiVersionContent1, UsersWikiVersionList1, UsersWikiVersionItem1
+  from .role_module import RoleModule
 
 
 class ContentWikiModule(BaseModule):
@@ -81,22 +87,29 @@ class ContentWikiModule(BaseModule):
     slug: str,
     title: str,
     content: str,
-    created_by: str,
+    user_guid: str | None,
+    role_mask: int,
     *,
     parent_slug: str | None = None,
     route_context: str | None = None,
     roles: int = 0,
     sequence: int = 0,
     edit_summary: str | None = None,
-  ) -> dict[str, Any]:
+  ) -> UsersWikiVersionContent1:
+    self._ensure_authenticated(user_guid)
+    access = await self._ensure_wiki_creation_allowed(user_guid=user_guid, role_mask=role_mask)
     assert self.db
+    existing = await self.get_page_by_slug(slug)
+    if existing:
+      raise HTTPException(status_code=409, detail="Page already exists")
+
     res = await self.db.run(
       create_wiki_request(
         CreateWikiParams(
           slug=slug,
           title=title,
           content=content,
-          created_by=created_by,
+          created_by=user_guid,
           parent_slug=parent_slug,
           route_context=route_context,
           roles=roles,
@@ -105,7 +118,18 @@ class ContentWikiModule(BaseModule):
         )
       )
     )
-    return dict(res.rows[0])
+    page = dict(res.rows[0])
+    from rpc.users.wiki.models import UsersWikiVersionContent1
+
+    return UsersWikiVersionContent1(
+      recid=page.get("recid", 0),
+      element_version=page.get("element_version", 1),
+      element_content=page.get("element_content", ""),
+      element_edit_summary=page.get("element_edit_summary"),
+      element_created_by=page.get("element_created_by", ""),
+      element_created_on=page.get("element_created_on"),
+      access=access,
+    )
 
   async def update_page(
     self,
@@ -142,39 +166,129 @@ class ContentWikiModule(BaseModule):
 
   async def create_version(
     self,
-    wiki_recid: int,
+    slug: str,
     content: str,
-    created_by: str,
+    user_guid: str | None,
+    role_mask: int,
     *,
     edit_summary: str | None = None,
-  ) -> dict[str, Any]:
+  ) -> UsersWikiVersionContent1:
+    page, access = await self._resolve_editable_page(slug=slug, user_guid=user_guid, role_mask=role_mask)
     assert self.db
     res = await self.db.run(
       create_version_request(
         CreateWikiVersionParams(
-          wiki_recid=wiki_recid,
+          wiki_recid=page["recid"],
           content=content,
-          created_by=created_by,
+          created_by=user_guid,
           edit_summary=edit_summary,
         )
       )
     )
-    return dict(res.rows[0])
+    version = dict(res.rows[0])
+    from rpc.users.wiki.models import UsersWikiVersionContent1
 
-  async def list_versions(self, wiki_recid: int) -> list[dict[str, Any]]:
+    return UsersWikiVersionContent1(
+      recid=version["recid"],
+      element_version=version["element_version"],
+      element_content=version["element_content"],
+      element_edit_summary=version.get("element_edit_summary"),
+      element_created_by=version["element_created_by"],
+      element_created_on=version.get("element_created_on"),
+      access=access,
+    )
+
+  async def list_versions(
+    self,
+    slug: str,
+    user_guid: str | None,
+    role_mask: int,
+  ) -> UsersWikiVersionList1:
+    page, access = await self._resolve_editable_page(slug=slug, user_guid=user_guid, role_mask=role_mask)
     assert self.db
-    res = await self.db.run(list_versions_request(ListWikiVersionsParams(wiki_recid=wiki_recid)))
-    return [dict(row) for row in res.rows]
+    res = await self.db.run(list_versions_request(ListWikiVersionsParams(wiki_recid=page["recid"])))
+    versions = [dict(row) for row in res.rows]
+    from rpc.users.wiki.models import UsersWikiVersionItem1, UsersWikiVersionList1
+
+    return UsersWikiVersionList1(
+      versions=[
+        UsersWikiVersionItem1(
+          recid=version["recid"],
+          element_version=version["element_version"],
+          element_edit_summary=version.get("element_edit_summary"),
+          element_created_by=version["element_created_by"],
+          element_created_on=version.get("element_created_on"),
+        )
+        for version in versions
+      ],
+      access=access,
+    )
 
   async def get_version(
     self,
-    *,
-    recid: int | None = None,
-    wiki_recid: int | None = None,
-    version: int | None = None,
-  ) -> dict[str, Any] | None:
+    slug: str,
+    version: int,
+    user_guid: str | None,
+    role_mask: int,
+  ) -> UsersWikiVersionContent1:
+    page, access = await self._resolve_editable_page(slug=slug, user_guid=user_guid, role_mask=role_mask)
     assert self.db
     res = await self.db.run(
-      get_version_request(GetWikiVersionParams(recid=recid, wiki_recid=wiki_recid, version=version))
+      get_version_request(GetWikiVersionParams(recid=None, wiki_recid=page["recid"], version=version))
     )
-    return dict(res.rows[0]) if res.rows else None
+    if not res.rows:
+      raise HTTPException(status_code=404, detail="Version not found")
+    version_row = dict(res.rows[0])
+    from rpc.users.wiki.models import UsersWikiVersionContent1
+
+    return UsersWikiVersionContent1(
+      recid=version_row["recid"],
+      element_version=version_row["element_version"],
+      element_content=version_row["element_content"],
+      element_edit_summary=version_row.get("element_edit_summary"),
+      element_created_by=version_row["element_created_by"],
+      element_created_on=version_row.get("element_created_on"),
+      access=access,
+    )
+
+  def _ensure_authenticated(self, user_guid: str | None):
+    if user_guid is None:
+      raise HTTPException(status_code=401, detail="Authentication required")
+
+  async def _ensure_wiki_creation_allowed(
+    self,
+    *,
+    user_guid: str | None,
+    role_mask: int,
+  ) -> ContentAccess:
+    self._ensure_authenticated(user_guid)
+    role_module: RoleModule = self.app.state.role
+    access = role_module.check_content_access(
+      user_guid=user_guid,
+      role_mask=role_mask,
+      owner_guid=user_guid,
+    )
+    if not access.can_edit:
+      raise HTTPException(status_code=403, detail="Forbidden")
+    return access
+
+  async def _resolve_editable_page(
+    self,
+    *,
+    slug: str,
+    user_guid: str | None,
+    role_mask: int,
+  ) -> tuple[dict[str, Any], ContentAccess]:
+    self._ensure_authenticated(user_guid)
+    page = await self.get_page_by_slug(slug)
+    if not page:
+      raise HTTPException(status_code=404, detail="Page not found")
+    role_module: RoleModule = self.app.state.role
+    access = role_module.check_content_access(
+      user_guid=user_guid,
+      role_mask=role_mask,
+      owner_guid=page.get("element_created_by"),
+    )
+    if not access.can_edit:
+      raise HTTPException(status_code=403, detail="Forbidden")
+    return page, access


### PR DESCRIPTION
### Motivation

- Centralize business logic for pages/wiki version operations in module layer so RPC services remain mechanical dispatchers.
- Return RPC response models directly from modules and include `ContentAccess` flags so the frontend can render edit/delete controls without extra logic.
- Move slug-to-recid resolution and authorization checks into modules to ensure consistent `401`/`403`/`404` behavior and to simplify services for codegen.

### Description

- Added an `access: ContentAccess` field to `UsersPagesVersionList1`, `UsersPagesVersionContent1`, `UsersWikiVersionList1`, and `UsersWikiVersionContent1` and aliased server `ContentAccess` inside the RPC model files. (`rpc/users/pages/models.py`, `rpc/users/wiki/models.py`).
- Updated `ContentPagesModule` and `ContentWikiModule` so relevant methods accept `slug`, `user_guid`, and `role_mask` and return RPC models directly, performing slug lookup, `role.check_content_access()` and raising `HTTPException` with `401/403/404` as appropriate. (`server/modules/content_pages_module.py`, `server/modules/content_wiki_module.py`).
- Moved helpers into modules: `_resolve_editable_page`, `_ensure_authenticated`, and `_ensure_wiki_creation_allowed` to encapsulate auth and ownership checks and to surface `ContentAccess` in responses.
- Simplified RPC service functions in `rpc/users/pages/services.py` and `rpc/users/wiki/services.py` to the mechanical dispatch pattern: `unbox_request` → parse payload → `await module.on_ready()` → call module method → return `RPCResponse` with `result.model_dump()`, removing in-service helpers and business logic.

### Testing

- Ran `python -m py_compile rpc/users/pages/services.py rpc/users/wiki/services.py server/modules/content_pages_module.py server/modules/content_wiki_module.py rpc/users/pages/models.py rpc/users/wiki/models.py` which completed successfully.
- Ran the unified harness `python scripts/run_tests.py` which completed successfully and returned the test suite results (all automated tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef8fa091c8325aeb34167339d4275)