### PR TITLE
Fix startup crash by removing dead finance/content imports

### DIFF
--- a/queryregistry/handler.py
+++ b/queryregistry/handler.py
@@ -6,9 +6,7 @@ from typing import Awaitable, Callable, Sequence
 
 from queryregistry.models import DBRequest, DBResponse
 
-from .content.handler import handle_content_request
 from .discord.handler import handle_discord_request
-from .finance.handler import handle_finance_request
 from .identity.handler import handle_identity_request
 from .reflection.handler import handle_reflection_request
 from .rpcdispatch.handler import handle_rpcdispatch_request
@@ -17,9 +15,7 @@ from .helpers import parse_query_request
 
 DomainHandler = Callable[[Sequence[str], DBRequest, str], Awaitable[DBResponse]]
 HANDLERS: dict[str, DomainHandler] = {
-  "content": handle_content_request,
   "discord": handle_discord_request,
-  "finance": handle_finance_request,
   "identity": handle_identity_request,
   "reflection": handle_reflection_request,
   "rpcdispatch": handle_rpcdispatch_request,

--- a/server/modules/mcp_gateway_module.py
+++ b/server/modules/mcp_gateway_module.py
@@ -14,8 +14,6 @@ from uuid import uuid4
 from fastapi import FastAPI, HTTPException
 from jose import jwt
 
-from queryregistry.finance.credits import get_credits_request
-from queryregistry.finance.credits.models import GetCreditsParams
 from queryregistry.identity.mcp_agents import (
   consume_auth_code_request,
   create_agent_token_request,
@@ -417,10 +415,7 @@ class McpGatewayModule(BaseModule):
     if not agent or not agent.get("user_guid"):
       raise HTTPException(status_code=404, detail="Agent is not linked to a user")
     user_guid = str(agent["user_guid"])
-    credits_res = await self.db.run(get_credits_request(GetCreditsParams(guid=user_guid)))
-    credits_row = credits_res.rows[0] if credits_res.rows else {}
-    credits = int(credits_row.get("element_credits") or 0)
-    return user_guid, credits
+    return user_guid, 0
 
   async def check_user_mcp_role(self, user_guid: str) -> bool:
     return await self.auth.user_has_role(user_guid, self.ROLE_MCP_ACCESS_MASK)

--- a/server/modules/oauth_module.py
+++ b/server/modules/oauth_module.py
@@ -48,8 +48,6 @@ from queryregistry.identity.sessions import (
   revoke_provider_tokens_request,
   update_device_token_request,
 )
-from queryregistry.finance.credits import set_credits_request
-from queryregistry.finance.credits.models import SetCreditsParams
 from queryregistry.system.config import get_config_request
 
 class UsersProvidersSetProviderResult1(BaseModel):


### PR DESCRIPTION
### Motivation
- The server crashed on startup due to imports from removed finance and content code paths, so the startup modules and query registry dispatcher must stop importing those deleted symbols.

### Description
- Removed `content` and `finance` domain imports and their `HANDLERS` entries from `queryregistry/handler.py`, leaving only the active domains (`discord`, `identity`, `reflection`, `rpcdispatch`, `system`).
- Removed imports of `set_credits_request` and `SetCreditsParams` from `server/modules/oauth_module.py` and removed any usage of those symbols.
- Removed imports of `get_credits_request` and `GetCreditsParams` from `server/modules/mcp_gateway_module.py` and replaced `resolve_agent_credits` with the simpler implementation that resolves the linked user and returns `(user_guid, 0)`.

### Testing
- Ran automated presence checks that verified the three files no longer reference `queryregistry.finance` or the `content` handler and they reported OK.
- Compiled the modified files with `python -m py_compile queryregistry/handler.py server/modules/oauth_module.py server/modules/mcp_gateway_module.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83fd7f4f0832591014974411a86e8)