### PR TITLE
Add object-tree RPC endpoints and CmsWorkbenchModule object-tree methods

### DIFF
--- a/migrations/v0.12.13.0_seed_object_tree_rpc.sql
+++ b/migrations/v0.12.13.0_seed_object_tree_rpc.sql
@@ -1,0 +1,93 @@
+-- =============================================================================
+-- v0.12.13.0_seed_object_tree_rpc (CORRECTED)
+-- Date: 2026-04-12
+-- Purpose:
+--   1) Register CmsWorkbenchModule object tree methods
+--   2) Seed RPC gateway method bindings for object tree operations
+--
+-- FIX: RPC gateway GUID corrected from 3D0C1FC1 (route subdomain)
+--      to 606C04E3 (actual io_gateways row for 'rpc').
+--      All GUIDs inlined (no DECLARE across GO boundaries).
+--
+-- GUIDs:
+--   RPC Gateway:          606C04E3-44F1-593D-9C8B-8006E0A377D3
+--   CmsWorkbenchModule:   CF85FB11-5981-56B7-8E43-9D453E611D43
+--   ROLE_SERVICE_ADMIN:   E8E1A4CC-0898-59F4-8B03-B2C9804516C0
+--
+-- UUID5 namespace: DECAFBAD-CAFE-FADE-BABE-C0FFEE420B67
+-- =============================================================================
+
+-- =============================================================================
+-- 1) CmsWorkbenchModule method registrations
+-- =============================================================================
+INSERT INTO [dbo].[system_objects_module_methods]
+  ([key_guid], [ref_module_guid], [pub_name], [pub_description], [pub_is_active])
+SELECT
+  src.[key_guid],
+  src.[ref_module_guid],
+  src.[pub_name],
+  src.[pub_description],
+  1
+FROM (VALUES
+  (N'C7C9F53E-2F31-52A0-923F-5E17CC34C1D0', N'CF85FB11-5981-56B7-8E43-9D453E611D43', N'read_object_tree_categories', N'Read top-level object tree category metadata for the workbench tree.'),
+  (N'4A3681CD-8323-574F-975D-34D48AD01893', N'CF85FB11-5981-56B7-8E43-9D453E611D43', N'read_object_tree_children',   N'Read object tree children for category tables or table columns.'),
+  (N'811868C6-593D-5B7A-B38C-E8AEDFD744DF', N'CF85FB11-5981-56B7-8E43-9D453E611D43', N'read_object_tree_detail',     N'Read bounded row details for a validated object tree table.')
+) src([key_guid], [ref_module_guid], [pub_name], [pub_description])
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM [dbo].[system_objects_module_methods] mm
+  WHERE mm.[key_guid] = src.[key_guid]
+);
+GO
+
+-- =============================================================================
+-- 2) RPC gateway method binding seeds
+--    ref_gateway_guid = 606C04E3-44F1-593D-9C8B-8006E0A377D3 (RPC gateway)
+-- =============================================================================
+INSERT INTO [dbo].[system_objects_gateway_method_bindings]
+  ([key_guid], [ref_gateway_guid], [pub_operation_name], [ref_method_guid],
+   [pub_required_scope], [ref_required_role_guid], [ref_required_entitlement_guid],
+   [pub_is_read_only], [pub_is_active])
+SELECT
+  src.[key_guid],
+  src.[ref_gateway_guid],
+  src.[pub_operation_name],
+  src.[ref_method_guid],
+  src.[pub_required_scope],
+  src.[ref_required_role_guid],
+  src.[ref_required_entitlement_guid],
+  src.[pub_is_read_only],
+  1
+FROM (VALUES
+  (N'7B9AD1AF-B07C-5F63-851F-31F4F1931C8D', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:public:route:read_object_tree_categories:1',  N'C7C9F53E-2F31-52A0-923F-5E17CC34C1D0', CAST(NULL AS NVARCHAR(128)), CAST(NULL AS UNIQUEIDENTIFIER),                          CAST(NULL AS UNIQUEIDENTIFIER), CAST(1 AS BIT)),
+  (N'6C940BAC-991D-5D1D-93C9-AA561C95C3A1', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:service:objects:read_object_tree_children:1',  N'4A3681CD-8323-574F-975D-34D48AD01893', CAST(NULL AS NVARCHAR(128)), N'E8E1A4CC-0898-59F4-8B03-B2C9804516C0',                  CAST(NULL AS UNIQUEIDENTIFIER), CAST(1 AS BIT)),
+  (N'936F21B6-6A18-558A-8062-0B46DFD9A034', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:service:objects:read_object_tree_detail:1',    N'811868C6-593D-5B7A-B38C-E8AEDFD744DF', CAST(NULL AS NVARCHAR(128)), N'E8E1A4CC-0898-59F4-8B03-B2C9804516C0',                  CAST(NULL AS UNIQUEIDENTIFIER), CAST(1 AS BIT))
+) src([key_guid], [ref_gateway_guid], [pub_operation_name], [ref_method_guid], [pub_required_scope], [ref_required_role_guid], [ref_required_entitlement_guid], [pub_is_read_only])
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM [dbo].[system_objects_gateway_method_bindings] b
+  WHERE b.[key_guid] = src.[key_guid]
+);
+GO
+
+-- =============================================================================
+-- 3) Verification
+-- =============================================================================
+SELECT mm.pub_name AS method, mod.pub_state_attr AS module
+FROM system_objects_module_methods mm
+JOIN system_objects_modules mod ON mod.key_guid = mm.ref_module_guid
+WHERE mm.ref_module_guid = N'CF85FB11-5981-56B7-8E43-9D453E611D43'
+ORDER BY mm.pub_name;
+GO
+
+SELECT b.pub_operation_name, mm.pub_name AS method, b.pub_is_read_only,
+       CASE WHEN b.ref_required_role_guid IS NOT NULL THEN 'SERVICE_ADMIN' ELSE 'public' END AS access
+FROM system_objects_gateway_method_bindings b
+JOIN system_objects_module_methods mm ON mm.key_guid = b.ref_method_guid
+WHERE b.key_guid IN (
+  N'7B9AD1AF-B07C-5F63-851F-31F4F1931C8D',
+  N'6C940BAC-991D-5D1D-93C9-AA561C95C3A1',
+  N'936F21B6-6A18-558A-8062-0B46DFD9A034'
+)
+ORDER BY b.pub_operation_name;
+GO

--- a/rpc/public/route/__init__.py
+++ b/rpc/public/route/__init__.py
@@ -1,7 +1,12 @@
-from .services import public_route_load_path_v1, public_route_read_navigation_v1
+from .services import (
+  public_route_load_path_v1,
+  public_route_read_navigation_v1,
+  public_route_read_object_tree_categories_v1,
+)
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("load_path", "1"): public_route_load_path_v1,
   ("read_navigation", "1"): public_route_read_navigation_v1,
+  ("read_object_tree_categories", "1"): public_route_read_object_tree_categories_v1,
 }

