### PR TITLE
Add navigation RPC and sidebar components: NavigationTreeView & DevModeToggle

### DIFF
--- a/client/src/api/rpc.ts
+++ b/client/src/api/rpc.ts
@@ -23,6 +23,18 @@ interface LoadPathResult {
 	componentData: Record<string, unknown>;
 }
 
+export interface NavigationRouteElement {
+	path: string;
+	title: string;
+	icon: string | null;
+	sequence: number;
+	parentRouteGuid: string | null;
+}
+
+export interface ReadNavigationResult {
+	elements: NavigationRouteElement[];
+}
+
 export interface GetTokenPayload {
 	provider: string;
 	idToken?: string | null;
@@ -145,6 +157,10 @@ export async function rpcCall<T>(op: string, payload: unknown = {}): Promise<T> 
 
 export async function loadPath(path: string): Promise<LoadPathResult> {
 	return rpcCall<LoadPathResult>('urn:public:route:load_path:1', { path });
+}
+
+export async function readNavigation(): Promise<ReadNavigationResult> {
+	return rpcCall<ReadNavigationResult>('urn:public:route:read_navigation:1');
 }
 
 export async function getToken(payload: GetTokenPayload): Promise<GetTokenResult> {

--- a/client/src/components/DevModeToggle.tsx
+++ b/client/src/components/DevModeToggle.tsx
@@ -1,0 +1,97 @@
+import CodeIcon from '@mui/icons-material/Code';
+import {
+	Box,
+	FormControlLabel,
+	IconButton,
+	Switch,
+	Tooltip,
+	Typography,
+} from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+interface UserLike {
+	isAuthenticated?: boolean;
+	roles?: string[];
+}
+
+export function DevModeToggle({ data }: CmsComponentProps): JSX.Element | null {
+	const user = (data.__user ?? null) as UserLike | null;
+	const isAuthenticated = user?.isAuthenticated === true;
+	const roles = Array.isArray(user?.roles) ? user.roles : [];
+	const isServiceAdmin = roles.some((role) => role === 'ROLE_SERVICE_ADMIN');
+
+	if (!isAuthenticated || !isServiceAdmin) {
+		return null;
+	}
+
+	const isOpen = data.__sidebarOpen === true;
+	const isDevMode = data.__devMode === true;
+	const toggleDevMode =
+		typeof data.__toggleDevMode === 'function' ? (data.__toggleDevMode as () => void) : undefined;
+
+	if (!toggleDevMode) {
+		return null;
+	}
+
+	if (!isOpen) {
+		return (
+			<Tooltip title={isDevMode ? 'Disable Dev Mode' : 'Enable Dev Mode'}>
+				<IconButton
+					onClick={toggleDevMode}
+					sx={{
+						width: 28,
+						height: 28,
+						borderRadius: 1,
+						color: isDevMode ? '#4CAF50' : '#FFFFFF',
+						border: '1px solid #1A1A1A',
+						'&:hover': {
+							backgroundColor: 'rgba(255, 255, 255, 0.04)',
+							borderColor: '#333333',
+						},
+					}}
+				>
+					<CodeIcon sx={{ fontSize: 18 }} />
+				</IconButton>
+			</Tooltip>
+		);
+	}
+
+	return (
+		<Box
+			sx={{
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'space-between',
+				gap: 1,
+			}}
+		>
+			<Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+				<CodeIcon sx={{ fontSize: 18, color: isDevMode ? '#4CAF50' : '#FFFFFF' }} />
+				<Typography variant="body2" sx={{ fontSize: '0.75rem', color: '#FFFFFF' }}>
+					Dev Mode
+				</Typography>
+			</Box>
+			<FormControlLabel
+				label=""
+				control={
+					<Switch
+						checked={isDevMode}
+						onChange={toggleDevMode}
+						size="small"
+						sx={{
+							'& .MuiSwitch-switchBase.Mui-checked': {
+								color: '#4CAF50',
+							},
+							'& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+								backgroundColor: '#4CAF50',
+								opacity: 0.6,
+							},
+						}}
+					/>
+				}
+				sx={{ mr: 0 }}
+			/>
+		</Box>
+	);
+}

--- a/client/src/components/NavigationTreeView.tsx
+++ b/client/src/components/NavigationTreeView.tsx
@@ -1,0 +1,153 @@
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Divider, List, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+
+import { readNavigation } from '../api/rpc';
+import type { NavigationRouteElement } from '../api/rpc';
+import { DynamicIcon } from './DynamicIcon';
+import type { CmsComponentProps } from '../engine/types';
+
+const getRouteSequence = (route: NavigationRouteElement): number => {
+	const raw = route.sequence;
+	if (typeof raw === 'number' && Number.isFinite(raw)) {
+		return raw;
+	}
+	return 0;
+};
+
+const getSectionKey = (sequence: number): number => {
+	if (!Number.isFinite(sequence)) {
+		return 0;
+	}
+	const bucketStart = Math.floor(sequence / 100) * 100;
+	return bucketStart < 0 ? 0 : bucketStart;
+};
+
+const isRouteActive = (pathname: string, routePath: string): boolean => {
+	if (routePath === '/') {
+		return pathname === '/';
+	}
+	return pathname === routePath || pathname.startsWith(`${routePath}/`);
+};
+
+const getUserRoleKey = (user: unknown): string => {
+	if (!user || typeof user !== 'object') {
+		return 'anon';
+	}
+	const roles = (user as { roles?: unknown }).roles;
+	if (!Array.isArray(roles)) {
+		return 'auth';
+	}
+	const normalized = roles
+		.filter((role): role is string => typeof role === 'string' && role.length > 0)
+		.map((role) => role.toUpperCase())
+		.sort();
+	return normalized.join('|');
+};
+
+export function NavigationTreeView({ data }: CmsComponentProps): JSX.Element {
+	const isOpen = data.__sidebarOpen === true;
+	const userRoleKey = useMemo(() => getUserRoleKey(data.__user), [data.__user]);
+	const [routes, setRoutes] = useState<NavigationRouteElement[]>([]);
+
+	useEffect(() => {
+		let mounted = true;
+		const hydrateRoutes = async (): Promise<void> => {
+			try {
+				const response = await readNavigation();
+				if (mounted) {
+					const elements = Array.isArray(response.elements) ? response.elements : [];
+					setRoutes(elements);
+				}
+			} catch {
+				if (mounted) {
+					setRoutes([]);
+				}
+			}
+		};
+
+		void hydrateRoutes();
+		return () => {
+			mounted = false;
+		};
+	}, [userRoleKey]);
+
+	const pathname = window.location.pathname;
+	const sections = useMemo(() => {
+		const grouped = new Map<number, NavigationRouteElement[]>();
+		const sorted = [...routes].sort((a, b) => getRouteSequence(a) - getRouteSequence(b));
+		sorted.forEach((route) => {
+			const key = getSectionKey(getRouteSequence(route));
+			const existing = grouped.get(key);
+			if (existing) {
+				existing.push(route);
+				return;
+			}
+			grouped.set(key, [route]);
+		});
+		return Array.from(grouped.entries()).sort(([a], [b]) => a - b);
+	}, [routes]);
+
+	return (
+		<List sx={{ px: 0.5, py: 0 }}>
+			{sections.map(([sectionKey, items], index) => (
+				<Fragment key={sectionKey}>
+					{index > 0 ? <Divider sx={{ borderColor: '#1A1A1A', my: 0.75 }} /> : null}
+					{items.map((route) => {
+						const active = isRouteActive(pathname, route.path);
+						return (
+							<ListItemButton
+								key={route.path}
+								onClick={() => {
+									window.location.href = route.path;
+								}}
+								sx={{
+									minHeight: 28,
+									px: '8px',
+									py: '5px',
+									borderRadius: 1,
+									justifyContent: isOpen ? 'flex-start' : 'center',
+									gap: isOpen ? 1 : 0,
+									color: active ? '#4CAF50' : '#FFFFFF',
+									backgroundColor: active ? 'rgba(76, 175, 80, 0.12)' : 'transparent',
+									'&:hover': {
+										backgroundColor: active
+											? 'rgba(76, 175, 80, 0.18)'
+											: 'rgba(255, 255, 255, 0.04)',
+										color: active ? '#4CAF50' : '#FFFFFF',
+									},
+								}}
+							>
+								<ListItemIcon
+									sx={{
+										minWidth: 0,
+										width: 18,
+										height: 18,
+										color: 'inherit',
+										justifyContent: 'center',
+										'& .MuiSvgIcon-root': {
+											fontSize: 18,
+										},
+									}}
+								>
+									<DynamicIcon name={route.icon} />
+								</ListItemIcon>
+								{isOpen ? (
+									<ListItemText
+										primary={route.title}
+										primaryTypographyProps={{
+											fontSize: '0.75rem',
+											lineHeight: 1.2,
+											whiteSpace: 'nowrap',
+											overflow: 'hidden',
+											textOverflow: 'ellipsis',
+										}}
+									/>
+								) : null}
+							</ListItemButton>
+						);
+					})}
+				</Fragment>
+			))}
+		</List>
+	);
+}

--- a/client/src/components/Workbench.tsx
+++ b/client/src/components/Workbench.tsx
@@ -6,6 +6,7 @@ import { useUserContext } from '../shared/UserContextProvider';
 
 export function Workbench({ children, enrichData }: CmsComponentProps): JSX.Element {
 	const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
+	const [devMode, setDevMode] = useState<boolean>(false);
 	const { user, sessionToken, isLoading, login, logout } = useUserContext();
 
 	const dataEnricher = useCallback(
@@ -13,13 +14,15 @@ export function Workbench({ children, enrichData }: CmsComponentProps): JSX.Elem
 			...baseData,
 			__sidebarOpen: sidebarOpen,
 			__toggleSidebar: (): void => setSidebarOpen((prev) => !prev),
+			__devMode: devMode,
+			__toggleDevMode: (): void => setDevMode((prev) => !prev),
 			__user: user,
 			__sessionToken: sessionToken,
 			__isAuthLoading: isLoading,
 			__login: login,
 			__logout: logout,
 		}),
-		[sidebarOpen, user, sessionToken, isLoading, login, logout],
+		[sidebarOpen, devMode, user, sessionToken, isLoading, login, logout],
 	);
 
 	useEffect(() => {

--- a/client/src/engine/registry.ts
+++ b/client/src/engine/registry.ts
@@ -1,11 +1,13 @@
 import type { ComponentType } from 'react';
 
+import { DevModeToggle } from '../components/DevModeToggle';
 import { ContentPanel } from '../components/ContentPanel';
 import { HamburgerToggle } from '../components/HamburgerToggle';
 import { ImageElement } from '../components/ImageElement';
 import { LabelElement } from '../components/LabelElement';
 import { LoginControl } from '../components/LoginControl';
 import { LinkButton } from '../components/LinkButton';
+import { NavigationTreeView } from '../components/NavigationTreeView';
 import { NavigationSidebar } from '../components/NavigationSidebar';
 import { SidebarContent } from '../components/SidebarContent';
 import { SidebarFooter } from '../components/SidebarFooter';
@@ -23,7 +25,9 @@ export const COMPONENT_REGISTRY: Record<string, ComponentType<CmsComponentProps>
 	SidebarHeader,
 	SidebarContent,
 	SidebarFooter,
+	DevModeToggle,
 	HamburgerToggle,
+	NavigationTreeView,
 	ContentPanel,
 	SimplePage,
 	ImageElement,

--- a/rpc/public/route/__init__.py
+++ b/rpc/public/route/__init__.py
@@ -1,6 +1,7 @@
-from .services import public_route_load_path_v1
+from .services import public_route_load_path_v1, public_route_read_navigation_v1
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("load_path", "1"): public_route_load_path_v1,
+  ("read_navigation", "1"): public_route_read_navigation_v1,
 }

--- a/rpc/public/route/services.py
+++ b/rpc/public/route/services.py
@@ -24,3 +24,18 @@ async def public_route_load_path_v1(request: Request):
     payload=result.model_dump(),
     version=rpc_request.version,
   )
