### PR TITLE
Rename reflection schema tables to reflection_db_* prefix

### DIFF
--- a/migrations/v0.11.10.0_rename_schema_tables_to_reflection_db.sql
+++ b/migrations/v0.11.10.0_rename_schema_tables_to_reflection_db.sql
@@ -1,0 +1,42 @@
+-- Rename system_schema_* tables to reflection_db_*
+-- Rename system_edt_mappings to reflection_db_edt_mappings
+
+EXEC sp_rename 'system_edt_mappings', 'reflection_db_edt_mappings';
+GO
+EXEC sp_rename 'system_schema_tables', 'reflection_db_tables';
+GO
+EXEC sp_rename 'system_schema_columns', 'reflection_db_columns';
+GO
+EXEC sp_rename 'system_schema_indexes', 'reflection_db_indexes';
+GO
+EXEC sp_rename 'system_schema_foreign_keys', 'reflection_db_foreign_keys';
+GO
+EXEC sp_rename 'system_schema_views', 'reflection_db_views';
+GO
+
+-- Update the reflection metadata: system_schema_tables stores its own name
+-- Update the cached table names in the tables registry itself
+UPDATE reflection_db_tables
+SET element_name = 'reflection_db_edt_mappings'
+WHERE element_schema = 'dbo' AND element_name = 'system_edt_mappings';
+
+UPDATE reflection_db_tables
+SET element_name = 'reflection_db_tables'
+WHERE element_schema = 'dbo' AND element_name = 'system_schema_tables';
+
+UPDATE reflection_db_tables
+SET element_name = 'reflection_db_columns'
+WHERE element_schema = 'dbo' AND element_name = 'system_schema_columns';
+
+UPDATE reflection_db_tables
+SET element_name = 'reflection_db_indexes'
+WHERE element_schema = 'dbo' AND element_name = 'system_schema_indexes';
+
+UPDATE reflection_db_tables
+SET element_name = 'reflection_db_foreign_keys'
+WHERE element_schema = 'dbo' AND element_name = 'system_schema_foreign_keys';
+
+UPDATE reflection_db_tables
+SET element_name = 'reflection_db_views'
+WHERE element_schema = 'dbo' AND element_name = 'system_schema_views';
+GO

--- a/queryregistry/reflection/edt/mssql.py
+++ b/queryregistry/reflection/edt/mssql.py
@@ -14,7 +14,7 @@ __all__ = ["list_edt_v1"]
 async def list_edt_v1(_: Mapping[str, Any]) -> DBResponse:
   sql = """
     SELECT recid, element_name
-    FROM system_edt_mappings
+    FROM reflection_db_edt_mappings
     ORDER BY recid
     FOR JSON PATH, INCLUDE_NULL_VALUES;
   """

--- a/queryregistry/reflection/schema/models.py
+++ b/queryregistry/reflection/schema/models.py
@@ -35,7 +35,7 @@ class FullSchemaParams(BaseModel):
 
 
 class TableRecord(TypedDict):
-  """Table metadata record from system_schema_tables."""
+  """Table metadata record from reflection_db_tables."""
 
   recid: int
   element_schema: str
@@ -57,7 +57,7 @@ class ColumnRecord(TypedDict):
 
 
 class IndexRecord(TypedDict):
-  """Index metadata record from system_schema_indexes."""
+  """Index metadata record from reflection_db_indexes."""
 
   tables_recid: int
   element_name: str
@@ -66,7 +66,7 @@ class IndexRecord(TypedDict):
 
 
 class ForeignKeyRecord(TypedDict):
-  """Foreign key metadata record from system_schema_foreign_keys."""
+  """Foreign key metadata record from reflection_db_foreign_keys."""
 
   tables_recid: int
   element_column_name: str
@@ -75,7 +75,7 @@ class ForeignKeyRecord(TypedDict):
 
 
 class ViewRecord(TypedDict):
-  """View metadata record from system_schema_views."""
+  """View metadata record from reflection_db_views."""
 
   element_schema: str
   element_name: str