--- a/rpc/public/route/models.py
+++ b/rpc/public/route/models.py
@@ -26,4 +26,16 @@ class LoadPathResult1(BaseModel):
   componentData: dict[str, Any]
 
 
+class ObjectTreeCategory1(BaseModel):
+  guid: str
+  name: str
+  display: str | None = None
+  icon: str | None = None
+  sequence: int
+
+
+class ObjectTreeCategoryList1(BaseModel):
+  elements: list[ObjectTreeCategory1]
+
+
 PathNode1.model_rebuild()

--- a/rpc/public/route/services.py
+++ b/rpc/public/route/services.py
@@ -7,7 +7,7 @@ from fastapi import Request
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
 
-from .models import LoadPathParams1
+from .models import LoadPathParams1, ObjectTreeCategory1, ObjectTreeCategoryList1
 
 if TYPE_CHECKING:
   from server.modules.cms_workbench_module import CmsWorkbenchModule
@@ -37,5 +37,21 @@ async def public_route_read_navigation_v1(request: Request):
   return RPCResponse(
     op=rpc_request.op,
     payload={"elements": result},
+    version=rpc_request.version,
+  )
+
+
+async def public_route_read_object_tree_categories_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.read_object_tree_categories()
+  payload = ObjectTreeCategoryList1(elements=[ObjectTreeCategory1(**item) for item in result])
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=payload.model_dump(),
     version=rpc_request.version,
   )

