### PR TITLE
Move ContentAccess to rpc/shared models

### DIFF
--- a/rpc/shared/models.py
+++ b/rpc/shared/models.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+
+class ContentAccess(BaseModel):
+  """Capability flags for a user's access to a content resource.
+
+  Computed server-side by RoleModule.check_content_access() and included
+  in RPC responses so the frontend can conditionally render controls
+  (edit buttons, delete options, etc.) without inspecting tokens or GUIDs.
+  """
+
+  can_view: bool = True
+  can_edit: bool = False
+  can_delete: bool = False
+  is_owner: bool = False
+  is_admin: bool = False

--- a/rpc/users/pages/models.py
+++ b/rpc/users/pages/models.py
@@ -1,11 +1,7 @@
 from typing import Optional
 
 from pydantic import BaseModel
-from server.models import ContentAccess as ServerContentAccess
-
-
-class ContentAccess(ServerContentAccess):
-  pass
+from rpc.shared.models import ContentAccess
 
 
 class UsersPagesCreateVersion1(BaseModel):

--- a/rpc/users/wiki/models.py
+++ b/rpc/users/wiki/models.py
@@ -1,11 +1,7 @@
 from typing import Optional
 
 from pydantic import BaseModel
-from server.models import ContentAccess as ServerContentAccess
-
-
-class ContentAccess(ServerContentAccess):
-  pass
+from rpc.shared.models import ContentAccess
 
 
 class UsersWikiCreateVersion1(BaseModel):

--- a/server/models.py
+++ b/server/models.py
@@ -12,20 +12,6 @@ class AuthContext(BaseModel):
   claims: dict[str, Any] = Field(default_factory=dict)
 
 
-class ContentAccess(BaseModel):
-  """Capability flags for a user's access to a content resource.
-
-  Computed server-side by RoleModule.check_content_access() and included
-  in RPC responses so the frontend can conditionally render controls
-  (edit buttons, delete options, etc.) without inspecting tokens or GUIDs.
-  """
-
-  can_view: bool = True
-  can_edit: bool = False
-  can_delete: bool = False
-  is_owner: bool = False
-  is_admin: bool = False
-
 
 """
 This is an internal domain class, when a user makes a request

--- a/server/modules/content_pages_module.py
+++ b/server/modules/content_pages_module.py
@@ -7,7 +7,6 @@ from fastapi import FastAPI, HTTPException
 
 from . import BaseModule
 from .db_module import DbModule
-from server.models import ContentAccess
 from queryregistry.content.pages import (
   create_page_request,
   create_version_request,
@@ -32,6 +31,7 @@ from queryregistry.content.pages.models import (
 )
 
 if TYPE_CHECKING:
+  from rpc.shared.models import ContentAccess
   from rpc.users.pages.models import UsersPagesVersionContent1, UsersPagesVersionList1, UsersPagesVersionItem1
   from .role_module import RoleModule
 
@@ -229,7 +229,7 @@ class ContentPagesModule(BaseModule):
     slug: str,
     user_guid: str | None,
     role_mask: int,
-  ) -> tuple[dict[str, Any], ContentAccess]:
+  ) -> tuple[dict[str, Any], "ContentAccess"]:
     if user_guid is None:
       raise HTTPException(status_code=401, detail="Authentication required")
 

--- a/server/modules/content_wiki_module.py
+++ b/server/modules/content_wiki_module.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from fastapi import FastAPI, HTTPException
 
-from server.models import ContentAccess
 from queryregistry.content.wiki import (
   create_version_request,
   create_wiki_request,
@@ -37,6 +36,7 @@ from . import BaseModule
 from .db_module import DbModule
 
 if TYPE_CHECKING:
+  from rpc.shared.models import ContentAccess
   from rpc.users.wiki.models import UsersWikiVersionContent1, UsersWikiVersionList1, UsersWikiVersionItem1
   from .role_module import RoleModule
 
@@ -278,7 +278,7 @@ class ContentWikiModule(BaseModule):
     slug: str,
     user_guid: str | None,
     role_mask: int,
-  ) -> tuple[dict[str, Any], ContentAccess]:
+  ) -> tuple[dict[str, Any], "ContentAccess"]:
     self._ensure_authenticated(user_guid)
     page = await self.get_page_by_slug(slug)
     if not page:

--- a/server/modules/role_module.py
+++ b/server/modules/role_module.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from fastapi import FastAPI
 
@@ -14,7 +14,10 @@ from queryregistry.system.roles import (
   update_system_role_request,
 )
 from queryregistry.system.roles.models import DeleteRoleParams, UpsertRoleParams
-from server.models import ContentAccess
+
+
+if TYPE_CHECKING:
+  from rpc.shared.models import ContentAccess
 
 from . import BaseModule
 from .db_module import DbModule
@@ -151,7 +154,7 @@ class RoleModule(BaseModule):
     role_mask: int = 0,
     owner_guid: str | None = None,
     admin_mask: int | None = None,
-  ) -> ContentAccess:
+  ) -> "ContentAccess":
     """Compute capability flags for a user against a content resource.
 
     Args:
@@ -171,6 +174,8 @@ class RoleModule(BaseModule):
     is_authenticated = user_guid is not None
     is_owner = is_authenticated and owner_guid is not None and user_guid == owner_guid
     is_admin = is_authenticated and bool(role_mask & admin_mask) if admin_mask else False
+
+    from rpc.shared.models import ContentAccess
 
     return ContentAccess(
       can_view=True,


### PR DESCRIPTION
### Motivation
- Place the `ContentAccess` Pydantic model under the `rpc/` tree so the RPC binding generator can discover and emit it, and eliminate same-name re-export subclassing that caused an alias resolution loop in the seed script.

### Description
- Add a new package `rpc/shared` and create `rpc/shared/models.py` defining `ContentAccess` with the original fields and docstring.
- Remove the `ContentAccess` definition from `server/models.py` while leaving `AuthContext`, `RPCRequest`, and `RPCResponse` unchanged.
- Update `rpc/users/pages/models.py` and `rpc/users/wiki/models.py` to import `ContentAccess` directly from `rpc.shared.models` instead of subclassing the server model.
- Update server modules to reference the shared model: `server/modules/content_pages_module.py` and `server/modules/content_wiki_module.py` import `ContentAccess` under `TYPE_CHECKING` and use quoted forward references for signatures, and `server/modules/role_module.py` uses a `TYPE_CHECKING` annotation and performs a local import (`from rpc.shared.models import ContentAccess`) inside `check_content_access` to avoid circular import issues.

### Testing
- Ran the unified harness test entry: `python scripts/run_tests.py --test`, and the test suite completed successfully with all tests passing (40 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf04e4fba0832588c876bd59d45a7b)