### PR TITLE
Add TypesBuilder UI and types metadata RPC/migration seeds

### DIFF
--- a/client/src/api/rpc.ts
+++ b/client/src/api/rpc.ts
@@ -248,6 +248,35 @@ export async function deleteDatabaseColumn(keyGuid: string): Promise<{ ok: boole
 	return rpcCall<{ ok: boolean }>('urn:service:objects:delete_database_column:1', { keyGuid });
 }
 
+export async function upsertType(payload: {
+	keyGuid?: string | null;
+	name: string;
+	mssqlType: string;
+	postgresqlType?: string | null;
+	mysqlType?: string | null;
+	pythonType: string;
+	typescriptType: string;
+	jsonType: string;
+	odbcTypeCode?: number | null;
+	maxLength?: number | null;
+	notes?: string | null;
+}): Promise<{ ok: boolean }> {
+	return rpcCall<{ ok: boolean }>('urn:service:objects:upsert_type:1', payload);
+}
+
+export async function deleteType(keyGuid: string): Promise<{ ok: boolean }> {
+	return rpcCall<{ ok: boolean }>('urn:service:objects:delete_type:1', { keyGuid });
+}
+
+export async function getTypeControls(
+	typeGuid: string,
+): Promise<{ guid: string; componentName: string; isDefault: boolean }[]> {
+	return rpcCall<{ guid: string; componentName: string; isDefault: boolean }[]>(
+		'urn:service:objects:get_type_controls:1',
+		{ typeGuid },
+	);
+}
+
 export async function getToken(payload: GetTokenPayload): Promise<GetTokenResult> {
 	return rpcCall<GetTokenResult>('urn:auth:session:get_token:1', payload);
 }

--- a/client/src/components/ObjectEditor.tsx
+++ b/client/src/components/ObjectEditor.tsx
@@ -3,6 +3,7 @@ import { Box, Typography } from '@mui/material';
 import type { CmsComponentProps } from '../engine/types';
 import type { SelectedNode } from './Workbench';
 import { DatabaseBuilder } from './DatabaseBuilder';