--- a/rpc/service/__init__.py
+++ b/rpc/service/__init__.py
@@ -4,7 +4,9 @@ Requires ROLE_SERVICE_ADMIN.
 """
 
 from .routes.handler import handle_routes_request
+from .objects.handler import handle_objects_request
 
 HANDLERS: dict[str, callable] = {
   "routes": handle_routes_request,
+  "objects": handle_objects_request,
 }

--- a/rpc/service/objects/__init__.py
+++ b/rpc/service/objects/__init__.py
@@ -1,0 +1,15 @@
+"""Service objects RPC namespace.
+
+Requires ROLE_SERVICE_ADMIN.
+"""
+
+from .services import (
+  service_objects_read_object_tree_children_v1,
+  service_objects_read_object_tree_detail_v1,
+)
+
+
+DISPATCHERS: dict[tuple[str, str], callable] = {
+  ("read_object_tree_children", "1"): service_objects_read_object_tree_children_v1,
+  ("read_object_tree_detail", "1"): service_objects_read_object_tree_detail_v1,
+}

--- a/rpc/service/objects/handler.py
+++ b/rpc/service/objects/handler.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException, Request
+
+from server.models import RPCResponse
+
+from . import DISPATCHERS
+
+
+async def handle_objects_request(parts: list[str], request: Request) -> RPCResponse:
+  key = tuple(parts[:2])
+  handler = DISPATCHERS.get(key)
+  if not handler:
+    raise HTTPException(status_code=404, detail="Unknown RPC operation")
+  return await handler(request)

--- a/rpc/service/objects/models.py
+++ b/rpc/service/objects/models.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class ServiceObjectsReadChildrenParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  categoryGuid: str
+  tableGuid: str | None = None
+
+
+class ServiceObjectsReadDetailParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  tableGuid: str
+  maxRows: int = 100

--- a/rpc/service/objects/services.py
+++ b/rpc/service/objects/services.py
@@ -1,0 +1,39 @@
+from fastapi import Request
+
+from rpc.helpers import unbox_request
+from server.models import RPCResponse
+from server.modules.cms_workbench_module import CmsWorkbenchModule
+
+from .models import ServiceObjectsReadChildrenParams1, ServiceObjectsReadDetailParams1
+
+
+async def service_objects_read_object_tree_children_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsReadChildrenParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.read_object_tree_children(params.categoryGuid, params.tableGuid)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload={"elements": result},
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_read_object_tree_detail_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsReadDetailParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.read_object_tree_detail(params.tableGuid, params.maxRows)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )

--- a/server/modules/cms_workbench_module.py
+++ b/server/modules/cms_workbench_module.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from fastapi import FastAPI, HTTPException
@@ -194,3 +195,125 @@ class CmsWorkbenchModule(BaseModule):
       )
 
     return filtered
+
+  @staticmethod
+  def _quote_ident(identifier: str) -> str:
+    return "[" + identifier.replace("]", "]]") + "]"
+
+  async def read_object_tree_categories(self) -> list[dict[str, Any]]:
+    from queryregistry.providers.mssql import run_rows_many
+
+    result = await run_rows_many(
+      """
+      SELECT
+        sev.key_guid AS guid,
+        sev.pub_name AS name,
+        sev.pub_display AS display,
+        sev.pub_icon AS icon,
+        sev.pub_sequence AS sequence
+      FROM service_enum_values sev
+      WHERE sev.ref_category_guid = ?
+      ORDER BY sev.pub_sequence;
+      """,
+      ("9E735725-2EFF-5978-B92F-73A6CB36DF7F",),
+    )
+    return [dict(row) for row in result.rows]
+
+  async def read_object_tree_children(
+    self,
+    category_guid: str,
+    table_guid: str | None = None,
+  ) -> list[dict[str, Any]]:
+    from queryregistry.providers.mssql import run_rows_many
+
+    if table_guid:
+      result = await run_rows_many(
+        """
+        SELECT
+          c.key_guid AS guid,
+          c.pub_name AS name,
+          c.pub_ordinal AS ordinal,
+          c.pub_is_primary_key AS isPrimaryKey,
+          c.pub_is_nullable AS isNullable,
+          t.pub_name AS typeName,
+          c.pub_max_length AS maxLength
+        FROM system_objects_database_columns c
+        LEFT JOIN system_objects_types t ON c.ref_type_guid = t.key_guid
+        WHERE c.ref_table_guid = ?
+        ORDER BY c.pub_ordinal;
+        """,
+        (table_guid,),
+      )
+      return [dict(row) for row in result.rows]
+
+    result = await run_rows_many(
+      """
+      SELECT
+        t.key_guid AS guid,
+        t.pub_name AS name,
+        t.pub_schema AS schema,
+        m.pub_is_root_table AS isRoot,
+        m.pub_sequence AS sequence
+      FROM system_objects_tree_category_tables m
+      JOIN system_objects_database_tables t ON m.ref_table_guid = t.key_guid
+      WHERE m.ref_category_guid = ?
+      ORDER BY m.pub_sequence;
+      """,
+      (category_guid,),
+    )
+    return [dict(row) for row in result.rows]
+
+  async def read_object_tree_detail(self, table_guid: str, max_rows: int = 100) -> dict[str, Any]:
+    from queryregistry.providers.mssql import run_rows_many, run_rows_one
+
+    bounded_max_rows = max(1, min(int(max_rows or 100), 1000))
+
+    resolved = await run_rows_one(
+      """
+      SELECT TOP 1 pub_name, pub_schema
+      FROM system_objects_database_tables
+      WHERE key_guid = ?;
+      """,
+      (table_guid,),
+    )
+    row = dict(resolved.rows[0]) if resolved.rows else None
+    if not row:
+      raise HTTPException(status_code=404, detail="Object tree table not found")
+
+    table_name = str(row.get("pub_name") or "")
+    schema_name = str(row.get("pub_schema") or "")
+    if not table_name or not schema_name:
+      raise HTTPException(status_code=400, detail="Object tree table metadata incomplete")
+
+    safe_schema = self._quote_ident(schema_name)
+    safe_table = self._quote_ident(table_name)
+    payload_result = await run_rows_many(
+      f"""
+      SELECT
+        (
+          SELECT TOP (?) *
+          FROM {safe_schema}.{safe_table}
+          FOR JSON PATH
+        ) AS rows_json,
+        (
+          SELECT COUNT(1)
+          FROM {safe_schema}.{safe_table}
+        ) AS row_count;
+      """,
+      (bounded_max_rows,),
+    )
+    payload_row = dict(payload_result.rows[0]) if payload_result.rows else {}
+    rows_json = payload_row.get("rows_json")
+
+    rows: list[dict[str, Any]] = []
+    if isinstance(rows_json, str) and rows_json.strip():
+      parsed = json.loads(rows_json)
+      if isinstance(parsed, list):
+        rows = parsed
+
+    return {
+      "tableName": table_name,
+      "schema": schema_name,
+      "rowCount": int(payload_row.get("row_count") or 0),
+      "rows": rows,
+    }


### PR DESCRIPTION
### Motivation
- Register CmsWorkbenchModule object-tree methods and seed RPC gateway bindings so object-tree operations are callable via RPC. 
- Expose a public operation to read top-level object-tree categories and service-only operations for reading category children and table detail. 
- Correct the RPC gateway GUID in the migration and inline GUIDs to avoid cross-`GO` DECLARE issues.

### Description
- Add migration `migrations/v0.12.13.0_seed_object_tree_rpc.sql` to register three module methods and three gateway method bindings, and fix the RPC gateway GUID to `606C04E3-44F1-593D-9C8B-8006E0A377D3`.
- Add public route support for `read_object_tree_categories` with new models `ObjectTreeCategory1` and `ObjectTreeCategoryList1` and service `public_route_read_object_tree_categories_v1` in `rpc/public/route`.
- Add a service namespace `objects` with dispatcher, handler, pydantic models, and two RPC handlers `service_objects_read_object_tree_children_v1` and `service_objects_read_object_tree_detail_v1` in `rpc/service/objects` and register the namespace in `rpc/service/__init__.py`.
- Implement `CmsWorkbenchModule` methods `read_object_tree_categories`, `read_object_tree_children`, and `read_object_tree_detail` with safe identifier quoting (`_quote_ident`), JSON row retrieval, and row bounds handling, and import `json` for parsing.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1d864cb08325a1fe1918eefc0bb4)