### PR TITLE
Align support RPC services with typed support-domain module responses

### DIFF
--- a/rpc/support/roles/services.py
+++ b/rpc/support/roles/services.py
@@ -10,7 +10,6 @@ from .models import (
   SupportRolesGetMembersRequest1,
   SupportRolesMembers1,
   SupportRolesRoleMemberUpdate1,
-  SupportRolesUserItem1,
 )
 
 if TYPE_CHECKING:
@@ -21,13 +20,12 @@ async def support_roles_get_members_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   input_payload = SupportRolesGetMembersRequest1(**(rpc_request.payload or {}))
   module: RoleAdminModule = request.app.state.role_admin
-  members_raw, non_raw = await module.get_role_members(input_payload.role)
-  members = [SupportRolesUserItem1(**m) for m in members_raw]
-  non_members = [SupportRolesUserItem1(**m) for m in non_raw]
-  res = SupportRolesMembers1(members=members, nonMembers=non_members)
+  await module.on_ready()
+
+  result: SupportRolesMembers1 = await module.get_role_members_for_support(input_payload.role)
   return RPCResponse(
     op=rpc_request.op,
-    payload=res.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -36,17 +34,16 @@ async def support_roles_add_member_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = SupportRolesRoleMemberUpdate1(**(rpc_request.payload or {}))
   module: RoleAdminModule = request.app.state.role_admin
-  members_raw, non_raw = await module.add_role_member(
+  await module.on_ready()
+
+  result: SupportRolesMembers1 = await module.add_role_member_for_support(
     data.role,
     data.userGuid,
     auth_ctx.role_mask,
   )
-  members = [SupportRolesUserItem1(**m) for m in members_raw]
-  non_members = [SupportRolesUserItem1(**m) for m in non_raw]
-  res = SupportRolesMembers1(members=members, nonMembers=non_members)
   return RPCResponse(
     op=rpc_request.op,
-    payload=res.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -55,16 +52,15 @@ async def support_roles_remove_member_v1(request: Request):
   rpc_request, auth_ctx, _ = await unbox_request(request)
   data = SupportRolesRoleMemberUpdate1(**(rpc_request.payload or {}))
   module: RoleAdminModule = request.app.state.role_admin
-  members_raw, non_raw = await module.remove_role_member(
+  await module.on_ready()
+
+  result: SupportRolesMembers1 = await module.remove_role_member_for_support(
     data.role,
     data.userGuid,
     auth_ctx.role_mask,
   )
-  members = [SupportRolesUserItem1(**m) for m in members_raw]
-  non_members = [SupportRolesUserItem1(**m) for m in non_raw]
-  res = SupportRolesMembers1(members=members, nonMembers=non_members)
   return RPCResponse(
     op=rpc_request.op,
-    payload=res.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )

--- a/rpc/support/users/services.py
+++ b/rpc/support/users/services.py
@@ -22,11 +22,12 @@ async def support_users_get_displayname_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = SupportUsersGuid1(**(rpc_request.payload or {}))
   module: UserAdminModule = request.app.state.user_admin
-  display = await module.get_displayname(data.userGuid)
-  res = SupportUsersDisplayName1(userGuid=data.userGuid, displayName=display)
+  await module.on_ready()
+
+  result: SupportUsersDisplayName1 = await module.get_displayname_for_support(data.userGuid)
   return RPCResponse(
     op=rpc_request.op,
-    payload=res.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -35,11 +36,12 @@ async def support_users_get_credits_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = SupportUsersGuid1(**(rpc_request.payload or {}))
   module: UserAdminModule = request.app.state.user_admin
-  credits = await module.get_credits(data.userGuid)
-  res = SupportUsersCredits1(userGuid=data.userGuid, credits=credits)
+  await module.on_ready()
+
+  result: SupportUsersCredits1 = await module.get_credits_for_support(data.userGuid)
   return RPCResponse(
     op=rpc_request.op,
-    payload=res.model_dump(),
+    payload=result.model_dump(),
     version=rpc_request.version,
   )
 
@@ -48,6 +50,8 @@ async def support_users_set_credits_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = SupportUsersSetCredits1(**(rpc_request.payload or {}))
   module: UserAdminModule = request.app.state.user_admin
+  await module.on_ready()
+
   await module.set_credits(data.userGuid, data.credits)
   return RPCResponse(
     op=rpc_request.op,
@@ -60,6 +64,8 @@ async def support_users_reset_display_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   data = SupportUsersGuid1(**(rpc_request.payload or {}))
   module: UserAdminModule = request.app.state.user_admin
+  await module.on_ready()
+
   await module.reset_display(data.userGuid)
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/role_admin_module.py
+++ b/server/modules/role_admin_module.py
@@ -22,6 +22,7 @@ from rpc.account.role.models import (
   AccountRoleRoleItem1,
   AccountRoleUserItem1,
 )
+from rpc.support.roles.models import SupportRolesMembers1, SupportRolesUserItem1
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
@@ -152,6 +153,40 @@ class RoleAdminModule(BaseModule):
     await self.role.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
 
+  async def get_role_members_for_support(self, role: str) -> SupportRolesMembers1:
+    scope = RoleScopeParams(role=role)
+    mem_res = await self.db.run(list_role_memberships_request(scope))
+    non_res = await self.db.run(list_role_non_memberships_request(scope))
+    members = [
+      SupportRolesUserItem1(
+        guid=r.get("guid", ""),
+        displayName=r.get("display_name", ""),
+      )
+      for r in _normalize_payload(mem_res.payload)
+    ]
+    non_members = [
+      SupportRolesUserItem1(
+        guid=r.get("guid", ""),
+        displayName=r.get("display_name", ""),
+      )
+      for r in _normalize_payload(non_res.payload)
+    ]
+    return SupportRolesMembers1(members=members, nonMembers=non_members)
+
+  async def add_role_member_for_support(
+    self,
+    role: str,
+    user_guid: str,
+    actor_mask: int | None = None,
+  ) -> SupportRolesMembers1:
+    if actor_mask is not None:
+      role_mask = self.role.roles.get(role, 0)
+      self._ensure_can_manage(actor_mask, role_mask)
+    payload = ModifyRoleMemberParams(role=role, user_guid=user_guid)
+    await self.db.run(create_role_membership_request(payload))
+    await self.role.refresh_user_roles(user_guid)
+    return await self.get_role_members_for_support(role)
+
   async def remove_role_member(
     self,
     role: str,
@@ -165,6 +200,20 @@ class RoleAdminModule(BaseModule):
     await self.db.run(delete_role_membership_request(payload))
     await self.role.refresh_user_roles(user_guid)
     return await self.get_role_members(role)
+
+  async def remove_role_member_for_support(
+    self,
+    role: str,
+    user_guid: str,
+    actor_mask: int | None = None,
+  ) -> SupportRolesMembers1:
+    if actor_mask is not None:
+      role_mask = self.role.roles.get(role, 0)
+      self._ensure_can_manage(actor_mask, role_mask)
+    payload = ModifyRoleMemberParams(role=role, user_guid=user_guid)
+    await self.db.run(delete_role_membership_request(payload))
+    await self.role.refresh_user_roles(user_guid)
+    return await self.get_role_members_for_support(role)
 
   async def upsert_role(
     self,

--- a/server/modules/user_admin_module.py
+++ b/server/modules/user_admin_module.py
@@ -4,6 +4,7 @@ from queryregistry.finance.credits.models import SetCreditsParams
 from queryregistry.identity.profiles import get_profile_request, update_profile_request
 from queryregistry.identity.profiles.models import GuidParams, UpdateProfileParams
 from rpc.account.user.models import AccountUserCredits1, AccountUserDisplayName1
+from rpc.support.users.models import SupportUsersCredits1, SupportUsersDisplayName1
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
@@ -46,6 +47,28 @@ class UserAdminModule(BaseModule):
     if credits is None:
       raise HTTPException(status_code=404, detail="Credits not found")
     return AccountUserCredits1(userGuid=guid, credits=credits)
+
+  async def get_displayname_for_support(self, guid: str) -> SupportUsersDisplayName1:
+    params = GuidParams(guid=guid)
+    res = await self.db.run(get_profile_request(params))
+    if not res.rows:
+      raise HTTPException(status_code=404, detail="Profile not found")
+    row = res.rows[0]
+    return SupportUsersDisplayName1(
+      userGuid=guid,
+      displayName=row.get("display_name", ""),
+    )
+
+  async def get_credits_for_support(self, guid: str) -> SupportUsersCredits1:
+    params = GuidParams(guid=guid)
+    res = await self.db.run(get_profile_request(params))
+    if not res.rows:
+      raise HTTPException(status_code=404, detail="Profile not found")
+    row = res.rows[0]
+    credits = row.get("credits")
+    if credits is None:
+      raise HTTPException(status_code=404, detail="Credits not found")
+    return SupportUsersCredits1(userGuid=guid, credits=credits)
 
   async def set_credits(self, guid: str, credits: int) -> None:
     await self.db.run(


### PR DESCRIPTION
### Motivation
- Bring the `support` domain into compliance with the canonical RPC service pattern so service functions are pure dispatchers and the module layer owns response models. 
- Preserve support-specific Pydantic models (do not import account-domain models into `rpc/support`), and ensure the AST-driven binding generator can extract non-void return types via `result:` annotations.

### Description
- Added support-specific response helpers to `UserAdminModule`: `get_displayname_for_support(...) -> SupportUsersDisplayName1` and `get_credits_for_support(...) -> SupportUsersCredits1` so modules return `rpc.support.users` models directly (`server/modules/user_admin_module.py`).
- Added support-specific response helpers to `RoleAdminModule`: `get_role_members_for_support(...)`, `add_role_member_for_support(...)`, and `remove_role_member_for_support(...)` returning `SupportRolesMembers1` (`server/modules/role_admin_module.py`).
- Refactored `rpc/support/users/services.py` to the canonical pass-through pattern by resolving `module`, calling `await module.on_ready()`, using typed `result:` annotations, and returning `RPCResponse(payload=result.model_dump())` without inline model construction.
- Refactored `rpc/support/roles/services.py` to call the new `_for_support` module methods, added `await module.on_ready()`, added typed `result:` annotations, and removed tuple/list comprehensions and inline model construction in the service layer.

### Testing
- Ran `python scripts/run_tests.py --test`, which completed successfully (`40 passed`) in this environment. 
- Ran `python scripts/generate_rpc_bindings.py`, which succeeded and produced updated TypeScript bindings reflecting `SupportUsersDisplayName1`, `SupportUsersCredits1`, and `SupportRolesMembers1` as return types. 
- Spot-checked generated frontend bindings under `frontend/src/rpc/support/*` and confirmed the non-void return types for the modified endpoints. 
- `python scripts/seed_rpcdispatch.py` was attempted but failed in this environment due to missing `AZURE_SQL_CONNECTION_STRING_DEV`/`AZURE_SQL_CONNECTION_STRING`, which is an expected environment limitation and not a code failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf2773c21483259b57f8fb5b1f592a)