### PR TITLE
Add dynamic builder dispatch via builderComponent

### DIFF
--- a/client/src/api/rpc.ts
+++ b/client/src/api/rpc.ts
@@ -42,6 +42,7 @@ export interface ObjectTreeCategory {
 	icon: string | null;
 	sequence: number;
 	treeDepth: number;
+	builderComponent: string | null;
 }
 
 export interface ObjectTreeTable {

--- a/client/src/components/ObjectEditor.tsx
+++ b/client/src/components/ObjectEditor.tsx
@@ -2,9 +2,7 @@ import { Box, Typography } from '@mui/material';
 
 import type { CmsComponentProps } from '../engine/types';
 import type { SelectedNode } from './Workbench';
-import { DatabaseBuilder } from './DatabaseBuilder';
-import { ModulesBuilder } from './ModulesBuilder';
-import { TypesBuilder } from './TypesBuilder';
+import { COMPONENT_REGISTRY } from '../engine/registry';
 
 export function ObjectEditor({ data, children }: CmsComponentProps): JSX.Element | null {
 	if (data.__devMode !== true) {
@@ -23,16 +21,12 @@ export function ObjectEditor({ data, children }: CmsComponentProps): JSX.Element
 		);
 	}
 
-	if (selected.categoryName === 'database') {
-		return <DatabaseBuilder data={data} selected={selected} />;
-	}
-
-	if (selected.categoryName === 'types') {
-		return <TypesBuilder data={data} selected={selected} />;
-	}
-
-	if (selected.categoryName === 'modules') {
-		return <ModulesBuilder data={data} selected={selected} />;
+	if (selected.builderComponent) {
+		const BuilderComponent = COMPONENT_REGISTRY[selected.builderComponent];
+		if (BuilderComponent) {
+			const builderProps = { data, selected } as any;
+			return <BuilderComponent {...builderProps} />;
+		}
 	}
 
 	return (

--- a/client/src/components/ObjectTreeView.tsx
+++ b/client/src/components/ObjectTreeView.tsx
@@ -241,6 +241,7 @@ export function ObjectTreeView({ data }: CmsComponentProps): JSX.Element | null 
 											nodeName: null,
 											childGuid: null,
 											childName: null,
+											builderComponent: category.builderComponent ?? null,
 										})
 									}
 									sx={rowSx(isCategorySelected, '#FFFFFF')}
@@ -280,6 +281,7 @@ export function ObjectTreeView({ data }: CmsComponentProps): JSX.Element | null 
 																nodeName: table.name,
 																childGuid: null,
 																childName: null,
+																builderComponent: category.builderComponent ?? null,
 															})
 														}
 														sx={rowSx(isTableSelected, '#BBBBBB')}
@@ -306,6 +308,7 @@ export function ObjectTreeView({ data }: CmsComponentProps): JSX.Element | null 
 																			nodeName: table.name,
 																			childGuid: column.guid,
 																			childName: column.name,
+																			builderComponent: category.builderComponent ?? null,
 																		})
 																	}
 																	sx={rowSx(isColumnSelected, '#888888')}

--- a/client/src/components/Workbench.tsx
+++ b/client/src/components/Workbench.tsx
@@ -11,6 +11,7 @@ export interface SelectedNode {
 	nodeName: string | null;
 	childGuid: string | null;
 	childName: string | null;
+	builderComponent?: string | null;
 }
 
 export function Workbench({ children, enrichData }: CmsComponentProps): JSX.Element {

--- a/client/src/engine/registry.ts
+++ b/client/src/engine/registry.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react';
 
 import { DevModeToggle } from '../components/DevModeToggle';
+import { DatabaseBuilder } from '../components/DatabaseBuilder';
 import { ContentPanel } from '../components/ContentPanel';
 import { HamburgerToggle } from '../components/HamburgerToggle';
 import { ImageElement } from '../components/ImageElement';
@@ -10,12 +11,14 @@ import { LinkButton } from '../components/LinkButton';
 import { NavigationTreeView } from '../components/NavigationTreeView';
 import { ObjectEditor } from '../components/ObjectEditor';
 import { ObjectTreeView } from '../components/ObjectTreeView';
+import { ModulesBuilder } from '../components/ModulesBuilder';
 import { NavigationSidebar } from '../components/NavigationSidebar';
 import { SidebarContent } from '../components/SidebarContent';
 import { SidebarFooter } from '../components/SidebarFooter';
 import { SidebarHeader } from '../components/SidebarHeader';
 import { SimplePage } from '../components/SimplePage';
 import { StringControl } from '../components/StringControl';
+import { TypesBuilder } from '../components/TypesBuilder';
 import { UserProfileControl } from '../components/UserProfileControl';
 import { Workbench } from '../components/Workbench';
 
@@ -40,4 +43,7 @@ export const COMPONENT_REGISTRY: Record<string, ComponentType<CmsComponentProps>
 	LoginControl,
 	UserProfileControl,
 	StringControl,
+	DatabaseBuilder: DatabaseBuilder as unknown as ComponentType<CmsComponentProps>,
+	TypesBuilder: TypesBuilder as unknown as ComponentType<CmsComponentProps>,
+	ModulesBuilder: ModulesBuilder as unknown as ComponentType<CmsComponentProps>,
 };

--- a/rpc/public/route/models.py
+++ b/rpc/public/route/models.py
@@ -34,6 +34,7 @@ class ObjectTreeCategory1(BaseModel):
   sequence: int
   treeDepth: int = 1
   description: str | None = None
+  builderComponent: str | None = None
 
 
 PathNode1.model_rebuild()


### PR DESCRIPTION
### Motivation
- Allow categories to declare which editor component to show instead of hardcoding `categoryName` checks in the UI.
- Propagate a `builderComponent` identifier from the server into the client selection so the `ObjectEditor` can resolve builders dynamically via the component registry.

### Description
- Added `builderComponent: str | None = None` to the RPC Pydantic model `ObjectTreeCategory1` so the server can return a component name for a category (`rpc/public/route/models.py`).
- Added `builderComponent: string | null` to the client `ObjectTreeCategory` interface so TypeScript knows the field is present (`client/src/api/rpc.ts`).
- Extended the selection shape by making `SelectedNode` carry an optional `builderComponent?: string | null` so selection state includes the component mapping (`client/src/components/Workbench.tsx`).
- Threaded `builderComponent: category.builderComponent ?? null` into every `selectNode?.({...})` call in `ObjectTreeView` (category, table, and column selection paths) so the chosen node includes the component hint (`client/src/components/ObjectTreeView.tsx`).
- Replaced the hardcoded `if (selected.categoryName === '...')` dispatch in `ObjectEditor` with a runtime lookup against `COMPONENT_REGISTRY[selected.builderComponent]`, passing `{ data, selected }` through when found and preserving the existing fallback UI when no builder is available (`client/src/components/ObjectEditor.tsx`).
- Registered `DatabaseBuilder`, `TypesBuilder`, and `ModulesBuilder` in `COMPONENT_REGISTRY` using type casts to satisfy the registry signature so components are instantiable by name at runtime (`client/src/engine/registry.ts`).

### Testing
- Ran `npm run type-check` in the `client/` directory (executes `tsc --noEmit`) and it completed successfully with no TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1b1f5d8c8325a1c979090448e124)