### PR TITLE
Update object tree category loading for paramless query and depth-aware expansion

### DIFF
--- a/client/src/api/rpc.ts
+++ b/client/src/api/rpc.ts
@@ -41,6 +41,7 @@ export interface ObjectTreeCategory {
 	display: string;
 	icon: string | null;
 	sequence: number;
+	treeDepth: number;
 }
 
 export interface ObjectTreeTable {

--- a/client/src/components/ObjectTreeView.tsx
+++ b/client/src/components/ObjectTreeView.tsx
@@ -264,9 +264,13 @@ export function ObjectTreeView({ data }: CmsComponentProps): JSX.Element | null 
 										return (
 											<Box key={table.guid}>
 												<Box sx={{ display: 'flex', alignItems: 'center' }}>
-													<IconButton size="small" onClick={() => void toggleNode(category.guid, table.guid, table.guid)} sx={{ color: '#BBBBBB', width: 22, height: 22 }}>
-														{tableState.expanded ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
-													</IconButton>
+													{category.treeDepth >= 2 ? (
+														<IconButton size="small" onClick={() => void toggleNode(category.guid, table.guid, table.guid)} sx={{ color: '#BBBBBB', width: 22, height: 22 }}>
+															{tableState.expanded ? <ExpandMoreIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+														</IconButton>
+													) : (
+														<Box sx={{ width: 22, height: 22 }} />
+													)}
 													<ListItemButton
 														onClick={() =>
 															selectNode?.({
@@ -286,7 +290,7 @@ export function ObjectTreeView({ data }: CmsComponentProps): JSX.Element | null 
 														{renderNodeText(table.name, '#BBBBBB')}
 													</ListItemButton>
 												</Box>
-												{tableState.expanded ? (
+												{category.treeDepth >= 2 && tableState.expanded ? (
 													<Box sx={{ pl: '24px' }}>
 														{tableColumns?.map((column) => {
 															const isColumnSelected =

--- a/server/modules/cms_workbench_module.py
+++ b/server/modules/cms_workbench_module.py
@@ -233,10 +233,7 @@ class CmsWorkbenchModule(BaseModule):
     return await run_json_many(sql, params)
 
   async def read_object_tree_categories(self) -> list[dict[str, Any]]:
-    result = await self._run_query(
-      "cms.object_tree.get_categories",
-      ("9E735725-2EFF-5978-B92F-73A6CB36DF7F",),
-    )
+    result = await self._run_query("cms.object_tree.get_categories")
     return [dict(row) for row in (result.rows if result else [])]
 
   async def read_object_tree_children(


### PR DESCRIPTION
### Motivation
- The backend query `cms.object_tree.get_categories` was updated to take no parameters, so the server call must stop passing the legacy GUID parameter.
- The UI needs to know category depth to decide whether table rows are expandable, so the client RPC model must expose a `treeDepth` field.

### Description
- Changed `CmsWorkbenchModule.read_object_tree_categories()` to call `await self._run_query("cms.object_tree.get_categories")` with no params. 
- Added `treeDepth: number` to the `ObjectTreeCategory` interface in `client/src/api/rpc.ts` so the frontend can consume depth metadata. 
- Updated `client/src/components/ObjectTreeView.tsx` to only render the table-level expand chevron and child rows when `category.treeDepth >= 2`, otherwise tables are rendered as leaf rows with no chevron. 
- Modified `ObjectTreeView` logic uses `category.treeDepth` alongside existing `tableState.expanded` to gate child rendering.

### Testing
- Ran the unified test harness via `python scripts/run_tests.py`, which completed successfully and reported `1 passed` for the test suite. 
- The frontend type-check (`tsc`) and unit test run completed as part of the harness and showed no failures, while `eslint` reported two unrelated warnings in other files. 
- No additional automated tests were added or changed for these modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0118f7f88325bd7810b8c45470d5)