+
+
+async def public_route_read_navigation_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+
+  user_roles = auth_ctx.roles if auth_ctx.user_guid else []
+  result = await module.read_navigation(user_roles)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload={"elements": result},
+    version=rpc_request.version,
+  )

--- a/server/modules/cms_workbench_module.py
+++ b/server/modules/cms_workbench_module.py
@@ -20,10 +20,27 @@ class CmsWorkbenchModule(BaseModule):
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.db: DbModule | None = None
+    self._role_guid_to_name: dict[str, str] = {}
 
   async def startup(self):
     self.db = self.app.state.db
     await self.db.on_ready()
+
+    from queryregistry.providers.mssql import run_rows_many
+
+    role_result = await run_rows_many(
+      """
+      SELECT key_guid, pub_name
+      FROM system_auth_roles;
+      """,
+      (),
+    )
+    self._role_guid_to_name = {
+      str(row.get("key_guid") or "").upper(): str(row.get("pub_name") or "")
+      for row in role_result.rows
+      if row.get("key_guid")
+    }
+
     self.mark_ready()
 
   async def shutdown(self):
@@ -128,3 +145,52 @@ class CmsWorkbenchModule(BaseModule):
         pass
 
     return LoadPathResult1(pathData=shell_nodes[shell_root_guid], componentData=component_data)
