### PR TITLE
Register missing CMS components in client registry

### DIFF
--- a/client/src/components/BoolToggle.tsx
+++ b/client/src/components/BoolToggle.tsx
@@ -1,0 +1,18 @@
+import { Box, Switch, Typography } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function BoolToggle({ node, data }: CmsComponentProps): JSX.Element {
+	const value = node.fieldBinding ? Boolean(data[node.fieldBinding]) : false;
+
+	return (
+		<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+			{node.label && (
+				<Typography variant="body2" color="text.secondary">
+					{node.label}
+				</Typography>
+			)}
+			<Switch checked={value} size="small" disabled />
+		</Box>
+	);
+}

--- a/client/src/components/ButtonLinkControl.tsx
+++ b/client/src/components/ButtonLinkControl.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function ButtonLinkControl({ node, data }: CmsComponentProps): JSX.Element {
+	const url = node.fieldBinding ? String(data[node.fieldBinding] ?? '') : '#';
+	const label = node.label ?? 'Link';
+
+	return (
+		<Button
+			variant="outlined"
+			size="small"
+			href={url}
+			target="_blank"
+			rel="noopener noreferrer"
+			sx={{ mb: 1 }}
+		>
+			{label}
+		</Button>
+	);
+}

--- a/client/src/components/CollapsibleSection.tsx
+++ b/client/src/components/CollapsibleSection.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+import { Box, Typography } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function CollapsibleSection({ node, children }: CmsComponentProps): JSX.Element {
+	const [open, setOpen] = useState(true);
+
+	return (
+		<Box sx={{ mb: 1 }}>
+			<Box
+				onClick={() => setOpen((prev) => !prev)}
+				sx={{
+					cursor: 'pointer',
+					bgcolor: '#0A0A0A',
+					border: '1px solid #1A1A1A',
+					px: 1,
+					py: 0.5,
+					'&:hover': { color: '#4CAF50' },
+				}}
+			>
+				<Typography variant="subtitle2">
+					{open ? '▾' : '▸'} {node.label ?? 'Section'}
+				</Typography>
+			</Box>
+			{open && <Box sx={{ pl: 1, pt: 0.5 }}>{children}</Box>}
+		</Box>
+	);
+}

--- a/client/src/components/IntControl.tsx
+++ b/client/src/components/IntControl.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function IntControl({ node, data }: CmsComponentProps): JSX.Element {
+	const value = node.fieldBinding ? data[node.fieldBinding] : null;
+
+	return (
+		<Box sx={{ mb: 1 }}>
+			{node.label && (
+				<Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+					{node.label}
+				</Typography>
+			)}
+			<Typography variant="body1" sx={{ fontFamily: 'monospace' }}>
+				{value != null ? String(value) : '—'}
+			</Typography>
+		</Box>
+	);
+}

--- a/client/src/components/NavigationItem.tsx
+++ b/client/src/components/NavigationItem.tsx
@@ -1,0 +1,16 @@
+import { ListItemButton, ListItemText } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function NavigationItem({ node, data }: CmsComponentProps): JSX.Element {
+	const path = node.fieldBinding ? String(data[node.fieldBinding] ?? '#') : '#';
+
+	return (
+		<ListItemButton component="a" href={path} sx={{ py: 0.5 }}>
+			<ListItemText
+				primary={node.label ?? 'Nav Item'}
+				primaryTypographyProps={{ fontSize: '0.85rem' }}
+			/>
+		</ListItemButton>
+	);
+}

--- a/client/src/components/ObjectTreeNode.tsx
+++ b/client/src/components/ObjectTreeNode.tsx
@@ -1,0 +1,14 @@
+import { Box, Typography } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function ObjectTreeNode({ node, children }: CmsComponentProps): JSX.Element {
+	return (
+		<Box sx={{ pl: 1 }}>
+			<Typography variant="body2" sx={{ py: 0.25 }}>
+				{node.label ?? node.component ?? 'Node'}
+			</Typography>
+			{children}
+		</Box>
+	);
+}

--- a/client/src/components/ReadOnlyDisplay.tsx
+++ b/client/src/components/ReadOnlyDisplay.tsx
@@ -1,0 +1,18 @@
+import { Box, Typography } from '@mui/material';
+
+import type { CmsComponentProps } from '../engine/types';
+
+export function ReadOnlyDisplay({ node, data }: CmsComponentProps): JSX.Element {
+	const value = node.fieldBinding ? data[node.fieldBinding] : null;
+
+	return (
+		<Box sx={{ mb: 1 }}>
+			{node.label && (
+				<Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+					{node.label}
+				</Typography>
+			)}
+			<Typography variant="body1">{value != null ? String(value) : '—'}</Typography>
+		</Box>
+	);
+}

--- a/client/src/engine/registry.ts
+++ b/client/src/engine/registry.ts
@@ -1,19 +1,26 @@
 import type { ComponentType } from 'react';
 
