### PR TITLE
Refine ComponentBuilder placeholder panels

### DIFF
--- a/client/src/components/builder/ComponentPreview.tsx
+++ b/client/src/components/builder/ComponentPreview.tsx
@@ -19,6 +19,8 @@ function categoryShape(category: string | null): JSX.Element {
 }
 
 export function ComponentPreview({ componentName, componentCategory, treeRows }: ComponentPreviewProps): JSX.Element {
+	void treeRows;
+
 	return (
 		<Box
 			sx={{
@@ -38,9 +40,6 @@ export function ComponentPreview({ componentName, componentCategory, treeRows }:
 			<Typography variant="body2">{componentName ?? 'No component selected'}</Typography>
 			<Typography variant="caption" sx={{ color: '#4CAF50' }}>
 				{componentCategory ?? '—'}
-			</Typography>
-			<Typography variant="caption" sx={{ color: '#9E9E9E' }}>
-				Tree nodes: {treeRows.length}
 			</Typography>
 		</Box>
 	);

--- a/client/src/components/builder/ContractPanel.tsx
+++ b/client/src/components/builder/ContractPanel.tsx
@@ -5,6 +5,8 @@ interface ContractPanelProps {
 }
 
 export function ContractPanel({ pageGuid }: ContractPanelProps): JSX.Element {
+	void pageGuid;
+
 	return (
 		<Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1, bgcolor: '#000000' }}>
 			<Box sx={{ p: 1.5, border: '1px solid #1A1A1A', bgcolor: '#0A0A0A' }}>
@@ -17,9 +19,6 @@ export function ContractPanel({ pageGuid }: ContractPanelProps): JSX.Element {
 				<Typography variant="subtitle2">Outbound Contract</Typography>
 				<Typography variant="body2" sx={{ color: '#BDBDBD' }}>
 					Outbound contract preview will appear when contract introspection is implemented.
-				</Typography>
-				<Typography variant="caption" sx={{ color: '#4CAF50' }}>
-					Context page: {pageGuid ?? 'none'}
 				</Typography>
 			</Box>
 		</Box>

--- a/client/src/components/builder/QueryPreviewPanel.tsx
+++ b/client/src/components/builder/QueryPreviewPanel.tsx
@@ -5,12 +5,11 @@ interface QueryPreviewPanelProps {
 }
 
 export function QueryPreviewPanel({ pageGuid }: QueryPreviewPanelProps): JSX.Element {
+	void pageGuid;
+
 	return (
 		<Box sx={{ p: 1.5, bgcolor: '#000000', border: '1px solid #1A1A1A' }}>
 			<Typography variant="body2">Query derivation available when ContractQueryBuilder is implemented.</Typography>
-			<Typography variant="caption" sx={{ color: '#4CAF50' }}>
-				Page GUID: {pageGuid ?? 'none'}
-			</Typography>
 		</Box>
 	);
 }


### PR DESCRIPTION
### Motivation
- Tidy up Phase 1 placeholder panels for the ComponentBuilder by removing noisy runtime details and keeping the UI focused on the preview/placeholder content.

### Description
- Simplified placeholders in `client/src/components/builder/ComponentPreview.tsx`, `client/src/components/builder/QueryPreviewPanel.tsx`, and `client/src/components/builder/ContractPanel.tsx` to remove tree-count / page GUID displays and keep only the phase-1 schematic and explanatory text, and added `void` uses to silence unused-prop warnings.

### Testing
- Ran `npm run lint` in `client/` which completed (there are 2 unrelated pre-existing warnings reported in other files). 
- Ran `npm run type-check` in `client/` which succeeded. 
- Ran the unified harness `python scripts/run_tests.py` which completed successfully (1 frontend test passed and the same pre-existing lint warnings were shown).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd6ad0b4ec83259a1ef7526f193a5f)