### PR TITLE
Fix Workbench enrichData setState bug

### DIFF
--- a/client/src/components/Workbench.tsx
+++ b/client/src/components/Workbench.tsx
@@ -19,9 +19,9 @@ export function Workbench({ children, enrichData }: CmsComponentProps): JSX.Elem
 		if (typeof enrichData === 'function') {
 			(
 				enrichData as unknown as (
-					enricher: (nextData: Record<string, unknown>) => Record<string, unknown>,
+					enricher: () => (nextData: Record<string, unknown>) => Record<string, unknown>,
 				) => void
-			)(dataEnricher);
+			)(() => dataEnricher);
 		}
 	}, [dataEnricher, enrichData]);
 


### PR DESCRIPTION
### Motivation
- The app crashed with `TypeError: a is not a function` because the enricher was stored as an object instead of a callable function in state. 
- The root cause was calling the `enrichData` setter with a function directly, which React interprets as a functional updater and invokes immediately.

### Description
- Wrap the `dataEnricher` in a thunk when passing to `enrichData` so React stores the function itself: pass `() => dataEnricher` instead of `dataEnricher`.
- Update the local casted setter type from a direct `enricher: (nextData) => nextData` payload to a thunk `enricher: () => (nextData) => nextData` to match the new call site.
- Change applied in `client/src/components/Workbench.tsx` inside the `useEffect` block.

### Testing
- Ran `npm --prefix client run type-check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd367b43c832588fe091580e2a911)