### PR TITLE
Fix object tree RPC responses to return raw arrays

### DIFF
--- a/rpc/public/route/models.py
+++ b/rpc/public/route/models.py
@@ -34,8 +34,4 @@ class ObjectTreeCategory1(BaseModel):
   sequence: int
 
 
-class ObjectTreeCategoryList1(BaseModel):
-  elements: list[ObjectTreeCategory1]
-
-
 PathNode1.model_rebuild()

--- a/rpc/public/route/services.py
+++ b/rpc/public/route/services.py
@@ -7,7 +7,7 @@ from fastapi import Request
 from rpc.helpers import unbox_request
 from server.models import RPCResponse
 
-from .models import LoadPathParams1, ObjectTreeCategory1, ObjectTreeCategoryList1
+from .models import LoadPathParams1, ObjectTreeCategory1
 
 if TYPE_CHECKING:
   from server.modules.cms_workbench_module import CmsWorkbenchModule
@@ -48,10 +48,9 @@ async def public_route_read_object_tree_categories_v1(request: Request):
   del auth_ctx
 
   result = await module.read_object_tree_categories()
-  payload = ObjectTreeCategoryList1(elements=[ObjectTreeCategory1(**item) for item in result])
 
   return RPCResponse(
     op=rpc_request.op,
-    payload=payload.model_dump(),
+    payload=[ObjectTreeCategory1(**item).model_dump() for item in result],
     version=rpc_request.version,
   )

--- a/rpc/service/objects/services.py
+++ b/rpc/service/objects/services.py
@@ -18,7 +18,7 @@ async def service_objects_read_object_tree_children_v1(request: Request):
 
   return RPCResponse(
     op=rpc_request.op,
-    payload={"elements": result},
+    payload=result,
     version=rpc_request.version,
   )
 


### PR DESCRIPTION
### Motivation

- The frontend expects `readObjectTreeCategories()` and `readObjectTreeChildren()` RPCs to return raw arrays, but the server was returning `{ "elements": [...] }` envelopes which prevented the ObjectTreeView from rendering.

### Description

- Updated `rpc/public/route/services.py` so `public_route_read_object_tree_categories_v1` returns a list of category payloads via `payload=[ObjectTreeCategory1(**item).model_dump() for item in result]` instead of an `elements` envelope.
- Removed the now-unused wrapper model `ObjectTreeCategoryList1` from `rpc/public/route/models.py`.
- Updated `rpc/service/objects/services.py` so `service_objects_read_object_tree_children_v1` returns `payload=result` directly instead of `payload={"elements": result}`.
- No changes were made to client contracts or module implementations; only the service layer payload shape was adjusted to match the client contract.

### Testing

- Ran the unified test harness with `python scripts/run_tests.py`, which runs frontend lint/type-check/tests and backend pytest, and the run completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc31f1f7b88325becc33298e9066ae)