### PR TITLE
Add CmsWorkbench module-method CRUD methods and RPC dispatch wiring

### DIFF
--- a/rpc/service/objects/__init__.py
+++ b/rpc/service/objects/__init__.py
@@ -6,12 +6,17 @@ Requires ROLE_SERVICE_ADMIN.
 from .services import (
   service_objects_delete_database_column_v1,
   service_objects_delete_database_table_v1,
+  service_objects_delete_module_method_v1,
   service_objects_delete_type_v1,
+  service_objects_get_method_contract_v1,
+  service_objects_get_module_methods_v1,
   service_objects_get_type_controls_v1,
   service_objects_read_object_tree_children_v1,
   service_objects_read_object_tree_detail_v1,
   service_objects_upsert_database_column_v1,
   service_objects_upsert_database_table_v1,
+  service_objects_upsert_module_method_v1,
+  service_objects_upsert_module_v1,
   service_objects_upsert_type_v1,
 )
 
@@ -26,4 +31,9 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("upsert_type", "1"): service_objects_upsert_type_v1,
   ("delete_type", "1"): service_objects_delete_type_v1,
   ("get_type_controls", "1"): service_objects_get_type_controls_v1,
+  ("get_module_methods", "1"): service_objects_get_module_methods_v1,
+  ("upsert_module", "1"): service_objects_upsert_module_v1,
+  ("upsert_module_method", "1"): service_objects_upsert_module_method_v1,
+  ("delete_module_method", "1"): service_objects_delete_module_method_v1,
+  ("get_method_contract", "1"): service_objects_get_method_contract_v1,
 }

--- a/rpc/service/objects/models.py
+++ b/rpc/service/objects/models.py
@@ -76,3 +76,39 @@ class ServiceObjectsGetTypeControlsParams1(BaseModel):
   model_config = ConfigDict(extra="forbid")
 
   typeGuid: str
+
+
+class ServiceObjectsGetModuleMethodsParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  moduleGuid: str
+
+
+class ServiceObjectsUpsertModuleParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  keyGuid: str
+  description: str | None = None
+  isActive: bool
+
+
+class ServiceObjectsUpsertModuleMethodParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  keyGuid: str | None = None
+  moduleGuid: str
+  name: str
+  description: str | None = None
+  isActive: bool
+
+
+class ServiceObjectsDeleteModuleMethodParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  keyGuid: str
+
+
+class ServiceObjectsGetMethodContractParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  methodGuid: str

--- a/rpc/service/objects/services.py
+++ b/rpc/service/objects/services.py
@@ -7,12 +7,17 @@ from server.modules.cms_workbench_module import CmsWorkbenchModule
 from .models import (
   ServiceObjectsDeleteDatabaseColumnParams1,
   ServiceObjectsDeleteDatabaseTableParams1,
+  ServiceObjectsDeleteModuleMethodParams1,
   ServiceObjectsDeleteTypeParams1,
+  ServiceObjectsGetMethodContractParams1,
+  ServiceObjectsGetModuleMethodsParams1,
   ServiceObjectsGetTypeControlsParams1,
   ServiceObjectsReadChildrenParams1,
   ServiceObjectsReadDetailParams1,
   ServiceObjectsUpsertDatabaseColumnParams1,
   ServiceObjectsUpsertDatabaseTableParams1,
+  ServiceObjectsUpsertModuleMethodParams1,
+  ServiceObjectsUpsertModuleParams1,
   ServiceObjectsUpsertTypeParams1,
 )
 
