### PR TITLE
Add composed ComponentBuilder UI with reusable builder panels

### DIFF
--- a/frontend/src/components/ComponentBuilder.tsx
+++ b/frontend/src/components/ComponentBuilder.tsx
@@ -1,0 +1,131 @@
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { Box, IconButton, Paper, Stack, Typography } from '@mui/material';
+import { useMemo, useState } from 'react';
+import ComponentPreview from './builder/ComponentPreview';
+import ContractPanel from './builder/ContractPanel';
+import ComponentTreePanel from './builder/ComponentTreePanel';
+import PropertyPanel from './builder/PropertyPanel';
+import QueryPreviewPanel from './builder/QueryPreviewPanel';
+import type { ComponentDefinition, ComponentTreeNode, DataBindingRow } from './builder/types';
+
+export interface ComponentBuilderProps {
+	components: ComponentDefinition[];
+	initialNodes: ComponentTreeNode[];
+	bindings?: DataBindingRow[];
+	onSaveNode?: (node: ComponentTreeNode) => Promise<void> | void;
+	onDeleteNode?: (nodeGuid: string) => Promise<void> | void;
+	onAddChild?: (parentGuid: string | null) => void;
+	onMoveNode?: (nodeGuid: string, direction: 'up' | 'down') => void;
+}
+
+type SectionKey = 'tree' | 'query' | 'contracts';
+
+const EMPTY_BINDINGS: DataBindingRow[] = [];
+
+function findNode(nodes: ComponentTreeNode[], guid: string | null): ComponentTreeNode | null {
+	if (!guid) {
+		return null;
+	}
+	for (const node of nodes) {
+		if (node.guid === guid) {
+			return node;
+		}
+		const child = findNode(node.children, guid);
+		if (child) {
+			return child;
+		}
+	}
+	return null;
+}
+
+function updateNode(nodes: ComponentTreeNode[], updatedNode: ComponentTreeNode): ComponentTreeNode[] {
+	return nodes.map((node) => {
+		if (node.guid === updatedNode.guid) {
+			return { ...updatedNode, children: node.children };
+		}
+		if (node.children.length === 0) {
+			return node;
+		}
+		return { ...node, children: updateNode(node.children, updatedNode) };
+	});
+}
+
+function CollapsiblePanel({
+	title,
+	open,
+	onToggle,
+	children,
+}: {
+	title: string;
+	open: boolean;
+	onToggle: () => void;
+	children: JSX.Element;
+}): JSX.Element {
+	return (
+		<Paper variant="outlined" sx={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+			<Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: 1.5, py: 1, borderBottom: open ? 1 : 0, borderColor: 'divider' }}>
+				<Typography variant="subtitle2">{title}</Typography>
+				<IconButton size="small" onClick={onToggle}>
+					{open ? <ExpandLessIcon fontSize="inherit" /> : <ExpandMoreIcon fontSize="inherit" />}
+				</IconButton>
+			</Stack>
+			{open ? <Box sx={{ minHeight: 0 }}>{children}</Box> : null}
+		</Paper>
+	);
+}
+
+export function ComponentBuilder({
+	components,
+	initialNodes,
+	bindings = EMPTY_BINDINGS,
+	onSaveNode,
+	onDeleteNode,
+	onAddChild,
+	onMoveNode,
+}: ComponentBuilderProps): JSX.Element {
+	const [nodes, setNodes] = useState(initialNodes);
+	const [selectedNodeGuid, setSelectedNodeGuid] = useState<string | null>(initialNodes[0]?.guid ?? null);
+	const [openSections, setOpenSections] = useState<Record<SectionKey, boolean>>({ tree: true, query: true, contracts: true });
+
+	const selectedNode = useMemo(() => findNode(nodes, selectedNodeGuid), [nodes, selectedNodeGuid]);
+
+	return (
+		<Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, height: '100%', minHeight: 680 }}>
+			<Box sx={{ display: 'flex', flex: 1, minHeight: 260 }}>
+				<ComponentPreview nodes={nodes} selectedNodeGuid={selectedNodeGuid} onSelectNode={setSelectedNodeGuid} onMoveNode={onMoveNode} />
+				<PropertyPanel
+					node={selectedNode}
+					components={components}
+					onChangeNode={(updatedNode) => setNodes((previous) => updateNode(previous, updatedNode))}
+					onSaveNode={onSaveNode}
+					onDeleteNode={onDeleteNode}
+				/>
+			</Box>
+
+			<CollapsiblePanel title="Component Tree" open={openSections.tree} onToggle={() => setOpenSections((previous) => ({ ...previous, tree: !previous.tree }))}>
+				<ComponentTreePanel
+					nodes={nodes}
+					selectedNodeGuid={selectedNodeGuid}
+					onSelectNode={setSelectedNodeGuid}
+					onAddChild={onAddChild}
+					onDeleteNode={onDeleteNode}
+					onMoveNode={onMoveNode}
+				/>
+			</CollapsiblePanel>
+
+			<CollapsiblePanel title="Query Preview" open={openSections.query} onToggle={() => setOpenSections((previous) => ({ ...previous, query: !previous.query }))}>
+				<QueryPreviewPanel />
+			</CollapsiblePanel>
+
+			<CollapsiblePanel title="Contracts" open={openSections.contracts} onToggle={() => setOpenSections((previous) => ({ ...previous, contracts: !previous.contracts }))}>
+				<Box sx={{ display: 'flex', gap: 1, p: 1 }}>
+					<ContractPanel direction="inbound" bindings={bindings} />
+					<ContractPanel direction="outbound" bindings={bindings} />
+				</Box>
+			</CollapsiblePanel>
+		</Box>
+	);
+}
+
+export default ComponentBuilder;

