### PR TITLE
Assemble CMS workbench shell tree with route page content

### DIFF
--- a/queryregistry/system/public/__init__.py
+++ b/queryregistry/system/public/__init__.py
@@ -8,8 +8,10 @@ from .models import RoutePathParams, UpsertRouteParams
 
 __all__ = [
   "delete_route_request",
+  "get_cms_shell_tree_request",
   "get_cms_tree_for_path_request",
   "get_config_value_request",
+  "get_page_data_bindings_request",
   "get_home_links_request",
   "get_navbar_routes_request",
   "get_routes_request",
@@ -47,6 +49,14 @@ def delete_route_request(params: RoutePathParams) -> DBRequest:
 
 def get_cms_tree_for_path_request(path: str) -> DBRequest:
   return DBRequest(op="db:system:public:get_cms_tree_for_path:1", payload={"path": path})
+
+
+def get_cms_shell_tree_request() -> DBRequest:
+  return DBRequest(op="db:system:public:get_cms_shell_tree:1", payload={})
+
+
+def get_page_data_bindings_request(path: str) -> DBRequest:
+  return DBRequest(op="db:system:public:get_page_data_bindings:1", payload={"path": path})
 
 
 def get_config_value_request(key: str) -> DBRequest:

--- a/queryregistry/system/public/mssql.py
+++ b/queryregistry/system/public/mssql.py
@@ -11,8 +11,10 @@ from queryregistry.models import DBResponse
 
 __all__ = [
   "delete_route_v1",
+  "get_cms_shell_tree_v1",
   "get_cms_tree_for_path_v1",
   "get_config_value_v1",
+  "get_page_data_bindings_v1",
   "get_home_links",
   "get_navbar_routes",
   "get_routes_v1",
@@ -71,6 +73,58 @@ async def delete_route_v1(args: Mapping[str, Any]) -> DBResponse:
   return DBResponse(payload=[], rowcount=0)
 
 
+
+
+async def get_cms_shell_tree_v1(args: Mapping[str, Any]) -> DBResponse:
+  """Walk the Workbench shell tree from the hardcoded root."""
+  del args
+  sql = """
+    WITH tree AS (
+      SELECT
+        t.key_guid AS guid,
+        t.ref_parent_guid AS parent_guid,
+        t.pub_sequence AS sequence,
+        t.pub_label AS label,
+        t.pub_field_binding AS field_binding,
+        c.pub_name AS component,
+        c.pub_category AS category,
+        0 AS depth
+      FROM system_objects_component_tree t
+      JOIN system_objects_components c ON c.key_guid = t.ref_component_guid
+      WHERE t.key_guid = 'EE3B1A30-83A2-5990-96FE-99F8154138E3'
+
+      UNION ALL
+
+      SELECT
+        child.key_guid AS guid,
+        child.ref_parent_guid AS parent_guid,
+        child.pub_sequence AS sequence,
+        child.pub_label AS label,
+        child.pub_field_binding AS field_binding,
+        cc.pub_name AS component,
+        cc.pub_category AS category,
+        parent.depth + 1 AS depth
+      FROM system_objects_component_tree child
+      JOIN tree parent ON parent.guid = child.ref_parent_guid
+      JOIN system_objects_components cc ON cc.key_guid = child.ref_component_guid
+    )
+    SELECT
+      guid,
+      parent_guid,
+      sequence,
+      label,
+      field_binding,
+      component,
+      category,
+      depth
+    FROM tree
+    ORDER BY depth, sequence;
+  """
+  response = await run_rows_many(sql, ())
+  rows = [dict(row) for row in response.rows]
+  return DBResponse(payload=rows, rowcount=len(rows))
+
+
 async def get_cms_tree_for_path_v1(args: Mapping[str, Any]) -> DBResponse:
   path = str(args.get("path") or "")
   sql = """
@@ -120,6 +174,31 @@ async def get_cms_tree_for_path_v1(args: Mapping[str, Any]) -> DBResponse:
       depth
     FROM tree
     ORDER BY depth, sequence;
+  """
+  response = await run_rows_many(sql, (path,))
+  rows = [dict(row) for row in response.rows]
+  return DBResponse(payload=rows, rowcount=len(rows))
+
+
+async def get_page_data_bindings_v1(args: Mapping[str, Any]) -> DBResponse:
+  """Get all data bindings for the page associated with a route path."""
+  path = str(args.get("path") or "")
+  sql = """
+    SELECT
+      b.pub_alias AS alias,
+      b.pub_source_type AS source_type,
+      b.pub_literal_value AS literal_value,
+      b.pub_config_key AS config_key,
+      col.pub_name AS column_name,
+      tbl.pub_name AS table_name
+    FROM system_objects_page_data_bindings b
+    JOIN system_objects_pages p ON p.key_guid = b.ref_page_guid
+    JOIN system_objects_routes r ON r.ref_page_guid = p.key_guid
+    LEFT JOIN system_objects_database_columns col ON col.key_guid = b.ref_column_guid
+    LEFT JOIN system_objects_database_tables tbl ON tbl.key_guid = col.ref_table_guid
+    WHERE r.pub_path = ?
+      AND r.pub_is_active = 1
+    ORDER BY b.pub_alias;
   """
   response = await run_rows_many(sql, (path,))
   rows = [dict(row) for row in response.rows]

--- a/server/modules/cms_workbench_module.py
+++ b/server/modules/cms_workbench_module.py
@@ -5,8 +5,10 @@ from typing import Any
 from fastapi import FastAPI, HTTPException
 
 from queryregistry.system.public import (
+  get_cms_shell_tree_request,
   get_cms_tree_for_path_request,
   get_config_value_request,
+  get_page_data_bindings_request,
 )
 from rpc.public.route.models import LoadPathResult1, PathNode1
 
@@ -27,19 +29,16 @@ class CmsWorkbenchModule(BaseModule):
   async def shutdown(self):
     self.db = None
 
-  async def load_path(self, path: str, user_context: dict[str, Any] | None) -> LoadPathResult1:
-    del user_context
-    assert self.db
+  @staticmethod
+  def _build_tree(rows: list[dict[str, Any]]) -> tuple[str | None, dict[str, PathNode1]]:
+    """Build a PathNode1 tree from flat CTE result rows.
 
-    tree_res = await self.db.run(get_cms_tree_for_path_request(path))
-    tree_rows = [dict(row) for row in tree_res.rows]
-    if not tree_rows:
-      raise HTTPException(status_code=404, detail=f"No CMS route found for path '{path}'")
-
+    Returns (root_guid, nodes_by_guid).
+    """
     nodes_by_guid: dict[str, PathNode1] = {}
     root_guid: str | None = None
 
-    for row in tree_rows:
+    for row in rows:
       guid = str(row.get("guid") or "")
       if not guid:
         continue
@@ -55,7 +54,7 @@ class CmsWorkbenchModule(BaseModule):
         children=[],
       )
 
-    for row in tree_rows:
+    for row in rows:
       guid = str(row.get("guid") or "")
       parent_guid = row.get("parent_guid")
       if not guid or parent_guid is None:
@@ -68,16 +67,64 @@ class CmsWorkbenchModule(BaseModule):
     for node in nodes_by_guid.values():
       node.children.sort(key=lambda child: child.sequence)
 
-    if not root_guid or root_guid not in nodes_by_guid:
-      raise HTTPException(status_code=500, detail="CMS route tree missing root node")
+    return root_guid, nodes_by_guid
+
+  async def load_path(self, path: str, user_context: dict[str, Any] | None) -> LoadPathResult1:
+    del user_context
+    assert self.db
+
+    shell_res = await self.db.run(get_cms_shell_tree_request())
+    shell_rows = [dict(row) for row in shell_res.rows]
+    if not shell_rows:
+      raise HTTPException(status_code=500, detail="Workbench shell tree not found")
+
+    shell_root_guid, shell_nodes = self._build_tree(shell_rows)
+    if not shell_root_guid or shell_root_guid not in shell_nodes:
+      raise HTTPException(status_code=500, detail="Workbench shell tree missing root node")
+
+    page_res = await self.db.run(get_cms_tree_for_path_request(path))
+    page_rows = [dict(row) for row in page_res.rows]
+    if not page_rows:
+      raise HTTPException(status_code=404, detail=f"No CMS route found for path '{path}'")
+
+    page_root_guid, page_nodes = self._build_tree(page_rows)
+    if not page_root_guid or page_root_guid not in page_nodes:
+      raise HTTPException(status_code=500, detail="Page tree missing root node")
+
+    content_panel: PathNode1 | None = None
+    for node in shell_nodes.values():
+      if node.component == "ContentPanel":
+        content_panel = node
+        break
+
+    if not content_panel:
+      raise HTTPException(status_code=500, detail="Shell tree missing ContentPanel")
+
+    content_panel.children.append(page_nodes[page_root_guid])
+    content_panel.children.sort(key=lambda child: child.sequence)
 
     component_data: dict[str, Any] = {}
-    for node in nodes_by_guid.values():
-      if node.fieldBinding != "version":
-        continue
-      version_res = await self.db.run(get_config_value_request("Version"))
-      version_rows = [dict(row) for row in version_res.rows]
-      if version_rows:
-        component_data["version"] = version_rows[0].get("element_value")
+    bindings_res = await self.db.run(get_page_data_bindings_request(path))
+    bindings_rows = [dict(row) for row in bindings_res.rows]
 
-    return LoadPathResult1(pathData=nodes_by_guid[root_guid], componentData=component_data)
+    for binding in bindings_rows:
+      alias = binding.get("alias")
+      source_type = binding.get("source_type", "")
+      if not alias:
+        continue
+
+      if source_type == "literal":
+        component_data[alias] = binding.get("literal_value")
+
+      elif source_type == "config":
+        config_key = binding.get("config_key")
+        if config_key:
+          config_res = await self.db.run(get_config_value_request(config_key))
+          config_rows = [dict(row) for row in config_res.rows]
+          if config_rows:
+            component_data[alias] = config_rows[0].get("element_value")
+
+      elif source_type == "column":
+        pass
+
+    return LoadPathResult1(pathData=shell_nodes[shell_root_guid], componentData=component_data)


### PR DESCRIPTION
### Motivation

- The server must return a single Workbench-rooted component tree by loading the immutable shell tree and stitching the resolved page tree into the shell `ContentPanel`, and must provide page `componentData` from page bindings.

### Description

- Added MSSQL query implementations `get_cms_shell_tree_v1` and `get_page_data_bindings_v1` and exported them from `queryregistry/system/public/mssql.py` to walk the fixed Workbench root and to read page data bindings respectively.
- Added request builders `get_cms_shell_tree_request()` and `get_page_data_bindings_request(path)` and exported them from `queryregistry/system/public/__init__.py`.
- Refactored `CmsWorkbenchModule.load_path` in `server/modules/cms_workbench_module.py` by extracting a reusable `_build_tree` helper, loading the shell and page trees independently, finding the shell `ContentPanel` node, appending the page root as a child, and assembling `componentData` from page bindings with `literal` and `config` source handling.
- The RPC return value remains `LoadPathResult1(pathData, componentData)` with the Workbench root as `pathData` so the client receives one unified tree.

### Testing

- Ran `python scripts/run_tests.py`, which failed in this environment due to a missing frontend ESLint dependency (`@eslint/js`).
- Verified Python syntax by running `python -m py_compile` on the modified files (`queryregistry/system/public/mssql.py`, `queryregistry/system/public/__init__.py`, `server/modules/cms_workbench_module.py`), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d986beff008325ac597cbeaeb1be36)