### PR TITLE
Fix ObjectTreeCategory1 treeDepth and description fields

### DIFF
--- a/rpc/public/route/models.py
+++ b/rpc/public/route/models.py
@@ -32,6 +32,8 @@ class ObjectTreeCategory1(BaseModel):
   display: str | None = None
   icon: str | None = None
   sequence: int
+  treeDepth: int = 1
+  description: str | None = None
 
 
 PathNode1.model_rebuild()


### PR DESCRIPTION
### Motivation

- The categories RPC response was losing `treeDepth` and `description` because the Pydantic model `ObjectTreeCategory1` omitted them, causing client-side depth checks to fail and UI expand chevrons to disappear.

### Description

- Add `treeDepth: int = 1` and `description: str | None = None` to the `ObjectTreeCategory1` model in `rpc/public/route/models.py` so RPC serialization preserves these fields.

### Testing

- Ran `python -m pytest tests -q` which passed (`1 passed`).
- Ran `python -m pytest tests -k object_tree -q` which had no matching tests (`1 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0a9e2738832582c80cf75dc76853)