--- a/frontend/src/components/PageComposer.tsx
+++ b/frontend/src/components/PageComposer.tsx
@@ -1,0 +1,7 @@
+import { ComponentTreePanel, type ComponentTreePanelProps } from './builder/ComponentTreePanel';
+
+export function PageComposer(props: ComponentTreePanelProps): JSX.Element {
+	return <ComponentTreePanel {...props} />;
+}
+
+export default PageComposer;

--- a/frontend/src/components/builder/ComponentPreview.tsx
+++ b/frontend/src/components/builder/ComponentPreview.tsx
@@ -1,0 +1,194 @@
+import { Box, Tooltip, Typography } from '@mui/material';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ComponentTreeNode } from './types';
+
+interface NodeBox {
+	nodeGuid: string;
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	depth: number;
+	label: string;
+	category: ComponentTreeNode['category'];
+}
+
+export interface ComponentPreviewProps {
+	nodes: ComponentTreeNode[];
+	selectedNodeGuid: string | null;
+	onSelectNode: (nodeGuid: string) => void;
+	onMoveNode?: (nodeGuid: string, direction: 'up' | 'down') => void;
+}
+
+const CATEGORY_COLORS: Record<ComponentTreeNode['category'], string> = {
+	page: '#1976d2',
+	section: '#2e7d32',
+	control: '#ef6c00',
+};
+
+function flattenTree(nodes: ComponentTreeNode[], depth = 0, yOffset = 24, xOffset = 24, rows: NodeBox[] = []): NodeBox[] {
+	let cursorY = yOffset;
+	for (const node of nodes) {
+		const height = 54;
+		rows.push({
+			nodeGuid: node.guid,
+			x: xOffset + depth * 42,
+			y: cursorY,
+			width: 320 - depth * 12,
+			height,
+			depth,
+			label: node.pubLabel ?? node.componentName,
+			category: node.category,
+		});
+		cursorY += height + 20;
+		if (node.children.length > 0) {
+			flattenTree(node.children, depth + 1, cursorY, xOffset, rows);
+			cursorY = rows[rows.length - 1].y + rows[rows.length - 1].height + 20;
+		}
+	}
+	return rows;
+}
+
+export function ComponentPreview({ nodes, selectedNodeGuid, onSelectNode, onMoveNode }: ComponentPreviewProps): JSX.Element {
+	const canvasRef = useRef<HTMLCanvasElement | null>(null);
+	const wrapperRef = useRef<HTMLDivElement | null>(null);
+	const [pan, setPan] = useState({ x: 0, y: 0 });
+	const [zoom, setZoom] = useState(1);
+	const [hoveredGuid, setHoveredGuid] = useState<string | null>(null);
+	const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
+	const [isPanning, setIsPanning] = useState(false);
+	const [lastPointer, setLastPointer] = useState({ x: 0, y: 0 });
+
+	const boxes = useMemo(() => flattenTree(nodes), [nodes]);
+
+	const draw = useCallback(() => {
+		const canvas = canvasRef.current;
+		const wrapper = wrapperRef.current;
+		if (!canvas || !wrapper) {
+			return;
+		}
+		const dpr = window.devicePixelRatio || 1;
+		const width = wrapper.clientWidth;
+		const height = wrapper.clientHeight;
+		canvas.width = Math.floor(width * dpr);
+		canvas.height = Math.floor(height * dpr);
+		canvas.style.width = `${width}px`;
+		canvas.style.height = `${height}px`;
+		const context = canvas.getContext('2d');
+		if (!context) {
+			return;
+		}
+
+		context.setTransform(dpr, 0, 0, dpr, 0, 0);
+		context.clearRect(0, 0, width, height);
+		context.save();
+		context.translate(pan.x, pan.y);
+		context.scale(zoom, zoom);
+
+		for (const box of boxes) {
+			const color = CATEGORY_COLORS[box.category];
+			const isSelected = selectedNodeGuid === box.nodeGuid;
+			const isHovered = hoveredGuid === box.nodeGuid;
+			context.beginPath();
+			context.roundRect(box.x, box.y, box.width, box.height, 10);
+			context.fillStyle = `${color}${box.category === 'control' ? 'DD' : 'A6'}`;
+			context.fill();
+			context.lineWidth = isSelected ? 3 : 1.5;
+			context.strokeStyle = isSelected ? '#ffffff' : color;
+			context.shadowColor = isHovered ? color : 'transparent';
+			context.shadowBlur = isHovered ? 20 : 0;
+			context.stroke();
+			context.shadowBlur = 0;
+
+			context.fillStyle = '#ffffff';
+			context.font = '13px monospace';
+			context.fillText(box.label, box.x + 12, box.y + 22);
+			context.font = '11px monospace';
+			context.fillText(box.category.toUpperCase(), box.x + 12, box.y + 40);
+		}
+
+		context.restore();
+	}, [boxes, hoveredGuid, pan.x, pan.y, selectedNodeGuid, zoom]);
+
+	useEffect(() => {
+		draw();
+	}, [draw]);
+
+	const screenToWorld = (screenX: number, screenY: number) => ({
+		x: (screenX - pan.x) / zoom,
+		y: (screenY - pan.y) / zoom,
+	});
+
+	const hitTest = useCallback((clientX: number, clientY: number) => {
+		const wrapper = wrapperRef.current;
+		if (!wrapper) {
+			return null;
+		}
+		const rect = wrapper.getBoundingClientRect();
+		const point = screenToWorld(clientX - rect.left, clientY - rect.top);
+		for (const box of boxes) {
+			const inX = point.x >= box.x && point.x <= box.x + box.width;
+			const inY = point.y >= box.y && point.y <= box.y + box.height;
+			if (inX && inY) {
+				return box;
+			}
+		}
+		return null;
+	}, [boxes, pan.x, pan.y, zoom]);
+
+	return (
+		<Box ref={wrapperRef} sx={{ flex: 1, minHeight: 260, position: 'relative', overflow: 'hidden', bgcolor: '#0f1115' }}>
+			<canvas
+				ref={canvasRef}
+				onMouseDown={(event) => {
+					setIsPanning(true);
+					setLastPointer({ x: event.clientX, y: event.clientY });
+				}}
+				onMouseUp={(event) => {
+					if (isPanning && Math.abs(event.clientX - lastPointer.x) < 2 && Math.abs(event.clientY - lastPointer.y) < 2) {
+						const hit = hitTest(event.clientX, event.clientY);
+						if (hit) {
+							onSelectNode(hit.nodeGuid);
+						}
+					}
+					setIsPanning(false);
+				}}
+				onMouseMove={(event) => {
+					const hit = hitTest(event.clientX, event.clientY);
+					setHoveredGuid(hit?.nodeGuid ?? null);
+					if (hit) {
+						setTooltipPosition({ x: event.nativeEvent.offsetX + 8, y: event.nativeEvent.offsetY + 8 });
+					}
+					if (isPanning) {
+						const deltaX = event.clientX - lastPointer.x;
+						const deltaY = event.clientY - lastPointer.y;
+						setPan((previous) => ({ x: previous.x + deltaX, y: previous.y + deltaY }));
+						setLastPointer({ x: event.clientX, y: event.clientY });
+					}
+				}}
+				onMouseLeave={() => {
+					setHoveredGuid(null);
+					setIsPanning(false);
+				}}
+				onWheel={(event) => {
+					event.preventDefault();
+					const delta = event.deltaY < 0 ? 1.1 : 0.9;
+					setZoom((previous) => Math.max(0.4, Math.min(2.2, previous * delta)));
+				}}
+				onDoubleClick={(event) => {
+					const hit = hitTest(event.clientX, event.clientY);
+					if (hit) {
+						onMoveNode?.(hit.nodeGuid, 'down');
+					}
+				}}
+			/>
+			{hoveredGuid ? (
+				<Tooltip open title={boxes.find((box) => box.nodeGuid === hoveredGuid)?.label ?? ''} placement="top-start">
+					<Typography sx={{ position: 'absolute', left: tooltipPosition.x, top: tooltipPosition.y, pointerEvents: 'none', color: 'transparent' }}>.</Typography>
+				</Tooltip>
+			) : null}
+		</Box>
+	);
+}
+
+export default ComponentPreview;

