### PR TITLE
Hotfix: Inline missing RPC Pydantic models in server modules

### DIFF
--- a/server/modules/finance_module.py
+++ b/server/modules/finance_module.py
@@ -8,8 +8,7 @@ from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import Any
 
 from fastapi import FastAPI
-
-from rpc.users.products.models import UsersProductItem1, UsersProductList1, UsersProductPurchaseResult1
+from pydantic import BaseModel
 
 from . import BaseModule
 from .db_module import DbModule
@@ -294,6 +293,31 @@ from .models.finance_statuses import (
   PERIOD_LOCKED,
   PERIOD_OPEN,
 )
+
+
+class UsersProductItem1(BaseModel):
+  sku: str
+  name: str
+  description: str | None = None
+  category: str
+  price: str
+  currency: str
+  credits: int
+  enablement_key: str | None = None
+  is_recurring: bool = False
+  sort_order: int = 0
+  already_enabled: bool = False
+
+
+class UsersProductList1(BaseModel):
+  products: list[UsersProductItem1]
+
+
+class UsersProductPurchaseResult1(BaseModel):
+  transaction_token: str
+  credits_granted: int | None = None
+  enablement_granted: str | None = None
+  lot_number: str | None = None
 
 
 _FIVE_PLACES = Decimal("0.00001")

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import base64, logging, uuid
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
 import aiohttp
 from datetime import datetime, timezone, timedelta
 
 from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 from queryregistry.identity.profiles import (
   get_profile_request,
   update_if_unedited_request,
@@ -52,14 +52,29 @@ from queryregistry.finance.credits import set_credits_request
 from queryregistry.finance.credits.models import SetCreditsParams
 from queryregistry.system.config import get_config_request
 
-if TYPE_CHECKING:
-  from rpc.users.providers.models import (
-    UsersProvidersCreateFromProviderResult1,
-    UsersProvidersGetByProviderIdentifierResult1,
-    UsersProvidersLinkProviderResult1,
-    UsersProvidersSetProviderResult1,
-    UsersProvidersUnlinkProviderResult1,
-  )
+class UsersProvidersSetProviderResult1(BaseModel):
+  provider: str
+  code: str | None = None
+  id_token: str | None = None
+  access_token: str | None = None
+
+
+class UsersProvidersLinkProviderResult1(BaseModel):
+  provider: str
+
+
+class UsersProvidersUnlinkProviderResult1(BaseModel):
+  provider: str
+
+
+class UsersProvidersGetByProviderIdentifierResult1(BaseModel):
+  guid: str | None = None
+  provider: str | None = None
+  provider_identifier: str | None = None
+
+
+class UsersProvidersCreateFromProviderResult1(BaseModel):
+  guid: str | None = None
 
 
 class OauthModule(BaseModule):
@@ -218,7 +233,6 @@ class OauthModule(BaseModule):
         display_name=display_name,
       )
       await self.db.run(update_if_unedited_request(params))
-    from rpc.users.providers.models import UsersProvidersSetProviderResult1
     return UsersProvidersSetProviderResult1(**original)
 
   async def link_user_provider(
@@ -256,7 +270,6 @@ class OauthModule(BaseModule):
         provider_identifier=provider_uid,
       ),
     )
-    from rpc.users.providers.models import UsersProvidersLinkProviderResult1
     return UsersProvidersLinkProviderResult1(provider=provider)
 
   async def unlink_user_provider(
@@ -290,7 +303,6 @@ class OauthModule(BaseModule):
           RevokeProviderTokensParams(guid=user_guid, provider=provider)
         )
       )
-    from rpc.users.providers.models import UsersProvidersUnlinkProviderResult1
     return UsersProvidersUnlinkProviderResult1(provider=provider)
 
   async def unlink_last_provider_record(self, guid: str, provider: str) -> None:
@@ -309,7 +321,6 @@ class OauthModule(BaseModule):
       ),
     )
     rows = self._normalize_query_payload(res.payload)
-    from rpc.users.providers.models import UsersProvidersGetByProviderIdentifierResult1
     if not rows:
       return UsersProvidersGetByProviderIdentifierResult1()
     return UsersProvidersGetByProviderIdentifierResult1(**rows[0])
