### PR TITLE
Support Google/Discord code flow in unified auth session `get_token`

### DIFF
--- a/rpc/auth/session/models.py
+++ b/rpc/auth/session/models.py
@@ -5,8 +5,11 @@ from pydantic import BaseModel
 
 class AuthSessionGetTokenRequest1(BaseModel):
   provider: str
-  id_token: str
-  access_token: str
+  id_token: str | None = None
+  access_token: str | None = None
+  idToken: str | None = None
+  accessToken: str | None = None
+  code: str | None = None
   fingerprint: str
   confirm: bool | None = None
   reAuthToken: str | None = None

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -15,6 +15,7 @@ from .models import (
 )
 
 if TYPE_CHECKING:
+  from server.modules.oauth_module import OauthModule
   from server.modules.session_module import SessionModule
 
 
@@ -22,30 +23,43 @@ async def auth_session_get_token_v1(request: Request):
   rpc_request, _, _ = await unbox_request(request)
   payload = AuthSessionGetTokenRequest1(**(rpc_request.payload or {}))
 
-  module: 'SessionModule' = request.app.state.session
+  module: 'OauthModule' = request.app.state.oauth
   await module.on_ready()
 
-  session_token, rotation_token, rot_exp, profile = await module.issue_token(
+  id_token = payload.idToken or payload.id_token
+  access_token = payload.accessToken or payload.access_token
+
+  result = await module.login_provider(
     payload.provider,
-    payload.id_token,
-    payload.access_token,
-    payload.fingerprint,
-    request.headers.get("user-agent"),
-    request.client.host if request.client else None,
-    payload.confirm,
-    payload.reAuthToken,
+    id_token=id_token,
+    access_token=access_token,
+    code=payload.code,
+    fingerprint=payload.fingerprint,
+    confirm=payload.confirm,
+    reauth_token=payload.reAuthToken,
+    user_agent=request.headers.get("user-agent"),
+    ip_address=request.client.host if request.client else None,
   )
 
-  response_payload = AuthSessionGetTokenResponse1(token=session_token, profile=profile)
+  user = result["user"]
+  response_payload = AuthSessionGetTokenResponse1(
+    token=result["session_token"],
+    profile={
+      "display_name": user.get("display_name"),
+      "email": user.get("email"),
+      "credits": user.get("credits"),
+      "profile_image": user.get("profile_image"),
+    },
+  )
   rpc_resp = RPCResponse(op=rpc_request.op, payload=response_payload.model_dump(), version=rpc_request.version)
   response = JSONResponse(content=jsonable_encoder(rpc_resp))
   response.set_cookie(
     "rotation_token",
-    rotation_token,
+    result["rotation_token"],
     httponly=True,
     secure=is_secure_request(request),
     samesite="lax",
-    expires=rot_exp,
+    expires=result["rotation_exp"],
   )
   return response
 


### PR DESCRIPTION
### Motivation
- The unified `auth_session_get_token_v1` endpoint rejected Google/Discord logins because `AuthSessionGetTokenRequest1` required `id_token`/`access_token` even though those providers send a `code` instead. 
- The single endpoint must accept both token-based and code-based OAuth payloads so all providers can be routed through the new client `LoginControl`.

### Description
- Updated `rpc/auth/session/models.py` to make `id_token` and `access_token` optional, add `code`, and accept camelCase aliases `idToken` and `accessToken` for client compatibility. 
- Replaced the `SessionModule.issue_token(...)` call in `rpc/auth/session/services.py` with `OauthModule.login_provider(...)` so provider-specific token/code handling is centralized. 
- Resolved camelCase aliases into `id_token`/`access_token`, forwarded `code`, `fingerprint`, `confirm`, `reAuthToken`, `user-agent`, and client IP to `login_provider`, and mapped the returned `session_token`/`rotation_token`/`user` into the existing RPC response shape and cookie. 
- Added a `TYPE_CHECKING` import reference to `OauthModule` and removed reliance on `SessionModule` in the unified get-token path.

### Testing
- Ran the repository test harness with `python scripts/run_tests.py` and it completed successfully (all automated tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe56b35ec8325a6cd1c1a868bedc4)