### PR TITLE
Add UserContextProvider and sidebar auth controls (LoginControl, UserProfileControl)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,7 @@
 	<meta charset="UTF-8">
 	<title>The Elideus Group CMS</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<script src="https://accounts.google.com/gsi/client" async></script>
 	<script type="module" src="/src/index.tsx"></script>
 </head>
 <body>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { loadPath } from './api/rpc';
 import { WorkbenchRenderer } from './engine/WorkbenchRenderer';
 import type { PathNode } from './engine/types';
 import { ElideusTheme } from './theme';
+import { UserContextProvider } from './shared/UserContextProvider';
 
 function App(): JSX.Element {
 	const [pathData, setPathData] = useState<PathNode | null>(null);
@@ -37,10 +38,12 @@ function App(): JSX.Element {
 	}
 
 	return (
-		<ThemeProvider theme={ElideusTheme}>
-			<CssBaseline />
-			<WorkbenchRenderer pathData={pathData} componentData={componentData} />
-		</ThemeProvider>
+		<UserContextProvider>
+			<ThemeProvider theme={ElideusTheme}>
+				<CssBaseline />
+				<WorkbenchRenderer pathData={pathData} componentData={componentData} />
+			</ThemeProvider>
+		</UserContextProvider>
 	);
 }
 

--- a/client/src/api/rpc.ts
+++ b/client/src/api/rpc.ts
@@ -1,11 +1,7 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 
 import type { PathNode } from '../engine/types';