@@ -176,6 +181,92 @@ async def service_objects_get_type_controls_v1(request: Request):
   del auth_ctx
 
   result = await module.get_type_controls(params.typeGuid)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_get_module_methods_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsGetModuleMethodsParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.get_module_methods(params.moduleGuid)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_upsert_module_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsUpsertModuleParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.upsert_module(params.keyGuid, params.description, params.isActive)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_upsert_module_method_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsUpsertModuleMethodParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.upsert_module_method(
+    params.keyGuid,
+    params.moduleGuid,
+    params.name,
+    params.description,
+    params.isActive,
+  )
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_delete_module_method_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsDeleteModuleMethodParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.delete_module_method(params.keyGuid)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_get_method_contract_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsGetMethodContractParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.get_method_contract(params.methodGuid)
 
   return RPCResponse(
     op=rpc_request.op,

--- a/server/modules/cms_workbench_module.py
+++ b/server/modules/cms_workbench_module.py
@@ -445,3 +445,46 @@ class CmsWorkbenchModule(BaseModule):
       (type_guid,),
     )
     return [dict(row) for row in (result.rows if result else [])]
+
+  async def get_module_methods(self, module_guid: str) -> list[dict[str, Any]]:
+    """Return methods for a module with joined model names."""
+    result = await self._run_query("cms.modules.get_methods", (module_guid,))
+    return [dict(row) for row in (result.rows if result else [])]
+
+  async def upsert_module(
+    self,
+    key_guid: str,
+    description: str | None,
+    is_active: bool,
+  ) -> dict[str, bool]:
+    """Update module description and is_active. Modules are code-loaded - no INSERT."""
+    await self._run_query(
+      "cms.modules.upsert_module",
+      (description, is_active, key_guid),
+    )
+    return {"ok": True}
+
+  async def upsert_module_method(
+    self,
+    key_guid: str | None,
+    module_guid: str,
+    name: str,
+    description: str | None,
+    is_active: bool,
+  ) -> dict[str, bool]:
+    """Insert or update a module method."""
+    await self._run_query(
+      "cms.modules.upsert_method",
+      (key_guid, module_guid, name, description, is_active),
+    )
+    return {"ok": True}
+
+  async def delete_module_method(self, key_guid: str) -> dict[str, bool]:
+    """Delete a module method by GUID."""
+    await self._run_query("cms.modules.delete_method", (key_guid,))
+    return {"ok": True}
+
+  async def get_method_contract(self, method_guid: str) -> list[dict[str, Any]]:
+    """Return contract info for a method, if one exists."""
+    result = await self._run_query("cms.modules.get_method_contract", (method_guid,))
+    return [dict(row) for row in (result.rows if result else [])]


### PR DESCRIPTION
### Motivation

- Expose CRUD operations and contract lookup for CMS module methods through the existing RPC `service:objects` surface so tooling can list, update, create, and remove module methods. 
- Keep data access data-driven via the `system_objects_queries` table and follow the established module/service dispatch patterns used elsewhere in the objects namespace.

### Description

- Added five module methods to `CmsWorkbenchModule`: `get_module_methods`, `upsert_module`, `upsert_module_method`, `delete_module_method`, and `get_method_contract`, all routing DB calls through `self._run_query` with `cms.modules.*` query keys. 
- Added request payload Pydantic models in `rpc/service/objects/models.py` (`ServiceObjectsGetModuleMethodsParams1`, `ServiceObjectsUpsertModuleParams1`, `ServiceObjectsUpsertModuleMethodParams1`, `ServiceObjectsDeleteModuleMethodParams1`, `ServiceObjectsGetMethodContractParams1`) each using `ConfigDict(extra="forbid")`. 
- Implemented service router functions in `rpc/service/objects/services.py` following the canonical pattern (`unbox_request`, validate params, resolve `module`, `await module.on_ready()`, call module method, return `RPCResponse`). 
- Wired the new service functions into `rpc/service/objects/__init__.py` by importing them and adding dispatcher entries for the new operations and versions, exposing the URNs `urn:service:objects:get_module_methods:1`, `urn:service:objects:upsert_module:1`, `urn:service:objects:upsert_module_method:1`, `urn:service:objects:delete_module_method:1`, and `urn:service:objects:get_method_contract:1`.

### Testing

- Compiled the modified Python modules with `python -m compileall server/modules/cms_workbench_module.py rpc/service/objects` and the files compiled successfully. 
- No additional automated tests were added or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8112a3908325a59a2b23c106a1d6)