--- a/queryregistry/reflection/schema/mssql.py
+++ b/queryregistry/reflection/schema/mssql.py
@@ -21,7 +21,7 @@ __all__ = [
 async def list_tables_v1(_: Mapping[str, Any]) -> DBResponse:
   sql = """
     SELECT recid, element_schema, element_name
-    FROM system_schema_tables
+    FROM reflection_db_tables
     ORDER BY element_schema, element_name
     FOR JSON PATH;
   """
@@ -35,9 +35,9 @@ async def list_columns_v1(args: Mapping[str, Any]) -> DBResponse:
     SELECT c.tables_recid, c.element_name, c.element_nullable, c.element_default,
            c.element_max_length, c.element_is_primary_key, c.element_is_identity,
            c.element_ordinal, m.element_mssql_type
-    FROM system_schema_columns c
-    JOIN system_edt_mappings m ON c.edt_recid = m.recid
-    JOIN system_schema_tables t ON c.tables_recid = t.recid
+    FROM reflection_db_columns c
+    JOIN reflection_db_edt_mappings m ON c.edt_recid = m.recid
+    JOIN reflection_db_tables t ON c.tables_recid = t.recid
     WHERE t.element_schema = ? AND t.element_name = ?
     ORDER BY c.element_ordinal
     FOR JSON PATH;
@@ -50,8 +50,8 @@ async def list_indexes_v1(args: Mapping[str, Any]) -> DBResponse:
   table_name = args["name"]
   sql = """
     SELECT i.tables_recid, i.element_name, i.element_columns, i.element_is_unique
-    FROM system_schema_indexes i
-    JOIN system_schema_tables t ON i.tables_recid = t.recid
+    FROM reflection_db_indexes i
+    JOIN reflection_db_tables t ON i.tables_recid = t.recid
     WHERE t.element_schema = ? AND t.element_name = ?
     ORDER BY i.element_name
     FOR JSON PATH;
@@ -65,8 +65,8 @@ async def list_foreign_keys_v1(args: Mapping[str, Any]) -> DBResponse:
   sql = """
     SELECT fk.tables_recid, fk.element_column_name, fk.referenced_tables_recid,
            fk.element_referenced_column
-    FROM system_schema_foreign_keys fk
-    JOIN system_schema_tables t ON fk.tables_recid = t.recid
+    FROM reflection_db_foreign_keys fk
+    JOIN reflection_db_tables t ON fk.tables_recid = t.recid
     WHERE t.element_schema = ? AND t.element_name = ?
     ORDER BY fk.element_column_name
     FOR JSON PATH;
@@ -77,7 +77,7 @@ async def list_foreign_keys_v1(args: Mapping[str, Any]) -> DBResponse:
 async def list_views_v1(_: Mapping[str, Any]) -> DBResponse:
   sql = """
     SELECT element_schema, element_name, element_definition
-    FROM system_schema_views
+    FROM reflection_db_views
     ORDER BY element_schema, element_name
     FOR JSON PATH;
   """
@@ -88,7 +88,7 @@ async def get_full_schema_v1(_: Mapping[str, Any]) -> DBResponse:
   tables = await run_json_many(
     """
     SELECT recid, element_schema, element_name
-    FROM system_schema_tables
+    FROM reflection_db_tables
     ORDER BY element_schema, element_name
     FOR JSON PATH;
     """
@@ -98,8 +98,8 @@ async def get_full_schema_v1(_: Mapping[str, Any]) -> DBResponse:
     SELECT c.tables_recid, c.element_name, c.element_nullable, c.element_default,
            c.element_max_length, c.element_is_primary_key, c.element_is_identity,
            c.element_ordinal, m.element_mssql_type
-    FROM system_schema_columns c
-    JOIN system_edt_mappings m ON c.edt_recid = m.recid
+    FROM reflection_db_columns c
+    JOIN reflection_db_edt_mappings m ON c.edt_recid = m.recid
     ORDER BY c.tables_recid, c.element_ordinal
     FOR JSON PATH;
     """
@@ -107,7 +107,7 @@ async def get_full_schema_v1(_: Mapping[str, Any]) -> DBResponse:
   indexes = await run_json_many(
     """
     SELECT i.tables_recid, i.element_name, i.element_columns, i.element_is_unique
-    FROM system_schema_indexes i
+    FROM reflection_db_indexes i
     ORDER BY i.tables_recid, i.element_name
     FOR JSON PATH;
     """
@@ -116,7 +116,7 @@ async def get_full_schema_v1(_: Mapping[str, Any]) -> DBResponse:
     """
     SELECT fk.tables_recid, fk.element_column_name, fk.referenced_tables_recid,
            fk.element_referenced_column
-    FROM system_schema_foreign_keys fk
+    FROM reflection_db_foreign_keys fk
     ORDER BY fk.tables_recid, fk.element_column_name
     FOR JSON PATH;
     """
@@ -124,7 +124,7 @@ async def get_full_schema_v1(_: Mapping[str, Any]) -> DBResponse:
   views = await run_json_many(
     """
     SELECT element_schema, element_name, element_definition
-    FROM system_schema_views
+    FROM reflection_db_views
     ORDER BY element_schema, element_name
     FOR JSON PATH;
     """


### PR DESCRIPTION
### Motivation

- Group database reflection metadata under a clear `reflection_db_*` prefix to separate it semantically from `reflection_rpc_*` metadata and to reflect that these tables store DB structure reflection data.
- Ensure SQL strings, TypedDict docstrings, and migration tooling refer to the correct table names so runtime queries and the reflection registry remain consistent after rename.

### Description

- Added migration `migrations/v0.11.10.0_rename_schema_tables_to_reflection_db.sql` containing `sp_rename` calls for the six tables and `UPDATE` statements to refresh self-referential rows in the table registry (`reflection_db_tables`).
- Updated SQL strings in `queryregistry/reflection/schema/mssql.py` to reference `reflection_db_tables`, `reflection_db_columns`, `reflection_db_indexes`, `reflection_db_foreign_keys`, `reflection_db_views`, and `reflection_db_edt_mappings`.
- Updated `queryregistry/reflection/edt/mssql.py` so `list_edt_v1` queries `reflection_db_edt_mappings`.
- Updated TypedDict docstrings in `queryregistry/reflection/schema/models.py` to name the new tables; no Python function names, op paths, or module/RPC-layer code were changed.

### Testing

- Ran `python scripts/run_tests.py --test` which completed successfully (test suite run as part of the unified harness).
- Ran `python scripts/generate_rpc_bindings.py` which succeeded and produced frontend bindings.
- Ran `python scripts/seed_rpcdispatch.py` which failed in this environment due to missing `AZURE_SQL_CONNECTION_STRING_DEV`/`AZURE_SQL_CONNECTION_STRING` environment variables, so database seeding was skipped in CI-like environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf3555ba3c83258c22dbd24df7d21a)