### PR TITLE
Fix object tree category expansion to return root table contents

### DIFF
--- a/server/modules/cms_workbench_module.py
+++ b/server/modules/cms_workbench_module.py
@@ -251,11 +251,48 @@ class CmsWorkbenchModule(BaseModule):
       )
       return [dict(row) for row in (result.rows if result else [])]
 
-    result = await self._run_query(
+    tables_result = await self._run_query(
       "cms.object_tree.get_category_tables",
       (category_guid,),
     )
-    return [dict(row) for row in (result.rows if result else [])]
+    tables = [dict(row) for row in (tables_result.rows if tables_result else [])]
+    root_table = next((table for table in tables if table.get("isRoot")), None)
+    if not root_table:
+      return []
+
+    root_table_guid = str(root_table.get("guid") or "")
+    root_table_name = str(root_table.get("name") or "")
+    if not root_table_guid:
+      return []
+
+    try:
+      detail = await self.read_object_tree_detail(root_table_guid, max_rows=500)
+    except Exception:
+      return []
+
+    children: list[dict[str, Any]] = []
+    for row in detail.get("rows", []):
+      key_guid = str(row.get("key_guid") or "")
+      if not key_guid:
+        continue
+      name = (
+        row.get("pub_name")
+        or row.get("pub_display")
+        or row.get("pub_path")
+        or row.get("pub_title")
+        or key_guid[:8]
+      )
+      children.append(
+        {
+          "guid": key_guid,
+          "name": str(name),
+          "tableName": root_table_name,
+          "isRoot": False,
+          "sequence": row.get("pub_sequence") or row.get("pub_ordinal") or 0,
+        }
+      )
+
+    return children
 
   async def read_object_tree_detail(self, table_guid: str, max_rows: int = 100) -> dict[str, Any]:
     from queryregistry.providers.mssql import run_rows_many, run_rows_one


### PR DESCRIPTION
### Motivation
- Category node expansion previously listed mapping entries from `system_objects_tree_category_tables` instead of the actual rows of the category's root table. 
- The category mapping contains a `pub_is_root_table = 1` flag that identifies which table should be dumped when a category is expanded. 
- Expanding a category should surface the rows of that root table (e.g. Database → rows from `system_objects_database_tables`) so subsequent expansions (table → columns) work correctly.

### Description
- Reworked `read_object_tree_children` in `server/modules/cms_workbench_module.py` so that when `table_guid` is not provided it now resolves the category mappings, finds the `isRoot` table, and dumps that root table's rows via the existing `read_object_tree_detail` call. 
- Transformed returned detail rows into tree-friendly nodes with normalized fields: `guid`, `name` (fallback chain: `pub_name` → `pub_display` → `pub_path` → `pub_title` → truncated `key_guid`), `tableName`, `isRoot`, and `sequence`. 
- Kept the existing `table_guid` branch unchanged so expanding a table still calls `cms.object_tree.get_table_columns`. 
- Changed function-local variable names and added safe guards around missing root mapping and the `read_object_tree_detail` call; limited dump to `max_rows=500` to avoid excessive payloads.

### Testing
- Ran the unified harness with `python scripts/run_tests.py`; the run completed successfully and all automated tests passed. 
- The test run included a pre-existing frontend lint warning in `client/src/shared/UserContextProvider.tsx`, which did not affect the test success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc511358d88325a941f36af204f920)