-
-interface LoadPathResult {
-	pathData: PathNode;
-	componentData: Record<string, unknown>;
-}
+import { getFingerprint } from '../shared/fingerprint';
 
 interface RpcEnvelope<TPayload> {
 	op: string;
@@ -14,14 +10,155 @@ interface RpcEnvelope<TPayload> {
 	timestamp?: string;
 }
 
+interface AuthTokens {
+	sessionToken: string;
+}
+
+interface RefreshTokenResult {
+	sessionToken: string;
+}
+
+interface LoadPathResult {
+	pathData: PathNode;
+	componentData: Record<string, unknown>;
+}
+
+export interface GetTokenPayload {
+	provider: string;
+	idToken?: string | null;
+	id_token?: string | null;
+	accessToken?: string | null;
+	access_token?: string | null;
+	code?: string;
+	fingerprint: string;
+	confirm?: boolean | null;
+	reAuthToken?: string | null;
+}
+
+export interface GetTokenResult {
+	sessionToken: string;
+	display_name: string;
+	credits: number;
+	profile_image: string | null;
+}
+
+export interface UserContext {
+	display: string;
+	email: string;
+	roles: string[];
+	entitlements: string[];
+	providers: string[];
+	sessionType: string;
+	isAuthenticated: boolean;
+}
+
+function getStoredSessionToken(): string | null {
+	try {
+		const raw = localStorage.getItem('authTokens');
+		if (!raw) {
+			return null;
+		}
+		const parsed = JSON.parse(raw) as Partial<AuthTokens>;
+		return typeof parsed.sessionToken === 'string' ? parsed.sessionToken : null;
+	} catch {
+		return null;
+	}
+}
+
+function setStoredSessionToken(sessionToken: string): void {
+	localStorage.setItem('authTokens', JSON.stringify({ sessionToken }));
+}
+
+function clearStoredSessionToken(): void {
+	localStorage.removeItem('authTokens');
+}
+
+async function tryRefreshToken(): Promise<string | null> {
+	try {
+		const refreshResponse = await axios.post<RpcEnvelope<RefreshTokenResult>>(
+			'/rpc',
+			{
+				op: 'urn:auth:session:refresh_token:1',
+				payload: { fingerprint: getFingerprint() },
+				version: 1,
+				timestamp: new Date().toISOString(),
+			},
+			{ headers: {} },
+		);
+		const refreshedToken = refreshResponse.data.payload.sessionToken;
+		if (!refreshedToken) {
+			throw new Error('No refreshed session token returned by server.');
+		}
+		setStoredSessionToken(refreshedToken);
+		return refreshedToken;
+	} catch {
+		clearStoredSessionToken();
+		window.dispatchEvent(new Event('sessionExpired'));
+		return null;
+	}
+}
+
+export async function rpcCall<T>(op: string, payload: unknown = {}): Promise<T> {
+	const sessionToken = getStoredSessionToken();
+	const headers: Record<string, string> = {};
+	if (sessionToken) {
+		headers.Authorization = `Bearer ${sessionToken}`;
+	}
+
+	try {
+		const response = await axios.post<RpcEnvelope<T>>(
+			'/rpc',
+			{
+				op,
+				payload,
+				version: 1,
+				timestamp: new Date().toISOString(),
+			},
+			{ headers },
+		);
+		return response.data.payload;
+	} catch (error) {
+		const isUnauthorized =
+			error instanceof AxiosError && error.response?.status === 401 && op !== 'urn:auth:session:refresh_token:1';
+		if (!isUnauthorized) {
+			throw error;
+		}
+
+		const refreshedToken = await tryRefreshToken();
+		if (!refreshedToken) {
+			throw error;
+		}
+
+		const retryResponse = await axios.post<RpcEnvelope<T>>(
+			'/rpc',
+			{
+				op,
+				payload,
+				version: 1,
+				timestamp: new Date().toISOString(),
+			},
+			{ headers: { Authorization: `Bearer ${refreshedToken}` } },
+		);
+		return retryResponse.data.payload;
+	}
+}
+
 export async function loadPath(path: string): Promise<LoadPathResult> {
-	const response = await axios.post<RpcEnvelope<LoadPathResult>>('/rpc', {
-		op: 'urn:public:route:load_path:1',
-		payload: {
-			path,
-		},
-		version: 1,
-		timestamp: new Date().toISOString(),
-	});
-	return response.data.payload;
+	return rpcCall<LoadPathResult>('urn:public:route:load_path:1', { path });
+}
+
+export async function getToken(payload: GetTokenPayload): Promise<GetTokenResult> {
+	return rpcCall<GetTokenResult>('urn:auth:session:get_token:1', payload);
+}
+
+export async function getUserContext(): Promise<UserContext> {
+	return rpcCall<UserContext>('urn:public:auth:context:get_user_context:1');
+}
+
+export async function invalidateToken(): Promise<{ ok: boolean }> {
+	return rpcCall<{ ok: boolean }>('urn:auth:session:invalidate_token:1');
+}
+
+export async function logoutDevice(): Promise<{ ok: boolean }> {
+	return rpcCall<{ ok: boolean }>('urn:auth:session:logout_device:1');
 }

--- a/client/src/components/LoginControl.tsx
+++ b/client/src/components/LoginControl.tsx
@@ -1,0 +1,223 @@
+import { useMemo, useState } from 'react';
+
+import { PublicClientApplication } from '@azure/msal-browser';
+import LoginIcon from '@mui/icons-material/Login';
+import {
+	Box,
+	Button,
+	CircularProgress,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	IconButton,
+	ListItemText,
+	Tooltip,
+	Typography,
+} from '@mui/material';
+
+import { getDiscordAuthorizeUrl } from '../config/discord';
+import googleConfig from '../config/google';
+import { loginRequest, msalConfig } from '../config/msal';
+import type { CmsComponentProps } from '../engine/types';
+import { getFingerprint } from '../shared/fingerprint';
+import Notification from './Notification';
+
+declare global {
+	interface Window {
+		google?: {
+			accounts?: {
+				oauth2?: {
+					initCodeClient: (config: {
+						client_id: string;
+						scope: string;
+						redirect_uri: string;
+						callback: (resp: { code: string }) => void;
+					}) => { requestCode: () => void };
+				};
+			};
+		};
+	}
+}
+
+const pca = new PublicClientApplication(msalConfig);
+
+type LoginFn = (provider: string, tokens: Record<string, unknown>) => Promise<void>;
+
+export function LoginControl({ data }: CmsComponentProps): JSX.Element {
+	const user = useMemo(
+		() => (data.__user && typeof data.__user === 'object' ? (data.__user as Record<string, unknown>) : null),
+		[data.__user],
+	);
+	const isLoading = data.__isAuthLoading === true;
+	const sidebarOpen = data.__sidebarOpen === true;
+	const login = typeof data.__login === 'function' ? (data.__login as LoginFn) : null;
+
+	const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+	const [notification, setNotification] = useState({
+		open: false,
+		severity: 'info' as 'info' | 'success' | 'warning' | 'error',
+		message: '',
+	});
+
+	const closeNotification = (): void => {
+		setNotification((prev) => ({ ...prev, open: false }));
+	};
+
+	const handleLoginError = (error: unknown): void => {
+		setNotification({
+			open: true,
+			severity: 'error',
+			message: `Login failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+		});
+	};
+
+	const runLogin = async (provider: string, tokens: Record<string, unknown>): Promise<void> => {
+		if (!login) {
+			throw new Error('Login handler is not available.');
+		}
+		setIsSubmitting(true);
+		try {
+			await login(provider, tokens);
+			setDialogOpen(false);
+			setNotification({
+				open: true,
+				severity: 'success',
+				message: 'Login successful!',
+			});
+		} catch (error) {
+			handleLoginError(error);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleMicrosoftLogin = async (): Promise<void> => {
+		await pca.initialize();
+		const loginResponse = await pca.loginPopup(loginRequest);
+		await runLogin('microsoft', {
+			idToken: loginResponse.idToken,
+			id_token: null,
+			accessToken: loginResponse.accessToken,
+			access_token: null,
+			fingerprint: getFingerprint(),
+		});
+	};
+
+	const handleDiscordLogin = async (): Promise<void> => {
+		const authorizeUrl = getDiscordAuthorizeUrl();
+		const authWindow = window.open(authorizeUrl, 'discordOAuth', 'width=500,height=600');
+		if (!authWindow) {
+			throw new Error('Failed to open Discord login window');
+		}
+		const code = await new Promise<string>((resolve, reject) => {
+			const interval = setInterval(() => {
+				if (authWindow.closed) {
+					clearInterval(interval);
+					reject(new Error('Login window closed'));
+					return;
+				}
+				try {
+					const url = new URL(authWindow.location.href);
+					if (url.origin === window.location.origin) {
+						const codeParam = url.searchParams.get('code');
+						if (codeParam) {
+							clearInterval(interval);
+							authWindow.close();
+							resolve(codeParam);
+						}
+					}
+				} catch {
+					// Ignore cross-origin access errors until redirect.
+				}
+			}, 500);
+		});
+		await runLogin('discord', { code, fingerprint: getFingerprint() });
+	};
+
+	const handleGoogleLogin = async (): Promise<void> => {
+		if (!window.google?.accounts?.oauth2) {
+			throw new Error('Google API not loaded');
+		}
+		const code = await new Promise<string>((resolve) => {
+			const client = window.google?.accounts?.oauth2?.initCodeClient({
+				client_id: googleConfig.clientId,
+				scope: googleConfig.scope,
+				redirect_uri: googleConfig.redirectUri,
+				callback: (resp) => resolve(resp.code),
+			});
+			client?.requestCode();
+		});
+		await runLogin('google', { code, fingerprint: getFingerprint() });
+	};
+
+	if (isLoading) {
+		return (
+			<Box sx={{ display: 'flex', alignItems: 'center', justifyContent: sidebarOpen ? 'flex-start' : 'center', p: 0.5 }}>
+				<CircularProgress size={18} />
+			</Box>
+		);
+	}
+
+	if (user) {
+		return <Box sx={{ minHeight: 32 }} />;
+	}
+
+	return (
+		<>
+			<Box sx={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
+				<Tooltip title="Login">
+					<IconButton
+						onClick={(): void => setDialogOpen(true)}
+						sx={{
+							width: 32,
+							height: 32,
+							color: '#FFFFFF',
+							border: '1px solid #1A1A1A',
+							borderRadius: 1,
+						}}
+					>
+						<LoginIcon sx={{ fontSize: 18 }} />
+					</IconButton>
+				</Tooltip>
+				{sidebarOpen ? (
+					<ListItemText
+						primary={<Typography sx={{ fontSize: '0.75rem', color: '#888888' }}>Login</Typography>}
+						sx={{ ml: '6px', minWidth: 0 }}
+					/>
+				) : null}
+			</Box>
+
+			<Dialog open={dialogOpen} onClose={(): void => setDialogOpen(false)} fullWidth maxWidth="xs">
+				<DialogTitle>Sign in</DialogTitle>
+				<DialogContent>
+					<Typography variant="body2" sx={{ mb: 2 }}>
+						Sign in using Microsoft, Discord, or Google.
+					</Typography>
+					<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+						<Button variant="contained" loading={isSubmitting} onClick={(): void => void handleMicrosoftLogin()}>
+							Sign in with Microsoft
+						</Button>
+						<Button variant="contained" loading={isSubmitting} onClick={(): void => void handleDiscordLogin()}>
+							Sign in with Discord
+						</Button>
+						<Button variant="contained" loading={isSubmitting} onClick={(): void => void handleGoogleLogin()}>
+							Sign in with Google
+						</Button>
+					</Box>
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={(): void => setDialogOpen(false)}>Cancel</Button>
+				</DialogActions>
+			</Dialog>
+
+			<Notification
+				open={notification.open}
+				handleClose={closeNotification}
+				severity={notification.severity}
+				message={notification.message}
+			/>
+		</>
+	);
+}

--- a/client/src/components/Notification.tsx
+++ b/client/src/components/Notification.tsx
@@ -1,0 +1,19 @@
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+
+interface NotificationProps {
+	open: boolean;
+	handleClose: () => void;
+	severity: 'success' | 'info' | 'warning' | 'error';
+	message: string;
+}
+
+const Notification = ({ open, handleClose, severity, message }: NotificationProps): JSX.Element => (
+	<Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
+		<Alert onClose={handleClose} severity={severity} sx={{ width: '100%' }}>
+			{message}
+		</Alert>
+	</Snackbar>
+);
+
+export default Notification;

--- a/client/src/components/UserProfileControl.tsx
+++ b/client/src/components/UserProfileControl.tsx
@@ -1,0 +1,126 @@
+import { useMemo, useState } from 'react';
+
+import { Avatar, Box, CircularProgress, IconButton, ListItemText, Tooltip, Typography } from '@mui/material';
+
+import type { UserContext } from '../api/rpc';
+import type { CmsComponentProps } from '../engine/types';
+import Notification from './Notification';
+
+type LogoutFn = () => Promise<void>;
+
+export function UserProfileControl({ data }: CmsComponentProps): JSX.Element {
+	const user = useMemo(() => {
+		if (!data.__user || typeof data.__user !== 'object') {
+			return null;
+		}
+		return data.__user as UserContext;
+	}, [data.__user]);
+
+	const sidebarOpen = data.__sidebarOpen === true;
+	const isLoading = data.__isAuthLoading === true;
+	const logout = typeof data.__logout === 'function' ? (data.__logout as LogoutFn) : null;
+	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+	const [notification, setNotification] = useState({
+		open: false,
+		severity: 'info' as 'info' | 'success' | 'warning' | 'error',
+		message: '',
+	});
+
+	const closeNotification = (): void => {
+		setNotification((prev) => ({ ...prev, open: false }));
+	};
+
+	const handleLogout = async (): Promise<void> => {
+		if (!logout) {
+			return;
+		}
+		setIsSubmitting(true);
+		try {
+			await logout();
+			setNotification({ open: true, severity: 'info', message: 'Logged out successfully.' });
+		} catch (error) {
+			setNotification({
+				open: true,
+				severity: 'error',
+				message: `Logout failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+			});
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	if (!user) {
+		return <Box sx={{ minHeight: isLoading ? 32 : 0 }} />;
+	}
+
+	const secondaryText = user.email || user.roles[0] || 'Authenticated';
+	const initials = user.display ? user.display.charAt(0).toUpperCase() : '?';
+
+	return (
+		<>
+			<Box sx={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
+				<Tooltip title="Logout">
+					<IconButton onClick={(): void => void handleLogout()} sx={{ width: 32, height: 32, color: '#FFFFFF' }}>
+						{isSubmitting ? (
+							<CircularProgress size={18} />
+						) : (
+							<Avatar
+								sx={{
+									width: 24,
+									height: 24,
+									bgcolor: '#1A1A1A',
+									color: '#FFFFFF',
+									fontSize: '0.75rem',
+									border: '1.5px solid #4CAF50',
+								}}
+							>
+								{initials}
+							</Avatar>
+						)}
+					</IconButton>
+				</Tooltip>
+				{sidebarOpen ? (
+					<ListItemText
+						primary={
+							<Box sx={{ minWidth: 0 }}>
+								<Typography
+									sx={{
+										display: 'block',
+										fontSize: '0.7rem',
+										lineHeight: 1.2,
+										color: '#888888',
+										whiteSpace: 'nowrap',
+										overflow: 'hidden',
+										textOverflow: 'ellipsis',
+									}}
+								>
+									{user.display}
+								</Typography>
+								<Typography
+									sx={{
+										display: 'block',
+										fontSize: '0.65rem',
+										lineHeight: 1.2,
+										color: '#555555',
+										whiteSpace: 'nowrap',
+										overflow: 'hidden',
+										textOverflow: 'ellipsis',
+									}}
+								>
+									{secondaryText}
+								</Typography>
+							</Box>
+						}
+						sx={{ ml: '6px', minWidth: 0 }}
+					/>
+				) : null}
+			</Box>
+			<Notification
+				open={notification.open}
+				handleClose={closeNotification}
+				severity={notification.severity}
+				message={notification.message}
+			/>
+		</>
+	);
+}

--- a/client/src/components/Workbench.tsx
+++ b/client/src/components/Workbench.tsx
@@ -2,17 +2,24 @@ import { useCallback, useEffect, useState } from 'react';
 import { Box } from '@mui/material';
 
 import type { CmsComponentProps } from '../engine/types';
+import { useUserContext } from '../shared/UserContextProvider';
 
 export function Workbench({ children, enrichData }: CmsComponentProps): JSX.Element {
 	const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
+	const { user, sessionToken, isLoading, login, logout } = useUserContext();
 
 	const dataEnricher = useCallback(
 		(baseData: Record<string, unknown>): Record<string, unknown> => ({
 			...baseData,
 			__sidebarOpen: sidebarOpen,
 			__toggleSidebar: (): void => setSidebarOpen((prev) => !prev),
+			__user: user,
+			__sessionToken: sessionToken,
+			__isAuthLoading: isLoading,
+			__login: login,
+			__logout: logout,
 		}),
-		[sidebarOpen],
+		[sidebarOpen, user, sessionToken, isLoading, login, logout],
 	);
 
 	useEffect(() => {

--- a/client/src/config/discord.ts
+++ b/client/src/config/discord.ts
@@ -1,0 +1,11 @@
+export const discordConfig = {
+        clientId: '1339726954986999878',
+        scope: 'identify email openid',
+        redirectUri: `${window.location.origin}`,
+        authorizeEndpoint: 'https://discord.com/oauth2/authorize',
+};
+
+export const getDiscordAuthorizeUrl = (): string => {
+        return `${discordConfig.authorizeEndpoint}?response_type=code&client_id=${discordConfig.clientId}&scope=${encodeURIComponent(discordConfig.scope)}&redirect_uri=${encodeURIComponent(discordConfig.redirectUri)}`;
+};
+export default discordConfig;

--- a/client/src/config/google.ts
+++ b/client/src/config/google.ts
@@ -1,0 +1,6 @@
+export const googleConfig = {
+        clientId: '295304659309-vkbjt5572fg3vjlqbj3qkkfgal83pcrj.apps.googleusercontent.com',
+        scope: 'openid profile email',
+        redirectUri: `${window.location.origin}`,
+};
+export default googleConfig;

--- a/client/src/config/msal.ts
+++ b/client/src/config/msal.ts
@@ -1,0 +1,11 @@
+export const msalConfig = {
+       auth: {
+               clientId: '6c725f5b-6a44-4bf0-a0d6-c2cfc15230be',
+               authority: 'https://login.microsoftonline.com/consumers',
+               redirectUri: window.location.origin,
+       },
+};
+
+export const loginRequest = {
+       scopes: ['User.Read'],
+};

--- a/client/src/engine/registry.ts
+++ b/client/src/engine/registry.ts
@@ -4,6 +4,7 @@ import { ContentPanel } from '../components/ContentPanel';
 import { HamburgerToggle } from '../components/HamburgerToggle';
 import { ImageElement } from '../components/ImageElement';
 import { LabelElement } from '../components/LabelElement';
+import { LoginControl } from '../components/LoginControl';
 import { LinkButton } from '../components/LinkButton';
 import { NavigationSidebar } from '../components/NavigationSidebar';
 import { SidebarContent } from '../components/SidebarContent';
@@ -11,6 +12,7 @@ import { SidebarFooter } from '../components/SidebarFooter';
 import { SidebarHeader } from '../components/SidebarHeader';
 import { SimplePage } from '../components/SimplePage';
 import { StringControl } from '../components/StringControl';
+import { UserProfileControl } from '../components/UserProfileControl';
 import { Workbench } from '../components/Workbench';
 
 import type { CmsComponentProps } from './types';
@@ -27,5 +29,7 @@ export const COMPONENT_REGISTRY: Record<string, ComponentType<CmsComponentProps>
 	ImageElement,
 	LinkButton,
 	LabelElement,
+	LoginControl,
+	UserProfileControl,
 	StringControl,
 };

--- a/client/src/shared/UserContextProvider.tsx
+++ b/client/src/shared/UserContextProvider.tsx
@@ -1,0 +1,141 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { getToken, getUserContext, invalidateToken, logoutDevice } from '../api/rpc';
+import type { GetTokenPayload, UserContext } from '../api/rpc';
+import { getFingerprint } from './fingerprint';
+
+export interface UserContextValue {
+	user: UserContext | null;
+	sessionToken: string | null;
+	isLoading: boolean;
+	login: (provider: string, tokens: Record<string, unknown>) => Promise<void>;
+	logout: () => Promise<void>;
+}
+
+const UserContextState = createContext<UserContextValue | undefined>(undefined);
+
+function readStoredSessionToken(): string | null {
+	try {
+		const raw = localStorage.getItem('authTokens');
+		if (!raw) {
+			return null;
+		}
+		const parsed = JSON.parse(raw) as { sessionToken?: unknown };
+		return typeof parsed.sessionToken === 'string' ? parsed.sessionToken : null;
+	} catch {
+		return null;
+	}
+}
+
+function clearStoredSession(): void {
+	localStorage.removeItem('authTokens');
+}
+
+function writeStoredSessionToken(sessionToken: string): void {
+	localStorage.setItem('authTokens', JSON.stringify({ sessionToken }));
+}
+
+export function UserContextProvider({ children }: { children: ReactNode }): JSX.Element {
+	const [user, setUser] = useState<UserContext | null>(null);
+	const [sessionToken, setSessionToken] = useState<string | null>(() => readStoredSessionToken());
+	const [isLoading, setIsLoading] = useState<boolean>(true);
+
+	const clearState = useCallback(() => {
+		clearStoredSession();
+		setSessionToken(null);
+		setUser(null);
+	}, []);
+
+	useEffect(() => {
+		let mounted = true;
+		const hydrateUser = async (): Promise<void> => {
+			const existingToken = readStoredSessionToken();
+			if (!existingToken) {
+				if (mounted) {
+					setIsLoading(false);
+				}
+				return;
+			}
+
+			try {
+				const currentUser = await getUserContext();
+				if (mounted) {
+					setSessionToken(existingToken);
+					setUser(currentUser);
+				}
+			} catch {
+				if (mounted) {
+					clearState();
+				}
+			} finally {
+				if (mounted) {
+					setIsLoading(false);
+				}
+			}
+		};
+
+		void hydrateUser();
+
+		return () => {
+			mounted = false;
+		};
+	}, [clearState]);
+
+	const login = useCallback(async (provider: string, tokens: Record<string, unknown>): Promise<void> => {
+		const payload: GetTokenPayload = {
+			provider,
+			fingerprint: getFingerprint(),
+			...(tokens as Partial<GetTokenPayload>),
+		};
+
+		const loginResult = await getToken(payload);
+		writeStoredSessionToken(loginResult.sessionToken);
+		setSessionToken(loginResult.sessionToken);
+		const currentUser = await getUserContext();
+		setUser(currentUser);
+	}, []);
+
+	const logout = useCallback(async (): Promise<void> => {
+		try {
+			await logoutDevice();
+		} finally {
+			try {
+				await invalidateToken();
+			} finally {
+				clearState();
+			}
+		}
+	}, [clearState]);
+
+	useEffect(() => {
+		const onSessionExpired = (): void => {
+			clearState();
+		};
+		window.addEventListener('sessionExpired', onSessionExpired);
+		return () => {
+			window.removeEventListener('sessionExpired', onSessionExpired);
+		};
+	}, [clearState]);
+
+	const contextValue = useMemo<UserContextValue>(
+		() => ({
+			user,
+			sessionToken,
+			isLoading,
+			login,
+			logout,
+		}),
+		[user, sessionToken, isLoading, login, logout],
+	);
+
+	return <UserContextState.Provider value={contextValue}>{children}</UserContextState.Provider>;
+}
+
+export function useUserContext(): UserContextValue {
+	const context = useContext(UserContextState);
+	if (!context) {
+		throw new Error('useUserContext must be used within a UserContextProvider.');
+	}
+	return context;
+}

--- a/client/src/shared/fingerprint.ts
+++ b/client/src/shared/fingerprint.ts
@@ -1,0 +1,8 @@
+export const getFingerprint = (): string => {
+	let fp = localStorage.getItem('deviceFingerprint');
+	if (!fp) {
+		fp = crypto.randomUUID();
+		localStorage.setItem('deviceFingerprint', fp);
+	}
+	return fp;
+};


### PR DESCRIPTION
### Motivation
- Wire authentication into the new client so the sidebar footer can show login UI and authenticated user info.
- Reuse proven legacy helpers (fingerprint, notification, OAuth configs) to avoid reimplementing provider flows.
- Provide a resilient RPC helper that injects bearer tokens and auto-refreshes sessions on 401.

### Description
- Copied legacy support files into the client: `client/src/shared/fingerprint.ts`, `client/src/components/Notification.tsx`, and OAuth configs `client/src/config/{msal,google,discord}.ts`, and added the Google Identity Services script to `client/index.html`.
- Implemented a generic `rpcCall<T>` in `client/src/api/rpc.ts` that injects `Authorization: Bearer <token>`, attempts refresh via `urn:auth:session:refresh_token:1` on 401, dispatches the `sessionExpired` window event on unrecoverable refresh, and added typed auth wrappers `getToken`, `getUserContext`, `invalidateToken`, and `logoutDevice`.
- Added a new `UserContextProvider` and `useUserContext` in `client/src/shared/UserContextProvider.tsx` that hydrates session on mount, exposes `login`/`logout`, stores the session token in `localStorage` as `authTokens`, and listens for `sessionExpired` to clear state.
- Wired provider into the app and rendering pipeline by wrapping `App` with `UserContextProvider`, injecting auth state/actions into the `Workbench` enrich-data channel (`__user`, `__sessionToken`, `__isAuthLoading`, `__login`, `__logout`), implemented `LoginControl` and `UserProfileControl` under `client/src/components/`, and registered them in `client/src/engine/registry.ts`.

### Testing
- Ran TypeScript checks with `cd client && npm run type-check` which completed successfully.
- Ran lint with `cd client && npm run lint` which completed and reported a single acceptable `react-refresh/only-export-components` warning in `UserContextProvider.tsx`.
- Sanity-verified that `loadPath` now uses `rpcCall` and that the new components compile under the project's strict type settings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbde1b08588325a2dc7c1c47dbc7ff)