### PR TITLE
Add basic CMS UI components (Image, Label, LinkButton, SimplePage) and register them

### DIFF
--- a/client/src/components/ImageElement.tsx
+++ b/client/src/components/ImageElement.tsx
@@ -1,0 +1,21 @@
+import { CardMedia } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function ImageElement({ node, data }: CmsComponentProps): JSX.Element {
+	const src = node.fieldBinding ? (data[node.fieldBinding] as string) : null;
+	const alt = node.label || '';
+
+	if (!src) {
+		return <></>;
+	}
+
+	return (
+		<CardMedia
+			component="img"
+			alt={alt}
+			image={src}
+			sx={{ maxWidth: { xs: '75%', sm: '40%' }, mb: 3 }}
+		/>
+	);
+}

--- a/client/src/components/LabelElement.tsx
+++ b/client/src/components/LabelElement.tsx
@@ -1,0 +1,13 @@
+import { Typography } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function LabelElement({ node, data }: CmsComponentProps): JSX.Element {
+	const text = node.fieldBinding ? (data[node.fieldBinding] as string) : node.label;
+
+	return (
+		<Typography variant="body2" color="text.secondary" sx={{ mt: 3 }}>
+			{text || ''}
+		</Typography>
+	);
+}

--- a/client/src/components/LinkButton.tsx
+++ b/client/src/components/LinkButton.tsx
@@ -1,0 +1,36 @@
+import { Link as MuiLink } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function LinkButton({ node, data }: CmsComponentProps): JSX.Element {
+	const href = node.fieldBinding ? (data[node.fieldBinding] as string) : null;
+	const label = node.label || 'Link';
+	const isExternal = href?.startsWith('http');
+
+	if (!href) {
+		return <></>;
+	}
+
+	return (
+		<MuiLink
+			href={href}
+			underline="none"
+			target={isExternal ? '_blank' : undefined}
+			rel={isExternal ? 'noopener noreferrer' : undefined}
+			sx={{
+				display: 'block',
+				padding: '10px',
+				margin: '8px 0',
+				borderRadius: '4px',
+				transition: 'background 0.3s',
+				color: '#ffffff',
+				backgroundColor: '#111',
+				textDecoration: 'none',
+				textAlign: 'center',
+				'&:hover': { backgroundColor: '#222' },
+			}}
+		>
+			{label}
+		</MuiLink>
+	);
+}

--- a/client/src/components/SimplePage.tsx
+++ b/client/src/components/SimplePage.tsx
@@ -1,0 +1,21 @@
+import { Container } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function SimplePage({ children }: CmsComponentProps): JSX.Element {
+	return (
+		<Container
+			maxWidth="md"
+			sx={{
+				display: 'flex',
+				flexDirection: 'column',
+				alignItems: 'center',
+				justifyContent: 'center',
+				py: 4,
+				minHeight: '100%',
+			}}
+		>
+			{children}
+		</Container>
+	);
+}

--- a/client/src/engine/registry.ts
+++ b/client/src/engine/registry.ts
@@ -1,6 +1,10 @@
 import type { ComponentType } from 'react';
 
 import { ContentPanel } from '../components/ContentPanel';
+import { ImageElement } from '../components/ImageElement';
+import { LabelElement } from '../components/LabelElement';
+import { LinkButton } from '../components/LinkButton';
+import { SimplePage } from '../components/SimplePage';
 import { StringControl } from '../components/StringControl';
 import { Workbench } from '../components/Workbench';
 
@@ -9,5 +13,9 @@ import type { CmsComponentProps } from './types';
 export const COMPONENT_REGISTRY: Record<string, ComponentType<CmsComponentProps>> = {
 	Workbench,
 	ContentPanel,
+	SimplePage,
+	ImageElement,
+	LinkButton,
+	LabelElement,
 	StringControl,
 };


### PR DESCRIPTION
### Motivation
- Introduce a small set of reusable presentation components for CMS-driven pages so content nodes can render images, labels, link buttons and simple page layout.
- Register the new components in the component registry so they are available to the CMS rendering engine.

### Description
- Added `ImageElement` that renders an image from a bound field using MUI `CardMedia` and respects `node.label` as `alt` text.
- Added `LabelElement` that renders supplementary text using MUI `Typography` and falls back to `node.label` when no binding is provided.
- Added `LinkButton` that renders a styled block `MuiLink`, detects external links to set `target`/`rel`, and uses the bound field or `node.label` for the href/label.
- Added `SimplePage` container component to center and constrain page content, and updated `COMPONENT_REGISTRY` to include the new components.

### Testing
- Ran the TypeScript build/compile to validate types and the app build (`npm run build`), and it completed successfully.
- Ran the existing automated test suite (`npm test`) with no failures.
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9a1550b3483258c4bca7080b06161)