@@ -338,7 +349,6 @@ class OauthModule(BaseModule):
       ),
     )
     rows = self._normalize_query_payload(res.payload)
-    from rpc.users.providers.models import UsersProvidersCreateFromProviderResult1
     if not rows:
       return UsersProvidersCreateFromProviderResult1()
     return UsersProvidersCreateFromProviderResult1(**rows[0])

--- a/server/modules/profile_module.py
+++ b/server/modules/profile_module.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 
-from rpc.users.profile.models import UsersProfileProfile1, UsersProfileRoles1
 from . import BaseModule
 from .auth_module import AuthModule
 from .db_module import DbModule
@@ -14,6 +14,21 @@ from queryregistry.identity.profiles.models import (
   ProfileRecord,
   UpdateProfileParams,
 )
+
+
+class UsersProfileProfile1(BaseModel):
+  guid: str
+  display_name: str
+  email: str
+  display_email: bool
+  credits: int
+  profile_image: str | None = None
+  default_provider: str
+  auth_providers: list[dict]
+
+
+class UsersProfileRoles1(BaseModel):
+  roles: int
 
 
 class ProfileModule(BaseModule):

--- a/server/modules/user_admin_module.py
+++ b/server/modules/user_admin_module.py
@@ -1,13 +1,32 @@
 from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 from queryregistry.finance.credits import set_credits_request
 from queryregistry.finance.credits.models import SetCreditsParams
 from queryregistry.identity.profiles import get_profile_request, update_profile_request
 from queryregistry.identity.profiles.models import GuidParams, UpdateProfileParams
-from rpc.account.user.models import AccountUserCredits1, AccountUserDisplayName1
-from rpc.support.users.models import SupportUsersCredits1, SupportUsersDisplayName1
 from server.modules import BaseModule
 from server.modules.db_module import DbModule
 from server.modules.discord_bot_module import DiscordBotModule
+
+
+class AccountUserDisplayName1(BaseModel):
+  userGuid: str
+  displayName: str
+
+
+class AccountUserCredits1(BaseModel):
+  userGuid: str
+  credits: int
+
+
+class SupportUsersDisplayName1(BaseModel):
+  userGuid: str
+  displayName: str
+
+
+class SupportUsersCredits1(BaseModel):
+  userGuid: str
+  credits: int
 
 
 class UserAdminModule(BaseModule):


### PR DESCRIPTION
### Motivation

- The server failed to start because several modules imported deleted `rpc.*` model packages, producing `ModuleNotFoundError` at startup.  
- The fix is to remove those broken imports and provide the minimal Pydantic models inline in the consuming modules to restore runtime compatibility without changing public method signatures.

### Description

- Removed `from rpc.users.products.models ...` import from `server/modules/finance_module.py`, added `from pydantic import BaseModel`, and inlined `UsersProductItem1`, `UsersProductList1`, and `UsersProductPurchaseResult1` directly into the file.  
- Scanned `server/modules/` for other broken RPC imports and inlined the required models into the consumers: `UsersProfileProfile1` and `UsersProfileRoles1` into `server/modules/profile_module.py`.  
- Inlined `AccountUserDisplayName1`, `AccountUserCredits1`, `SupportUsersDisplayName1`, and `SupportUsersCredits1` into `server/modules/user_admin_module.py`.  
- Inlined `UsersProviders*` result models into `server/modules/oauth_module.py` and removed the now-invalid in-function imports, preserving existing return types and behavior.

### Testing

- Ran the repository scan command `grep -rn "from rpc\.(account|support|users.products|users.profile|users.providers|system.config|system.storage|system.models|system.roles|system.conversations|discord.guilds|discord.personas|service.renewals|service.payment_requests)" server/modules/` and confirmed no remaining matches.  
- Compiled the modified modules with `python -m py_compile server/modules/finance_module.py server/modules/profile_module.py server/modules/user_admin_module.py server/modules/oauth_module.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d314da854c8325b0eedbe95dde02d7)