+
+  async def read_navigation(self, user_role_names: list[str] | None = None) -> list[dict[str, Any]]:
+    """Return active routes filtered by user roles."""
+    assert self.db
+
+    from queryregistry.providers.mssql import run_rows_many
+
+    result = await run_rows_many(
+      """
+      SELECT
+        r.pub_path AS path,
+        r.pub_title AS title,
+        r.pub_icon AS icon,
+        r.pub_sequence AS sequence,
+        r.ref_parent_route_guid AS parent_route_guid,
+        r.ref_required_role_guid AS required_role_guid
+      FROM system_objects_routes r
+      WHERE r.pub_is_active = 1
+      ORDER BY r.pub_sequence;
+      """,
+      (),
+    )
+    rows = [dict(row) for row in result.rows]
+
+    role_names_upper = {
+      str(name).upper()
+      for name in (user_role_names or [])
+      if isinstance(name, str) and name.strip()
+    }
+    filtered: list[dict[str, Any]] = []
+
+    for row in rows:
+      required_guid = row.get("required_role_guid")
+      if required_guid:
+        role_name = self._role_guid_to_name.get(str(required_guid).upper())
+        if not role_name or role_name.upper() not in role_names_upper:
+          continue
+
+      filtered.append(
+        {
+          "path": str(row.get("path") or ""),
+          "title": str(row.get("title") or ""),
+          "icon": row.get("icon"),
+          "sequence": int(row.get("sequence") or 0),
+          "parentRouteGuid": row.get("parent_route_guid"),
+        }
+      )
+
+    return filtered