--- a/frontend/src/components/builder/ComponentTreePanel.tsx
+++ b/frontend/src/components/builder/ComponentTreePanel.tsx
@@ -1,0 +1,118 @@
+import { Box, IconButton, List, ListItemButton, ListItemText, Stack, Typography } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import DeleteIcon from '@mui/icons-material/Delete';
+import type { ComponentTreeNode } from './types';
+
+export interface ComponentTreePanelProps {
+	nodes: ComponentTreeNode[];
+	selectedNodeGuid: string | null;
+	onSelectNode: (nodeGuid: string) => void;
+	onAddChild?: (parentGuid: string | null) => void;
+	onDeleteNode?: (nodeGuid: string) => void;
+	onMoveNode?: (nodeGuid: string, direction: 'up' | 'down') => void;
+}
+
+interface TreeRowProps {
+	node: ComponentTreeNode;
+	depth: number;
+	selectedNodeGuid: string | null;
+	onSelectNode: (nodeGuid: string) => void;
+	onAddChild?: (parentGuid: string | null) => void;
+	onDeleteNode?: (nodeGuid: string) => void;
+	onMoveNode?: (nodeGuid: string, direction: 'up' | 'down') => void;
+}
+
+function categoryColor(category: ComponentTreeNode['category']): string {
+	switch (category) {
+		case 'page':
+			return '#1976d2';
+		case 'section':
+			return '#2e7d32';
+		default:
+			return '#ef6c00';
+	}
+}
+
+function TreeRow({ node, depth, selectedNodeGuid, onSelectNode, onAddChild, onDeleteNode, onMoveNode }: TreeRowProps): JSX.Element {
+	const label = node.pubLabel ?? node.componentName;
+	return (
+		<>
+			<ListItemButton
+				selected={selectedNodeGuid === node.guid}
+				onClick={() => onSelectNode(node.guid)}
+				sx={{
+					pl: 1 + depth * 2,
+					borderLeft: `3px solid ${categoryColor(node.category)}`,
+					mb: 0.5,
+					borderRadius: 1,
+				}}
+			>
+				<ListItemText
+					primary={label}
+					secondary={`${node.componentName} • seq ${node.sequence}`}
+					primaryTypographyProps={{ noWrap: true }}
+					secondaryTypographyProps={{ noWrap: true }}
+				/>
+				<Stack direction="row" spacing={0.5}>
+					<IconButton size="small" onClick={(event) => { event.stopPropagation(); onMoveNode?.(node.guid, 'up'); }}>
+						<ArrowUpwardIcon fontSize="inherit" />
+					</IconButton>
+					<IconButton size="small" onClick={(event) => { event.stopPropagation(); onMoveNode?.(node.guid, 'down'); }}>
+						<ArrowDownwardIcon fontSize="inherit" />
+					</IconButton>
+					<IconButton size="small" onClick={(event) => { event.stopPropagation(); onAddChild?.(node.guid); }}>
+						<AddIcon fontSize="inherit" />
+					</IconButton>
+					<IconButton size="small" color="error" onClick={(event) => { event.stopPropagation(); onDeleteNode?.(node.guid); }}>
+						<DeleteIcon fontSize="inherit" />
+					</IconButton>
+				</Stack>
+			</ListItemButton>
+			{node.children.map((child) => (
+				<TreeRow
+					key={child.guid}
+					node={child}
+					depth={depth + 1}
+					selectedNodeGuid={selectedNodeGuid}
+					onSelectNode={onSelectNode}
+					onAddChild={onAddChild}
+					onDeleteNode={onDeleteNode}
+					onMoveNode={onMoveNode}
+				/>
+			))}
+		</>
+	);
+}
+
+export function ComponentTreePanel(props: ComponentTreePanelProps): JSX.Element {
+	const { nodes, selectedNodeGuid, onSelectNode, onAddChild, onDeleteNode, onMoveNode } = props;
+	if (nodes.length === 0) {
+		return (
+			<Box sx={{ p: 2 }}>
+				<Typography variant="body2" color="text.secondary">
+					No composition tree — this is a leaf component.
+				</Typography>
+			</Box>
+		);
+	}
+	return (
+		<List dense disablePadding>
+			{nodes.map((node) => (
+				<TreeRow
+					key={node.guid}
+					node={node}
+					depth={0}
+					selectedNodeGuid={selectedNodeGuid}
+					onSelectNode={onSelectNode}
+					onAddChild={onAddChild}
+					onDeleteNode={onDeleteNode}
+					onMoveNode={onMoveNode}
+				/>
+			))}
+		</List>
+	);
+}
+
+export default ComponentTreePanel;

