### PR TITLE
Remove TRY_CAST GUID casts from object tree queries

### DIFF
--- a/server/modules/cms_workbench_module.py
+++ b/server/modules/cms_workbench_module.py
@@ -239,7 +239,7 @@ class CmsWorkbenchModule(BaseModule):
           c.pub_max_length AS maxLength
         FROM system_objects_database_columns c
         LEFT JOIN system_objects_types t ON c.ref_type_guid = t.key_guid
-        WHERE c.ref_table_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)
+        WHERE c.ref_table_guid = ?
         ORDER BY c.pub_ordinal;
         """,
         (table_guid,),
@@ -256,7 +256,7 @@ class CmsWorkbenchModule(BaseModule):
         m.pub_sequence AS sequence
       FROM system_objects_tree_category_tables m
       JOIN system_objects_database_tables t ON m.ref_table_guid = t.key_guid
-      WHERE m.ref_category_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)
+      WHERE m.ref_category_guid = ?
       ORDER BY m.pub_sequence;
       """,
       (category_guid,),
@@ -272,7 +272,7 @@ class CmsWorkbenchModule(BaseModule):
       """
       SELECT TOP 1 pub_name, pub_schema
       FROM system_objects_database_tables
-      WHERE key_guid = TRY_CAST(? AS UNIQUEIDENTIFIER);
+      WHERE key_guid = ?;
       """,
       (table_guid,),
     )


### PR DESCRIPTION
### Motivation
- The `TRY_CAST(? AS UNIQUEIDENTIFIER)` wrappers in object-tree lookup queries caused child/detail queries to return empty results even though GUID string parameters are handled correctly by the ODBC driver and the analogous `read_object_tree_categories` query uses a plain `?` and works.

### Description
- In `server/modules/cms_workbench_module.py` replaced three occurrences of `TRY_CAST(? AS UNIQUEIDENTIFIER)` with plain `?` in `read_object_tree_children` (columns branch and category-tables branch) and `read_object_tree_detail` so parameter binding matches the working query pattern.

### Testing
- Ran `python -m compileall server/modules/cms_workbench_module.py` and the compilation check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3d976ebc83258e08e896aa0c456a)