### PR TITLE
Add collapsible sidebar framework and hamburger toggle to Workbench

### DIFF
--- a/client/src/components/DynamicIcon.tsx
+++ b/client/src/components/DynamicIcon.tsx
@@ -1,0 +1,16 @@
+import { memo } from 'react';
+import * as MuiIcons from '@mui/icons-material';
+
+interface DynamicIconProps {
+	name: string | null | undefined;
+}
+
+export const DynamicIcon = memo(({ name }: DynamicIconProps): JSX.Element => {
+	const IconComponent = name
+		? (MuiIcons as Record<string, typeof MuiIcons.Adjust>)[name] ?? MuiIcons.Adjust
+		: MuiIcons.Adjust;
+
+	return <IconComponent />;
+});
+
+DynamicIcon.displayName = 'DynamicIcon';

--- a/client/src/components/HamburgerToggle.tsx
+++ b/client/src/components/HamburgerToggle.tsx
@@ -1,0 +1,35 @@
+import MenuIcon from '@mui/icons-material/Menu';
+import { IconButton, Tooltip } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function HamburgerToggle({ data }: CmsComponentProps): JSX.Element {
+	const onToggle = typeof data.__toggleSidebar === 'function' ? data.__toggleSidebar : null;
+
+	const handleClick = (): void => {
+		if (onToggle) {
+			(onToggle as () => void)();
+		}
+	};
+
+	return (
+		<Tooltip title="Toggle Menu">
+			<IconButton
+				onClick={handleClick}
+				sx={{
+					width: 32,
+					height: 32,
+					color: '#FFFFFF',
+					border: '1px solid #1A1A1A',
+					borderRadius: 1,
+					'&:hover': {
+						borderColor: '#333333',
+						backgroundColor: 'rgba(255, 255, 255, 0.04)',
+					},
+				}}
+			>
+				<MenuIcon sx={{ fontSize: 18 }} />
+			</IconButton>
+		</Tooltip>
+	);
+}

--- a/client/src/components/NavigationSidebar.tsx
+++ b/client/src/components/NavigationSidebar.tsx
@@ -1,0 +1,27 @@
+import { Box } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+import { LAYOUT } from '../theme/layoutConstants';
+
+export function NavigationSidebar({ data, children }: CmsComponentProps): JSX.Element {
+	const isOpen = data.__sidebarOpen === true;
+
+	return (
+		<Box
+			sx={{
+				display: 'flex',
+				flexDirection: 'column',
+				width: isOpen ? LAYOUT.NAV_WIDTH_EXPANDED : LAYOUT.NAV_WIDTH_COLLAPSED,
+				minHeight: '100vh',
+				bgcolor: '#000000',
+				color: '#FFFFFF',
+				borderRight: '1px solid #1A1A1A',
+				transition: 'width 0.2s ease',
+				flexShrink: 0,
+				overflow: 'hidden',
+			}}
+		>
+			{children}
+		</Box>
+	);
+}

--- a/client/src/components/SidebarContent.tsx
+++ b/client/src/components/SidebarContent.tsx
@@ -1,0 +1,19 @@
+import { Box } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function SidebarContent({ children }: CmsComponentProps): JSX.Element {
+	return (
+		<Box
+			sx={{
+				flexGrow: 1,
+				overflowX: 'hidden',
+				overflowY: 'auto',
+				px: 0.5,
+				py: 0,
+			}}
+		>
+			{children}
+		</Box>
+	);
+}

--- a/client/src/components/SidebarFooter.tsx
+++ b/client/src/components/SidebarFooter.tsx
@@ -1,0 +1,16 @@
+import { Box } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function SidebarFooter({ children }: CmsComponentProps): JSX.Element {
+	return (
+		<Box
+			sx={{
+				borderTop: '1px solid #1A1A1A',
+				p: 1,
+			}}
+		>
+			{children}
+		</Box>
+	);
+}

--- a/client/src/components/SidebarHeader.tsx
+++ b/client/src/components/SidebarHeader.tsx
@@ -1,0 +1,19 @@
+import { Box } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function SidebarHeader({ children }: CmsComponentProps): JSX.Element {
+	return (
+		<Box
+			sx={{
+				display: 'flex',
+				justifyContent: 'flex-start',
+				alignItems: 'center',
+				pl: 1,
+				py: 1,
+			}}
+		>
+			{children}
+		</Box>
+	);
+}

--- a/client/src/components/Workbench.tsx
+++ b/client/src/components/Workbench.tsx
@@ -1,8 +1,30 @@
+import { useCallback, useEffect, useState } from 'react';
 import { Box } from '@mui/material';
 
 import type { CmsComponentProps } from '../engine/types';
 
