### PR TITLE
Fix rpcdispatch DBResponse handling for JSON query results

### DIFF
--- a/server/modules/rpcdispatch_module.py
+++ b/server/modules/rpcdispatch_module.py
@@ -268,6 +268,8 @@ class RpcdispatchModule(BaseModule):
   def _as_list(payload: Any) -> list[dict[str, Any]]:
     if payload is None:
       return []
+    if hasattr(payload, "rows"):
+      return [dict(row) if isinstance(row, dict) else row for row in payload.rows]
     if isinstance(payload, list):
       return [dict(row) if isinstance(row, dict) else row for row in payload]
     if isinstance(payload, dict):
@@ -410,6 +412,11 @@ class RpcdispatchModule(BaseModule):
 
   async def get_schema_version(self) -> Any:
     data = await run_json_one(_GET_VERSION_SQL)
+    if hasattr(data, "rows") and data.rows:
+      row = data.rows[0]
+      if isinstance(row, dict):
+        return row.get("element_value", row)
+      return row
     if isinstance(data, dict):
       return data.get("element_value", data)
     return data


### PR DESCRIPTION
### Motivation
- `run_json_many` / `run_json_one` return `DBResponse` objects with a `.rows` collection, but the module only handled `None`, `list`, and `dict`, causing query results to be dropped as empty lists.
- The change ensures MCP tooling and schema helpers extract rows from `DBResponse` so data is returned correctly.

### Description
- Updated `RpcdispatchModule._as_list` in `server/modules/rpcdispatch_module.py` to detect `DBResponse`-like payloads via `hasattr(payload, "rows")` and convert `payload.rows` into a list of dicts when appropriate.
- Updated `RpcdispatchModule.get_schema_version` to extract the first row from a `DBResponse.rows` result and return the `element_value` when present, preserving existing dict fallback behavior.
- No SQL queries or other files were modified; changes are limited to `server/modules/rpcdispatch_module.py`.

### Testing
- Ran `python -m compileall server/modules/rpcdispatch_module.py`, which completed successfully.
- No additional automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa48e1af4832594bc174603c47884)