### PR TITLE
Migrate CMS object tree reads to data-driven query execution

### DIFF
--- a/migrations/v0.12.14.0_seed_object_tree_queries.sql
+++ b/migrations/v0.12.14.0_seed_object_tree_queries.sql
@@ -1,0 +1,88 @@
+-- Object tree queries for CmsWorkbenchModule
+-- UUID5 namespace: DECAFBAD-CAFE-FADE-BABE-C0FFEE420B67
+-- query:cms.object_tree.get_categories -> 1CAC0976-063B-56FA-A314-A3C13968F5F8
+-- query:cms.object_tree.get_category_tables -> A90D9592-8424-58E5-98B6-A750E478279A
+-- query:cms.object_tree.get_table_columns -> 8FE9C76B-DE7E-5876-937E-C9EC3FD2E341
+
+MERGE INTO system_objects_queries AS target
+USING (
+  SELECT
+    N'1CAC0976-063B-56FA-A314-A3C13968F5F8' AS key_guid,
+    N'cms.object_tree.get_categories' AS pub_name,
+    N'SELECT
+  sev.key_guid AS guid,
+  sev.pub_name AS name,
+  sev.pub_display AS display,
+  sev.pub_icon AS icon,
+  sev.pub_sequence AS sequence
+FROM service_enum_values sev
+WHERE sev.ref_category_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)
+ORDER BY sev.pub_sequence
+FOR JSON PATH, INCLUDE_NULL_VALUES;' AS pub_query_text,
+    N'Fetch object tree top-level categories from the object_tree_categories enum.' AS pub_description,
+    N'CF85FB11-5981-56B7-8E43-9D453E611D43' AS ref_module_guid,
+    1 AS pub_is_parameterized,
+    N'category_enum_guid' AS pub_parameter_names
+
+  UNION ALL SELECT
+    N'A90D9592-8424-58E5-98B6-A750E478279A',
+    N'cms.object_tree.get_category_tables',
+    N'SELECT
+  t.key_guid AS guid,
+  t.pub_name AS name,
+  t.pub_schema AS [schema],
+  m.pub_is_root_table AS isRoot,
+  m.pub_sequence AS sequence
+FROM system_objects_tree_category_tables m
+JOIN system_objects_database_tables t ON m.ref_table_guid = t.key_guid
+WHERE m.ref_category_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)
+ORDER BY m.pub_sequence
+FOR JSON PATH, INCLUDE_NULL_VALUES;',
+    N'Fetch tables mapped to an object tree category.',
+    N'CF85FB11-5981-56B7-8E43-9D453E611D43',
+    1,
+    N'category_guid'
+
+  UNION ALL SELECT
+    N'8FE9C76B-DE7E-5876-937E-C9EC3FD2E341',
+    N'cms.object_tree.get_table_columns',
+    N'SELECT
+  c.key_guid AS guid,
+  c.pub_name AS name,
+  c.pub_ordinal AS ordinal,
+  c.pub_is_primary_key AS isPrimaryKey,
+  c.pub_is_nullable AS isNullable,
+  t.pub_name AS typeName,
+  c.pub_max_length AS maxLength
+FROM system_objects_database_columns c
+LEFT JOIN system_objects_types t ON c.ref_type_guid = t.key_guid
+WHERE c.ref_table_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)
+ORDER BY c.pub_ordinal
+FOR JSON PATH, INCLUDE_NULL_VALUES;',
+    N'Fetch columns for a specific table in the object tree.',
+    N'CF85FB11-5981-56B7-8E43-9D453E611D43',
+    1,
+    N'table_guid'
+
+) AS source (key_guid, pub_name, pub_query_text, pub_description, ref_module_guid, pub_is_parameterized, pub_parameter_names)
+ON target.key_guid = TRY_CAST(source.key_guid AS UNIQUEIDENTIFIER)
+WHEN MATCHED THEN
+  UPDATE SET
+    pub_name = source.pub_name,
+    pub_query_text = source.pub_query_text,
+    pub_description = source.pub_description,
+    pub_is_parameterized = source.pub_is_parameterized,
+    pub_parameter_names = source.pub_parameter_names,
+    priv_modified_on = SYSUTCDATETIME()
+WHEN NOT MATCHED THEN
+  INSERT (key_guid, pub_name, pub_query_text, pub_description, ref_module_guid, pub_is_parameterized, pub_parameter_names)
+  VALUES (
+    TRY_CAST(source.key_guid AS UNIQUEIDENTIFIER),
+    source.pub_name,
+    source.pub_query_text,
+    source.pub_description,
+    TRY_CAST(source.ref_module_guid AS UNIQUEIDENTIFIER),
+    source.pub_is_parameterized,
+    source.pub_parameter_names
+  );
+GO