### PR DESCRIPTION
### Motivation

- Provide the sidebar with a server-backed route list and enforce role-gated visibility so users only see routes they are permitted to access.
- Expose a developer-mode toggle gated to service administrators for future dev-only UI features in the Workbench.

### Description

- Added `CmsWorkbenchModule.read_navigation()` and startup caching of `system_auth_roles` GUID→name map to filter `system_objects_routes` by role names and return `path/title/icon/sequence/parentRouteGuid` payloads.
- Implemented RPC wiring `public_route_read_navigation_v1` and registered `("read_navigation","1")` in the domain dispatchers to expose `urn:public:route:read_navigation:1`.
- Extended client RPC bindings with `NavigationRouteElement`, `ReadNavigationResult`, and `readNavigation()` in `client/src/api/rpc.ts`.
- Implemented `NavigationTreeView` to fetch and render navigation sections/icons/active styling and `DevModeToggle` to present a role-gated toggle UI, added `__devMode`/`__toggleDevMode` to the Workbench data enricher, and registered both components in the client component registry.

### Testing

- Ran `python -m compileall server/modules/cms_workbench_module.py rpc/public/route` which completed successfully.
- Ran `npm run type-check` in `client/` which completed successfully with no type errors.
- Ran `npm run lint` in `client/` which completed successfully (one pre-existing non-blocking warning in `src/shared/UserContextProvider.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf762cc708325a314e277e3a3583e)