### PR TITLE
Add DatabaseBuilder editor, object-tree selection state, and metadata CRUD RPCs

### DIFF
--- a/client/src/api/rpc.ts
+++ b/client/src/api/rpc.ts
@@ -217,6 +217,37 @@ export async function readObjectTreeDetail(
 	return rpcCall<ObjectTreeDetail>('urn:service:objects:read_object_tree_detail:1', { tableGuid, maxRows });
 }
 
+export async function upsertDatabaseTable(payload: {
+	keyGuid?: string;
+	name: string;
+	schema: string;
+}): Promise<{ ok: boolean }> {
+	return rpcCall<{ ok: boolean }>('urn:service:objects:upsert_database_table:1', payload);
+}
+
+export async function deleteDatabaseTable(keyGuid: string): Promise<{ ok: boolean }> {
+	return rpcCall<{ ok: boolean }>('urn:service:objects:delete_database_table:1', { keyGuid });
+}
+
+export async function upsertDatabaseColumn(payload: {
+	keyGuid?: string;
+	tableGuid: string;
+	typeGuid: string;
+	name: string;
+	ordinal: number;
+	isNullable: boolean;
+	isPrimaryKey: boolean;
+	isIdentity: boolean;
+	defaultValue?: string | null;
+	maxLength?: number | null;
+}): Promise<{ ok: boolean }> {
+	return rpcCall<{ ok: boolean }>('urn:service:objects:upsert_database_column:1', payload);
+}
+
+export async function deleteDatabaseColumn(keyGuid: string): Promise<{ ok: boolean }> {
+	return rpcCall<{ ok: boolean }>('urn:service:objects:delete_database_column:1', { keyGuid });
+}
+
 export async function getToken(payload: GetTokenPayload): Promise<GetTokenResult> {
 	return rpcCall<GetTokenResult>('urn:auth:session:get_token:1', payload);
 }

