### PR TITLE
Fix GUID parameter casting in CMS object tree queries

### DIFF
--- a/server/modules/cms_workbench_module.py
+++ b/server/modules/cms_workbench_module.py
@@ -239,7 +239,7 @@ class CmsWorkbenchModule(BaseModule):
           c.pub_max_length AS maxLength
         FROM system_objects_database_columns c
         LEFT JOIN system_objects_types t ON c.ref_type_guid = t.key_guid
-        WHERE c.ref_table_guid = ?
+        WHERE c.ref_table_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)
         ORDER BY c.pub_ordinal;
         """,
         (table_guid,),
@@ -256,7 +256,7 @@ class CmsWorkbenchModule(BaseModule):
         m.pub_sequence AS sequence
       FROM system_objects_tree_category_tables m
       JOIN system_objects_database_tables t ON m.ref_table_guid = t.key_guid
-      WHERE m.ref_category_guid = ?
+      WHERE m.ref_category_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)
       ORDER BY m.pub_sequence;
       """,
       (category_guid,),
@@ -272,7 +272,7 @@ class CmsWorkbenchModule(BaseModule):
       """
       SELECT TOP 1 pub_name, pub_schema
       FROM system_objects_database_tables
-      WHERE key_guid = ?;
+      WHERE key_guid = TRY_CAST(? AS UNIQUEIDENTIFIER);
       """,
       (table_guid,),
     )


### PR DESCRIPTION
### Motivation
- MSSQL ODBC does not always implicitly cast string parameters to `UNIQUEIDENTIFIER`, causing object tree queries to return no rows when GUIDs are passed as parameters; explicit `TRY_CAST` is required to match existing code patterns and restore correct query behavior.

### Description
- Added `TRY_CAST(? AS UNIQUEIDENTIFIER)` to the parameterized GUID comparisons in `server/modules/cms_workbench_module.py` for the columns branch (`WHERE c.ref_table_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)`), the category tables branch (`WHERE m.ref_category_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)`), and the table detail lookup (`WHERE key_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)`).
- Only `server/modules/cms_workbench_module.py` was modified and the change follows the existing pattern used elsewhere in the codebase for GUID parameters.

### Testing
- Ran `python -m py_compile server/modules/cms_workbench_module.py` and it completed successfully.
- No other automated test commands were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc379fd1b88325af5e0ed6364211cb)