### PR TITLE
Build: switch to client directory and remove codegen steps from Docker & workflows

### DIFF
--- a/.github/workflows/main_elideus-group.yml
+++ b/.github/workflows/main_elideus-group.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install Node dependencies
       run: |
-        cd frontend
+        cd client
         npm ci
 
     - name: Install MSSQL ODBC Driver
@@ -48,12 +48,6 @@ jobs:
         echo "deb [signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" | sudo tee /etc/apt/sources.list.d/mssql-release.list
         sudo apt-get update
         sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
-
-    - name: Generate bindings and namespaces
-      run: |
-        python scripts/generate_rpc_bindings.py
-        python scripts/generate_db_namespace.py
-        python scripts/generate_nav_pages.py
 
     - name: Run tests
       run: python scripts/run_tests.py

--- a/.github/workflows/test_elideus-group-test.yml
+++ b/.github/workflows/test_elideus-group-test.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install Node dependencies
       run: |
-        cd frontend
+        cd client
         npm ci
 
     - name: Install MSSQL ODBC Driver
@@ -48,12 +48,6 @@ jobs:
         echo "deb [signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" | sudo tee /etc/apt/sources.list.d/mssql-release.list
         sudo apt-get update
         sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
-
-    - name: Generate bindings and namespaces
-      run: |
-        python scripts/generate_rpc_bindings.py
-        python scripts/generate_db_namespace.py
-        python scripts/generate_nav_pages.py
 
     - name: Run tests
       run: python scripts/run_tests.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,7 @@ ENV AZURE_SQL_CONNECTION_STRING=$AZURE_SQL_CONNECTION_STRING
 
 COPY . .
 
-RUN python3 scripts/generate_rpc_bindings.py
-RUN python3 scripts/generate_db_namespace.py
-RUN python3 scripts/generate_nav_pages.py
-
-WORKDIR /app/frontend
+WORKDIR /app/client
 
 RUN npm ci
 RUN npm run build


### PR DESCRIPTION
### Motivation
- The build should target the `client` app directory instead of `frontend`, and repository-level code generation should no longer run during image/workflow builds.

### Description
- Updated `Dockerfile` frontend build stage to use `WORKDIR /app/client` and removed `RUN python3 scripts/generate_rpc_bindings.py`, `RUN python3 scripts/generate_db_namespace.py`, and `RUN python3 scripts/generate_nav_pages.py` from the image build.
- Updated `.github/workflows/test_elideus-group-test.yml` to change the Node install step to `cd client` and removed the `Generate bindings and namespaces` step.
- Updated `.github/workflows/main_elideus-group.yml` to change the Node install step to `cd client` and removed the `Generate bindings and namespaces` step.

### Testing
- Ran `git diff --check` to validate there are no whitespace or patch format issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93e0ccee48325865fe93bd9aae4d9)