+import { TypesBuilder } from './TypesBuilder';
 
 export function ObjectEditor({ data, children }: CmsComponentProps): JSX.Element | null {
 	if (data.__devMode !== true) {
@@ -23,6 +24,10 @@ export function ObjectEditor({ data, children }: CmsComponentProps): JSX.Element
 
 	if (selected.categoryName === 'database') {
 		return <DatabaseBuilder data={data} selected={selected} />;
+	}
+
+	if (selected.categoryName === 'types') {
+		return <TypesBuilder data={data} selected={selected} />;
 	}
 
 	return (

--- a/client/src/components/TypesBuilder.tsx
+++ b/client/src/components/TypesBuilder.tsx
@@ -1,0 +1,406 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import {
+	Box,
+	Breadcrumbs,
+	Button,
+	Checkbox,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	IconButton,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableRow,
+	TextField,
+	Typography,
+} from '@mui/material';
+
+import {
+	deleteType,
+	getTypeControls,
+	readObjectTreeDetail,
+	upsertType,
+} from '../api/rpc';
+import type { SelectedNode } from './Workbench';
+
+const TYPES_TABLE_GUID = '73377644-3E86-5FE6-B982-0B224749C358';
+
+interface TypesBuilderProps {
+	data: Record<string, unknown>;
+	selected: SelectedNode;
+}
+
+interface TypeRow {
+	key_guid: string;
+	pub_name: string;
+	pub_mssql_type: string;
+	pub_postgresql_type?: string | null;
+	pub_mysql_type?: string | null;
+	pub_python_type: string;
+	pub_typescript_type: string;
+	pub_json_type: string;
+	pub_odbc_type_code?: number | null;
+	pub_max_length?: number | null;
+	pub_notes?: string | null;
+}
+
+interface TypeControlBinding {
+	guid: string;
+	componentName: string;
+	isDefault: boolean;
+}
+
+interface TypeDraft {
+	keyGuid: string;
+	name: string;
+	mssqlType: string;
+	postgresqlType: string;
+	mysqlType: string;
+	pythonType: string;
+	typescriptType: string;
+	jsonType: string;
+	odbcTypeCode: string;
+	maxLength: string;
+	notes: string;
+}
+
+const EMPTY_DRAFT: TypeDraft = {
+	keyGuid: '',
+	name: '',
+	mssqlType: '',
+	postgresqlType: '',
+	mysqlType: '',
+	pythonType: '',
+	typescriptType: '',
+	jsonType: '',
+	odbcTypeCode: '',
+	maxLength: '',
+	notes: '',
+};
+
+export function TypesBuilder({ data, selected }: TypesBuilderProps): JSX.Element {
+	const selectNode = data.__selectNode as ((node: SelectedNode | null) => void) | undefined;
+	const [types, setTypes] = useState<TypeRow[]>([]);
+	const [bindings, setBindings] = useState<TypeControlBinding[]>([]);
+	const [dialogOpen, setDialogOpen] = useState(false);
+	const [draft, setDraft] = useState<TypeDraft>(EMPTY_DRAFT);
+
+	const selectedType = useMemo(
+		() => types.find((row) => row.key_guid === selected.nodeGuid) ?? null,
+		[types, selected.nodeGuid],
+	);
+
+	const refreshTypes = useCallback(async (): Promise<void> => {
+		const detail = await readObjectTreeDetail(TYPES_TABLE_GUID, 1000);
+		const rows = Array.isArray(detail.rows)
+			? detail.rows.map((row) => {
+					const payload = row as Record<string, unknown>;
+					return {
+						key_guid: String(payload.key_guid ?? ''),
+						pub_name: String(payload.pub_name ?? ''),
+						pub_mssql_type: String(payload.pub_mssql_type ?? ''),
+						pub_postgresql_type: payload.pub_postgresql_type ? String(payload.pub_postgresql_type) : null,
+						pub_mysql_type: payload.pub_mysql_type ? String(payload.pub_mysql_type) : null,
+						pub_python_type: String(payload.pub_python_type ?? ''),
+						pub_typescript_type: String(payload.pub_typescript_type ?? ''),
+						pub_json_type: String(payload.pub_json_type ?? ''),
+						pub_odbc_type_code: payload.pub_odbc_type_code ? Number(payload.pub_odbc_type_code) : null,
+						pub_max_length: payload.pub_max_length ? Number(payload.pub_max_length) : null,
+						pub_notes: payload.pub_notes ? String(payload.pub_notes) : null,
+					};
+				})
+			: [];
+		setTypes(rows);
+	}, []);
+
+	const refreshBindings = useCallback(async (): Promise<void> => {
+		if (!selected.nodeGuid) {
+			setBindings([]);
+			return;
+		}
+		const rows = await getTypeControls(selected.nodeGuid);
+		setBindings(rows);
+	}, [selected.nodeGuid]);
+
+	useEffect(() => {
+		void refreshTypes();
+	}, [refreshTypes]);
+
+	useEffect(() => {
+		void refreshBindings();
+	}, [refreshBindings]);
+
+	const renderFrame = (content: JSX.Element): JSX.Element => (
+		<Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', p: 2, color: '#FFFFFF' }}>{content}</Box>
+	);
+
+	const openEditDialog = (row: TypeRow): void => {
+		setDraft({
+			keyGuid: row.key_guid,
+			name: row.pub_name,
+			mssqlType: row.pub_mssql_type,
+			postgresqlType: row.pub_postgresql_type ?? '',
+			mysqlType: row.pub_mysql_type ?? '',
+			pythonType: row.pub_python_type,
+			typescriptType: row.pub_typescript_type,
+			jsonType: row.pub_json_type,
+			odbcTypeCode: row.pub_odbc_type_code === null || row.pub_odbc_type_code === undefined ? '' : String(row.pub_odbc_type_code),
+			maxLength: row.pub_max_length === null || row.pub_max_length === undefined ? '' : String(row.pub_max_length),
+			notes: row.pub_notes ?? '',
+		});
+		setDialogOpen(true);
+	};
+
+	const saveDraft = async (): Promise<void> => {
+		await upsertType({
+			keyGuid: draft.keyGuid || null,
+			name: draft.name,
+			mssqlType: draft.mssqlType,
+			postgresqlType: draft.postgresqlType || null,
+			mysqlType: draft.mysqlType || null,
+			pythonType: draft.pythonType,
+			typescriptType: draft.typescriptType,
+			jsonType: draft.jsonType,
+			odbcTypeCode: draft.odbcTypeCode === '' ? null : Number(draft.odbcTypeCode),
+			maxLength: draft.maxLength === '' ? null : Number(draft.maxLength),
+			notes: draft.notes || null,
+		});
+		setDialogOpen(false);
+		setDraft(EMPTY_DRAFT);
+		await refreshTypes();
+		if (selected.nodeGuid) {
+			await refreshBindings();
+		}
+	};
+
+	const saveDetail = async (): Promise<void> => {
+		if (!selected.nodeGuid) {
+			return;
+		}
+		await upsertType({
+			keyGuid: selected.nodeGuid,
+			name: draft.name,
+			mssqlType: draft.mssqlType,
+			postgresqlType: draft.postgresqlType || null,
+			mysqlType: draft.mysqlType || null,
+			pythonType: draft.pythonType,
+			typescriptType: draft.typescriptType,
+			jsonType: draft.jsonType,
+			odbcTypeCode: draft.odbcTypeCode === '' ? null : Number(draft.odbcTypeCode),
+			maxLength: draft.maxLength === '' ? null : Number(draft.maxLength),
+			notes: draft.notes || null,
+		});
+		await refreshTypes();
+	};
+
+	useEffect(() => {
+		if (!selectedType) {
+			return;
+		}
+		setDraft({
+			keyGuid: selectedType.key_guid,
+			name: selectedType.pub_name,
+			mssqlType: selectedType.pub_mssql_type,
+			postgresqlType: selectedType.pub_postgresql_type ?? '',
+			mysqlType: selectedType.pub_mysql_type ?? '',
+			pythonType: selectedType.pub_python_type,
+			typescriptType: selectedType.pub_typescript_type,
+			jsonType: selectedType.pub_json_type,
+			odbcTypeCode:
+				selectedType.pub_odbc_type_code === null || selectedType.pub_odbc_type_code === undefined
+					? ''
+					: String(selectedType.pub_odbc_type_code),
+			maxLength:
+				selectedType.pub_max_length === null || selectedType.pub_max_length === undefined
+					? ''
+					: String(selectedType.pub_max_length),
+			notes: selectedType.pub_notes ?? '',
+		});
+	}, [selectedType]);
+
+	if (!selected.nodeGuid) {
+		return renderFrame(
+			<>
+				<Breadcrumbs sx={{ color: '#4CAF50', mb: 1 }}>
+					<Typography color="#4CAF50">Types</Typography>
+				</Breadcrumbs>
+				<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+					<Typography variant="h5">Types</Typography>
+					<Button
+						variant="contained"
+						onClick={() => {
+							setDraft(EMPTY_DRAFT);
+							setDialogOpen(true);
+						}}
+					>
+						New Type
+					</Button>
+				</Box>
+				<Table size="small" sx={{ '& td, & th': { borderColor: '#1A1A1A' } }}>
+					<TableHead>
+						<TableRow>
+							<TableCell>Name</TableCell>
+							<TableCell>MSSQL</TableCell>
+							<TableCell>Python</TableCell>
+							<TableCell>TypeScript</TableCell>
+							<TableCell>JSON</TableCell>
+							<TableCell align="right">Actions</TableCell>
+						</TableRow>
+					</TableHead>
+					<TableBody>
+						{types.map((row) => (
+							<TableRow key={row.key_guid} hover>
+								<TableCell>
+									<Button
+										variant="text"
+										onClick={() =>
+											selectNode?.({
+												categoryGuid: selected.categoryGuid,
+												categoryName: selected.categoryName,
+												nodeGuid: row.key_guid,
+												nodeName: row.pub_name,
+												childGuid: null,
+												childName: null,
+											})
+										}
+									>
+										{row.pub_name}
+									</Button>
+								</TableCell>
+								<TableCell>{row.pub_mssql_type}</TableCell>
+								<TableCell>{row.pub_python_type}</TableCell>
+								<TableCell>{row.pub_typescript_type}</TableCell>
+								<TableCell>{row.pub_json_type}</TableCell>
+								<TableCell align="right">
+									<IconButton onClick={() => openEditDialog(row)}>
+										<EditIcon fontSize="small" />
+									</IconButton>
+									<IconButton
+										onClick={async () => {
+											await deleteType(row.key_guid);
+											await refreshTypes();
+										}}
+									>
+										<DeleteIcon fontSize="small" />
+									</IconButton>
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+				<Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
+					<DialogTitle>{draft.keyGuid ? 'Edit Type' : 'New Type'}</DialogTitle>
+					<DialogContent sx={{ display: 'grid', gap: 1, minWidth: 480, pt: '12px !important' }}>
+						<TextField label="Type Name" value={draft.name} onChange={(event) => setDraft((prev) => ({ ...prev, name: event.target.value }))} />
+						<TextField label="MSSQL Type" value={draft.mssqlType} onChange={(event) => setDraft((prev) => ({ ...prev, mssqlType: event.target.value }))} />
+						<TextField label="PostgreSQL Type" value={draft.postgresqlType} onChange={(event) => setDraft((prev) => ({ ...prev, postgresqlType: event.target.value }))} />
+						<TextField label="MySQL Type" value={draft.mysqlType} onChange={(event) => setDraft((prev) => ({ ...prev, mysqlType: event.target.value }))} />
+						<TextField label="Python Type" value={draft.pythonType} onChange={(event) => setDraft((prev) => ({ ...prev, pythonType: event.target.value }))} />
+						<TextField label="TypeScript Type" value={draft.typescriptType} onChange={(event) => setDraft((prev) => ({ ...prev, typescriptType: event.target.value }))} />
+						<TextField label="JSON Type" value={draft.jsonType} onChange={(event) => setDraft((prev) => ({ ...prev, jsonType: event.target.value }))} />
+						<TextField type="number" label="ODBC Type Code" value={draft.odbcTypeCode} onChange={(event) => setDraft((prev) => ({ ...prev, odbcTypeCode: event.target.value }))} />
+						<TextField type="number" label="Max Length" value={draft.maxLength} onChange={(event) => setDraft((prev) => ({ ...prev, maxLength: event.target.value }))} />
+						<TextField label="Notes" multiline minRows={3} value={draft.notes} onChange={(event) => setDraft((prev) => ({ ...prev, notes: event.target.value }))} />
+					</DialogContent>
+					<DialogActions>
+						<Button onClick={() => setDialogOpen(false)}>Cancel</Button>
+						<Button onClick={() => void saveDraft()} variant="contained">
+							Save
+						</Button>
+					</DialogActions>
+				</Dialog>
+			</>,
+		);
+	}
+
+	return renderFrame(
+		<>
+			<Breadcrumbs sx={{ color: '#4CAF50', mb: 1 }}>
+				<Typography color="#4CAF50">Types</Typography>
+				<Typography color="#4CAF50">{selectedType?.pub_name ?? selected.nodeName ?? ''}</Typography>
+			</Breadcrumbs>
+			<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+				<Typography variant="h5">Type Properties</Typography>
+				<Box sx={{ display: 'flex', gap: 1 }}>
+					<Button
+						variant="outlined"
+						onClick={() =>
+							selectNode?.({
+								categoryGuid: selected.categoryGuid,
+								categoryName: selected.categoryName,
+								nodeGuid: null,
+								nodeName: null,
+								childGuid: null,
+								childName: null,
+							})
+						}
+					>
+						Back
+					</Button>
+					<Button variant="contained" onClick={() => void saveDetail()}>
+						Save
+					</Button>
+					<Button
+						color="error"
+						variant="outlined"
+						onClick={async () => {
+							if (!selected.nodeGuid) {
+								return;
+							}
+							await deleteType(selected.nodeGuid);
+							await refreshTypes();
+							selectNode?.({
+								categoryGuid: selected.categoryGuid,
+								categoryName: selected.categoryName,
+								nodeGuid: null,
+								nodeName: null,
+								childGuid: null,
+								childName: null,
+							});
+						}}
+					>
+						Delete
+					</Button>
+				</Box>
+			</Box>
+			<Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(220px, 1fr))', gap: 1, maxWidth: 900, mb: 2 }}>
+				<TextField label="Type Name" value={draft.name} onChange={(event) => setDraft((prev) => ({ ...prev, name: event.target.value }))} />
+				<TextField label="MSSQL Type" value={draft.mssqlType} onChange={(event) => setDraft((prev) => ({ ...prev, mssqlType: event.target.value }))} />
+				<TextField label="PostgreSQL Type" value={draft.postgresqlType} onChange={(event) => setDraft((prev) => ({ ...prev, postgresqlType: event.target.value }))} />
+				<TextField label="MySQL Type" value={draft.mysqlType} onChange={(event) => setDraft((prev) => ({ ...prev, mysqlType: event.target.value }))} />
+				<TextField label="Python Type" value={draft.pythonType} onChange={(event) => setDraft((prev) => ({ ...prev, pythonType: event.target.value }))} />
+				<TextField label="TypeScript Type" value={draft.typescriptType} onChange={(event) => setDraft((prev) => ({ ...prev, typescriptType: event.target.value }))} />
+				<TextField label="JSON Type" value={draft.jsonType} onChange={(event) => setDraft((prev) => ({ ...prev, jsonType: event.target.value }))} />
+				<TextField type="number" label="ODBC Type Code" value={draft.odbcTypeCode} onChange={(event) => setDraft((prev) => ({ ...prev, odbcTypeCode: event.target.value }))} />
+				<TextField type="number" label="Max Length" value={draft.maxLength} onChange={(event) => setDraft((prev) => ({ ...prev, maxLength: event.target.value }))} />
+				<TextField label="Notes" multiline minRows={3} value={draft.notes} onChange={(event) => setDraft((prev) => ({ ...prev, notes: event.target.value }))} sx={{ gridColumn: '1 / -1' }} />
+			</Box>
+			<Typography variant="h6" sx={{ mb: 1 }}>
+				Component Bindings
+			</Typography>
+			<Table size="small" sx={{ maxWidth: 700, '& td, & th': { borderColor: '#1A1A1A' } }}>
+				<TableHead>
+					<TableRow>
+						<TableCell>Component</TableCell>
+						<TableCell>Is Default</TableCell>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					{bindings.map((binding) => (
+						<TableRow key={binding.guid} hover>
+							<TableCell>{binding.componentName}</TableCell>
+							<TableCell>
+								<Checkbox checked={binding.isDefault} disabled size="small" />
+							</TableCell>
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
+		</>,
+	);
+}

--- a/migrations/v0.12.16.0_seed_types_builder_rpc.sql
+++ b/migrations/v0.12.16.0_seed_types_builder_rpc.sql
@@ -1,0 +1,154 @@
+-- =============================================================================
+-- v0.12.16.0_seed_types_builder_rpc
+-- Date: 2026-04-13
+-- Purpose:
+--   1) Seed type metadata queries for CmsWorkbenchModule
+--   2) Register CmsWorkbenchModule type methods
+--   3) Register RPC gateway bindings for type metadata operations
+--
+-- UUID5 namespace: DECAFBAD-CAFE-FADE-BABE-C0FFEE420B67
+--   query:cms.types.upsert_type                -> 85F84FE7-623D-5F58-B8DB-72C5687AD9BB
+--   query:cms.types.delete_type                -> 3A0A9050-D079-51F6-A363-7E185FE464FA
+--   query:cms.types.get_type_controls          -> C74E7A3F-2CFE-56FB-BE1D-B296599D44E3
+--   CmsWorkbenchModule.upsert_type             -> 60C88DA3-79BD-5BD9-BF5F-C16671FFDC84
+--   CmsWorkbenchModule.delete_type             -> 6E075002-1B6C-5BD4-BC73-6F9BB8ECD5B9
+--   CmsWorkbenchModule.get_type_controls       -> A393E831-CA69-5F00-89A4-1FE5378CEE12
+--   binding:urn:service:objects:upsert_type:1 -> DA6501ED-B272-54AE-BBE6-A35AD58B3F0F
+--   binding:urn:service:objects:delete_type:1 -> 00560E3A-201C-582D-B3EB-38C7608498B9
+--   binding:urn:service:objects:get_type_controls:1 -> D03F2FAA-89C7-562D-9138-DB79CFC134F3
+-- =============================================================================
+
+MERGE INTO [dbo].[system_objects_queries] AS target
+USING (
+  SELECT
+    N'85F84FE7-623D-5F58-B8DB-72C5687AD9BB' AS [key_guid],
+    N'cms.types.upsert_type' AS [pub_name],
+    N'MERGE INTO [dbo].[system_objects_types] AS target
+USING (SELECT
+  TRY_CAST(? AS UNIQUEIDENTIFIER) AS key_guid,
+  ? AS pub_name,
+  ? AS pub_mssql_type,
+  ? AS pub_postgresql_type,
+  ? AS pub_mysql_type,
+  ? AS pub_python_type,
+  ? AS pub_typescript_type,
+  ? AS pub_json_type,
+  TRY_CAST(? AS INT) AS pub_odbc_type_code,
+  TRY_CAST(? AS INT) AS pub_max_length,
+  ? AS pub_notes
+) AS source
+ON target.key_guid = source.key_guid
+WHEN MATCHED THEN
+  UPDATE SET
+    pub_name = source.pub_name,
+    pub_mssql_type = source.pub_mssql_type,
+    pub_postgresql_type = source.pub_postgresql_type,
+    pub_mysql_type = source.pub_mysql_type,
+    pub_python_type = source.pub_python_type,
+    pub_typescript_type = source.pub_typescript_type,
+    pub_json_type = source.pub_json_type,
+    pub_odbc_type_code = source.pub_odbc_type_code,
+    pub_max_length = source.pub_max_length,
+    pub_notes = source.pub_notes,
+    priv_modified_on = SYSUTCDATETIME()
+WHEN NOT MATCHED THEN
+  INSERT (key_guid, pub_name, pub_mssql_type, pub_postgresql_type, pub_mysql_type, pub_python_type, pub_typescript_type, pub_json_type, pub_odbc_type_code, pub_max_length, pub_notes)
+  VALUES (ISNULL(source.key_guid, NEWID()), source.pub_name, source.pub_mssql_type, source.pub_postgresql_type, source.pub_mysql_type, source.pub_python_type, source.pub_typescript_type, source.pub_json_type, source.pub_odbc_type_code, source.pub_max_length, source.pub_notes);' AS [pub_query_text],
+    N'Upsert type metadata in system_objects_types.' AS [pub_description],
+    N'CF85FB11-5981-56B7-8E43-9D453E611D43' AS [ref_module_guid],
+    1 AS [pub_is_parameterized],
+    N'key_guid,name,mssql_type,postgresql_type,mysql_type,python_type,typescript_type,json_type,odbc_type_code,max_length,notes' AS [pub_parameter_names]
+
+  UNION ALL SELECT
+    N'3A0A9050-D079-51F6-A363-7E185FE464FA',
+    N'cms.types.delete_type',
+    N'DELETE FROM [dbo].[system_objects_types]
+WHERE key_guid = TRY_CAST(? AS UNIQUEIDENTIFIER);',
+    N'Delete type metadata row.',
+    N'CF85FB11-5981-56B7-8E43-9D453E611D43',
+    1,
+    N'key_guid'
+
+  UNION ALL SELECT
+    N'C74E7A3F-2CFE-56FB-BE1D-B296599D44E3',
+    N'cms.types.get_type_controls',
+    N'SELECT
+  tc.key_guid AS guid,
+  c.pub_name AS componentName,
+  tc.pub_is_default AS isDefault
+FROM system_objects_type_controls tc
+JOIN system_objects_components c ON c.key_guid = tc.ref_component_guid
+WHERE tc.ref_type_guid = TRY_CAST(? AS UNIQUEIDENTIFIER)
+ORDER BY c.pub_name
+FOR JSON PATH, INCLUDE_NULL_VALUES;',
+    N'Read default component bindings for a type.',
+    N'CF85FB11-5981-56B7-8E43-9D453E611D43',
+    1,
+    N'type_guid'
+
+) AS source ([key_guid], [pub_name], [pub_query_text], [pub_description], [ref_module_guid], [pub_is_parameterized], [pub_parameter_names])
+ON target.[key_guid] = TRY_CAST(source.[key_guid] AS UNIQUEIDENTIFIER)
+WHEN MATCHED THEN
+  UPDATE SET
+    [pub_name] = source.[pub_name],
+    [pub_query_text] = source.[pub_query_text],
+    [pub_description] = source.[pub_description],
+    [pub_is_parameterized] = source.[pub_is_parameterized],
+    [pub_parameter_names] = source.[pub_parameter_names],
+    [priv_modified_on] = SYSUTCDATETIME()
+WHEN NOT MATCHED THEN
+  INSERT ([key_guid], [pub_name], [pub_query_text], [pub_description], [ref_module_guid], [pub_is_parameterized], [pub_parameter_names])
+  VALUES (
+    TRY_CAST(source.[key_guid] AS UNIQUEIDENTIFIER),
+    source.[pub_name],
+    source.[pub_query_text],
+    source.[pub_description],
+    TRY_CAST(source.[ref_module_guid] AS UNIQUEIDENTIFIER),
+    source.[pub_is_parameterized],
+    source.[pub_parameter_names]
+  );
+GO
+
+INSERT INTO [dbo].[system_objects_module_methods]
+  ([key_guid], [ref_module_guid], [pub_name], [pub_description], [pub_is_active])
+SELECT
+  source.[key_guid],
+  source.[ref_module_guid],
+  source.[pub_name],
+  source.[pub_description],
+  CAST(1 AS BIT)
+FROM (VALUES
+  (N'60C88DA3-79BD-5BD9-BF5F-C16671FFDC84', N'CF85FB11-5981-56B7-8E43-9D453E611D43', N'upsert_type', N'Upsert type metadata.'),
+  (N'6E075002-1B6C-5BD4-BC73-6F9BB8ECD5B9', N'CF85FB11-5981-56B7-8E43-9D453E611D43', N'delete_type', N'Delete type metadata.'),
+  (N'A393E831-CA69-5F00-89A4-1FE5378CEE12', N'CF85FB11-5981-56B7-8E43-9D453E611D43', N'get_type_controls', N'Read type control bindings metadata.')
+) AS source([key_guid], [ref_module_guid], [pub_name], [pub_description])
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM [dbo].[system_objects_module_methods] methods
+  WHERE methods.[key_guid] = source.[key_guid]
+);
+GO
+
+INSERT INTO [dbo].[system_objects_gateway_method_bindings]
+  ([key_guid], [ref_gateway_guid], [pub_operation_name], [ref_method_guid], [pub_required_scope], [ref_required_role_guid], [ref_required_entitlement_guid], [pub_is_read_only], [pub_is_active])
+SELECT
+  source.[key_guid],
+  source.[ref_gateway_guid],
+  source.[pub_operation_name],
+  source.[ref_method_guid],
+  source.[pub_required_scope],
+  source.[ref_required_role_guid],
+  source.[ref_required_entitlement_guid],
+  source.[pub_is_read_only],
+  CAST(1 AS BIT)
+FROM (VALUES
+  (N'DA6501ED-B272-54AE-BBE6-A35AD58B3F0F', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:service:objects:upsert_type:1', N'60C88DA3-79BD-5BD9-BF5F-C16671FFDC84', CAST(NULL AS NVARCHAR(128)), N'E8E1A4CC-0898-59F4-8B03-B2C9804516C0', CAST(NULL AS UNIQUEIDENTIFIER), CAST(0 AS BIT)),
+  (N'00560E3A-201C-582D-B3EB-38C7608498B9', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:service:objects:delete_type:1', N'6E075002-1B6C-5BD4-BC73-6F9BB8ECD5B9', CAST(NULL AS NVARCHAR(128)), N'E8E1A4CC-0898-59F4-8B03-B2C9804516C0', CAST(NULL AS UNIQUEIDENTIFIER), CAST(0 AS BIT)),
+  (N'D03F2FAA-89C7-562D-9138-DB79CFC134F3', N'606C04E3-44F1-593D-9C8B-8006E0A377D3', N'urn:service:objects:get_type_controls:1', N'A393E831-CA69-5F00-89A4-1FE5378CEE12', CAST(NULL AS NVARCHAR(128)), N'E8E1A4CC-0898-59F4-8B03-B2C9804516C0', CAST(NULL AS UNIQUEIDENTIFIER), CAST(1 AS BIT))
+) AS source([key_guid], [ref_gateway_guid], [pub_operation_name], [ref_method_guid], [pub_required_scope], [ref_required_role_guid], [ref_required_entitlement_guid], [pub_is_read_only])
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM [dbo].[system_objects_gateway_method_bindings] bindings
+  WHERE bindings.[key_guid] = source.[key_guid]
+);
+GO

--- a/rpc/service/objects/__init__.py
+++ b/rpc/service/objects/__init__.py
@@ -6,10 +6,13 @@ Requires ROLE_SERVICE_ADMIN.
 from .services import (
   service_objects_delete_database_column_v1,
   service_objects_delete_database_table_v1,
+  service_objects_delete_type_v1,
+  service_objects_get_type_controls_v1,
   service_objects_read_object_tree_children_v1,
   service_objects_read_object_tree_detail_v1,
   service_objects_upsert_database_column_v1,
   service_objects_upsert_database_table_v1,
+  service_objects_upsert_type_v1,
 )
 
 
@@ -20,4 +23,7 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("delete_database_table", "1"): service_objects_delete_database_table_v1,
   ("upsert_database_column", "1"): service_objects_upsert_database_column_v1,
   ("delete_database_column", "1"): service_objects_delete_database_column_v1,
+  ("upsert_type", "1"): service_objects_upsert_type_v1,
+  ("delete_type", "1"): service_objects_delete_type_v1,
+  ("get_type_controls", "1"): service_objects_get_type_controls_v1,
 }

--- a/rpc/service/objects/models.py
+++ b/rpc/service/objects/models.py
@@ -48,3 +48,31 @@ class ServiceObjectsDeleteDatabaseColumnParams1(BaseModel):
   model_config = ConfigDict(extra="forbid")
 
   keyGuid: str
+
+
+class ServiceObjectsUpsertTypeParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  keyGuid: str | None = None
+  name: str
+  mssqlType: str
+  postgresqlType: str | None = None
+  mysqlType: str | None = None
+  pythonType: str
+  typescriptType: str
+  jsonType: str
+  odbcTypeCode: int | None = None
+  maxLength: int | None = None
+  notes: str | None = None
+
+
+class ServiceObjectsDeleteTypeParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  keyGuid: str
+
+
+class ServiceObjectsGetTypeControlsParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  typeGuid: str

--- a/rpc/service/objects/services.py
+++ b/rpc/service/objects/services.py
@@ -7,10 +7,13 @@ from server.modules.cms_workbench_module import CmsWorkbenchModule
 from .models import (
   ServiceObjectsDeleteDatabaseColumnParams1,
   ServiceObjectsDeleteDatabaseTableParams1,
+  ServiceObjectsDeleteTypeParams1,
+  ServiceObjectsGetTypeControlsParams1,
   ServiceObjectsReadChildrenParams1,
   ServiceObjectsReadDetailParams1,
   ServiceObjectsUpsertDatabaseColumnParams1,
   ServiceObjectsUpsertDatabaseTableParams1,
+  ServiceObjectsUpsertTypeParams1,
 )
 
 
@@ -113,6 +116,66 @@ async def service_objects_delete_database_column_v1(request: Request):
   del auth_ctx
 
   result = await module.delete_database_column(params.keyGuid)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_upsert_type_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsUpsertTypeParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.upsert_type(
+    params.keyGuid,
+    params.name,
+    params.mssqlType,
+    params.postgresqlType,
+    params.mysqlType,
+    params.pythonType,
+    params.typescriptType,
+    params.jsonType,
+    params.odbcTypeCode,
+    params.maxLength,
+    params.notes,
+  )
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_delete_type_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsDeleteTypeParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.delete_type(params.keyGuid)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_get_type_controls_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsGetTypeControlsParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.get_type_controls(params.typeGuid)
 
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/cms_workbench_module.py
+++ b/server/modules/cms_workbench_module.py
@@ -399,3 +399,49 @@ class CmsWorkbenchModule(BaseModule):
       (key_guid,),
     )
     return {"ok": True}
+
+  async def upsert_type(
+    self,
+    key_guid: str | None,
+    name: str,
+    mssql_type: str,
+    postgresql_type: str | None,
+    mysql_type: str | None,
+    python_type: str,
+    typescript_type: str,
+    json_type: str,
+    odbc_type_code: int | None,
+    max_length: int | None,
+    notes: str | None,
+  ) -> dict[str, bool]:
+    await self._run_query(
+      "cms.types.upsert_type",
+      (
+        key_guid,
+        name,
+        mssql_type,
+        postgresql_type,
+        mysql_type,
+        python_type,
+        typescript_type,
+        json_type,
+        odbc_type_code,
+        max_length,
+        notes,
+      ),
+    )
+    return {"ok": True}
+
+  async def delete_type(self, key_guid: str) -> dict[str, bool]:
+    await self._run_query(
+      "cms.types.delete_type",
+      (key_guid,),
+    )
+    return {"ok": True}
+
+  async def get_type_controls(self, type_guid: str) -> list[dict[str, Any]]:
+    result = await self._run_query(
+      "cms.types.get_type_controls",
+      (type_guid,),
+    )
+    return [dict(row) for row in (result.rows if result else [])]


### PR DESCRIPTION
### Motivation
- Add a Types metadata editor to the Object Editor so admins can list, create, edit, and delete scalar types and inspect their default component bindings.
- Provide server-side RPC endpoints and module methods to persist type metadata and to read type→component bindings from the metadata tables.
- Seed the database reflection tables with the parameterized queries and RPC gateway bindings needed to expose the operations through the existing RPC gateway.

### Description
- New UI: `client/src/components/TypesBuilder.tsx` implements the Types list view and Type detail editor (create/edit/delete/back) and a read-only Component Bindings table, following the existing DatabaseBuilder patterns and using table GUID `73377644-3E86-5FE6-B982-0B224749C358`.
- Client RPC: added `upsertType`, `deleteType`, and `getTypeControls` helpers to `client/src/api/rpc.ts` and wired `TypesBuilder` into `ObjectEditor.tsx` so the editor shows for the `types` category.
- Server module: added `upsert_type`, `delete_type`, and `get_type_controls` methods to `CmsWorkbenchModule` (`server/modules/cms_workbench_module.py`) that call the corresponding parameterized queries via the query registry.
- RPC layer: added Pydantic models and service handlers in `rpc/service/objects/models.py` and `rpc/service/objects/services.py`, and registered the new dispatchers in `rpc/service/objects/__init__.py` to expose `upsert_type`, `delete_type`, and `get_type_controls` under the objects service.
- Migration seed: new `migrations/v0.12.16.0_seed_types_builder_rpc.sql` seeds three queries (`cms.types.upsert_type`, `cms.types.delete_type`, `cms.types.get_type_controls`), registers the module methods, and inserts RPC gateway method bindings (SERVICE_ADMIN gated) for the new URNs.

### Testing
- Ran the unified harness with `python scripts/run_tests.py` which completed successfully (server tests passed); local compile checks for modified Python modules passed via `python -m compileall`.
- Frontend checks: `cd client && npm run lint` and `cd client && npm run type-check` both completed successfully; lint produced only pre-existing warnings in `DatabaseBuilder.tsx` and `UserContextProvider.tsx` but no new errors.
- Frontend unit test run completed (`npm test`), and the added TypeScript code type-checked with `tsc --noEmit` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc60c7d3f08325ad85312b119f0fc8)