--- a/client/src/components/DatabaseBuilder.tsx
+++ b/client/src/components/DatabaseBuilder.tsx
@@ -1,0 +1,570 @@
+import { useEffect, useMemo, useState } from 'react';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import {
+	Box,
+	Breadcrumbs,
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	FormControlLabel,
+	IconButton,
+	MenuItem,
+	Select,
+	Switch,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableRow,
+	TextField,
+	Typography,
+} from '@mui/material';
+
+import {
+	deleteDatabaseColumn,
+	deleteDatabaseTable,
+	readObjectTreeChildren,
+	readObjectTreeDetail,
+	type ObjectTreeColumn,
+	upsertDatabaseColumn,
+	upsertDatabaseTable,
+} from '../api/rpc';
+import type { SelectedNode } from './Workbench';
+
+const DATABASE_TABLES_GUID = '78D4E217-6810-5A05-8999-ED57016229B6';
+const DATABASE_COLUMNS_GUID = '4241CCF3-A1F8-5A80-86BD-82632E121495';
+const TYPES_CATEGORY_GUID = 'EFAB32FE-8DF8-58FD-8C68-39D3B9E3BE00';
+
+interface DatabaseBuilderProps {
+	data: Record<string, unknown>;
+	selected: SelectedNode;
+}
+
+interface TableRow {
+	key_guid: string;
+	pub_name: string;
+	pub_schema: string;
+	priv_created_on?: string;
+	priv_modified_on?: string;
+}
+
+interface ColumnRow extends ObjectTreeColumn {
+	ref_type_guid?: string | null;
+	pub_default?: string | null;
+	pub_is_identity?: boolean;
+}
+
+interface TypeRow {
+	guid: string;
+	name: string;
+}
+
+export function DatabaseBuilder({ data, selected }: DatabaseBuilderProps): JSX.Element {
+	const selectNode = data.__selectNode as ((node: SelectedNode | null) => void) | undefined;
+	const [tables, setTables] = useState<TableRow[]>([]);
+	const [columns, setColumns] = useState<ColumnRow[]>([]);
+	const [types, setTypes] = useState<TypeRow[]>([]);
+	const [tableDialogOpen, setTableDialogOpen] = useState(false);
+	const [columnDialogOpen, setColumnDialogOpen] = useState(false);
+	const [tableDraft, setTableDraft] = useState({ keyGuid: '', name: '', schema: 'dbo' });
+	const [columnDraft, setColumnDraft] = useState({
+		keyGuid: '',
+		name: '',
+		typeGuid: '',
+		ordinal: 1,
+		isNullable: true,
+		isPrimaryKey: false,
+		isIdentity: false,
+		defaultValue: '',
+		maxLength: '',
+	});
+
+	const selectedColumn = useMemo(
+		() => columns.find((column) => column.guid === selected.childGuid) ?? null,
+		[columns, selected.childGuid],
+	);
+
+	const refreshTables = async (): Promise<void> => {
+		const detail = await readObjectTreeDetail(DATABASE_TABLES_GUID, 1000);
+		const nextRows = Array.isArray(detail.rows)
+			? detail.rows.map((row) => {
+					const payload = row as Record<string, unknown>;
+					return {
+						key_guid: String(payload.key_guid ?? ''),
+						pub_name: String(payload.pub_name ?? ''),
+						pub_schema: String(payload.pub_schema ?? 'dbo'),
+						priv_created_on: payload.priv_created_on ? String(payload.priv_created_on) : undefined,
+						priv_modified_on: payload.priv_modified_on ? String(payload.priv_modified_on) : undefined,
+					};
+				})
+			: [];
+		setTables(nextRows);
+	};
+
+	const refreshColumns = async (): Promise<void> => {
+		if (!selected.nodeGuid) {
+			setColumns([]);
+			return;
+		}
+		const treeColumns = await readObjectTreeChildren(selected.categoryGuid, selected.nodeGuid);
+		const detail = await readObjectTreeDetail(DATABASE_COLUMNS_GUID, 2000);
+		const detailRows = Array.isArray(detail.rows) ? detail.rows : [];
+		const byGuid = new Map(
+			detailRows
+				.filter((row) => String((row as { ref_table_guid?: string }).ref_table_guid || '') === selected.nodeGuid)
+				.map((row) => [String((row as { key_guid?: string }).key_guid || ''), row]),
+		);
+		const merged = (treeColumns as ObjectTreeColumn[]).map((column) => {
+			const detailRow = byGuid.get(column.guid) as Record<string, unknown> | undefined;
+			return {
+				...column,
+				ref_type_guid: (detailRow?.ref_type_guid as string | undefined) ?? null,
+				pub_default: (detailRow?.pub_default as string | undefined) ?? null,
+				pub_is_identity: Boolean(detailRow?.pub_is_identity ?? false),
+			};
+		});
+		setColumns(merged);
+	};
+
+	useEffect(() => {
+		void refreshTables();
+	}, []);
+
+	useEffect(() => {
+		void refreshColumns();
+	}, [selected.categoryGuid, selected.nodeGuid]);
+
+	useEffect(() => {
+		let mounted = true;
+		const loadTypes = async (): Promise<void> => {
+			const values = await readObjectTreeChildren(TYPES_CATEGORY_GUID);
+			if (!mounted) {
+				return;
+			}
+			setTypes((values as { guid: string; name: string }[]).map((row) => ({ guid: row.guid, name: row.name })));
+		};
+		void loadTypes();
+		return () => {
+			mounted = false;
+		};
+	}, []);
+
+	const renderFrame = (content: JSX.Element): JSX.Element => (
+		<Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', p: 2, color: '#FFFFFF' }}>{content}</Box>
+	);
+
+	const saveTable = async (): Promise<void> => {
+		await upsertDatabaseTable({
+			keyGuid: tableDraft.keyGuid || undefined,
+			name: tableDraft.name,
+			schema: tableDraft.schema || 'dbo',
+		});
+		setTableDialogOpen(false);
+		setTableDraft({ keyGuid: '', name: '', schema: 'dbo' });
+		await refreshTables();
+	};
+
+	const saveColumn = async (): Promise<void> => {
+		if (!selected.nodeGuid) {
+			return;
+		}
+		await upsertDatabaseColumn({
+			keyGuid: columnDraft.keyGuid || undefined,
+			tableGuid: selected.nodeGuid,
+			typeGuid: columnDraft.typeGuid,
+			name: columnDraft.name,
+			ordinal: Number(columnDraft.ordinal),
+			isNullable: columnDraft.isNullable,
+			isPrimaryKey: columnDraft.isPrimaryKey,
+			isIdentity: columnDraft.isIdentity,
+			defaultValue: columnDraft.defaultValue || null,
+			maxLength: columnDraft.maxLength === '' ? null : Number(columnDraft.maxLength),
+		});
+		setColumnDialogOpen(false);
+		await refreshColumns();
+	};
+
+	if (!selected.nodeGuid) {
+		return renderFrame(
+			<>
+				<Breadcrumbs sx={{ color: '#4CAF50', mb: 1 }}>
+					<Typography color="#4CAF50">Database</Typography>
+				</Breadcrumbs>
+				<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+					<Typography variant="h5">Tables</Typography>
+					<Button variant="contained" onClick={() => setTableDialogOpen(true)}>
+						New Table
+					</Button>
+				</Box>
+				<Table size="small" sx={{ '& td, & th': { borderColor: '#1A1A1A' } }}>
+					<TableHead>
+						<TableRow>
+							<TableCell>Name</TableCell>
+							<TableCell>Schema</TableCell>
+							<TableCell>Created</TableCell>
+							<TableCell>Modified</TableCell>
+							<TableCell align="right">Actions</TableCell>
+						</TableRow>
+					</TableHead>
+					<TableBody>
+						{tables.map((row) => (
+							<TableRow key={row.key_guid} hover>
+								<TableCell>
+									<Button
+										variant="text"
+										onClick={() =>
+											selectNode?.({
+												categoryGuid: selected.categoryGuid,
+												categoryName: selected.categoryName,
+												nodeGuid: row.key_guid,
+												nodeName: row.pub_name,
+												childGuid: null,
+												childName: null,
+											})
+										}
+									>
+										{row.pub_name}
+									</Button>
+								</TableCell>
+								<TableCell>{row.pub_schema}</TableCell>
+								<TableCell>{row.priv_created_on ?? ''}</TableCell>
+								<TableCell>{row.priv_modified_on ?? ''}</TableCell>
+								<TableCell align="right">
+									<IconButton
+										onClick={() => {
+											setTableDraft({ keyGuid: row.key_guid, name: row.pub_name, schema: row.pub_schema });
+											setTableDialogOpen(true);
+										}}
+									>
+										<EditIcon fontSize="small" />
+									</IconButton>
+									<IconButton
+										onClick={async () => {
+											await deleteDatabaseTable(row.key_guid);
+											await refreshTables();
+										}}
+									>
+										<DeleteIcon fontSize="small" />
+									</IconButton>
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+				<Dialog open={tableDialogOpen} onClose={() => setTableDialogOpen(false)}>
+					<DialogTitle>{tableDraft.keyGuid ? 'Edit Table' : 'New Table'}</DialogTitle>
+					<DialogContent sx={{ display: 'grid', gap: 1, minWidth: 320, pt: '12px !important' }}>
+						<TextField
+							label="Name"
+							value={tableDraft.name}
+							onChange={(event) => setTableDraft((prev) => ({ ...prev, name: event.target.value }))}
+						/>
+						<TextField
+							label="Schema"
+							value={tableDraft.schema}
+							onChange={(event) => setTableDraft((prev) => ({ ...prev, schema: event.target.value }))}
+						/>
+					</DialogContent>
+					<DialogActions>
+						<Button onClick={() => setTableDialogOpen(false)}>Cancel</Button>
+						<Button onClick={() => void saveTable()} variant="contained">
+							Save
+						</Button>
+					</DialogActions>
+				</Dialog>
+			</>,
+		);
+	}
+
+	if (!selected.childGuid) {
+		return renderFrame(
+			<>
+				<Breadcrumbs sx={{ color: '#4CAF50', mb: 1 }}>
+					<Typography color="#4CAF50">Database</Typography>
+					<Typography color="#4CAF50">{selected.nodeName}</Typography>
+				</Breadcrumbs>
+				<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+					<Typography variant="h5">Columns</Typography>
+					<Button
+						variant="contained"
+						onClick={() => {
+							setColumnDraft({
+								keyGuid: '',
+								name: '',
+								typeGuid: types[0]?.guid ?? '',
+								ordinal: columns.length + 1,
+								isNullable: true,
+								isPrimaryKey: false,
+								isIdentity: false,
+								defaultValue: '',
+								maxLength: '',
+							});
+							setColumnDialogOpen(true);
+						}}
+					>
+						Add Column
+					</Button>
+				</Box>
+				<Table size="small" sx={{ '& td, & th': { borderColor: '#1A1A1A' } }}>
+					<TableHead>
+						<TableRow>
+							<TableCell>#</TableCell>
+							<TableCell>Name</TableCell>
+							<TableCell>Type</TableCell>
+							<TableCell>PK</TableCell>
+							<TableCell>Nullable</TableCell>
+							<TableCell>Identity</TableCell>
+							<TableCell>Default</TableCell>
+							<TableCell>Max Length</TableCell>
+							<TableCell align="right">Actions</TableCell>
+						</TableRow>
+					</TableHead>
+					<TableBody>
+						{columns.map((column) => (
+							<TableRow key={column.guid} hover>
+								<TableCell>{column.ordinal}</TableCell>
+								<TableCell>
+									<Button
+										variant="text"
+										onClick={() =>
+											selectNode?.({
+												categoryGuid: selected.categoryGuid,
+												categoryName: selected.categoryName,
+												nodeGuid: selected.nodeGuid,
+												nodeName: selected.nodeName,
+												childGuid: column.guid,
+												childName: column.name,
+											})
+										}
+									>
+										{column.name}
+									</Button>
+								</TableCell>
+								<TableCell>{column.typeName ?? ''}</TableCell>
+								<TableCell>{column.isPrimaryKey ? '✓' : ''}</TableCell>
+								<TableCell>{column.isNullable ? '✓' : ''}</TableCell>
+								<TableCell>{column.pub_is_identity ? '✓' : ''}</TableCell>
+								<TableCell>{column.pub_default ?? ''}</TableCell>
+								<TableCell>{column.maxLength ?? ''}</TableCell>
+								<TableCell align="right">
+									<IconButton
+										onClick={() => {
+											setColumnDraft({
+												keyGuid: column.guid,
+												name: column.name,
+												typeGuid: column.ref_type_guid ?? '',
+												ordinal: column.ordinal,
+												isNullable: column.isNullable,
+												isPrimaryKey: column.isPrimaryKey,
+												isIdentity: Boolean(column.pub_is_identity),
+												defaultValue: column.pub_default ?? '',
+												maxLength: column.maxLength === null ? '' : String(column.maxLength),
+											});
+											setColumnDialogOpen(true);
+										}}
+									>
+										<EditIcon fontSize="small" />
+									</IconButton>
+									<IconButton
+										onClick={async () => {
+											await deleteDatabaseColumn(column.guid);
+											await refreshColumns();
+										}}
+									>
+										<DeleteIcon fontSize="small" />
+									</IconButton>
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+				<Dialog open={columnDialogOpen} onClose={() => setColumnDialogOpen(false)}>
+					<DialogTitle>{columnDraft.keyGuid ? 'Edit Column' : 'Add Column'}</DialogTitle>
+					<DialogContent sx={{ display: 'grid', gap: 1, minWidth: 360, pt: '12px !important' }}>
+						<TextField
+							label="Name"
+							value={columnDraft.name}
+							onChange={(event) => setColumnDraft((prev) => ({ ...prev, name: event.target.value }))}
+						/>
+						<Select
+							value={columnDraft.typeGuid}
+							onChange={(event) => setColumnDraft((prev) => ({ ...prev, typeGuid: String(event.target.value) }))}
+						>
+							{types.map((type) => (
+								<MenuItem key={type.guid} value={type.guid}>
+									{type.name}
+								</MenuItem>
+							))}
+						</Select>
+						<TextField
+							type="number"
+							label="Ordinal"
+							value={columnDraft.ordinal}
+							onChange={(event) =>
+								setColumnDraft((prev) => ({ ...prev, ordinal: Number(event.target.value) || 1 }))
+							}
+						/>
+						<TextField
+							label="Default"
+							value={columnDraft.defaultValue}
+							onChange={(event) => setColumnDraft((prev) => ({ ...prev, defaultValue: event.target.value }))}
+						/>
+						<TextField
+							type="number"
+							label="Max Length"
+							value={columnDraft.maxLength}
+							onChange={(event) => setColumnDraft((prev) => ({ ...prev, maxLength: event.target.value }))}
+						/>
+						<FormControlLabel
+							control={
+								<Switch
+									checked={columnDraft.isNullable}
+									onChange={(event) => setColumnDraft((prev) => ({ ...prev, isNullable: event.target.checked }))}
+								/>
+							}
+							label="Nullable"
+						/>
+						<FormControlLabel
+							control={
+								<Switch
+									checked={columnDraft.isPrimaryKey}
+									onChange={(event) =>
+										setColumnDraft((prev) => ({ ...prev, isPrimaryKey: event.target.checked }))
+									}
+								/>
+							}
+							label="Primary Key"
+						/>
+						<FormControlLabel
+							control={
+								<Switch
+									checked={columnDraft.isIdentity}
+									onChange={(event) => setColumnDraft((prev) => ({ ...prev, isIdentity: event.target.checked }))}
+								/>
+							}
+							label="Identity"
+						/>
+					</DialogContent>
+					<DialogActions>
+						<Button onClick={() => setColumnDialogOpen(false)}>Cancel</Button>
+						<Button onClick={() => void saveColumn()} variant="contained">
+							Save
+						</Button>
+					</DialogActions>
+				</Dialog>
+			</>,
+		);
+	}
+
+	return renderFrame(
+		<>
+			<Breadcrumbs sx={{ color: '#4CAF50', mb: 1 }}>
+				<Typography color="#4CAF50">Database</Typography>
+				<Typography color="#4CAF50">{selected.nodeName}</Typography>
+				<Typography color="#4CAF50">{selected.childName}</Typography>
+			</Breadcrumbs>
+			<Typography variant="h6" sx={{ mb: 1 }}>
+				Column Details
+			</Typography>
+			{selectedColumn ? (
+				<Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(220px, 1fr))', gap: 1, maxWidth: 900 }}>
+					<TextField
+						label="Column Name"
+						value={columnDraft.name || selectedColumn.name}
+						onChange={(event) => setColumnDraft((prev) => ({ ...prev, keyGuid: selectedColumn.guid, name: event.target.value }))}
+					/>
+					<TextField
+						type="number"
+						label="Ordinal"
+						value={columnDraft.keyGuid ? columnDraft.ordinal : selectedColumn.ordinal}
+						onChange={(event) =>
+							setColumnDraft((prev) => ({ ...prev, keyGuid: selectedColumn.guid, ordinal: Number(event.target.value) || 1 }))
+						}
+					/>
+					<Select
+						value={columnDraft.typeGuid || selectedColumn.ref_type_guid || ''}
+						onChange={(event) =>
+							setColumnDraft((prev) => ({ ...prev, keyGuid: selectedColumn.guid, typeGuid: String(event.target.value) }))
+						}
+					>
+						{types.map((type) => (
+							<MenuItem key={type.guid} value={type.guid}>
+								{type.name}
+							</MenuItem>
+						))}
+					</Select>
+					<TextField
+						label="Default Value"
+						value={columnDraft.keyGuid ? columnDraft.defaultValue : selectedColumn.pub_default || ''}
+						onChange={(event) =>
+							setColumnDraft((prev) => ({ ...prev, keyGuid: selectedColumn.guid, defaultValue: event.target.value }))
+						}
+					/>
+					<TextField
+						type="number"
+						label="Max Length"
+						value={columnDraft.keyGuid ? columnDraft.maxLength : selectedColumn.maxLength || ''}
+						onChange={(event) =>
+							setColumnDraft((prev) => ({ ...prev, keyGuid: selectedColumn.guid, maxLength: event.target.value }))
+						}
+					/>
+					<FormControlLabel
+						control={
+							<Switch
+								checked={columnDraft.keyGuid ? columnDraft.isNullable : selectedColumn.isNullable}
+								onChange={(event) =>
+									setColumnDraft((prev) => ({ ...prev, keyGuid: selectedColumn.guid, isNullable: event.target.checked }))
+								}
+							/>
+						}
+						label="Nullable"
+					/>
+					<FormControlLabel
+						control={
+							<Switch
+								checked={columnDraft.keyGuid ? columnDraft.isPrimaryKey : selectedColumn.isPrimaryKey}
+								onChange={(event) =>
+									setColumnDraft((prev) => ({ ...prev, keyGuid: selectedColumn.guid, isPrimaryKey: event.target.checked }))
+								}
+							/>
+						}
+						label="Primary Key"
+					/>
+					<FormControlLabel
+						control={
+							<Switch
+								checked={columnDraft.keyGuid ? columnDraft.isIdentity : Boolean(selectedColumn.pub_is_identity)}
+								onChange={(event) =>
+									setColumnDraft((prev) => ({ ...prev, keyGuid: selectedColumn.guid, isIdentity: event.target.checked }))
+								}
+							/>
+						}
+						label="Identity"
+					/>
+				</Box>
+			) : null}
+			<Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+				<Button variant="contained" onClick={() => void saveColumn()}>
+					Save
+				</Button>
+				<Button
+					color="error"
+					onClick={async () => {
+						if (!selected.childGuid) {
+							return;
+						}
+						await deleteDatabaseColumn(selected.childGuid);
+						selectNode?.({ ...selected, childGuid: null, childName: null });
+						await refreshColumns();
+					}}
+				>
+					Delete
+				</Button>
+				<Button onClick={() => selectNode?.({ ...selected, childGuid: null, childName: null })}>Back to Table</Button>
+			</Box>
+		</>,
+	);
+}

--- a/client/src/components/ObjectEditor.tsx
+++ b/client/src/components/ObjectEditor.tsx
@@ -1,11 +1,28 @@
 import { Box, Typography } from '@mui/material';
 
 import type { CmsComponentProps } from '../engine/types';
+import type { SelectedNode } from './Workbench';
+import { DatabaseBuilder } from './DatabaseBuilder';
 
 export function ObjectEditor({ data, children }: CmsComponentProps): JSX.Element | null {
-	const isDevMode = data.__devMode === true;
-	if (!isDevMode) {
+	if (data.__devMode !== true) {
 		return null;
+	}
+
+	const selected = (data.__selectedNode as SelectedNode | null) ?? null;
+	if (!selected) {
+		return (
+			<Box sx={{ p: 2 }}>
+				<Typography variant="h2">Object Editor</Typography>
+				<Typography variant="body2" color="text.secondary">
+					Select a node in the Object Tree to edit.
+				</Typography>
+			</Box>
+		);
+	}
+
+	if (selected.categoryName === 'database') {
+		return <DatabaseBuilder data={data} selected={selected} />;
 	}
 
 	return (
@@ -19,9 +36,9 @@ export function ObjectEditor({ data, children }: CmsComponentProps): JSX.Element
 				gap: 1,
 			}}
 		>
-			<Typography variant="h2">Object Editor</Typography>
+			<Typography variant="h2">{selected.categoryName}</Typography>
 			<Typography variant="body2" color="text.secondary">
-				Component Builder will render here.
+				Editor not available for this category yet.
 			</Typography>
 			{children}
 		</Box>

--- a/client/src/components/ObjectTreeView.tsx
+++ b/client/src/components/ObjectTreeView.tsx
@@ -5,6 +5,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
 	Box,
 	CircularProgress,
+	IconButton,
 	List,
 	ListItemButton,
 	ListItemIcon,
@@ -21,6 +22,7 @@ import {
 } from '../api/rpc';
 import { DynamicIcon } from './DynamicIcon';
 import type { CmsComponentProps } from '../engine/types';
+import type { SelectedNode } from './Workbench';
 
 interface TreeNodeState {
 	expanded: boolean;
@@ -61,6 +63,8 @@ const sortColumns = (items: ObjectTreeColumn[]): ObjectTreeColumn[] =>
 export function ObjectTreeView({ data }: CmsComponentProps): JSX.Element | null {
 	const isDevMode = data.__devMode === true;
 	const isOpen = data.__sidebarOpen === true;
+	const selected = (data.__selectedNode as SelectedNode | null) ?? null;
+	const selectNode = data.__selectNode as ((node: SelectedNode | null) => void) | undefined;
 	const [categories, setCategories] = useState<ObjectTreeCategory[]>([]);
 	const [categoriesLoading, setCategoriesLoading] = useState(false);
 	const [categoriesError, setCategoriesError] = useState<string | null>(null);
@@ -168,6 +172,21 @@ export function ObjectTreeView({ data }: CmsComponentProps): JSX.Element | null 
 		}
 	};
 
+	const rowSx = (active: boolean, color: string) => ({
+		minHeight: 28,
+		px: '8px',
+		py: '5px',
+		borderRadius: 1,
+		justifyContent: isOpen ? 'flex-start' : 'center',
+		gap: isOpen ? 1 : 0,
+		color,
+		backgroundColor: active ? 'rgba(76, 175, 80, 0.12)' : 'transparent',
+		'&:hover': {
+			backgroundColor: active ? 'rgba(76, 175, 80, 0.18)' : 'rgba(255, 255, 255, 0.04)',
+			color,
+		},
+	});
+
 	const renderNodeText = (label: string, color: string): JSX.Element | null =>
 		isOpen ? (
 			<ListItemText
@@ -186,17 +205,7 @@ export function ObjectTreeView({ data }: CmsComponentProps): JSX.Element | null 
 	return (
 		<Box sx={{ px: 0.5, py: 0.5 }}>
 			{isOpen ? (
-				<Typography
-					variant="body2"
-					sx={{
-						fontSize: '0.65rem',
-						textTransform: 'uppercase',
-						letterSpacing: '0.06em',
-						color: '#555555',
-						px: 1,
-						py: 0.5,
-					}}
-				>
+				<Typography variant="body2" sx={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.06em', color: '#555555', px: 1, py: 0.5 }}>
 					Object Tree
 				</Typography>
 			) : null}
@@ -209,224 +218,101 @@ export function ObjectTreeView({ data }: CmsComponentProps): JSX.Element | null 
 				{categoriesError ? (
 					<Box sx={{ display: 'flex', alignItems: 'center', px: 1, py: 0.5, color: '#E57373', gap: 0.5 }}>
 						<ErrorOutlineIcon sx={{ fontSize: 14 }} />
-						{isOpen ? (
-							<Typography sx={{ fontSize: '0.7rem', lineHeight: 1.2, color: 'inherit' }}>
-								{categoriesError}
-							</Typography>
-						) : null}
+						{isOpen ? <Typography sx={{ fontSize: '0.7rem', lineHeight: 1.2, color: 'inherit' }}>{categoriesError}</Typography> : null}
 					</Box>
 				) : null}
 				{categories.map((category) => {
 					const categoryState = getNodeState(nodeStates, category.guid);
-					const categoryTables = categoryState.children?.filter(
-						(child): child is ObjectTreeTable => !isObjectTreeColumn(child),
-					);
+					const categoryTables = categoryState.children?.filter((child): child is ObjectTreeTable => !isObjectTreeColumn(child));
+					const isCategorySelected = selected?.categoryGuid === category.guid && !selected.nodeGuid && !selected.childGuid;
 
 					return (
 						<Box key={category.guid}>
-							<ListItemButton
-								onClick={() => {
-									void toggleNode(category.guid, category.guid);
-								}}
-								sx={{
-									minHeight: 28,
-									px: '8px',
-									py: '5px',
-									borderRadius: 1,
-									justifyContent: isOpen ? 'flex-start' : 'center',
-									gap: isOpen ? 1 : 0,
-									color: '#FFFFFF',
-									'&:hover': {
-										backgroundColor: 'rgba(255, 255, 255, 0.04)',
-										color: '#FFFFFF',
-									},
-								}}
-							>
-								{isOpen ? (
-									<ListItemIcon
-										sx={{
-											minWidth: 0,
-											width: 16,
-											height: 18,
-											color: 'inherit',
-											justifyContent: 'center',
-											'& .MuiSvgIcon-root': { fontSize: 16 },
-										}}
-									>
-										{categoryState.expanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
-									</ListItemIcon>
-								) : null}
-								<ListItemIcon
-									sx={{
-										minWidth: 0,
-										width: 18,
-										height: 18,
-										color: 'inherit',
-										justifyContent: 'center',
-										'& .MuiSvgIcon-root': { fontSize: 18 },
-									}}
+							<Box sx={{ display: 'flex', alignItems: 'center' }}>
+								<IconButton size="small" onClick={() => void toggleNode(category.guid, category.guid)} sx={{ color: '#FFFFFF', width: 22, height: 22 }}>
+									{categoryState.expanded ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+								</IconButton>
+								<ListItemButton
+									onClick={() =>
+										selectNode?.({
+											categoryGuid: category.guid,
+											categoryName: category.name,
+											nodeGuid: null,
+											nodeName: null,
+											childGuid: null,
+											childName: null,
+										})
+									}
+									sx={rowSx(isCategorySelected, '#FFFFFF')}
 								>
-									<DynamicIcon name={category.icon} />
-								</ListItemIcon>
-								{renderNodeText(category.display, '#FFFFFF')}
-							</ListItemButton>
+									<ListItemIcon sx={{ minWidth: 0, width: 18, height: 18, color: 'inherit', justifyContent: 'center', '& .MuiSvgIcon-root': { fontSize: 18 } }}>
+										<DynamicIcon name={category.icon} />
+									</ListItemIcon>
+									{renderNodeText(category.display, '#FFFFFF')}
+								</ListItemButton>
+							</Box>
 							{categoryState.expanded && isOpen ? (
-								<Box sx={{ pl: isOpen ? '16px' : 0 }}>
-									{categoryState.loading ? (
-										<Box sx={{ display: 'flex', alignItems: 'center', px: 1, py: 0.5 }}>
-											<CircularProgress size={12} thickness={5} />
-										</Box>
-									) : null}
-									{categoryState.error ? (
-										<Box
-											sx={{
-												display: 'flex',
-												alignItems: 'center',
-												px: 1,
-												py: 0.5,
-												color: '#E57373',
-												gap: 0.5,
-											}}
-										>
-											<ErrorOutlineIcon sx={{ fontSize: 14 }} />
-											{isOpen ? (
-												<Typography sx={{ fontSize: '0.7rem', lineHeight: 1.2, color: 'inherit' }}>
-													{categoryState.error}
-												</Typography>
-											) : null}
-										</Box>
-									) : null}
-									{!categoryState.loading &&
-									!categoryState.error &&
-									Array.isArray(categoryTables) &&
-									categoryTables.length === 0 &&
-									isOpen ? (
-										<Typography sx={{ fontSize: '0.7rem', color: '#777777', px: 1, py: 0.5 }}>
-											No items
-										</Typography>
-									) : null}
+								<Box sx={{ pl: '16px' }}>
+									{categoryState.loading ? <Box sx={{ display: 'flex', alignItems: 'center', px: 1, py: 0.5 }}><CircularProgress size={12} thickness={5} /></Box> : null}
+									{categoryState.error ? <Box sx={{ display: 'flex', alignItems: 'center', px: 1, py: 0.5, color: '#E57373', gap: 0.5 }}><ErrorOutlineIcon sx={{ fontSize: 14 }} /><Typography sx={{ fontSize: '0.7rem', lineHeight: 1.2, color: 'inherit' }}>{categoryState.error}</Typography></Box> : null}
+									{!categoryState.loading && !categoryState.error && Array.isArray(categoryTables) && categoryTables.length === 0 ? <Typography sx={{ fontSize: '0.7rem', color: '#777777', px: 1, py: 0.5 }}>No items</Typography> : null}
 									{categoryTables?.map((table) => {
 										const tableState = getNodeState(nodeStates, table.guid);
 										const tableColumns = tableState.children?.filter(isObjectTreeColumn);
+										const isTableSelected = selected?.categoryGuid === category.guid && selected?.nodeGuid === table.guid && !selected?.childGuid;
+
 										return (
 											<Box key={table.guid}>
-												<ListItemButton
-													onClick={() => {
-														void toggleNode(category.guid, table.guid, table.guid);
-													}}
-													sx={{
-														minHeight: 28,
-														px: isOpen ? '8px' : '0px',
-														py: '5px',
-														borderRadius: 1,
-														justifyContent: isOpen ? 'flex-start' : 'center',
-														gap: isOpen ? 1 : 0,
-														color: '#BBBBBB',
-														'&:hover': {
-															backgroundColor: 'rgba(255, 255, 255, 0.04)',
-															color: '#BBBBBB',
-														},
-													}}
-												>
-													{isOpen ? (
-														<ListItemIcon
-															sx={{
-																minWidth: 0,
-																width: 16,
-																height: 18,
-																color: 'inherit',
-																justifyContent: 'center',
-																'& .MuiSvgIcon-root': { fontSize: 16 },
-															}}
-														>
-															{tableState.expanded ? <ExpandMoreIcon /> : <ChevronRightIcon />}
-														</ListItemIcon>
-													) : null}
-													<ListItemIcon
-														sx={{
-															minWidth: 0,
-															width: 18,
-															height: 18,
-															color: 'inherit',
-															justifyContent: 'center',
-															'& .MuiSvgIcon-root': { fontSize: 18 },
-														}}
+												<Box sx={{ display: 'flex', alignItems: 'center' }}>
+													<IconButton size="small" onClick={() => void toggleNode(category.guid, table.guid, table.guid)} sx={{ color: '#BBBBBB', width: 22, height: 22 }}>
+														{tableState.expanded ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+													</IconButton>
+													<ListItemButton
+														onClick={() =>
+															selectNode?.({
+																categoryGuid: category.guid,
+																categoryName: category.name,
+																nodeGuid: table.guid,
+																nodeName: table.name,
+																childGuid: null,
+																childName: null,
+															})
+														}
+														sx={rowSx(isTableSelected, '#BBBBBB')}
 													>
-														<DynamicIcon name="DataObject" />
-													</ListItemIcon>
-													{renderNodeText(table.name, '#BBBBBB')}
-												</ListItemButton>
-												{tableState.expanded && isOpen ? (
-													<Box sx={{ pl: isOpen ? '24px' : 0 }}>
-														{tableState.loading ? (
-															<Box sx={{ display: 'flex', alignItems: 'center', px: 1, py: 0.5 }}>
-																<CircularProgress size={12} thickness={5} />
-															</Box>
-														) : null}
-														{tableState.error ? (
-															<Box
-																sx={{
-																	display: 'flex',
-																	alignItems: 'center',
-																	px: 1,
-																	py: 0.5,
-																	color: '#E57373',
-																	gap: 0.5,
-																}}
-															>
-																<ErrorOutlineIcon sx={{ fontSize: 14 }} />
-																{isOpen ? (
-																	<Typography
-																		sx={{ fontSize: '0.7rem', lineHeight: 1.2, color: 'inherit' }}
-																	>
-																		{tableState.error}
-																	</Typography>
-																) : null}
-															</Box>
-														) : null}
-														{!tableState.loading &&
-														!tableState.error &&
-														Array.isArray(tableColumns) &&
-														tableColumns.length === 0 &&
-														isOpen ? (
-															<Typography
-																sx={{ fontSize: '0.7rem', color: '#777777', px: 1, py: 0.5 }}
-															>
-																No items
-															</Typography>
-														) : null}
-														{tableColumns?.map((column) => (
-															<ListItemButton
-																key={column.guid}
-																sx={{
-																	minHeight: 28,
-																	px: isOpen ? '8px' : '0px',
-																	py: '5px',
-																	borderRadius: 1,
-																	justifyContent: isOpen ? 'flex-start' : 'center',
-																	gap: isOpen ? 1 : 0,
-																	color: '#888888',
-																	'&:hover': {
-																		backgroundColor: 'rgba(255, 255, 255, 0.04)',
-																		color: '#888888',
-																	},
-																}}
-															>
-																<ListItemIcon
-																	sx={{
-																		minWidth: 0,
-																		width: 18,
-																		height: 18,
-																		color: 'inherit',
-																		justifyContent: 'center',
-																		'& .MuiSvgIcon-root': { fontSize: 18 },
-																	}}
+														<ListItemIcon sx={{ minWidth: 0, width: 18, height: 18, color: 'inherit', justifyContent: 'center', '& .MuiSvgIcon-root': { fontSize: 18 } }}>
+															<DynamicIcon name="DataObject" />
+														</ListItemIcon>
+														{renderNodeText(table.name, '#BBBBBB')}
+													</ListItemButton>
+												</Box>
+												{tableState.expanded ? (
+													<Box sx={{ pl: '24px' }}>
+														{tableColumns?.map((column) => {
+															const isColumnSelected =
+																selected?.categoryGuid === category.guid && selected?.nodeGuid === table.guid && selected?.childGuid === column.guid;
+															return (
+																<ListItemButton
+																	key={column.guid}
+																	onClick={() =>
+																		selectNode?.({
+																			categoryGuid: category.guid,
+																			categoryName: category.name,
+																			nodeGuid: table.guid,
+																			nodeName: table.name,
+																			childGuid: column.guid,
+																			childName: column.name,
+																		})
+																	}
+																	sx={rowSx(isColumnSelected, '#888888')}
 																>
-																	<DynamicIcon name="List" />
-																</ListItemIcon>
-																{renderNodeText(column.name, '#888888')}
-															</ListItemButton>
-														))}
+																	<ListItemIcon sx={{ minWidth: 0, width: 18, height: 18, color: 'inherit', justifyContent: 'center', '& .MuiSvgIcon-root': { fontSize: 18 } }}>
+																		<DynamicIcon name="List" />
+																	</ListItemIcon>
+																	{renderNodeText(column.name, '#888888')}
+																</ListItemButton>
+															);
+														})}
 													</Box>
 												) : null}
 											</Box>

--- a/client/src/components/Workbench.tsx
+++ b/client/src/components/Workbench.tsx
@@ -4,9 +4,19 @@ import { Box } from '@mui/material';
 import type { CmsComponentProps } from '../engine/types';
 import { useUserContext } from '../shared/UserContextProvider';
 
+export interface SelectedNode {
+	categoryGuid: string;
+	categoryName: string;
+	nodeGuid: string | null;
+	nodeName: string | null;
+	childGuid: string | null;
+	childName: string | null;
+}
+
 export function Workbench({ children, enrichData }: CmsComponentProps): JSX.Element {
 	const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
 	const [devMode, setDevMode] = useState<boolean>(false);
+	const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
 	const { user, sessionToken, isLoading, login, logout } = useUserContext();
 
 	useEffect(() => {
@@ -22,13 +32,15 @@ export function Workbench({ children, enrichData }: CmsComponentProps): JSX.Elem
 			__toggleSidebar: (): void => setSidebarOpen((prev) => !prev),
 			__devMode: devMode,
 			__toggleDevMode: (): void => setDevMode((prev) => !prev),
+			__selectedNode: selectedNode,
+			__selectNode: (node: SelectedNode | null): void => setSelectedNode(node),
 			__user: user,
 			__sessionToken: sessionToken,
 			__isAuthLoading: isLoading,
 			__login: login,
 			__logout: logout,
 		}),
-		[sidebarOpen, devMode, user, sessionToken, isLoading, login, logout],
+		[sidebarOpen, devMode, selectedNode, user, sessionToken, isLoading, login, logout],
 	);
 
 	useEffect(() => {

--- a/migrations/v0.12.15.0_seed_database_builder_rpc.sql
+++ b/migrations/v0.12.15.0_seed_database_builder_rpc.sql
@@ -1,0 +1,206 @@
+-- =============================================================================
+-- v0.12.15.0_seed_database_builder_rpc
+-- Date: 2026-04-13
+-- Purpose:
+--   1) Seed database metadata CRUD queries for CmsWorkbenchModule
+--   2) Register CmsWorkbenchModule methods for database metadata CRUD
+--   3) Register RPC gateway bindings for database metadata CRUD operations
+-- =============================================================================
+
+MERGE INTO [dbo].[system_objects_queries] AS target
+USING (
+  SELECT
+    N'62D45D9F-C906-5B93-8FC3-4615DBFDCEB4' AS [key_guid],
+    N'cms.database.upsert_table' AS [pub_name],
+    N'DECLARE @key_guid UNIQUEIDENTIFIER = TRY_CAST(? AS UNIQUEIDENTIFIER);
+DECLARE @pub_name NVARCHAR(128) = ?;
+DECLARE @pub_schema NVARCHAR(128) = ?;
+DECLARE @resolved_key UNIQUEIDENTIFIER = COALESCE(@key_guid, NEWID());
+
+MERGE INTO [dbo].[system_objects_database_tables] AS target
+USING (
+  SELECT
+    @resolved_key AS [key_guid],
+    @pub_name AS [pub_name],
+    @pub_schema AS [pub_schema]
+) AS source
+ON target.[key_guid] = source.[key_guid]
+WHEN MATCHED THEN
+  UPDATE SET
+    [pub_name] = source.[pub_name],
+    [pub_schema] = source.[pub_schema],
+    [priv_modified_on] = SYSUTCDATETIME()
+WHEN NOT MATCHED THEN
+  INSERT ([key_guid], [pub_name], [pub_schema])
+  VALUES (source.[key_guid], source.[pub_name], source.[pub_schema]);
+
+SELECT CAST(1 AS BIT) AS [ok]
+FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;' AS [pub_query_text],
+    N'Upsert database table metadata row in system_objects_database_tables.' AS [pub_description],
+    N'CF85FB11-5981-56B7-8E43-9D453E611D43' AS [ref_module_guid],
+    1 AS [pub_is_parameterized],
+    N'key_guid,pub_name,pub_schema' AS [pub_parameter_names]
+
+  UNION ALL SELECT
+    N'C9285A8F-D9F6-5E6F-B471-9D9FCFBB5046',
+    N'cms.database.delete_table',
+    N'DECLARE @key_guid UNIQUEIDENTIFIER = TRY_CAST(? AS UNIQUEIDENTIFIER);
+
+IF EXISTS (
+  SELECT 1
+  FROM [dbo].[system_objects_database_columns]
+  WHERE [ref_table_guid] = @key_guid
+)
+BEGIN
+  THROW 50001, ''Cannot delete table metadata while columns exist. Delete columns first.'', 1;
+END;
+
+DELETE FROM [dbo].[system_objects_database_tables]
+WHERE [key_guid] = @key_guid;
+
+SELECT CAST(1 AS BIT) AS [ok]
+FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;',
+    N'Delete database table metadata row when no dependent columns exist.',
+    N'CF85FB11-5981-56B7-8E43-9D453E611D43',
+    1,
+    N'key_guid'
+
+  UNION ALL SELECT
+    N'938279F8-EC41-5C08-9742-BBFB08A7643B',
+    N'cms.database.upsert_column',
+    N'DECLARE @key_guid UNIQUEIDENTIFIER = TRY_CAST(? AS UNIQUEIDENTIFIER);
+DECLARE @ref_table_guid UNIQUEIDENTIFIER = TRY_CAST(? AS UNIQUEIDENTIFIER);
+DECLARE @ref_type_guid UNIQUEIDENTIFIER = TRY_CAST(? AS UNIQUEIDENTIFIER);
+DECLARE @pub_name NVARCHAR(128) = ?;
+DECLARE @pub_ordinal INT = ?;
+DECLARE @pub_is_nullable BIT = ?;
+DECLARE @pub_is_primary_key BIT = ?;
+DECLARE @pub_is_identity BIT = ?;
+DECLARE @pub_default NVARCHAR(512) = ?;
+DECLARE @pub_max_length INT = ?;
+DECLARE @resolved_key UNIQUEIDENTIFIER = COALESCE(@key_guid, NEWID());
+
+MERGE INTO [dbo].[system_objects_database_columns] AS target
+USING (
+  SELECT
+    @resolved_key AS [key_guid],
+    @ref_table_guid AS [ref_table_guid],
+    @ref_type_guid AS [ref_type_guid],
+    @pub_name AS [pub_name],
+    @pub_ordinal AS [pub_ordinal],
+    @pub_is_nullable AS [pub_is_nullable],
+    @pub_is_primary_key AS [pub_is_primary_key],
+    @pub_is_identity AS [pub_is_identity],
+    @pub_default AS [pub_default],
+    @pub_max_length AS [pub_max_length]
+) AS source
+ON target.[key_guid] = source.[key_guid]
+WHEN MATCHED THEN
+  UPDATE SET
+    [ref_table_guid] = source.[ref_table_guid],
+    [ref_type_guid] = source.[ref_type_guid],
+    [pub_name] = source.[pub_name],
+    [pub_ordinal] = source.[pub_ordinal],
+    [pub_is_nullable] = source.[pub_is_nullable],
+    [pub_is_primary_key] = source.[pub_is_primary_key],
+    [pub_is_identity] = source.[pub_is_identity],
+    [pub_default] = source.[pub_default],
+    [pub_max_length] = source.[pub_max_length]
+WHEN NOT MATCHED THEN
+  INSERT (
+    [key_guid], [ref_table_guid], [ref_type_guid], [pub_name], [pub_ordinal],
+    [pub_is_nullable], [pub_is_primary_key], [pub_is_identity], [pub_default], [pub_max_length]
+  )
+  VALUES (
+    source.[key_guid], source.[ref_table_guid], source.[ref_type_guid], source.[pub_name], source.[pub_ordinal],
+    source.[pub_is_nullable], source.[pub_is_primary_key], source.[pub_is_identity], source.[pub_default], source.[pub_max_length]
+  );
+
+SELECT CAST(1 AS BIT) AS [ok]
+FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;',
+    N'Upsert database column metadata row in system_objects_database_columns.',
+    N'CF85FB11-5981-56B7-8E43-9D453E611D43',
+    1,
+    N'key_guid,ref_table_guid,ref_type_guid,pub_name,pub_ordinal,pub_is_nullable,pub_is_primary_key,pub_is_identity,pub_default,pub_max_length'
+
+  UNION ALL SELECT
+    N'44A23C51-AB25-5C9A-94BA-FC32F9126CF7',
+    N'cms.database.delete_column',
+    N'DELETE FROM [dbo].[system_objects_database_columns]
+WHERE [key_guid] = TRY_CAST(? AS UNIQUEIDENTIFIER);
+
+SELECT CAST(1 AS BIT) AS [ok]
+FOR JSON PATH, WITHOUT_ARRAY_WRAPPER, INCLUDE_NULL_VALUES;',
+    N'Delete database column metadata row.',
+    N'CF85FB11-5981-56B7-8E43-9D453E611D43',
+    1,
+    N'key_guid'
+
+) AS source ([key_guid], [pub_name], [pub_query_text], [pub_description], [ref_module_guid], [pub_is_parameterized], [pub_parameter_names])
+ON target.[key_guid] = TRY_CAST(source.[key_guid] AS UNIQUEIDENTIFIER)
+WHEN MATCHED THEN
+  UPDATE SET
+    [pub_name] = source.[pub_name],
+    [pub_query_text] = source.[pub_query_text],
+    [pub_description] = source.[pub_description],
+    [pub_is_parameterized] = source.[pub_is_parameterized],
+    [pub_parameter_names] = source.[pub_parameter_names],
+    [priv_modified_on] = SYSUTCDATETIME()
+WHEN NOT MATCHED THEN
+  INSERT ([key_guid], [pub_name], [pub_query_text], [pub_description], [ref_module_guid], [pub_is_parameterized], [pub_parameter_names])
+  VALUES (
+    TRY_CAST(source.[key_guid] AS UNIQUEIDENTIFIER),
+    source.[pub_name],
+    source.[pub_query_text],
+    source.[pub_description],
+    TRY_CAST(source.[ref_module_guid] AS UNIQUEIDENTIFIER),
+    source.[pub_is_parameterized],
+    source.[pub_parameter_names]
+  );
+GO
+
+INSERT INTO [dbo].[system_objects_module_methods]
+  ([key_guid], [ref_module_guid], [pub_name], [pub_description], [pub_is_active])
+SELECT
+  source.[key_guid],
+  source.[ref_module_guid],
+  source.[pub_name],
+  source.[pub_description],
+  CAST(1 AS BIT)
+FROM (VALUES
+  (N'4861B5FC-C30B-56C4-A091-01269574FB53', N'CF85FB11-5981-56B7-8E43-9D453E611D43', N'upsert_database_table', N'Upsert database table metadata.'),
+  (N'DDB0D57B-3962-539B-B466-786E031AE4EE', N'CF85FB11-5981-56B7-8E43-9D453E611D43', N'delete_database_table', N'Delete database table metadata.'),
+  (N'ED2F5575-BD09-5570-9BE0-BBDFB859A691', N'CF85FB11-5981-56B7-8E43-9D453E611D43', N'upsert_database_column', N'Upsert database column metadata.'),
+  (N'A384CF5B-956A-5FDC-B245-24E8C3290B5F', N'CF85FB11-5981-56B7-8E43-9D453E611D43', N'delete_database_column', N'Delete database column metadata.')
+) AS source([key_guid], [ref_module_guid], [pub_name], [pub_description])
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM [dbo].[system_objects_module_methods] methods
+  WHERE methods.[key_guid] = source.[key_guid]
+);
+GO
+
+INSERT INTO [dbo].[system_objects_gateway_method_bindings]
+  ([key_guid], [ref_gateway_guid], [pub_operation_name], [ref_method_guid], [pub_required_scope], [ref_required_role_guid], [ref_required_entitlement_guid], [pub_is_read_only], [pub_is_active])
+SELECT
+  source.[key_guid],
+  source.[ref_gateway_guid],
+  source.[pub_operation_name],
+  source.[ref_method_guid],
+  source.[pub_required_scope],
+  source.[ref_required_role_guid],
+  source.[ref_required_entitlement_guid],
+  source.[pub_is_read_only],
+  CAST(1 AS BIT)
+FROM (VALUES
+  (N'8AA4187A-7951-506B-912C-B5450EB47BEA', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:service:objects:upsert_database_table:1',  N'4861B5FC-C30B-56C4-A091-01269574FB53', CAST(NULL AS NVARCHAR(128)), N'E8E1A4CC-0898-59F4-8B03-B2C9804516C0', CAST(NULL AS UNIQUEIDENTIFIER), CAST(0 AS BIT)),
+  (N'30C5A3BC-B2DF-5E1C-AE50-8A9EAA0A4286', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:service:objects:delete_database_table:1',  N'DDB0D57B-3962-539B-B466-786E031AE4EE', CAST(NULL AS NVARCHAR(128)), N'E8E1A4CC-0898-59F4-8B03-B2C9804516C0', CAST(NULL AS UNIQUEIDENTIFIER), CAST(0 AS BIT)),
+  (N'67B4A241-5BD0-502C-8D96-8CFE31FA0A27', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:service:objects:upsert_database_column:1', N'ED2F5575-BD09-5570-9BE0-BBDFB859A691', CAST(NULL AS NVARCHAR(128)), N'E8E1A4CC-0898-59F4-8B03-B2C9804516C0', CAST(NULL AS UNIQUEIDENTIFIER), CAST(0 AS BIT)),
+  (N'9E88E84E-61F4-5B65-A0C9-70CA00505539', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:service:objects:delete_database_column:1', N'A384CF5B-956A-5FDC-B245-24E8C3290B5F', CAST(NULL AS NVARCHAR(128)), N'E8E1A4CC-0898-59F4-8B03-B2C9804516C0', CAST(NULL AS UNIQUEIDENTIFIER), CAST(0 AS BIT))
+) AS source([key_guid], [ref_gateway_guid], [pub_operation_name], [ref_method_guid], [pub_required_scope], [ref_required_role_guid], [ref_required_entitlement_guid], [pub_is_read_only])
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM [dbo].[system_objects_gateway_method_bindings] bindings
+  WHERE bindings.[key_guid] = source.[key_guid]
+);
+GO

--- a/rpc/service/objects/__init__.py
+++ b/rpc/service/objects/__init__.py
@@ -4,12 +4,20 @@ Requires ROLE_SERVICE_ADMIN.
 """
 
 from .services import (
+  service_objects_delete_database_column_v1,
+  service_objects_delete_database_table_v1,
   service_objects_read_object_tree_children_v1,
   service_objects_read_object_tree_detail_v1,
+  service_objects_upsert_database_column_v1,
+  service_objects_upsert_database_table_v1,
 )
 
 
 DISPATCHERS: dict[tuple[str, str], callable] = {
   ("read_object_tree_children", "1"): service_objects_read_object_tree_children_v1,
   ("read_object_tree_detail", "1"): service_objects_read_object_tree_detail_v1,
+  ("upsert_database_table", "1"): service_objects_upsert_database_table_v1,
+  ("delete_database_table", "1"): service_objects_delete_database_table_v1,
+  ("upsert_database_column", "1"): service_objects_upsert_database_column_v1,
+  ("delete_database_column", "1"): service_objects_delete_database_column_v1,
 }

--- a/rpc/service/objects/models.py
+++ b/rpc/service/objects/models.py
@@ -13,3 +13,38 @@ class ServiceObjectsReadDetailParams1(BaseModel):
 
   tableGuid: str
   maxRows: int = 100
+
+
+class ServiceObjectsUpsertDatabaseTableParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  keyGuid: str | None = None
+  name: str
+  schema: str
+
+
+class ServiceObjectsDeleteDatabaseTableParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  keyGuid: str
+
+
+class ServiceObjectsUpsertDatabaseColumnParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  keyGuid: str | None = None
+  tableGuid: str
+  typeGuid: str
+  name: str
+  ordinal: int
+  isNullable: bool
+  isPrimaryKey: bool
+  isIdentity: bool
+  defaultValue: str | None = None
+  maxLength: int | None = None
+
+
+class ServiceObjectsDeleteDatabaseColumnParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  keyGuid: str

--- a/rpc/service/objects/services.py
+++ b/rpc/service/objects/services.py
@@ -4,7 +4,14 @@ from rpc.helpers import unbox_request
 from server.models import RPCResponse
 from server.modules.cms_workbench_module import CmsWorkbenchModule
 
-from .models import ServiceObjectsReadChildrenParams1, ServiceObjectsReadDetailParams1
+from .models import (
+  ServiceObjectsDeleteDatabaseColumnParams1,
+  ServiceObjectsDeleteDatabaseTableParams1,
+  ServiceObjectsReadChildrenParams1,
+  ServiceObjectsReadDetailParams1,
+  ServiceObjectsUpsertDatabaseColumnParams1,
+  ServiceObjectsUpsertDatabaseTableParams1,
+)
 
 
 async def service_objects_read_object_tree_children_v1(request: Request):
@@ -31,6 +38,81 @@ async def service_objects_read_object_tree_detail_v1(request: Request):
   del auth_ctx
 
   result = await module.read_object_tree_detail(params.tableGuid, params.maxRows)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_upsert_database_table_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsUpsertDatabaseTableParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.upsert_database_table(params.keyGuid, params.name, params.schema)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_delete_database_table_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsDeleteDatabaseTableParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.delete_database_table(params.keyGuid)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_upsert_database_column_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsUpsertDatabaseColumnParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.upsert_database_column(
+    params.keyGuid,
+    params.tableGuid,
+    params.typeGuid,
+    params.name,
+    params.ordinal,
+    params.isNullable,
+    params.isPrimaryKey,
+    params.isIdentity,
+    params.defaultValue,
+    params.maxLength,
+  )
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_delete_database_column_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsDeleteDatabaseColumnParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.delete_database_column(params.keyGuid)
 
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/cms_workbench_module.py
+++ b/server/modules/cms_workbench_module.py
@@ -348,3 +348,54 @@ class CmsWorkbenchModule(BaseModule):
       "rowCount": int(payload_row.get("row_count") or 0),
       "rows": rows,
     }
+
+  async def upsert_database_table(self, key_guid: str | None, name: str, schema: str) -> dict[str, bool]:
+    await self._run_query(
+      "cms.database.upsert_table",
+      (key_guid, name, schema),
+    )
+    return {"ok": True}
+
+  async def delete_database_table(self, key_guid: str) -> dict[str, bool]:
+    await self._run_query(
+      "cms.database.delete_table",
+      (key_guid,),
+    )
+    return {"ok": True}
+
+  async def upsert_database_column(
+    self,
+    key_guid: str | None,
+    table_guid: str,
+    type_guid: str,
+    name: str,
+    ordinal: int,
+    is_nullable: bool,
+    is_primary_key: bool,
+    is_identity: bool,
+    default_value: str | None = None,
+    max_length: int | None = None,
+  ) -> dict[str, bool]:
+    await self._run_query(
+      "cms.database.upsert_column",
+      (
+        key_guid,
+        table_guid,
+        type_guid,
+        name,
+        ordinal,
+        is_nullable,
+        is_primary_key,
+        is_identity,
+        default_value,
+        max_length,
+      ),
+    )
+    return {"ok": True}
+
+  async def delete_database_column(self, key_guid: str) -> dict[str, bool]:
+    await self._run_query(
+      "cms.database.delete_column",
+      (key_guid,),
+    )
+    return {"ok": True}


### PR DESCRIPTION
### Motivation

- Provide a first-class metadata editor for the Database category in the Object Tree so users can view and edit table/column metadata without executing DDL.
- Surface a selection context from the Object Tree into the ObjectEditor so an editor can render based on the currently selected category/table/column.
- Add secure server RPCs and data-driven queries to persist metadata edits into the registry tables (`system_objects_database_*`).

### Description

- Introduced a `SelectedNode` state in `Workbench` and exposed `__selectedNode` / `__selectNode` via the `enrichData` enricher so UI components can read and update the active selection (file: `client/src/components/Workbench.tsx`).
- Updated `ObjectTreeView` to separate expand/collapse (chevrons) from label clicks, emit selection contexts for category/table/column into `__selectNode`, and render a green-tinted active selection highlight (file: `client/src/components/ObjectTreeView.tsx`).
- Updated `ObjectEditor` to dispatch `database` category selections to a new `DatabaseBuilder` and show a fallback message for other categories (file: `client/src/components/ObjectEditor.tsx`).
- Added `DatabaseBuilder` (`client/src/components/DatabaseBuilder.tsx`) implementing three context-sensitive views (Table list, Column list, Column detail) with MUI tables/forms and dialog flows, wired to client RPC helpers for upsert/delete operations.
- Added client RPC wrappers for metadata CRUD: `upsertDatabaseTable`, `deleteDatabaseTable`, `upsertDatabaseColumn`, `deleteDatabaseColumn` (file: `client/src/api/rpc.ts`).
- Added Pydantic request models, RPC service handlers, and dispatcher registrations for the new operations under `rpc/service/objects` (files: `rpc/service/objects/models.py`, `rpc/service/objects/services.py`, `rpc/service/objects/__init__.py`).
- Extended `CmsWorkbenchModule` with methods that call data-driven queries (`upsert_database_table`, `delete_database_table`, `upsert_database_column`, `delete_database_column`) so business logic stays in the module layer (file: `server/modules/cms_workbench_module.py`).
- Added a migration `migrations/v0.12.15.0_seed_database_builder_rpc.sql` which seeds the `cms.database.*` query texts, module method registrations, and RPC gateway bindings (SERVICE_ADMIN gated) used by the new server methods.

### Testing

- Ran frontend static type-check with `npm run type-check` (from `client/`) and it succeeded without type errors.
- Verified server and RPC Python sources compile with `python -m py_compile server/modules/cms_workbench_module.py rpc/service/objects/models.py rpc/service/objects/services.py` and the compilation succeeded.
- No browser UI screenshot or runtime end-to-end test was performed in this environment (headless UI validation was not available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc56a85a5083258831931c44c9ed14)