### PR TITLE
Align account RPC services with module-owned response models

### DIFF
--- a/rpc/account/role/services.py
+++ b/rpc/account/role/services.py
@@ -4,28 +4,25 @@ from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.role_admin_module import RoleAdminModule
 from .models import (
-  AccountRoleAggregateItem1,
   AccountRoleAggregateList1,
-  AccountRoleRoleItem1,
-  AccountRoleList1,
+  AccountRoleDeleteRole1,
   AccountRoleGetMembersRequest1,
+  AccountRoleList1,
   AccountRoleMemberUpdate1,
   AccountRoleMembers1,
-  AccountRoleUserItem1,
   AccountRoleUpsertRole1,
-  AccountRoleDeleteRole1,
 )
 
 
 async def account_role_get_roles_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   module: RoleAdminModule = request.app.state.role_admin
-  roles_raw = await module.list_roles(auth_ctx.role_mask)
-  roles = [AccountRoleRoleItem1(**r) for r in roles_raw]
-  payload = AccountRoleList1(roles=roles)
+  await module.on_ready()
+
+  result: AccountRoleList1 = await module.list_roles(auth_ctx.role_mask)
   return RPCResponse(
     op=rpc_request.op,
-    payload=payload.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -33,12 +30,12 @@ async def account_role_get_roles_v1(request: Request):
 async def account_role_get_all_role_members_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   module: RoleAdminModule = request.app.state.role_admin
-  roles_raw = await module.get_all_role_members(auth_ctx.role_mask)
-  roles = [AccountRoleAggregateItem1(**r) for r in roles_raw]
-  payload = AccountRoleAggregateList1(roles=roles)
+  await module.on_ready()
+
+  result: AccountRoleAggregateList1 = await module.get_all_role_members(auth_ctx.role_mask)
   return RPCResponse(
     op=rpc_request.op,
-    payload=payload.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -47,13 +44,12 @@ async def account_role_get_role_members_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   input_payload = AccountRoleGetMembersRequest1(**(rpc_request.payload or {}))
   module: RoleAdminModule = request.app.state.role_admin
-  members_raw, non_raw = await module.get_role_members(input_payload.role)
-  members = [AccountRoleUserItem1(**m) for m in members_raw]
-  non_members = [AccountRoleUserItem1(**m) for m in non_raw]
-  res = AccountRoleMembers1(members=members, nonMembers=non_members)
+  await module.on_ready()
+
+  result: AccountRoleMembers1 = await module.get_role_members(input_payload.role)
   return RPCResponse(
     op=rpc_request.op,
-    payload=res.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -62,17 +58,16 @@ async def account_role_add_role_member_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleMemberUpdate1(**(rpc_request.payload or {}))
   module: RoleAdminModule = request.app.state.role_admin
-  members_raw, non_raw = await module.add_role_member(
+  await module.on_ready()
+
+  result: AccountRoleMembers1 = await module.add_role_member(
     data.role,
     data.userGuid,
     auth_ctx.role_mask,
   )
-  members = [AccountRoleUserItem1(**m) for m in members_raw]
-  non_members = [AccountRoleUserItem1(**m) for m in non_raw]
-  res = AccountRoleMembers1(members=members, nonMembers=non_members)
   return RPCResponse(
     op=rpc_request.op,
-    payload=res.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -81,17 +76,16 @@ async def account_role_remove_role_member_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleMemberUpdate1(**(rpc_request.payload or {}))
   module: RoleAdminModule = request.app.state.role_admin
-  members_raw, non_raw = await module.remove_role_member(
+  await module.on_ready()
+
+  result: AccountRoleMembers1 = await module.remove_role_member(
     data.role,
     data.userGuid,
     auth_ctx.role_mask,
   )
-  members = [AccountRoleUserItem1(**m) for m in members_raw]
-  non_members = [AccountRoleUserItem1(**m) for m in non_raw]
-  res = AccountRoleMembers1(members=members, nonMembers=non_members)
   return RPCResponse(
     op=rpc_request.op,
-    payload=res.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -100,9 +94,11 @@ async def account_role_upsert_role_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleUpsertRole1(**(rpc_request.payload or {}))
   module: RoleAdminModule = request.app.state.role_admin
+  await module.on_ready()
+
   await module.upsert_role(
     data.name,
-    int(data.mask),
+    data.mask,
     data.display,
     auth_ctx.role_mask,
   )
@@ -117,6 +113,8 @@ async def account_role_delete_role_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = AccountRoleDeleteRole1(**(rpc_request.payload or {}))
   module: RoleAdminModule = request.app.state.role_admin
+  await module.on_ready()
+
   await module.delete_role(data.name, auth_ctx.role_mask)
   return RPCResponse(
     op=rpc_request.op,

--- a/rpc/account/user/services.py
+++ b/rpc/account/user/services.py
@@ -1,14 +1,15 @@
 from fastapi import Request
+
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
-from server.modules.user_admin_module import UserAdminModule
 from server.modules.storage_module import StorageModule
+from server.modules.user_admin_module import UserAdminModule
 from .models import (
+  AccountUserCreateFolder1,
+  AccountUserCredits1,
+  AccountUserDisplayName1,
   AccountUserGuid1,
   AccountUserSetCredits1,
-  AccountUserDisplayName1,
-  AccountUserCredits1,
-  AccountUserCreateFolder1,
 )
 
 
@@ -16,11 +17,12 @@ async def account_user_get_displayname_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountUserGuid1(**(rpc_request.payload or {}))
   module: UserAdminModule = request.app.state.user_admin
-  display = await module.get_displayname(data.userGuid)
-  res = AccountUserDisplayName1(userGuid=data.userGuid, displayName=display)
+  await module.on_ready()
+
+  result: AccountUserDisplayName1 = await module.get_displayname(data.userGuid)
   return RPCResponse(
     op=rpc_request.op,
-    payload=res.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -29,11 +31,12 @@ async def account_user_get_credits_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountUserGuid1(**(rpc_request.payload or {}))
   module: UserAdminModule = request.app.state.user_admin
-  credits = await module.get_credits(data.userGuid)
-  res = AccountUserCredits1(userGuid=data.userGuid, credits=credits)
+  await module.on_ready()
+
+  result: AccountUserCredits1 = await module.get_credits(data.userGuid)
   return RPCResponse(
     op=rpc_request.op,
-    payload=res.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -42,6 +45,8 @@ async def account_user_set_credits_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountUserSetCredits1(**(rpc_request.payload or {}))
   module: UserAdminModule = request.app.state.user_admin
+  await module.on_ready()
+
   await module.set_credits(data.userGuid, data.credits)
   return RPCResponse(
     op=rpc_request.op,
@@ -54,6 +59,8 @@ async def account_user_reset_display_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountUserGuid1(**(rpc_request.payload or {}))
   module: UserAdminModule = request.app.state.user_admin
+  await module.on_ready()
+
   await module.reset_display(data.userGuid)
   return RPCResponse(
     op=rpc_request.op,
@@ -66,6 +73,8 @@ async def account_user_create_folder_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = AccountUserCreateFolder1(**(rpc_request.payload or {}))
   module: StorageModule = request.app.state.storage
+  await module.on_ready()
+
   await module.create_user_folder(data.userGuid, data.path)
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -14,10 +14,18 @@ from queryregistry.identity.roles.models import (
   RoleScopeParams,
 )
 from queryregistry.system.roles import list_system_roles_request
+from rpc.account.role.models import (
+  AccountRoleAggregateItem1,
+  AccountRoleAggregateList1,
+  AccountRoleList1,
+  AccountRoleMembers1,
+  AccountRoleRoleItem1,
+  AccountRoleUserItem1,
+)
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
-from server.modules.role_module import RoleModule
 from server.modules.discord_bot_module import DiscordBotModule
+from server.modules.role_module import RoleModule
 
 
 def _normalize_payload(payload: Any | None) -> list[dict[str, Any]]:
@@ -58,37 +66,43 @@ class RoleAdminModule(BaseModule):
     if target_mask > max_mask:
       raise HTTPException(status_code=403, detail="Forbidden")
 
-  async def list_roles(self, actor_mask: int | None = None) -> list[dict]:
+  async def list_roles(self, actor_mask: int | None = None) -> AccountRoleList1:
     res = await self.db.run(list_system_roles_request())
     roles = [
-      {
-        "name": r.get("name", ""),
-        "mask": str(r.get("mask", "")),
-        "display": r.get("display"),
-      }
+      AccountRoleRoleItem1(
+        name=r.get("name", ""),
+        mask=str(r.get("mask", "")),
+        display=r.get("display"),
+      )
       for r in _normalize_payload(res.payload)
     ]
-    roles.sort(key=lambda r: int(r.get("mask", 0)))
+    roles.sort(key=lambda r: int(r.mask))
     if actor_mask is not None:
       max_mask = self._max_mask(actor_mask)
-      roles = [r for r in roles if int(r.get("mask", 0)) <= max_mask]
-    return roles
+      roles = [r for r in roles if int(r.mask) <= max_mask]
+    return AccountRoleList1(roles=roles)
 
-  async def get_role_members(self, role: str) -> tuple[list[dict], list[dict]]:
+  async def get_role_members(self, role: str) -> AccountRoleMembers1:
     scope = RoleScopeParams(role=role)
     mem_res = await self.db.run(list_role_memberships_request(scope))
     non_res = await self.db.run(list_role_non_memberships_request(scope))
     members = [
-      {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
+      AccountRoleUserItem1(
+        guid=r.get("guid", ""),
+        displayName=r.get("display_name", ""),
+      )
       for r in _normalize_payload(mem_res.payload)
     ]
     non_members = [
-      {"guid": r.get("guid", ""), "displayName": r.get("display_name", "")}
+      AccountRoleUserItem1(
+        guid=r.get("guid", ""),
+        displayName=r.get("display_name", ""),
+      )
       for r in _normalize_payload(non_res.payload)
     ]
-    return members, non_members
+    return AccountRoleMembers1(members=members, nonMembers=non_members)
 
-  async def get_all_role_members(self, actor_mask: int | None = None) -> list[dict]:
+  async def get_all_role_members(self, actor_mask: int | None = None) -> AccountRoleAggregateList1:
     """Return all roles with members and non-members in a single query."""
     res = await self.db.run(list_all_role_memberships_request())
     roles = []
@@ -101,24 +115,35 @@ class RoleAdminModule(BaseModule):
       members_raw = r.get("members") or []
       non_members_raw = r.get("non_members") or []
       roles.append(
-        {
-          "name": r.get("name", ""),
-          "mask": str(mask_val),
-          "display": r.get("display"),
-          "members": [
-            {"guid": m.get("guid", ""), "displayName": m.get("display_name", "")}
+        AccountRoleAggregateItem1(
+          name=r.get("name", ""),
+          mask=str(mask_val),
+          display=r.get("display"),
+          members=[
+            AccountRoleUserItem1(
+              guid=m.get("guid", ""),
+              displayName=m.get("display_name", ""),
+            )
             for m in members_raw
           ],
-          "nonMembers": [
-            {"guid": m.get("guid", ""), "displayName": m.get("display_name", "")}
+          nonMembers=[
+            AccountRoleUserItem1(
+              guid=m.get("guid", ""),
+              displayName=m.get("display_name", ""),
+            )
             for m in non_members_raw
           ],
-        }
+        )
       )
-    roles.sort(key=lambda r: int(r.get("mask", 0)))
-    return roles
+    roles.sort(key=lambda r: int(r.mask))
+    return AccountRoleAggregateList1(roles=roles)
 
-  async def add_role_member(self, role: str, user_guid: str, actor_mask: int | None = None) -> tuple[list[dict], list[dict]]:
+  async def add_role_member(
+    self,
+    role: str,
+    user_guid: str,
+    actor_mask: int | None = None,
+  ) -> AccountRoleMembers1:
     if actor_mask is not None:
       role_mask = self.role.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
@@ -127,7 +152,12 @@ class RoleAdminModule(BaseModule):
     await self.role.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 
-  async def remove_role_member(self, role: str, user_guid: str, actor_mask: int | None = None) -> tuple[list[dict], list[dict]]:
+  async def remove_role_member(
+    self,
+    role: str,
+    user_guid: str,
+    actor_mask: int | None = None,
+  ) -> AccountRoleMembers1:
     if actor_mask is not None:
       role_mask = self.role.roles.get(role, 0)
       self._ensure_can_manage(actor_mask, role_mask)
@@ -136,10 +166,17 @@ class RoleAdminModule(BaseModule):
     await self.role.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 
-  async def upsert_role(self, name: str, mask: int, display: str | None, actor_mask: int | None = None) -> None:
+  async def upsert_role(
+    self,
+    name: str,
+    mask: str,
+    display: str | None,
+    actor_mask: int | None = None,
+  ) -> None:
+    role_mask = int(mask)
     if actor_mask is not None:
-      self._ensure_can_manage(actor_mask, mask)
-    await self.role.upsert_role(name, mask, display)
+      self._ensure_can_manage(actor_mask, role_mask)
+    await self.role.upsert_role(name, role_mask, display)
 
   async def delete_role(self, name: str, actor_mask: int | None = None) -> None:
     if actor_mask is not None:

--- a/server/modules/user_admin_module.py
+++ b/server/modules/user_admin_module.py
@@ -1,11 +1,12 @@
 from fastapi import FastAPI, HTTPException
+from queryregistry.finance.credits import set_credits_request
+from queryregistry.finance.credits.models import SetCreditsParams
+from queryregistry.identity.profiles import get_profile_request, update_profile_request
+from queryregistry.identity.profiles.models import GuidParams, UpdateProfileParams
+from rpc.account.user.models import AccountUserCredits1, AccountUserDisplayName1
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
-from queryregistry.identity.profiles import get_profile_request, update_profile_request
-from queryregistry.identity.profiles.models import GuidParams, UpdateProfileParams
-from queryregistry.finance.credits.models import SetCreditsParams
-from queryregistry.finance.credits import set_credits_request
 
 
 class UserAdminModule(BaseModule):
@@ -24,15 +25,18 @@ class UserAdminModule(BaseModule):
   async def shutdown(self):
     pass
 
-  async def get_displayname(self, guid: str) -> str:
+  async def get_displayname(self, guid: str) -> AccountUserDisplayName1:
     params = GuidParams(guid=guid)
     res = await self.db.run(get_profile_request(params))
     if not res.rows:
       raise HTTPException(status_code=404, detail="Profile not found")
     row = res.rows[0]
-    return row.get("display_name", "")
+    return AccountUserDisplayName1(
+      userGuid=guid,
+      displayName=row.get("display_name", ""),
+    )
 
-  async def get_credits(self, guid: str) -> int:
+  async def get_credits(self, guid: str) -> AccountUserCredits1:
     params = GuidParams(guid=guid)
     res = await self.db.run(get_profile_request(params))
     if not res.rows:
@@ -41,7 +45,7 @@ class UserAdminModule(BaseModule):
     credits = row.get("credits")
     if credits is None:
       raise HTTPException(status_code=404, detail="Credits not found")
-    return credits
+    return AccountUserCredits1(userGuid=guid, credits=credits)
 
   async def set_credits(self, guid: str, credits: int) -> None:
     await self.db.run(


### PR DESCRIPTION
### Motivation
- Enforce the RPC dispatch pattern so modules own response model construction and service functions are thin security/dispatch routers per `PATTERNS.md`. 
- Remove service-layer data shaping and coercion so the binding generator can reliably extract response types (§0.2) and modules perform all column/name mapping (§3.2–3.3).
- Ensure runtime readiness synchronization by calling `module.on_ready()` in every audited account service (§0.1).

### Description
- Moved response model construction into `RoleAdminModule` so query methods now return `AccountRoleList1`, `AccountRoleMembers1`, and `AccountRoleAggregateList1` instead of raw `dict`/`tuple` results. 
- Updated `UserAdminModule` query methods to return `AccountUserDisplayName1` and `AccountUserCredits1` directly instead of scalars. 
- Refactored `rpc/account/role/services.py` and `rpc/account/user/services.py` into thin dispatchers that `await module.on_ready()`, call module methods, assign typed `result` variables (e.g. `result: AccountRoleList1 = ...`), and return `payload=result.model_dump()` with no service-side model construction. 
- Moved `mask` coercion out of the service and into `RoleAdminModule.upsert_role` (now accepts `mask: str` and coerces to `int` internally), and retained `_normalize_payload` as still referenced. 

### Testing
- Ran `python scripts/run_tests.py --test`, which starts the unified harness but failed during the frontend TypeScript `tsc` step due to pre-existing missing `RpcModels` exports unrelated to these backend changes (failure noted). 
- Ran `python scripts/generate_rpc_bindings.py`, which completed successfully and confirmed the binding generator now extracts correct `account.role` and `account.user` response contracts from the typed `result` annotations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf0abe22c88325ab39787142913c55)