### PR TITLE
Add ComponentBuilder: server RPC, deterministic GUID helper, client API & UI

### DIFF
--- a/client/src/api/rpc.ts
+++ b/client/src/api/rpc.ts
@@ -348,3 +348,70 @@ export async function invalidateToken(): Promise<{ ok: boolean }> {
 export async function logoutDevice(): Promise<{ ok: boolean }> {
 	return rpcCall<{ ok: boolean }>('urn:auth:session:logout_device:1');
 }
+
+
+export interface PageTreeNode {
+	guid: string;
+	parent_guid: string | null;
+	component_name: string;
+	component_category: string;
+	component_guid: string;
+	label: string | null;
+	field_binding: string | null;
+	sequence: number;
+	rpc_operation: string | null;
+	rpc_contract: string | null;
+	mutation_operation: string | null;
+	is_editable: boolean;
+	depth: number;
+}
+
+export interface ComponentEntry {
+	guid: string;
+	name: string;
+	category: string;
+	description: string | null;
+}
+
+export async function getPageTree(pageGuid: string): Promise<PageTreeNode[]> {
+	return rpcCall<PageTreeNode[]>('urn:service:objects:get_page_tree:1', { pageGuid });
+}
+
+export async function listComponents(): Promise<ComponentEntry[]> {
+	return rpcCall<ComponentEntry[]>('urn:service:objects:list_components:1');
+}
+
+export async function createTreeNode(payload: {
+	pageGuid: string;
+	parentGuid: string | null;
+	componentGuid: string;
+	label?: string | null;
+	fieldBinding?: string | null;
+	sequence?: number;
+}): Promise<{ ok: boolean; keyGuid: string }> {
+	return rpcCall<{ ok: boolean; keyGuid: string }>('urn:service:objects:create_tree_node:1', payload);
+}
+
+export async function updateTreeNode(payload: {
+	keyGuid: string;
+	label?: string | null;
+	fieldBinding?: string | null;
+	sequence?: number | null;
+	rpcOperation?: string | null;
+	rpcContract?: string | null;
+	componentGuid?: string | null;
+}): Promise<{ ok: boolean }> {
+	return rpcCall<{ ok: boolean }>('urn:service:objects:update_tree_node:1', payload);
+}
+
+export async function deleteTreeNode(keyGuid: string): Promise<{ ok: boolean }> {
+	return rpcCall<{ ok: boolean }>('urn:service:objects:delete_tree_node:1', { keyGuid });
+}
+
+export async function moveTreeNode(payload: {
+	keyGuid: string;
+	newParentGuid: string | null;
+	newSequence: number;
+}): Promise<{ ok: boolean }> {
+	return rpcCall<{ ok: boolean }>('urn:service:objects:move_tree_node:1', payload);
+}

--- a/client/src/components/ComponentBuilder.tsx
+++ b/client/src/components/ComponentBuilder.tsx
@@ -1,0 +1,518 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+	Box,
+	Breadcrumbs,
+	Button,
+	Chip,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	IconButton,
+	MenuItem,
+	Select,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableRow,
+	TextField,
+	Typography,
+} from '@mui/material';
+
+import {
+	createTreeNode,
+	deleteTreeNode,
+	getPageTree,
+	listComponents,
+	moveTreeNode,
+	type ComponentEntry,
+	type PageTreeNode,
+	updateTreeNode,
+} from '../api/rpc';
+import type { SelectedNode } from './Workbench';
+
+interface ComponentBuilderProps {
+	data: Record<string, unknown>;
+	selected: SelectedNode;
+}
+
+interface NodeDraft {
+	keyGuid: string;
+	componentGuid: string;
+	label: string;
+	fieldBinding: string;
+	sequence: number;
+	rpcOperation: string;
+	rpcContract: string;
+}
+
+interface AddDraft {
+	parentGuid: string;
+	componentGuid: string;
+	label: string;
+	fieldBinding: string;
+	sequence: number;
+}
+
+const EMPTY_NODE_DRAFT: NodeDraft = {
+	keyGuid: '',
+	componentGuid: '',
+	label: '',
+	fieldBinding: '',
+	sequence: 0,
+	rpcOperation: '',
+	rpcContract: '',
+};
+
+function categoryColor(category: string): string {
+	if (category === 'page') {
+		return '#1565C0';
+	}
+	if (category === 'section') {
+		return '#2E7D32';
+	}
+	if (category === 'control') {
+		return '#E65100';
+	}
+	return '#616161';
+}
+
+export function ComponentBuilder({ data, selected }: ComponentBuilderProps): JSX.Element {
+	const selectNode = data.__selectNode as ((node: SelectedNode | null) => void) | undefined;
+	const [treeRows, setTreeRows] = useState<PageTreeNode[]>([]);
+	const [components, setComponents] = useState<ComponentEntry[]>([]);
+	const [detailDraft, setDetailDraft] = useState<NodeDraft>(EMPTY_NODE_DRAFT);
+	const [addDialogOpen, setAddDialogOpen] = useState(false);
+	const [addDraft, setAddDraft] = useState<AddDraft>({
+		parentGuid: '',
+		componentGuid: '',
+		label: '',
+		fieldBinding: '',
+		sequence: 0,
+	});
+
+	const selectedNode = useMemo(
+		() => treeRows.find((row) => row.guid === selected.childGuid) ?? null,
+		[treeRows, selected.childGuid],
+	);
+
+	const refreshTree = useCallback(async (): Promise<void> => {
+		if (!selected.nodeGuid) {
+			setTreeRows([]);
+			return;
+		}
+		const rows = await getPageTree(selected.nodeGuid);
+		setTreeRows(rows);
+	}, [selected.nodeGuid]);
+
+	useEffect(() => {
+		void refreshTree();
+	}, [refreshTree]);
+
+	useEffect(() => {
+		let mounted = true;
+		const loadComponents = async (): Promise<void> => {
+			const rows = await listComponents();
+			if (mounted) {
+				setComponents(rows);
+			}
+		};
+		void loadComponents();
+		return () => {
+			mounted = false;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!selectedNode) {
+			setDetailDraft(EMPTY_NODE_DRAFT);
+			return;
+		}
+		setDetailDraft({
+			keyGuid: selectedNode.guid,
+			componentGuid: selectedNode.component_guid,
+			label: selectedNode.label ?? '',
+			fieldBinding: selectedNode.field_binding ?? '',
+			sequence: selectedNode.sequence,
+			rpcOperation: selectedNode.rpc_operation ?? '',
+			rpcContract: selectedNode.rpc_contract ?? '',
+		});
+	}, [selectedNode]);
+
+	const nestedRows = useMemo(() => {
+		const byParent = new Map<string | null, PageTreeNode[]>();
+		for (const row of treeRows) {
+			const parent = row.parent_guid;
+			const list = byParent.get(parent) ?? [];
+			list.push(row);
+			byParent.set(parent, list);
+		}
+		for (const rows of byParent.values()) {
+			rows.sort((a, b) => a.sequence - b.sequence);
+		}
+		const flattened: Array<PageTreeNode & { level: number }> = [];
+		const walk = (parentGuid: string | null, level: number): void => {
+			const children = byParent.get(parentGuid) ?? [];
+			for (const child of children) {
+				flattened.push({ ...child, level });
+				walk(child.guid, level + 1);
+			}
+		};
+		walk(null, 0);
+		return flattened;
+	}, [treeRows]);
+
+	const renderFrame = (content: JSX.Element): JSX.Element => (
+		<Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', p: 2, color: '#FFFFFF', bgcolor: '#000000' }}>
+			{content}
+		</Box>
+	);
+
+	const openAddDialog = (parentGuid: string | null): void => {
+		setAddDraft({
+			parentGuid: parentGuid ?? '',
+			componentGuid: components[0]?.guid ?? '',
+			label: '',
+			fieldBinding: '',
+			sequence: 0,
+		});
+		setAddDialogOpen(true);
+	};
+
+	const saveAdd = async (): Promise<void> => {
+		if (!selected.nodeGuid || !addDraft.componentGuid) {
+			return;
+		}
+		await createTreeNode({
+			pageGuid: selected.nodeGuid,
+			parentGuid: addDraft.parentGuid || null,
+			componentGuid: addDraft.componentGuid,
+			label: addDraft.label || null,
+			fieldBinding: addDraft.fieldBinding || null,
+			sequence: Number(addDraft.sequence || 0),
+		});
+		setAddDialogOpen(false);
+		await refreshTree();
+	};
+
+	if (!selected.nodeGuid) {
+		return renderFrame(
+			<>
+				<Breadcrumbs sx={{ color: '#4CAF50', mb: 1 }}>
+					<Typography color="#4CAF50">Pages</Typography>
+				</Breadcrumbs>
+				<Typography variant="body1">Select a page node to open ComponentBuilder.</Typography>
+			</>,
+		);
+	}
+
+	if (!selected.childGuid) {
+		return renderFrame(
+			<>
+				<Breadcrumbs sx={{ color: '#4CAF50', mb: 1 }}>
+					<Typography color="#4CAF50">Pages</Typography>
+					<Typography color="#4CAF50">{selected.nodeName}</Typography>
+				</Breadcrumbs>
+				<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+					<Typography variant="h5">Component Tree</Typography>
+					<Button variant="contained" onClick={() => openAddDialog(null)}>
+						Add Node
+					</Button>
+				</Box>
+				<Table size="small" sx={{ '& td, & th': { borderColor: '#1A1A1A' } }}>
+					<TableHead>
+						<TableRow>
+							<TableCell>Component</TableCell>
+							<TableCell>Category</TableCell>
+							<TableCell>Label</TableCell>
+							<TableCell>Field Binding</TableCell>
+							<TableCell>Sequence</TableCell>
+							<TableCell align="right">Actions</TableCell>
+						</TableRow>
+					</TableHead>
+					<TableBody>
+						{nestedRows.map((row) => (
+							<TableRow key={row.guid} hover>
+								<TableCell>
+									<Button
+										variant="text"
+										sx={{ pl: row.level * 2, justifyContent: 'flex-start' }}
+										onClick={() =>
+											selectNode?.({
+												categoryGuid: selected.categoryGuid,
+												categoryName: selected.categoryName,
+												nodeGuid: selected.nodeGuid,
+												nodeName: selected.nodeName,
+												childGuid: row.guid,
+												childName: row.component_name,
+											})
+										}
+									>
+										{row.component_name}
+									</Button>
+								</TableCell>
+								<TableCell>
+									<Chip
+										label={row.component_category}
+										size="small"
+										sx={{ bgcolor: categoryColor(row.component_category), color: '#FFFFFF' }}
+									/>
+								</TableCell>
+								<TableCell>{row.label ?? '—'}</TableCell>
+								<TableCell sx={{ color: '#4CAF50', fontFamily: 'monospace' }}>
+									{row.field_binding ?? '—'}
+								</TableCell>
+								<TableCell>{row.sequence}</TableCell>
+								<TableCell align="right">
+									<IconButton
+										onClick={async () => {
+											await moveTreeNode({
+												keyGuid: row.guid,
+												newParentGuid: row.parent_guid,
+												newSequence: row.sequence - 1,
+											});
+											await refreshTree();
+										}}
+									>
+										<ArrowUpwardIcon fontSize="small" />
+									</IconButton>
+									<IconButton
+										onClick={async () => {
+											await moveTreeNode({
+												keyGuid: row.guid,
+												newParentGuid: row.parent_guid,
+												newSequence: row.sequence + 1,
+											});
+											await refreshTree();
+										}}
+									>
+										<ArrowDownwardIcon fontSize="small" />
+									</IconButton>
+									<IconButton
+										onClick={async () => {
+											await deleteTreeNode(row.guid);
+											await refreshTree();
+										}}
+									>
+										<DeleteIcon fontSize="small" />
+									</IconButton>
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+				<Dialog open={addDialogOpen} onClose={() => setAddDialogOpen(false)}>
+					<DialogTitle>Add Node</DialogTitle>
+					<DialogContent sx={{ display: 'grid', gap: 1, minWidth: 360, pt: '12px !important' }}>
+						<Select
+							value={addDraft.parentGuid}
+							onChange={(event) => setAddDraft((prev) => ({ ...prev, parentGuid: String(event.target.value) }))}
+						>
+							<MenuItem value="">(Root)</MenuItem>
+							{nestedRows.map((row) => (
+								<MenuItem key={row.guid} value={row.guid}>
+									{`${'\u00A0\u00A0'.repeat(row.level)}${row.component_name}`}
+								</MenuItem>
+							))}
+						</Select>
+						<Select
+							value={addDraft.componentGuid}
+							onChange={(event) => setAddDraft((prev) => ({ ...prev, componentGuid: String(event.target.value) }))}
+						>
+							{components.map((component) => (
+								<MenuItem key={component.guid} value={component.guid}>
+									{component.name}
+								</MenuItem>
+							))}
+						</Select>
+						<TextField
+							label="Label"
+							value={addDraft.label}
+							onChange={(event) => setAddDraft((prev) => ({ ...prev, label: event.target.value }))}
+						/>
+						<TextField
+							label="Field Binding"
+							value={addDraft.fieldBinding}
+							onChange={(event) => setAddDraft((prev) => ({ ...prev, fieldBinding: event.target.value }))}
+							sx={{ '& input': { fontFamily: 'monospace' } }}
+						/>
+						<TextField
+							type="number"
+							label="Sequence"
+							value={addDraft.sequence}
+							onChange={(event) => setAddDraft((prev) => ({ ...prev, sequence: Number(event.target.value || 0) }))}
+						/>
+					</DialogContent>
+					<DialogActions>
+						<Button onClick={() => setAddDialogOpen(false)}>Cancel</Button>
+						<Button variant="contained" onClick={() => void saveAdd()}>
+							Create
+						</Button>
+					</DialogActions>
+				</Dialog>
+			</>,
+		);
+	}
+
+	return renderFrame(
+		<>
+			<Breadcrumbs sx={{ color: '#4CAF50', mb: 1 }}>
+				<Typography color="#4CAF50">Pages</Typography>
+				<Typography color="#4CAF50">{selected.nodeName}</Typography>
+				<Typography color="#4CAF50">{selected.childName ?? 'Component'}</Typography>
+			</Breadcrumbs>
+			<Typography variant="h5" sx={{ mb: 2 }}>
+				Node Detail
+			</Typography>
+			<Box sx={{ display: 'grid', gap: 1.5, maxWidth: 600 }}>
+				<Select
+					value={detailDraft.componentGuid}
+					onChange={(event) => setDetailDraft((prev) => ({ ...prev, componentGuid: String(event.target.value) }))}
+				>
+					{components.map((component) => (
+						<MenuItem key={component.guid} value={component.guid}>
+							{component.name}
+						</MenuItem>
+					))}
+				</Select>
+				<TextField
+					label="Label"
+					value={detailDraft.label}
+					onChange={(event) => setDetailDraft((prev) => ({ ...prev, label: event.target.value }))}
+				/>
+				<TextField
+					label="Field Binding"
+					value={detailDraft.fieldBinding}
+					onChange={(event) => setDetailDraft((prev) => ({ ...prev, fieldBinding: event.target.value }))}
+					sx={{ '& input': { fontFamily: 'monospace' } }}
+				/>
+				<TextField
+					type="number"
+					label="Sequence"
+					value={detailDraft.sequence}
+					onChange={(event) => setDetailDraft((prev) => ({ ...prev, sequence: Number(event.target.value || 0) }))}
+				/>
+				<TextField
+					label="RPC Operation"
+					value={detailDraft.rpcOperation}
+					onChange={(event) => setDetailDraft((prev) => ({ ...prev, rpcOperation: event.target.value }))}
+					sx={{ '& input': { fontFamily: 'monospace' } }}
+				/>
+				<TextField
+					label="RPC Contract"
+					value={detailDraft.rpcContract}
+					onChange={(event) => setDetailDraft((prev) => ({ ...prev, rpcContract: event.target.value }))}
+					sx={{ '& input': { fontFamily: 'monospace' } }}
+				/>
+				<TextField label="GUID" value={detailDraft.keyGuid} InputProps={{ readOnly: true }} sx={{ '& input': { fontFamily: 'monospace' } }} />
+				<Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+					<Button
+						variant="contained"
+						onClick={async () => {
+							await updateTreeNode({
+								keyGuid: detailDraft.keyGuid,
+								label: detailDraft.label || null,
+								fieldBinding: detailDraft.fieldBinding || null,
+								sequence: detailDraft.sequence,
+								rpcOperation: detailDraft.rpcOperation || null,
+								rpcContract: detailDraft.rpcContract || null,
+								componentGuid: detailDraft.componentGuid,
+							});
+							await refreshTree();
+						}}
+					>
+						Save
+					</Button>
+					<Button variant="outlined" onClick={() => openAddDialog(detailDraft.keyGuid)}>
+						Add Child
+					</Button>
+					<Button
+						variant="outlined"
+						color="error"
+						onClick={async () => {
+							await deleteTreeNode(detailDraft.keyGuid);
+							selectNode?.({
+								categoryGuid: selected.categoryGuid,
+								categoryName: selected.categoryName,
+								nodeGuid: selected.nodeGuid,
+								nodeName: selected.nodeName,
+								childGuid: null,
+								childName: null,
+							});
+							await refreshTree();
+						}}
+					>
+						Delete
+					</Button>
+					<Button
+						onClick={() =>
+							selectNode?.({
+								categoryGuid: selected.categoryGuid,
+								categoryName: selected.categoryName,
+								nodeGuid: selected.nodeGuid,
+								nodeName: selected.nodeName,
+								childGuid: null,
+								childName: null,
+							})
+						}
+					>
+						Back to Tree
+					</Button>
+				</Box>
+			</Box>
+			<Dialog open={addDialogOpen} onClose={() => setAddDialogOpen(false)}>
+				<DialogTitle>Add Node</DialogTitle>
+				<DialogContent sx={{ display: 'grid', gap: 1, minWidth: 360, pt: '12px !important' }}>
+					<Select
+						value={addDraft.parentGuid}
+						onChange={(event) => setAddDraft((prev) => ({ ...prev, parentGuid: String(event.target.value) }))}
+					>
+						<MenuItem value="">(Root)</MenuItem>
+						{nestedRows.map((row) => (
+							<MenuItem key={row.guid} value={row.guid}>
+								{`${'\u00A0\u00A0'.repeat(row.level)}${row.component_name}`}
+							</MenuItem>
+						))}
+					</Select>
+					<Select
+						value={addDraft.componentGuid}
+						onChange={(event) => setAddDraft((prev) => ({ ...prev, componentGuid: String(event.target.value) }))}
+					>
+						{components.map((component) => (
+							<MenuItem key={component.guid} value={component.guid}>
+								{component.name}
+							</MenuItem>
+						))}
+					</Select>
+					<TextField
+						label="Label"
+						value={addDraft.label}
+						onChange={(event) => setAddDraft((prev) => ({ ...prev, label: event.target.value }))}
+					/>
+					<TextField
+						label="Field Binding"
+						value={addDraft.fieldBinding}
+						onChange={(event) => setAddDraft((prev) => ({ ...prev, fieldBinding: event.target.value }))}
+						sx={{ '& input': { fontFamily: 'monospace' } }}
+					/>
+					<TextField
+						type="number"
+						label="Sequence"
+						value={addDraft.sequence}
+						onChange={(event) => setAddDraft((prev) => ({ ...prev, sequence: Number(event.target.value || 0) }))}
+					/>
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={() => setAddDialogOpen(false)}>Cancel</Button>
+					<Button variant="contained" onClick={() => void saveAdd()}>
+						Create
+					</Button>
+				</DialogActions>
+			</Dialog>
+		</>,
+	);
+}

--- a/client/src/engine/registry.ts
+++ b/client/src/engine/registry.ts
@@ -3,6 +3,7 @@ import type { ComponentType } from 'react';
 import { DevModeToggle } from '../components/DevModeToggle';
 import { DatabaseBuilder } from '../components/DatabaseBuilder';
 import { ContentPanel } from '../components/ContentPanel';
+import { ComponentBuilder } from '../components/ComponentBuilder';
 import { HamburgerToggle } from '../components/HamburgerToggle';
 import { ImageElement } from '../components/ImageElement';
 import { LabelElement } from '../components/LabelElement';
@@ -46,4 +47,5 @@ export const COMPONENT_REGISTRY: Record<string, ComponentType<CmsComponentProps>
 	DatabaseBuilder: DatabaseBuilder as unknown as ComponentType<CmsComponentProps>,
 	TypesBuilder: TypesBuilder as unknown as ComponentType<CmsComponentProps>,
 	ModulesBuilder: ModulesBuilder as unknown as ComponentType<CmsComponentProps>,
+	ComponentBuilder: ComponentBuilder as unknown as ComponentType<CmsComponentProps>,
 };

--- a/rpc/service/objects/__init__.py
+++ b/rpc/service/objects/__init__.py
@@ -4,16 +4,22 @@ Requires ROLE_SERVICE_ADMIN.
 """
 
 from .services import (
+  service_objects_create_tree_node_v1,
   service_objects_delete_database_column_v1,
   service_objects_delete_database_table_v1,
   service_objects_delete_module_method_v1,
+  service_objects_delete_tree_node_v1,
   service_objects_delete_type_v1,
   service_objects_get_method_contract_v1,
   service_objects_get_module_methods_v1,
+  service_objects_get_page_tree_v1,
   service_objects_get_type_controls_v1,
+  service_objects_list_components_v1,
+  service_objects_move_tree_node_v1,
   service_objects_read_object_tree_children_v1,
   service_objects_read_object_tree_detail_v1,
   service_objects_upsert_database_column_v1,
+  service_objects_update_tree_node_v1,
   service_objects_upsert_database_table_v1,
   service_objects_upsert_module_method_v1,
   service_objects_upsert_module_v1,
@@ -36,4 +42,10 @@ DISPATCHERS: dict[tuple[str, str], callable] = {
   ("upsert_module_method", "1"): service_objects_upsert_module_method_v1,
   ("delete_module_method", "1"): service_objects_delete_module_method_v1,
   ("get_method_contract", "1"): service_objects_get_method_contract_v1,
+  ("get_page_tree", "1"): service_objects_get_page_tree_v1,
+  ("list_components", "1"): service_objects_list_components_v1,
+  ("create_tree_node", "1"): service_objects_create_tree_node_v1,
+  ("update_tree_node", "1"): service_objects_update_tree_node_v1,
+  ("delete_tree_node", "1"): service_objects_delete_tree_node_v1,
+  ("move_tree_node", "1"): service_objects_move_tree_node_v1,
 }

--- a/rpc/service/objects/models.py
+++ b/rpc/service/objects/models.py
@@ -112,3 +112,50 @@ class ServiceObjectsGetMethodContractParams1(BaseModel):
   model_config = ConfigDict(extra="forbid")
 
   methodGuid: str
+
+
+class ServiceObjectsGetPageTreeParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  pageGuid: str
+
+
+class ServiceObjectsListComponentsParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+
+class ServiceObjectsCreateTreeNodeParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  pageGuid: str
+  parentGuid: str | None = None
+  componentGuid: str
+  label: str | None = None
+  fieldBinding: str | None = None
+  sequence: int = 0
+
+
+class ServiceObjectsUpdateTreeNodeParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  keyGuid: str
+  label: str | None = None
+  fieldBinding: str | None = None
+  sequence: int | None = None
+  rpcOperation: str | None = None
+  rpcContract: str | None = None
+  componentGuid: str | None = None
+
+
+class ServiceObjectsDeleteTreeNodeParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  keyGuid: str
+
+
+class ServiceObjectsMoveTreeNodeParams1(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  keyGuid: str
+  newParentGuid: str | None = None
+  newSequence: int = 0

--- a/rpc/service/objects/services.py
+++ b/rpc/service/objects/services.py
@@ -9,13 +9,19 @@ from .models import (
   ServiceObjectsDeleteDatabaseTableParams1,
   ServiceObjectsDeleteModuleMethodParams1,
   ServiceObjectsDeleteTypeParams1,
+  ServiceObjectsDeleteTreeNodeParams1,
   ServiceObjectsGetMethodContractParams1,
   ServiceObjectsGetModuleMethodsParams1,
+  ServiceObjectsGetPageTreeParams1,
   ServiceObjectsGetTypeControlsParams1,
+  ServiceObjectsListComponentsParams1,
+  ServiceObjectsMoveTreeNodeParams1,
   ServiceObjectsReadChildrenParams1,
   ServiceObjectsReadDetailParams1,
+  ServiceObjectsCreateTreeNodeParams1,
   ServiceObjectsUpsertDatabaseColumnParams1,
   ServiceObjectsUpsertDatabaseTableParams1,
+  ServiceObjectsUpdateTreeNodeParams1,
   ServiceObjectsUpsertModuleMethodParams1,
   ServiceObjectsUpsertModuleParams1,
   ServiceObjectsUpsertTypeParams1,
@@ -267,6 +273,121 @@ async def service_objects_get_method_contract_v1(request: Request):
   del auth_ctx
 
   result = await module.get_method_contract(params.methodGuid)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_get_page_tree_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsGetPageTreeParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.get_page_tree(params.pageGuid)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_list_components_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsListComponentsParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.list_components()
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_create_tree_node_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsCreateTreeNodeParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.create_tree_node(
+    params.pageGuid,
+    params.parentGuid,
+    params.componentGuid,
+    params.label,
+    params.fieldBinding,
+    params.sequence,
+  )
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_update_tree_node_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsUpdateTreeNodeParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.update_tree_node(
+    params.keyGuid,
+    params.label,
+    params.fieldBinding,
+    params.sequence,
+    params.rpcOperation,
+    params.rpcContract,
+    params.componentGuid,
+  )
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_delete_tree_node_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsDeleteTreeNodeParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.delete_tree_node(params.keyGuid)
+
+  return RPCResponse(
+    op=rpc_request.op,
+    payload=result,
+    version=rpc_request.version,
+  )
+
+
+async def service_objects_move_tree_node_v1(request: Request):
+  rpc_request, auth_ctx, _ = await unbox_request(request)
+  params = ServiceObjectsMoveTreeNodeParams1.model_validate(rpc_request.payload or {})
+  module: CmsWorkbenchModule = request.app.state.cms_workbench
+  await module.on_ready()
+  del auth_ctx
+
+  result = await module.move_tree_node(
+    params.keyGuid,
+    params.newParentGuid,
+    params.newSequence,
+  )
 
   return RPCResponse(
     op=rpc_request.op,

--- a/server/helpers/strings.py
+++ b/server/helpers/strings.py
@@ -2,3 +2,16 @@ def camel_case(name: str) -> str:
   """Convert snake_case names to CamelCase."""
   return "".join(part.capitalize() for part in name.split("_"))
 
+
+
+import uuid
+
+DETERMINISTIC_NS = uuid.UUID('DECAFBAD-CAFE-FADE-BABE-C0FFEE420B67')
+
+def deterministic_guid(entity_type: str, natural_key: str) -> str:
+  """Compute a deterministic UUID5 from the platform namespace.
+
+  Formula: uuid5(DECAFBAD-CAFE-FADE-BABE-C0FFEE420B67, '{entity_type}:{natural_key}')
+  Returns uppercase string with hyphens.
+  """
+  return str(uuid.uuid5(DETERMINISTIC_NS, f'{entity_type}:{natural_key}')).upper()

--- a/server/modules/cms_workbench_module.py
+++ b/server/modules/cms_workbench_module.py
@@ -12,6 +12,7 @@ from queryregistry.system.public import (
   get_page_data_bindings_request,
 )
 from rpc.public.route.models import LoadPathResult1, PathNode1
+from server.helpers.strings import deterministic_guid
 
 from . import BaseModule
 from .db_module import DbModule
@@ -485,3 +486,121 @@ class CmsWorkbenchModule(BaseModule):
     """Return contract info for a method, if one exists."""
     result = await self._run_query("cms.modules.get_method_contract", (method_guid,))
     return [dict(row) for row in (result.rows if result else [])]
+
+
+  async def get_page_tree(self, page_guid: str) -> list[dict[str, Any]]:
+    """Return the recursive component tree for a page."""
+    result = await self._run_query("cms.pages.get_page_tree", (page_guid,))
+    return [dict(row) for row in (result.rows if result else [])]
+
+  async def list_components(self) -> list[dict[str, Any]]:
+    """Return all registered components for the component picker."""
+    result = await self._run_query("cms.pages.list_components")
+    return [dict(row) for row in (result.rows if result else [])]
+
+  async def create_tree_node(
+    self,
+    page_guid: str,
+    parent_guid: str | None,
+    component_guid: str,
+    label: str | None = None,
+    field_binding: str | None = None,
+    sequence: int = 0,
+  ) -> dict[str, Any]:
+    """Insert a new component tree node with a deterministic GUID.
+
+    Computes the tree path by resolving the parent chain, then generates
+    uuid5(NS, 'tree:{full_path}') as the key_guid.
+    """
+    comp_result = await self._run_query("cms.pages.list_components")
+    comp_rows = [dict(row) for row in (comp_result.rows if comp_result else [])]
+    comp_name = next(
+      (row.get("name") for row in comp_rows if str(row.get("guid", "")).upper() == component_guid.upper()),
+      "Unknown",
+    )
+
+    segment = comp_name
+    if field_binding:
+      segment = f"{comp_name}:{field_binding}"
+    elif label:
+      segment = f"{comp_name}:{label}"
+
+    if parent_guid:
+      tree_result = await self._run_query("cms.pages.get_page_tree", (page_guid,))
+      tree_rows = [dict(row) for row in (tree_result.rows if tree_result else [])]
+      parent_path = self._resolve_tree_path(tree_rows, parent_guid)
+      full_path = f"{parent_path}.{segment}" if parent_path else segment
+    else:
+      full_path = segment
+
+    key_guid = deterministic_guid("tree", full_path)
+
+    result = await self._run_query(
+      "cms.pages.create_tree_node",
+      (key_guid, parent_guid, component_guid, label, field_binding, sequence, page_guid, key_guid),
+    )
+    row = dict(result.rows[0]) if result and result.rows else {}
+    return {"ok": True, "keyGuid": row.get("key_guid", key_guid)}
+
+  @staticmethod
+  def _resolve_tree_path(tree_rows: list[dict[str, Any]], target_guid: str) -> str:
+    """Walk the parent chain to build the full dot-delimited tree path."""
+    by_guid: dict[str, dict[str, Any]] = {}
+    for row in tree_rows:
+      guid = str(row.get("guid", "")).upper()
+      if guid:
+        by_guid[guid] = row
+
+    segments: list[str] = []
+    current = target_guid.upper()
+    while current and current in by_guid:
+      row = by_guid[current]
+      name = str(row.get("component_name", "Unknown"))
+      binding = row.get("field_binding")
+      label = row.get("label")
+      if binding:
+        segments.append(f"{name}:{binding}")
+      elif label:
+        segments.append(f"{name}:{label}")
+      else:
+        segments.append(name)
+      parent = row.get("parent_guid")
+      current = str(parent).upper() if parent else ""
+
+    segments.reverse()
+    return ".".join(segments)
+
+  async def update_tree_node(
+    self,
+    key_guid: str,
+    label: str | None = None,
+    field_binding: str | None = None,
+    sequence: int | None = None,
+    rpc_operation: str | None = None,
+    rpc_contract: str | None = None,
+    component_guid: str | None = None,
+  ) -> dict[str, bool]:
+    """Update tree node properties. COALESCE in SQL preserves existing when None."""
+    await self._run_query(
+      "cms.pages.update_tree_node",
+      (label, field_binding, sequence, rpc_operation, rpc_contract, component_guid, key_guid),
+    )
+    return {"ok": True}
+
+  async def delete_tree_node(self, key_guid: str) -> dict[str, bool]:
+    """Delete a tree node and cascade all descendants."""
+    await self._run_query("cms.pages.delete_tree_node", (key_guid,))
+    return {"ok": True}
+
+  async def move_tree_node(
+    self,
+    key_guid: str,
+    new_parent_guid: str | None,
+    new_sequence: int,
+  ) -> dict[str, bool]:
+    """Move a node to a new parent and/or sequence."""
+    await self._run_query(
+      "cms.pages.move_tree_node",
+      (new_parent_guid, new_sequence, key_guid),
+    )
+    return {"ok": True}


### PR DESCRIPTION
### Motivation

- Provide the server and client plumbing to manage CMS page component trees and enforce deterministic GUIDs for node creation. 
- Expose a typed RPC surface so the UI can read/write page trees and components with the same layer contracts used elsewhere. 
- Deliver a builder UI that mirrors existing builder patterns (Database/Types/Modules) so editors can inspect and mutate page component trees.

### Description

- Added deterministic UUID helper `deterministic_guid` in `server/helpers/strings.py` which returns `UUID5(DECAFBAD-CAFE-FADE-BABE-C0FFEE420B67, '{entity_type}:{natural_key}')` as an uppercase hyphenated string.
- Extended `CmsWorkbenchModule` (`server/modules/cms_workbench_module.py`) with new methods: `get_page_tree`, `list_components`, `create_tree_node`, `_resolve_tree_path`, `update_tree_node`, `delete_tree_node`, and `move_tree_node`; `create_tree_node` computes the deterministic `key_guid` (uses `_resolve_tree_path`) before invoking the SQL query.
- Added request models in `rpc/service/objects/models.py` for the new RPC operations using `ConfigDict(extra="forbid")` per conventions.
- Implemented service handlers in `rpc/service/objects/services.py` and registered them in `rpc/service/objects/__init__.py` for the operations: `get_page_tree`, `list_components`, `create_tree_node`, `update_tree_node`, `delete_tree_node`, `move_tree_node` following the established `unbox_request` → `module.on_ready()` pattern.
- Added client-side RPC API functions and types to `client/src/api/rpc.ts`: `getPageTree`, `listComponents`, `createTreeNode`, `updateTreeNode`, `deleteTreeNode`, and `moveTreeNode` plus `PageTreeNode` / `ComponentEntry` interfaces.
- Implemented a new `ComponentBuilder` UI at `client/src/components/ComponentBuilder.tsx` that follows the DatabaseBuilder pattern with breadcrumb navigation, recursive/indented tree table, node detail editor, add-node dialog, and actions for move/update/delete/create.
- Registered `ComponentBuilder` in `client/src/engine/registry.ts` so the pages tree can resolve the builder component.

### Testing

- Ran the unified harness with `python scripts/run_tests.py`, which executes frontend lint/type-check/tests and backend pytest, and it completed successfully (all automated checks passed).
- Frontend tooling: `eslint` produced two pre-existing warnings unrelated to these changes, and the client unit test suite ran (1 test) and passed under the harness.
- Backend: `pytest` executed as part of the harness and the test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd32e3e1888325b2c3a7a08e6fe094)