### PR TITLE
Formalize RPC as IoService gateway: add RpcIoServiceModule and seed gateway bindings

### DIFF
--- a/migrations/v0.13.0.0_rpc_gateway_bindings.sql
+++ b/migrations/v0.13.0.0_rpc_gateway_bindings.sql
@@ -1,0 +1,112 @@
+-- ==========================================================================
+-- v0.13.0.0_rpc_gateway_bindings
+-- Phase 3: RPC gateway formalization seeds
+--   1) Register SessionModule methods in system_objects_module_methods
+--   2) Seed RPC gateway method bindings in system_objects_gateway_method_bindings
+--   3) Seed missing SessionModule data-driven query:
+--      security.sessions.list_user_sessions
+--
+-- UUID5 namespace: DECAFBAD-CAFE-FADE-BABE-C0FFEE420B67
+-- ==========================================================================
+
+DECLARE @RPC_GATEWAY_GUID UNIQUEIDENTIFIER = N'606C04E3-44F1-593D-9C8B-8006E0A377D3';
+DECLARE @SESSION_MODULE_GUID UNIQUEIDENTIFIER = N'6D818DCB-5B60-5B80-91F1-A1D19DC03110';
+DECLARE @ROLE_SYSTEM_ADMIN UNIQUEIDENTIFIER = N'20F0C823-4742-51BE-938B-7AA5B9D36B81';
+GO
+
+-- ==========================================================================
+-- 1) SessionModule method registrations (missing from object tree)
+-- ==========================================================================
+
+INSERT INTO [dbo].[system_objects_module_methods]
+  ([key_guid], [ref_module_guid], [pub_name], [pub_description], [pub_is_active])
+SELECT
+  src.[key_guid],
+  src.[ref_module_guid],
+  src.[pub_name],
+  src.[pub_description],
+  1
+FROM (VALUES
+  (N'578E9F0B-2C40-58A8-9921-4FB125A95100', N'6D818DCB-5B60-5B80-91F1-A1D19DC03110', N'issue_token',      N'Issue session and rotation tokens for authenticated provider login.'),
+  (N'6221F741-E7F3-5C80-B714-7BF741CCD73B', N'6D818DCB-5B60-5B80-91F1-A1D19DC03110', N'refresh_token',    N'Refresh session token from rotation token.'),
+  (N'20424F76-90C6-5A44-AF5C-0D2D22046ECD', N'6D818DCB-5B60-5B80-91F1-A1D19DC03110', N'invalidate_token', N'Revoke all active sessions for a user.'),
+  (N'6C086B5F-5308-5A1D-8E8F-2ED96A92BD5F', N'6D818DCB-5B60-5B80-91F1-A1D19DC03110', N'logout_device',    N'Revoke the current device token.'),
+  (N'1A025F00-F1B7-52A9-B2CE-4F617CF00858', N'6D818DCB-5B60-5B80-91F1-A1D19DC03110', N'get_session',      N'Read and validate the current session payload.')
+) src([key_guid], [ref_module_guid], [pub_name], [pub_description])
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM [dbo].[system_objects_module_methods] mm
+  WHERE mm.[key_guid] = src.[key_guid]
+);
+GO
+
+-- ==========================================================================
+-- 2) RPC gateway method binding seeds
+-- ==========================================================================
+
+INSERT INTO [dbo].[system_objects_gateway_method_bindings]
+  ([key_guid], [ref_gateway_guid], [pub_operation_name], [ref_method_guid],
+   [pub_required_scope], [ref_required_role_guid], [ref_required_entitlement_guid],
+   [pub_is_read_only], [pub_is_active])
+SELECT
+  src.[key_guid],
+  src.[ref_gateway_guid],
+  src.[pub_operation_name],
+  src.[ref_method_guid],
+  src.[pub_required_scope],
+  src.[ref_required_role_guid],
+  src.[ref_required_entitlement_guid],
+  src.[pub_is_read_only],
+  1
+FROM (VALUES
+  (N'455F2B23-1368-59E3-89E2-9FF4148D9DC9', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:public:route:load_shell:1',              N'4427A371-81DF-57C4-A16C-E03008BA1AB9', NULL, NULL, NULL, 1),
+  (N'52D6E030-0C70-5E8C-83FB-F85A87AA414D', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:public:route:load_page:1',               N'D207AE62-AF24-514D-A7C5-FBEC5200DC24', NULL, NULL, NULL, 1),
+  (N'DDADA624-F75E-55EF-80BE-14F7C529024C', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:public:route:read_navigation:1',         N'88EB34E5-DBF0-5254-AEE4-D61D18ACCF8F', NULL, NULL, NULL, 1),
+  (N'7D5B7DA5-92BC-5325-96A5-002E70DDFBBC', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:public:auth:get_auth_state:1',           N'2D3B31B8-62EB-5CBB-A15C-C3FB19A975F6', NULL, NULL, NULL, 1),
+  (N'18A3A986-8499-5BC8-B9DC-F2CA4E30CF15', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:public:auth:read_current_user:1',        N'5C9020C1-BA56-5898-A271-E0B62E00BC99', NULL, NULL, NULL, 1),
+  (N'2363D705-96F7-5119-8B57-37572A7636ED', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:public:auth:context:get_user_context:1', N'C57DE8A4-674B-5D1D-AE99-A2D8CC529E11', NULL, NULL, NULL, 1),
+  (N'4609D116-BE89-5752-9D8B-C2E2FC6284B7', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:system:config:read_config:1',            N'79EF9D0C-D111-555C-A77E-1C39A01E076C', NULL, N'20F0C823-4742-51BE-938B-7AA5B9D36B81', NULL, 1),
+  (N'F0CB2B43-8E38-5614-80C3-A99C4EF9A36D', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:system:config:upsert_config:1',          N'573886C1-F179-5EB4-8C16-7B410041E73B', NULL, N'20F0C823-4742-51BE-938B-7AA5B9D36B81', NULL, 0),
+  (N'538EA266-1B8B-5750-9B35-F4BF64A6A43C', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:system:config:delete_config:1',          N'EAE41724-3FCB-5EA6-8E5B-8F23A55B96D6', NULL, N'20F0C823-4742-51BE-938B-7AA5B9D36B81', NULL, 0),
+
+  (N'71806D25-6FE0-5ADD-BC9C-9AC83D999020', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:auth:session:get_token:1',               N'578E9F0B-2C40-58A8-9921-4FB125A95100', NULL, NULL, NULL, 0),
+  (N'5658D6E2-2393-50A8-9949-A064E00569D8', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:auth:session:refresh_token:1',           N'6221F741-E7F3-5C80-B714-7BF741CCD73B', NULL, NULL, NULL, 0),
+  (N'07C67CFC-0628-5808-967B-5396BB1444E9', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:auth:session:invalidate_token:1',        N'20424F76-90C6-5A44-AF5C-0D2D22046ECD', NULL, NULL, NULL, 0),
+  (N'3D4122D9-B020-5A10-95BF-821842BA1339', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:auth:session:logout_device:1',           N'6C086B5F-5308-5A1D-8E8F-2ED96A92BD5F', NULL, NULL, NULL, 0),
+  (N'2CAAC3F5-7EE8-5CDE-AA54-2F4FD9190ED1', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:auth:session:get_session:1',             N'1A025F00-F1B7-52A9-B2CE-4F617CF00858', NULL, NULL, NULL, 1)
+) src([key_guid], [ref_gateway_guid], [pub_operation_name], [ref_method_guid], [pub_required_scope], [ref_required_role_guid], [ref_required_entitlement_guid], [pub_is_read_only])
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM [dbo].[system_objects_gateway_method_bindings] b
+  WHERE b.[key_guid] = src.[key_guid]
+);
+GO
+
+-- ==========================================================================
+-- 3) Missing SessionModule query seed
+-- ==========================================================================
+
+INSERT INTO [dbo].[system_objects_queries]
+  ([key_guid], [pub_name], [pub_description], [ref_module_guid],
+   [pub_is_parameterized], [pub_parameter_names], [pub_query_text], [pub_is_active])
+SELECT
+  N'75EAF5A1-37A2-5828-B8A0-6FBF495ABB4D',
+  N'security.sessions.list_user_sessions',
+  N'List all active sessions for a user.',
+  N'6D818DCB-5B60-5B80-91F1-A1D19DC03110',
+  1,
+  N'user_guid',
+  N'SELECT s.[key_guid] AS session_guid, s.[pub_is_active] AS is_active,
+         s.[pub_expires_at] AS expires_at, st.[pub_name] AS session_type
+  FROM [dbo].[system_sessions] s
+  JOIN [dbo].[service_enum_values] st ON st.[key_guid] = s.[ref_session_type_guid]
+  WHERE s.[ref_user_guid] = TRY_CAST(? AS UNIQUEIDENTIFIER)
+    AND s.[pub_is_active] = 1
+  FOR JSON PATH, INCLUDE_NULL_VALUES;',
+  1
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM [dbo].[system_objects_queries] q
+  WHERE q.[pub_name] = N'security.sessions.list_user_sessions'
+);
+GO

--- a/server/modules/rpc_io_service_module.py
+++ b/server/modules/rpc_io_service_module.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from fastapi import FastAPI
+
+from queryregistry.providers.mssql import run_json_many, run_json_one
+
+from . import BaseModule
+from .auth_module import AuthModule
+from .db_module import DbModule
+from .role_module import RoleModule
+
+_GET_RPC_GATEWAY_SQL = """
+SELECT key_guid, pub_name, ref_transport_guid, pub_description, ref_module_guid, pub_is_active
+FROM system_objects_io_gateways
+WHERE pub_name = ?
+FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;
+"""
+
+_LIST_IDENTITY_STRATEGIES_SQL = """
+SELECT ip.key_guid, ip.ref_strategy_guid, ip.pub_priority, ip.pub_description,
+       v.pub_name AS strategy_name
+FROM system_objects_gateway_identity_providers ip
+JOIN service_enum_values v ON v.key_guid = ip.ref_strategy_guid
+WHERE ip.ref_gateway_guid = ?
+  AND ip.pub_is_active = 1
+ORDER BY ip.pub_priority
+FOR JSON PATH, INCLUDE_NULL_VALUES;
+"""
+
+_LIST_METHOD_BINDINGS_SQL = """
+SELECT mb.key_guid, mb.pub_operation_name, mb.pub_required_scope,
+       mb.ref_required_role_guid, mb.ref_required_entitlement_guid,
+       mb.pub_is_read_only, mb.pub_is_active,
+       mm.pub_name AS method_name, mod.pub_state_attr AS module_attr
+FROM system_objects_gateway_method_bindings mb
+JOIN system_objects_module_methods mm ON mm.key_guid = mb.ref_method_guid
+JOIN system_objects_modules mod ON mod.key_guid = mm.ref_module_guid
+WHERE mb.ref_gateway_guid = ?
+  AND mb.pub_is_active = 1
+ORDER BY mb.pub_operation_name
+FOR JSON PATH, INCLUDE_NULL_VALUES;
+"""
+
+_LIST_USER_ENTITLEMENTS_SQL = """
+SELECT e.key_guid, e.pub_name
+FROM system_user_entitlements ue
+JOIN system_auth_entitlements e ON e.key_guid = ue.ref_entitlement_guid
+WHERE ue.ref_user_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)
+FOR JSON PATH, INCLUDE_NULL_VALUES;
+"""
+
+
+class RpcIoServiceModule(BaseModule):
+  def __init__(self, app: FastAPI):
+    super().__init__(app)
+    self.db: DbModule | None = None
+    self.auth: AuthModule | None = None
+    self.role: RoleModule | None = None
+    self.gateway_guid: str = ""
+    self.strategies: list[dict[str, Any]] = []
+    self.bindings: dict[str, dict[str, Any]] = {}
+
+  async def startup(self):
+    try:
+      self.db = self.app.state.db
+      await self.db.on_ready()
+      self.auth = self.app.state.auth
+      await self.auth.on_ready()
+      self.role = self.app.state.role
+      await self.role.on_ready()
+
+      gateway_result = await run_json_one(_GET_RPC_GATEWAY_SQL, ("rpc",))
+      gateway_row = self._coerce_row(gateway_result.rows if gateway_result else None)
+      if not gateway_row:
+        raise RuntimeError("RPC gateway registration was not found in system_objects_io_gateways")
+
+      self.gateway_guid = str(gateway_row.get("key_guid") or "")
+      if not self.gateway_guid:
+        raise RuntimeError("RPC gateway registration is missing key_guid")
+
+      strategies_result = await run_json_many(_LIST_IDENTITY_STRATEGIES_SQL, (self.gateway_guid,))
+      strategy_rows = strategies_result.rows if strategies_result and strategies_result.rows else []
+      self.strategies = [self._coerce_dict(row) for row in strategy_rows]
+
+      bindings_result = await run_json_many(_LIST_METHOD_BINDINGS_SQL, (self.gateway_guid,))
+      binding_rows = bindings_result.rows if bindings_result and bindings_result.rows else []
+      self.bindings = {
+        str(row.get("pub_operation_name")): self._coerce_dict(row)
+        for row in binding_rows
+        if row.get("pub_operation_name")
+      }
+
+      logging.info(
+        "[RpcIoServiceModule] Loaded gateway=%s strategies=%s method_bindings=%s",
+        self.gateway_guid,
+        len(self.strategies),
+        len(self.bindings),
+      )
+      self.mark_ready()
+    except Exception:
+      logging.exception("[RpcIoServiceModule] startup failed")
+      raise
+
+  async def shutdown(self):
+    self.gateway_guid = ""
+    self.strategies = []
+    self.bindings = {}
+    self.db = None
+    self.auth = None
+    self.role = None
+
+  async def resolve_identity(self, bearer_token: str | None, discord_id: str | None = None) -> dict[str, Any] | None:
+    assert self.auth
+    assert self.role
+
+    for strategy in self.strategies:
+      strategy_name = str(strategy.get("strategy_name") or "")
+
+      if strategy_name == "bearer_jwt" and bearer_token:
+        try:
+          claims = await self.auth.decode_session_token(bearer_token)
+          user_guid = str(claims.get("sub") or "")
+          if not user_guid:
+            continue
+          roles, role_mask = await self.role.get_user_roles(user_guid)
+          entitlements = await self._get_user_entitlements(user_guid)
+          return {
+            "user_guid": user_guid,
+            "roles": roles,
+            "role_mask": role_mask,
+            "entitlements": entitlements,
+            "session_type": str(claims.get("session_type") or "browser"),
+            "scopes": claims.get("scopes") or [],
+            "source": "bearer_jwt",
+          }
+        except Exception:
+          logging.debug("[RpcIoServiceModule] bearer_jwt strategy failed", exc_info=True)
+
+      if strategy_name == "discord_user_id" and discord_id:
+        try:
+          user_guid, roles, role_mask = await self.auth.get_discord_user_security(discord_id)
+          if not user_guid:
+            continue
+          entitlements = await self._get_user_entitlements(user_guid)
+          return {
+            "user_guid": user_guid,
+            "roles": roles,
+            "role_mask": role_mask,
+            "entitlements": entitlements,
+            "session_type": "bot",
+            "scopes": [],
+            "source": "discord_user_id",
+          }
+        except Exception:
+          logging.debug("[RpcIoServiceModule] discord_user_id strategy failed", exc_info=True)
+
+    return None
+
+  async def check_authorization(self, identity: dict[str, Any], operation_name: str) -> bool:
+    binding = self.bindings.get(operation_name)
+    if not binding:
+      return False
+
+    required_role = binding.get("ref_required_role_guid")
+    if required_role:
+      roles = {str(role).upper() for role in (identity.get("roles") or [])}
+      if str(required_role).upper() not in roles:
+        return False
+
+    required_entitlement = binding.get("ref_required_entitlement_guid")
+    if required_entitlement:
+      entitlements = {str(entitlement).upper() for entitlement in (identity.get("entitlements") or [])}
+      if str(required_entitlement).upper() not in entitlements:
+        return False
+
+    return True
+
+  async def get_binding(self, operation_name: str) -> dict[str, Any] | None:
+    return self.bindings.get(operation_name)
+
+  async def _get_user_entitlements(self, user_guid: str) -> list[str]:
+    result = await run_json_many(_LIST_USER_ENTITLEMENTS_SQL, (user_guid,))
+    rows = result.rows if result and result.rows else []
+    entitlements: list[str] = []
+    for row in rows:
+      row_dict = self._coerce_dict(row)
+      entitlement_guid = row_dict.get("key_guid")
+      if entitlement_guid:
+        entitlements.append(str(entitlement_guid))
+    return entitlements
+
+  @staticmethod
+  def _coerce_row(rows: Any) -> dict[str, Any] | None:
+    if not rows:
+      return None
+    if isinstance(rows, Mapping):
+      return dict(rows)
+    if isinstance(rows, list) and rows:
+      first = rows[0]
+      if isinstance(first, Mapping):
+        return dict(first)
+    return None
+
+  @staticmethod
+  def _coerce_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+      return dict(value)
+    return {}


### PR DESCRIPTION
### Motivation
- Formalize the existing RPC router as a registered IoService gateway so other gateway implementations can reuse a single identity-resolution and authz contract. 
- Persist method bindings and missing SessionModule metadata into the object tree so RPC operations are addressable and auditable via the object tree. 
- Provide an additive implementation that does not change the current RPC dispatch pipeline but exposes `IdentityResolver`/`AuthzGate` style methods for future phases.

### Description
- Added `server/modules/rpc_io_service_module.py` implementing `RpcIoServiceModule` which waits for `DbModule`, `AuthModule`, and `RoleModule` readiness, loads the `rpc` gateway row, ordered identity strategies, and active method bindings into memory, logs loaded counts, and clears state on shutdown. 
- Implemented runtime contracts on the module: `resolve_identity(bearer_token, discord_id)`, `check_authorization(identity, operation_name)`, and `get_binding(operation_name)`, using `run_json_one`/`run_json_many` from `queryregistry.providers.mssql` and the same JSON SQL patterns used elsewhere. 
- Added `migrations/v0.13.0.0_rpc_gateway_bindings.sql` which idempotently registers five missing `SessionModule` methods in `system_objects_module_methods`, seeds deterministic UUID5 gateway method bindings for existing RPC operations (including `auth:session` entries), and inserts the `security.sessions.list_user_sessions` query, using `GO` separators and `WHERE NOT EXISTS` guards. 
- Kept all existing RPC files and dispatch code unchanged; the module is additive and discovered as `rpc_io` by `ModuleManager` (file name required to be `rpc_io_service_module.py`).

### Testing
- Compiled the new module with `python -m py_compile server/modules/rpc_io_service_module.py` which succeeded. 
- Compiled `server/modules/session_module.py` with `python -m py_compile server/modules/session_module.py` which succeeded. 
- Ran the full harness with `python scripts/run_tests.py` which completed successfully (test runner passed and the repo-level test suite returned success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab26f13e88325837f9e2ac9d97a31)