--- a/frontend/src/components/builder/ContractPanel.tsx
+++ b/frontend/src/components/builder/ContractPanel.tsx
@@ -1,0 +1,41 @@
+import { Box, Paper, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
+import type { DataBindingRow } from './types';
+
+export interface ContractPanelProps {
+	direction: 'inbound' | 'outbound';
+	bindings: DataBindingRow[];
+}
+
+export function ContractPanel({ direction, bindings }: ContractPanelProps): JSX.Element {
+	return (
+		<Paper variant="outlined" sx={{ p: 2, flex: 1, minHeight: 180 }}>
+			<Typography variant="subtitle2" gutterBottom>
+				{direction === 'inbound' ? 'Inbound Contract' : 'Outbound Contract'}
+			</Typography>
+			{bindings.length === 0 ? (
+				<Box sx={{ color: 'text.secondary' }}>No data binding rows yet.</Box>
+			) : (
+				<Table size="small">
+					<TableHead>
+						<TableRow>
+							<TableCell>Source</TableCell>
+							<TableCell>Alias</TableCell>
+							<TableCell>Value</TableCell>
+						</TableRow>
+					</TableHead>
+					<TableBody>
+						{bindings.map((binding) => (
+							<TableRow key={binding.guid}>
+								<TableCell>{binding.sourceType}</TableCell>
+								<TableCell sx={{ fontFamily: 'monospace' }}>{binding.alias}</TableCell>
+								<TableCell sx={{ fontFamily: 'monospace' }}>{binding.value}</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			)}
+		</Paper>
+	);
+}
+
+export default ContractPanel;

--- a/frontend/src/components/builder/PropertyPanel.tsx
+++ b/frontend/src/components/builder/PropertyPanel.tsx
@@ -1,0 +1,97 @@
+import { Box, Button, Divider, MenuItem, Stack, TextField, Typography } from '@mui/material';
+import { useEffect, useMemo, useState } from 'react';
+import type { ComponentDefinition, ComponentTreeNode } from './types';
+
+export interface PropertyPanelProps {
+	node: ComponentTreeNode | null;
+	components: ComponentDefinition[];
+	onChangeNode: (updated: ComponentTreeNode) => void;
+	onSaveNode?: (updated: ComponentTreeNode) => Promise<void> | void;
+	onDeleteNode?: (nodeGuid: string) => Promise<void> | void;
+}
+
+export function PropertyPanel({ node, components, onChangeNode, onSaveNode, onDeleteNode }: PropertyPanelProps): JSX.Element {
+	const [draft, setDraft] = useState<ComponentTreeNode | null>(node);
+
+	useEffect(() => {
+		setDraft(node);
+	}, [node]);
+
+	const selectedDefinition = useMemo(() => {
+		if (!draft) {
+			return null;
+		}
+		return components.find((component) => component.guid === draft.componentGuid) ?? null;
+	}, [components, draft]);
+
+	if (!draft) {
+		return (
+			<Box sx={{ width: 360, p: 2, borderLeft: 1, borderColor: 'divider' }}>
+				<Typography variant="body2" color="text.secondary">
+					Select a component node to edit properties.
+				</Typography>
+			</Box>
+		);
+	}
+
+	const updateDraft = <K extends keyof ComponentTreeNode>(key: K, value: ComponentTreeNode[K]) => {
+		const updated = { ...draft, [key]: value };
+		setDraft(updated);
+		onChangeNode(updated);
+	};
+
+	return (
+		<Box sx={{ width: 360, p: 2, borderLeft: 1, borderColor: 'divider', overflowY: 'auto' }}>
+			<Stack spacing={1.5}>
+				<Typography variant="subtitle1">Properties</Typography>
+				<TextField
+					select
+					label="Component type"
+					value={draft.componentGuid}
+					onChange={(event) => {
+						const component = components.find((entry) => entry.guid === event.target.value);
+						updateDraft('componentGuid', event.target.value);
+						if (component) {
+							updateDraft('componentName', component.name);
+							updateDraft('category', component.category);
+						}
+					}}
+				>
+					{components.map((component) => (
+						<MenuItem key={component.guid} value={component.guid}>
+							{component.name}
+						</MenuItem>
+					))}
+				</TextField>
+				<TextField label="Label" value={draft.pubLabel ?? ''} onChange={(event) => updateDraft('pubLabel', event.target.value)} />
+				<TextField label="Field Binding" value={draft.fieldBinding ?? ''} onChange={(event) => updateDraft('fieldBinding', event.target.value)} InputProps={{ sx: { fontFamily: 'monospace' } }} />
+				<TextField
+					label="Sequence"
+					type="number"
+					value={draft.sequence}
+					onChange={(event) => updateDraft('sequence', Number(event.target.value))}
+				/>
+				<TextField label="RPC Operation" value={draft.rpcOperation ?? ''} onChange={(event) => updateDraft('rpcOperation', event.target.value)} InputProps={{ sx: { fontFamily: 'monospace' } }} />
+				<TextField label="RPC Contract" value={draft.rpcContract ?? ''} onChange={(event) => updateDraft('rpcContract', event.target.value)} InputProps={{ sx: { fontFamily: 'monospace' } }} />
+				<Divider />
+				<TextField
+					label="Default Type"
+					value={selectedDefinition?.defaultTypeName ?? selectedDefinition?.refDefaultTypeGuid ?? ''}
+					InputProps={{ readOnly: true, sx: { fontFamily: 'monospace' } }}
+				/>
+				<TextField label="Category" value={selectedDefinition?.category ?? draft.category} InputProps={{ readOnly: true }} />
+				<TextField label="GUID" value={draft.guid} InputProps={{ readOnly: true, sx: { fontFamily: 'monospace' } }} />
+				<Stack direction="row" spacing={1}>
+					<Button variant="contained" onClick={() => onSaveNode?.(draft)}>
+						Save
+					</Button>
+					<Button variant="outlined" color="error" onClick={() => onDeleteNode?.(draft.guid)}>
+						Delete
+					</Button>
+				</Stack>
+			</Stack>
+		</Box>
+	);
+}
+
+export default PropertyPanel;

--- a/frontend/src/components/builder/QueryPreviewPanel.tsx
+++ b/frontend/src/components/builder/QueryPreviewPanel.tsx
@@ -1,0 +1,16 @@
+import { Box, Paper, Typography } from '@mui/material';
+
+export function QueryPreviewPanel(): JSX.Element {
+	return (
+		<Paper variant="outlined" sx={{ p: 2, minHeight: 120 }}>
+			<Typography variant="subtitle2" gutterBottom>
+				Query Preview
+			</Typography>
+			<Box sx={{ fontFamily: 'monospace', color: 'text.secondary', whiteSpace: 'pre-wrap' }}>
+				Query derivation available when ContractQueryBuilder is implemented.
+			</Box>
+		</Paper>
+	);
+}
+
+export default QueryPreviewPanel;

--- a/frontend/src/components/builder/index.ts
+++ b/frontend/src/components/builder/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './ComponentPreview';
+export * from './PropertyPanel';
+export * from './ComponentTreePanel';
+export * from './QueryPreviewPanel';
+export * from './ContractPanel';

--- a/frontend/src/components/builder/types.ts
+++ b/frontend/src/components/builder/types.ts
@@ -1,0 +1,36 @@
+export type ComponentCategory = 'page' | 'section' | 'control';
+
+export interface ComponentDefinition {
+	guid: string;
+	name: string;
+	category: ComponentCategory;
+	refDefaultTypeGuid?: string | null;
+	defaultTypeName?: string | null;
+}
+
+export interface ComponentTreeNode {
+	guid: string;
+	parentGuid: string | null;
+	componentGuid: string;
+	componentName: string;
+	category: ComponentCategory;
+	sequence: number;
+	pubLabel?: string;
+	fieldBinding?: string;
+	rpcOperation?: string;
+	rpcContract?: string;
+	children: ComponentTreeNode[];
+}
+
+export interface DataBindingRow {
+	guid: string;
+	sourceType: string;
+	alias: string;
+	value: string;
+}
+
+export interface TreeMoveRequest {
+	nodeGuid: string;
+	newParentGuid: string | null;
+	newSequence: number;
+}


### PR DESCRIPTION
### Motivation
- Provide a composed visual editor for TSX components that lifts shared state and composes a canvas preview, property editor, composition tree, query preview, and contract panels. 
- Extract the existing page-composition surface into a dedicated `PageComposer` so the tree becomes a reusable sub-panel inside the real `ComponentBuilder`.
- Ship placeholder panels for query derivation and contract inspection so the UI shape is present while the `ContractQueryBuilder` and analysis paths are implemented later.

### Description
- Added a composed root `ComponentBuilder` that wires the preview workspace, `PropertyPanel`, and three collapsible lower sections (`ComponentTreePanel`, `QueryPreviewPanel`, `ContractPanel`) and manages shared state; file: `frontend/src/components/ComponentBuilder.tsx`.
- Extracted the page composer surface into `PageComposer` which re-exports the tree panel API; file: `frontend/src/components/PageComposer.tsx`.
- Implemented reusable builder sub-panels and types under `frontend/src/components/builder/`: `ComponentPreview.tsx` (canvas pan/zoom/select), `PropertyPanel.tsx` (editable node form), `ComponentTreePanel.tsx` (recursive tree with add/delete/reorder), `QueryPreviewPanel.tsx` (placeholder), `ContractPanel.tsx` (bindings table), and `types.ts` plus a barrel `index.ts`.
- Panels expose prop-based hooks for selection, node changes, saves/deletes, and move operations so they can be integrated with RPC/server wiring later, and no server-side schema/SQL changes were made.

### Testing
- Ran `cd frontend && npm run lint`, which failed due to missing local npm dev dependencies in this environment (ESLint error: `@eslint/js` not found).
- Ran `cd frontend && npm run type-check`, which failed due to missing installed frontend dependencies and generated artifacts causing multiple module resolution `tsc` errors.
- No backend automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3f59fe948325987985a317ff0b08)