### PR TITLE
Harden MSSQL fetch_json parsing for concatenated JSON objects

### DIFF
--- a/server/modules/providers/database/mssql_provider/db_helpers.py
+++ b/server/modules/providers/database/mssql_provider/db_helpers.py
@@ -67,9 +67,30 @@ async def fetch_json(query: str, params: tuple[Any, ...] = (), *, many: bool = F
           parts.append(row[0])
         if not parts:
           return DBResponse()
-        data = json.loads("".join(parts))
+        raw = "".join(parts)
+        try:
+          data = json.loads(raw)
+        except json.JSONDecodeError:
+          # WITHOUT_ARRAY_WRAPPER with multiple rows produces concatenated
+          # JSON objects: {"a":1}{"a":2}. Wrap in array brackets to parse.
+          try:
+            # Insert commas between adjacent }{ boundaries
+            import re
+            wrapped = "[" + re.sub(r'\}\s*\{', '},{', raw) + "]"
+            data = json.loads(wrapped)
+            logging.warning(
+              "fetch_json recovered concatenated JSON objects (%d items). "
+              "Consider adding TOP 1 to the query or removing WITHOUT_ARRAY_WRAPPER.",
+              len(data) if isinstance(data, list) else 1,
+            )
+          except json.JSONDecodeError:
+            logging.error(f"[JSONDecodeError] fetch_json — unparseable JSON:\n{raw[:500]}")
+            raise
         if many and isinstance(data, list):
           return DBResponse(rows=data, rowcount=len(data))
+        if isinstance(data, list):
+          # many=False but got a list (recovered from concatenation) — return first
+          return DBResponse(rows=[data[0]] if data else [], rowcount=1)
         return DBResponse(rows=[data], rowcount=1)
   except Exception as e:
     logging.error(f"Query failed:\n{query}\nArgs: {params}\nError: {e}")


### PR DESCRIPTION
### Motivation
- `fetch_json` concatenated cursor rows and called `json.loads()` which fails with `json.JSONDecodeError` when MSSQL `FOR JSON PATH, WITHOUT_ARRAY_WRAPPER` returns multiple rows that are concatenated like `{"a":1}{"a":2}`.

### Description
- Replace the direct `json.loads("".join(parts))` call with a guarded parse that first tries to load the raw string and catches `json.JSONDecodeError`.
- On parse failure, attempt recovery by inserting commas between adjacent `}{` boundaries using an inline `re` import, wrapping the result in array brackets, and retrying `json.loads`.
- Emit a `logging.warning` when recovery succeeds and return a single element when `many=False` but the recovered payload is a list, while preserving the `many=True` behavior for lists.
- Preserve function signatures, the existing cursor/fetch logic, no new module-level imports, and the outer `except Exception` re-raise behavior.

### Testing
- Ran `python -m py_compile server/modules/providers/database/mssql_provider/db_helpers.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbcfc891588325aced67030126720c)