--- a/server/modules/cms_workbench_module.py
+++ b/server/modules/cms_workbench_module.py
@@ -18,16 +18,19 @@ from .db_module import DbModule
 
 
 class CmsWorkbenchModule(BaseModule):
+  MODULE_GUID = "CF85FB11-5981-56B7-8E43-9D453E611D43"
+
   def __init__(self, app: FastAPI):
     super().__init__(app)
     self.db: DbModule | None = None
     self._role_guid_to_name: dict[str, str] = {}
+    self._queries: dict[str, str] = {}
 
   async def startup(self):
     self.db = self.app.state.db
     await self.db.on_ready()
 
-    from queryregistry.providers.mssql import run_rows_many
+    from queryregistry.providers.mssql import run_json_many, run_rows_many
 
     role_result = await run_rows_many(
       """
@@ -41,6 +44,25 @@ class CmsWorkbenchModule(BaseModule):
       for row in role_result.rows
       if row.get("key_guid")
     }
+
+    query_sql = """
+      SELECT pub_name, pub_query_text
+      FROM system_objects_queries
+      WHERE ref_module_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)
+        AND pub_is_active = 1
+      FOR JSON PATH, INCLUDE_NULL_VALUES;
+    """
+    loaded = await run_json_many(query_sql, (self.MODULE_GUID,))
+    rows = loaded.rows if loaded else []
+    self._queries = {
+      str(row.get("pub_name")): str(row.get("pub_query_text"))
+      for row in rows
+      if row.get("pub_name") and row.get("pub_query_text")
+    }
+
+    import logging
+
+    logging.info("[CmsWorkbenchModule] Loaded %s data-driven queries", len(self._queries))
 
     self.mark_ready()
 
@@ -200,68 +222,40 @@ class CmsWorkbenchModule(BaseModule):
   def _quote_ident(identifier: str) -> str:
     return "[" + identifier.replace("]", "]]") + "]"
 
-  async def read_object_tree_categories(self) -> list[dict[str, Any]]:
-    from queryregistry.providers.mssql import run_rows_many
+  async def _run_query(self, query_name: str, params: tuple = ()) -> Any:
+    from queryregistry.providers.mssql import run_json_many, run_json_one
 
-    result = await run_rows_many(
-      """
-      SELECT
-        sev.key_guid AS guid,
-        sev.pub_name AS name,
-        sev.pub_display AS display,
-        sev.pub_icon AS icon,
-        sev.pub_sequence AS sequence
-      FROM service_enum_values sev
-      WHERE sev.ref_category_guid = ?
-      ORDER BY sev.pub_sequence;
-      """,
+    sql = self._queries.get(query_name)
+    if not sql:
+      raise HTTPException(status_code=500, detail=f"Query not found: {query_name}")
+    if "WITHOUT_ARRAY_WRAPPER" in sql:
+      return await run_json_one(sql, params)
+    return await run_json_many(sql, params)
+
+  async def read_object_tree_categories(self) -> list[dict[str, Any]]:
+    result = await self._run_query(
+      "cms.object_tree.get_categories",
       ("9E735725-2EFF-5978-B92F-73A6CB36DF7F",),
     )
-    return [dict(row) for row in result.rows]
+    return [dict(row) for row in (result.rows if result else [])]
 
   async def read_object_tree_children(
     self,
     category_guid: str,
     table_guid: str | None = None,
   ) -> list[dict[str, Any]]:
-    from queryregistry.providers.mssql import run_rows_many
-
     if table_guid:
-      result = await run_rows_many(
-        f"""
-        SELECT
-          c.key_guid AS guid,
-          c.pub_name AS name,
-          c.pub_ordinal AS ordinal,
-          c.pub_is_primary_key AS isPrimaryKey,
-          c.pub_is_nullable AS isNullable,
-          t.pub_name AS typeName,
-          c.pub_max_length AS maxLength
-        FROM system_objects_database_columns c
-        LEFT JOIN system_objects_types t ON c.ref_type_guid = t.key_guid
-        WHERE c.ref_table_guid = '{table_guid}'
-        ORDER BY c.pub_ordinal;
-        """,
-        (),
+      result = await self._run_query(
+        "cms.object_tree.get_table_columns",
+        (table_guid,),
       )
-      return [dict(row) for row in result.rows]
+      return [dict(row) for row in (result.rows if result else [])]
 
-    result = await run_rows_many(
-      f"""
-      SELECT
-        t.key_guid AS guid,
-        t.pub_name AS name,
-        t.pub_schema AS schema,
-        m.pub_is_root_table AS isRoot,
-        m.pub_sequence AS sequence
-      FROM system_objects_tree_category_tables m
-      JOIN system_objects_database_tables t ON m.ref_table_guid = t.key_guid
-      WHERE m.ref_category_guid = '{category_guid}'
-      ORDER BY m.pub_sequence;
-      """,
-      (),
+    result = await self._run_query(
+      "cms.object_tree.get_category_tables",
+      (category_guid,),
     )
-    return [dict(row) for row in result.rows]
+    return [dict(row) for row in (result.rows if result else [])]
 
   async def read_object_tree_detail(self, table_guid: str, max_rows: int = 100) -> dict[str, Any]:
     from queryregistry.providers.mssql import run_rows_many, run_rows_one


### PR DESCRIPTION
### Motivation

- The object-tree read path returned empty results because queries were written inline and executed via `run_rows_many`, which can silently swallow errors; the goal is to adopt the established data-driven `SessionModule` pattern so queries are loaded from `system_objects_queries` and executed via the JSON path.

### Description

- Add `MODULE_GUID` and a `_queries` cache to `CmsWorkbenchModule`, and load all active queries for the module at `startup()` using `run_json_many` and cache them with a log of the loaded count.
- Add `_run_query(query_name, params)` to resolve named queries from `_queries` and execute them via `run_json_many` / `run_json_one`, raising an HTTP 500 if a query is missing.
- Replace inline SQL in `read_object_tree_categories` and `read_object_tree_children` with calls to `_run_query` for `cms.object_tree.get_categories`, `cms.object_tree.get_category_tables`, and `cms.object_tree.get_table_columns`, converting JSON provider results to lists of dicts.
- Add a migration `migrations/v0.12.14.0_seed_object_tree_queries.sql` that MERGEs the three queries into `system_objects_queries` with UUID5-derived keys and `FOR JSON PATH` bodies so they are available to the new data-driven flow; note `read_object_tree_detail` remains unchanged because it uses dynamic table identifiers.

### Testing

- Ran the unified harness with `python scripts/run_tests.py`, which completed successfully and reported all automated tests passing (one eslint warning in `client/src/shared/UserContextProvider.tsx`).
- Frontend unit tests executed as part of the harness (`npm test`) passed for the sample test suite included in the repo.
- No automated DB migration was run in CI; the SQL migration file was added for manual execution in SSMS prior to deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4afe499c8325b72fdc1cd4bb6856)