### PR TITLE
Align auth get-token response key with frontend (`sessionToken`)

### DIFF
--- a/rpc/auth/session/models.py
+++ b/rpc/auth/session/models.py
@@ -20,7 +20,7 @@ class AuthSessionRefreshTokenRequest1(BaseModel):
 
 
 class AuthSessionGetTokenResponse1(BaseModel):
-  token: str
+  sessionToken: str
   profile: dict[str, Any]
 
 

--- a/rpc/auth/session/services.py
+++ b/rpc/auth/session/services.py
@@ -43,7 +43,7 @@ async def auth_session_get_token_v1(request: Request):
 
   user = result["user"]
   response_payload = AuthSessionGetTokenResponse1(
-    token=result["session_token"],
+    sessionToken=result["session_token"],
     profile={
       "display_name": user.get("display_name"),
       "email": user.get("email"),


### PR DESCRIPTION
### Motivation
- Fix 401s caused by a field-name mismatch where the server returned `token` but the frontend expected and stored `sessionToken`, resulting in missing Authorization headers on subsequent RPC calls.

### Description
- Rename the response field to `sessionToken` in `rpc/auth/session/models.py` and update `auth_session_get_token_v1` in `rpc/auth/session/services.py` to populate `sessionToken` from the module result, so the RPC payload matches frontend expectations (`authTokens.sessionToken`).

### Testing
- Ran the unified harness `python scripts/run_tests.py`, which completed successfully and reported the JS/unit tests and Python test(s) passing (overall `1 passed`); lint reported a single non-blocking ESLint warning but no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbecdc3eac8325a0fe4fdacbb9a704)