-import { DevModeToggle } from '../components/DevModeToggle';
-import { DatabaseBuilder } from '../components/DatabaseBuilder';
-import { ContentPanel } from '../components/ContentPanel';
+import { BoolToggle } from '../components/BoolToggle';
+import { ButtonLinkControl } from '../components/ButtonLinkControl';
+import { CollapsibleSection } from '../components/CollapsibleSection';
 import { ComponentBuilder } from '../components/ComponentBuilder';
+import { ContentPanel } from '../components/ContentPanel';
+import { DatabaseBuilder } from '../components/DatabaseBuilder';
+import { DevModeToggle } from '../components/DevModeToggle';
 import { HamburgerToggle } from '../components/HamburgerToggle';
 import { ImageElement } from '../components/ImageElement';
+import { IntControl } from '../components/IntControl';
 import { LabelElement } from '../components/LabelElement';
-import { LoginControl } from '../components/LoginControl';
 import { LinkButton } from '../components/LinkButton';
+import { LoginControl } from '../components/LoginControl';
+import { ModulesBuilder } from '../components/ModulesBuilder';
+import { NavigationItem } from '../components/NavigationItem';
+import { NavigationSidebar } from '../components/NavigationSidebar';
 import { NavigationTreeView } from '../components/NavigationTreeView';
 import { ObjectEditor } from '../components/ObjectEditor';
+import { ObjectTreeNode } from '../components/ObjectTreeNode';
 import { ObjectTreeView } from '../components/ObjectTreeView';
-import { ModulesBuilder } from '../components/ModulesBuilder';
-import { NavigationSidebar } from '../components/NavigationSidebar';
+import { ReadOnlyDisplay } from '../components/ReadOnlyDisplay';
 import { SidebarContent } from '../components/SidebarContent';
 import { SidebarFooter } from '../components/SidebarFooter';
 import { SidebarHeader } from '../components/SidebarHeader';
@@ -22,6 +29,13 @@ import { StringControl } from '../components/StringControl';
 import { TypesBuilder } from '../components/TypesBuilder';
 import { UserProfileControl } from '../components/UserProfileControl';
 import { Workbench } from '../components/Workbench';
+import {
+	ComponentPreview,
+	ComponentTreePanel,
+	ContractPanel,
+	PropertyPanel,
+	QueryPreviewPanel,
+} from '../components/builder';
 
 import type { CmsComponentProps } from './types';
 
@@ -44,8 +58,20 @@ export const COMPONENT_REGISTRY: Record<string, ComponentType<CmsComponentProps>
 	LoginControl,
 	UserProfileControl,
 	StringControl,
+	BoolToggle,
+	ButtonLinkControl,
+	CollapsibleSection,
+	IntControl,
+	NavigationItem,
+	ObjectTreeNode,
+	ReadOnlyDisplay,
 	DatabaseBuilder: DatabaseBuilder as unknown as ComponentType<CmsComponentProps>,
 	TypesBuilder: TypesBuilder as unknown as ComponentType<CmsComponentProps>,
 	ModulesBuilder: ModulesBuilder as unknown as ComponentType<CmsComponentProps>,
 	ComponentBuilder: ComponentBuilder as unknown as ComponentType<CmsComponentProps>,
+	ComponentPreview: ComponentPreview as unknown as ComponentType<CmsComponentProps>,
+	ComponentTreePanel: ComponentTreePanel as unknown as ComponentType<CmsComponentProps>,
+	ContractPanel: ContractPanel as unknown as ComponentType<CmsComponentProps>,
+	PropertyPanel: PropertyPanel as unknown as ComponentType<CmsComponentProps>,
+	QueryPreviewPanel: QueryPreviewPanel as unknown as ComponentType<CmsComponentProps>,
 };


### PR DESCRIPTION
### Motivation

- The rendering engine could not resolve 12 components that exist in the database because five were not registered and seven had no TSX implementations, causing fallback rendering in the builder UI.
- The goal is to make the client-side `COMPONENT_REGISTRY` match the database `system_objects_components` so any component tree persisted in the DB can be rendered in the app.

### Description

- Added seven stub component implementations under `client/src/components/`: `BoolToggle.tsx`, `IntControl.tsx`, `ReadOnlyDisplay.tsx`, `ButtonLinkControl.tsx`, `CollapsibleSection.tsx`, `NavigationItem.tsx`, and `ObjectTreeNode.tsx`. 
- Updated `client/src/engine/registry.ts` to import and register the seven new stubs plus five builder sub-components from `client/src/components/builder` so `COMPONENT_REGISTRY` now contains 34 entries. 
- Reused the existing builder barrel export (`client/src/components/builder/index.ts`) which already exports `ComponentPreview`, `ComponentTreePanel`, `ContractPanel`, `PropertyPanel`, and `QueryPreviewPanel`. 
- All components implement the `CmsComponentProps` shape from `client/src/engine/types.ts` and follow the leaf/container rendering patterns used in the codebase.

### Testing

- Ran `npm run lint` in the `client` package and it completed successfully with two pre-existing warnings that are unrelated to these changes. 
- Ran `npm run type-check` in the `client` package and TypeScript checks passed with no errors. 
- Verified the registry entry count with a small script and confirmed `COMPONENT_REGISTRY` contains `34` entries, matching the DB component list.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9d9fc73883258399c57d7869652d)