### PR TITLE
Add sidebar dev-mode switching with ObjectTreeView stub

### DIFF
--- a/client/src/components/NavigationTreeView.tsx
+++ b/client/src/components/NavigationTreeView.tsx
@@ -44,8 +44,9 @@ const getUserRoleKey = (user: unknown): string => {
 	return normalized.join('|');
 };
 
-export function NavigationTreeView({ data }: CmsComponentProps): JSX.Element {
+export function NavigationTreeView({ data }: CmsComponentProps): JSX.Element | null {
 	const isOpen = data.__sidebarOpen === true;
+	const isDevMode = data.__devMode === true;
 	const userRoleKey = useMemo(() => getUserRoleKey(data.__user), [data.__user]);
 	const [routes, setRoutes] = useState<NavigationRouteElement[]>([]);
 
@@ -86,6 +87,10 @@ export function NavigationTreeView({ data }: CmsComponentProps): JSX.Element {
 		});
 		return Array.from(grouped.entries()).sort(([a], [b]) => a - b);
 	}, [routes]);
+
+	if (isDevMode) {
+		return null;
+	}
 
 	return (
 		<List sx={{ px: 0.5, py: 0 }}>

--- a/client/src/components/ObjectTreeView.tsx
+++ b/client/src/components/ObjectTreeView.tsx
@@ -1,0 +1,80 @@
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
+import { Box, List, ListItemButton, ListItemIcon, ListItemText, Typography } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+const OBJECT_TREE_CATEGORIES = ['Components', 'Pages', 'Routes', 'Modules', 'Types'] as const;
+
+export function ObjectTreeView({ data }: CmsComponentProps): JSX.Element | null {
+	const isDevMode = data.__devMode === true;
+	if (!isDevMode) {
+		return null;
+	}
+
+	const isOpen = data.__sidebarOpen === true;
+
+	return (
+		<Box sx={{ px: 0.5, py: 0.5 }}>
+			{isOpen ? (
+				<Typography
+					variant="body2"
+					sx={{
+						fontSize: '0.65rem',
+						textTransform: 'uppercase',
+						letterSpacing: '0.06em',
+						color: '#555555',
+						px: 1,
+						py: 0.5,
+					}}
+				>
+					Object Tree
+				</Typography>
+			) : null}
+			<List sx={{ px: 0, py: 0 }}>
+				{OBJECT_TREE_CATEGORIES.map((category) => (
+					<ListItemButton
+						key={category}
+						sx={{
+							minHeight: 28,
+							px: '8px',
+							py: '5px',
+							borderRadius: 1,
+							justifyContent: isOpen ? 'flex-start' : 'center',
+							gap: isOpen ? 1 : 0,
+							color: '#888888',
+							'&:hover': {
+								backgroundColor: 'rgba(255, 255, 255, 0.04)',
+								color: '#FFFFFF',
+							},
+						}}
+					>
+						<ListItemIcon
+							sx={{
+								minWidth: 0,
+								width: 18,
+								height: 18,
+								color: 'inherit',
+								justifyContent: 'center',
+								'& .MuiSvgIcon-root': { fontSize: 18 },
+							}}
+						>
+							<AccountTreeIcon />
+						</ListItemIcon>
+						{isOpen ? (
+							<ListItemText
+								primary={category}
+								primaryTypographyProps={{
+									fontSize: '0.75rem',
+									lineHeight: 1.2,
+									whiteSpace: 'nowrap',
+									overflow: 'hidden',
+									textOverflow: 'ellipsis',
+								}}
+							/>
+						) : null}
+					</ListItemButton>
+				))}
+			</List>
+		</Box>
+	);
+}

--- a/client/src/engine/registry.ts
+++ b/client/src/engine/registry.ts
@@ -9,6 +9,7 @@ import { LoginControl } from '../components/LoginControl';
 import { LinkButton } from '../components/LinkButton';
 import { NavigationTreeView } from '../components/NavigationTreeView';
 import { ObjectEditor } from '../components/ObjectEditor';
+import { ObjectTreeView } from '../components/ObjectTreeView';
 import { NavigationSidebar } from '../components/NavigationSidebar';
 import { SidebarContent } from '../components/SidebarContent';
 import { SidebarFooter } from '../components/SidebarFooter';
@@ -29,6 +30,7 @@ export const COMPONENT_REGISTRY: Record<string, ComponentType<CmsComponentProps>
 	DevModeToggle,
 	HamburgerToggle,
 	NavigationTreeView,
+	ObjectTreeView,
 	ContentPanel,
 	SimplePage,
 	ObjectEditor,


### PR DESCRIPTION
### Motivation

- Provide symmetrical dev-mode behavior for the sidebar so the route navigation hides in dev mode and an object-tree browser can be shown instead, matching the existing ContentPanel SimplePage/ObjectEditor pattern.
- Deliver an initial visual stub for the object-tree browser so the dev-mode UX can be iterated on without backend queries.

### Description

- Updated `client/src/components/NavigationTreeView.tsx` to read `data.__devMode` and return `null` when dev mode is active while keeping hooks unconditional (so hooks remain above the early return).
- Added a new `client/src/components/ObjectTreeView.tsx` component that returns `null` when `data.__devMode` is false and otherwise renders a static stub with categories `Components`, `Pages`, `Routes`, `Modules`, `Types` and MUI styling/icons, respecting `data.__sidebarOpen` for collapsed/expanded layout.
- Registered `ObjectTreeView` in `client/src/engine/registry.ts` so it can be resolved from CMS component trees.

### Testing

- Ran `npm run lint` in `client/` which completed successfully with one existing warning in `src/shared/UserContextProvider.tsx` unrelated to these changes.
- Ran `npm run type-check` (`tsc --noEmit`) in `client/` which completed with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0eb7b51c83259bfc6d27a8a24cc3)