-export function Workbench({ children }: CmsComponentProps): JSX.Element {
+export function Workbench({ children, enrichData }: CmsComponentProps): JSX.Element {
+	const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
+
+	const dataEnricher = useCallback(
+		(baseData: Record<string, unknown>): Record<string, unknown> => ({
+			...baseData,
+			__sidebarOpen: sidebarOpen,
+			__toggleSidebar: (): void => setSidebarOpen((prev) => !prev),
+		}),
+		[sidebarOpen],
+	);
+
+	useEffect(() => {
+		if (typeof enrichData === 'function') {
+			(
+				enrichData as unknown as (
+					enricher: (nextData: Record<string, unknown>) => Record<string, unknown>,
+				) => void
+			)(dataEnricher);
+		}
+	}, [dataEnricher, enrichData]);
+
 	return (
 		<Box
 			sx={{

--- a/client/src/engine/WorkbenchRenderer.tsx
+++ b/client/src/engine/WorkbenchRenderer.tsx
@@ -1,15 +1,19 @@
+import { useState } from 'react';
 import { Box, Typography } from '@mui/material';
 
 import { COMPONENT_REGISTRY } from './registry';
-import type { PathNode } from './types';
+import type { CmsComponentProps, PathNode } from './types';
 
 interface WorkbenchRendererProps {
 	pathData: PathNode;
 	componentData: Record<string, unknown>;
 }
 
+type DataEnricher = (data: Record<string, unknown>) => Record<string, unknown>;
+
 function RenderNode({ node, data }: { node: PathNode; data: Record<string, unknown> }): JSX.Element {
 	const Component = COMPONENT_REGISTRY[node.component];
+	const [registeredEnricher, setRegisteredEnricher] = useState<DataEnricher | null>(null);
 
 	if (!Component) {
 		return (
@@ -21,13 +25,18 @@ function RenderNode({ node, data }: { node: PathNode; data: Record<string, unkno
 		);
 	}
 
+	const childData = registeredEnricher ? registeredEnricher(data) : data;
 	const sortedChildren = [...node.children].sort((a, b) => a.sequence - b.sequence);
 	const renderedChildren = sortedChildren.map((child) => (
-		<RenderNode key={child.guid} node={child} data={data} />
+		<RenderNode key={child.guid} node={child} data={childData} />
 	));
 
 	return (
-		<Component node={node} data={data}>
+		<Component
+			node={node}
+			data={data}
+			enrichData={setRegisteredEnricher as unknown as CmsComponentProps['enrichData']}
+		>
 			{renderedChildren}
 		</Component>
 	);

--- a/client/src/engine/registry.ts
+++ b/client/src/engine/registry.ts
@@ -1,9 +1,14 @@
 import type { ComponentType } from 'react';
 
 import { ContentPanel } from '../components/ContentPanel';
+import { HamburgerToggle } from '../components/HamburgerToggle';
 import { ImageElement } from '../components/ImageElement';
 import { LabelElement } from '../components/LabelElement';
 import { LinkButton } from '../components/LinkButton';
+import { NavigationSidebar } from '../components/NavigationSidebar';
+import { SidebarContent } from '../components/SidebarContent';
+import { SidebarFooter } from '../components/SidebarFooter';
+import { SidebarHeader } from '../components/SidebarHeader';
 import { SimplePage } from '../components/SimplePage';
 import { StringControl } from '../components/StringControl';
 import { Workbench } from '../components/Workbench';
@@ -12,6 +17,11 @@ import type { CmsComponentProps } from './types';
 
 export const COMPONENT_REGISTRY: Record<string, ComponentType<CmsComponentProps>> = {
 	Workbench,
+	NavigationSidebar,
+	SidebarHeader,
+	SidebarContent,
+	SidebarFooter,
+	HamburgerToggle,
 	ContentPanel,
 	SimplePage,
 	ImageElement,

--- a/client/src/engine/types.ts
+++ b/client/src/engine/types.ts
@@ -14,4 +14,5 @@ export interface CmsComponentProps {
 	node: PathNode;
 	data: Record<string, unknown>;
 	children?: ReactNode;
+	enrichData?: (data: Record<string, unknown>) => Record<string, unknown>;
 }


### PR DESCRIPTION
### Motivation

- Provide the structural components and plumbing for a left-hand navigation drawer that can collapse/expand under Workbench control.
- Push sidebar state through the CMS data channel so components (like the hamburger) can drive UI changes without React context.
- Prepare a small utility (`DynamicIcon`) needed for the upcoming navigation tree implementation.

### Description

- Added CMS UI components `NavigationSidebar`, `SidebarHeader`, `SidebarContent`, `SidebarFooter`, and `HamburgerToggle` under `client/src/components/` with the requested dark styling and `LAYOUT`-based collapsed/expanded widths. 
- Introduced a `enrichData` hook on `CmsComponentProps` and implemented a data-enrichment flow in `WorkbenchRenderer` so parent components can register an enricher that transforms the `data` passed to children. 
- Updated `Workbench` to own `sidebarOpen` state and register an enricher that injects `__sidebarOpen` and `__toggleSidebar` into descendant `data`. 
- Registered the new components in `COMPONENT_REGISTRY` and copied `DynamicIcon` into `client/src/components` for future use.

### Testing

- Ran the frontend checks `cd client && npm run lint` which completed successfully after the Workbench unused-variable fix. 
- Ran type checks with `cd client && npm run type-check` and `tsc` completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db11bde0e083258e15e74821fe1311)