### PR TITLE
Add db.run boundary guardrail and enforce in test harness

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -328,7 +328,8 @@ Module lifecycle:
 1. `__init__(app)` — store app reference, initialize fields to None
 2. `startup()` — resolve dependencies via `self.app.state`, await their `on_ready()`, then call `self.mark_ready()`
 3. Business methods — all data access through `self.db.run(request_builder())`, return the RPC response Pydantic model directly
-4. `shutdown()` — release references
+4. Module/business code must use canonical QueryRegistry request builders/operations and must not invoke provider internals or direct `db.run(...)` outside approved infrastructure boundaries.
+5. `shutdown()` — release references
 
 ### 3.3 Model Ownership
 

--- a/queryregistry/AGENTS.md
+++ b/queryregistry/AGENTS.md
@@ -21,6 +21,12 @@ Do not add new code to `server/registry/`.
 - Not a place for business logic, conditional workflows, or application rules;
   those belong in `server/modules/`.
 
+## Direct execution guardrail
+
+- Business/module code must call canonical QueryRegistry operations/request builders.
+- Do **not** invoke provider execution directly from business/module code.
+- Direct `db.run(...)` usage is restricted to approved infrastructure boundaries.
+
 ---
 
 ## Core files and dispatch flow

--- a/queryregistry/finance/staging_purge_log/services.py
+++ b/queryregistry/finance/staging_purge_log/services.py
@@ -7,6 +7,7 @@ from typing import Any
 from queryregistry.models import DBRequest, DBResponse
 
 from . import mssql
+from . import get_purge_log_request, upsert_purge_log_request
 from .models import (
   CheckPurgedKeyParams,
   GetPurgeLogParams,
@@ -15,6 +16,7 @@ from .models import (
 )
 
 _Dispatcher = Callable[[Mapping[str, Any]], Awaitable[DBResponse]]
+_RunRequest = Callable[[DBRequest], Awaitable[DBResponse]]
 
 
 def _select_dispatcher(provider: str, dispatchers: dict[str, _Dispatcher]) -> _Dispatcher:
@@ -48,12 +50,11 @@ async def upsert_purge_log_v1(request: DBRequest, *, provider: str) -> DBRespons
   return DBResponse(op=request.op, payload=result.payload, rowcount=result.rowcount)
 
 
-async def append_purged_keys(db, vendors_recid: int, period_key: str, new_keys: list[str]) -> None:
-  existing_res = await db.run(
-    DBRequest(
-      op="db:finance:staging_purge_log:get_purge_log:1",
-      payload={"vendors_recid": vendors_recid, "period_key": period_key},
-    )
+async def append_purged_keys(
+  run_request: _RunRequest, vendors_recid: int, period_key: str, new_keys: list[str]
+) -> None:
+  existing_res = await run_request(
+    get_purge_log_request(GetPurgeLogParams(vendors_recid=vendors_recid, period_key=period_key))
   )
   existing_keys: set[str] = set()
   if existing_res.rows:
@@ -65,14 +66,13 @@ async def append_purged_keys(db, vendors_recid: int, period_key: str, new_keys: 
   merged = existing_keys | set(new_keys)
   merged_json = json.dumps({"batch_purged": sorted(merged)})
 
-  await db.run(
-    DBRequest(
-      op="db:finance:staging_purge_log:upsert_purge_log:1",
-      payload={
-        "vendors_recid": vendors_recid,
-        "period_key": period_key,
-        "purged_keys_json": merged_json,
-        "purged_count": len(merged),
-      },
+  await run_request(
+    upsert_purge_log_request(
+      UpsertPurgeLogParams(
+        vendors_recid=vendors_recid,
+        period_key=period_key,
+        purged_keys_json=merged_json,
+        purged_count=len(merged),
+      )
     )
   )

--- a/scripts/check_db_run_boundaries.py
+++ b/scripts/check_db_run_boundaries.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+APPROVED_PATH_PREFIXES = (
+  "server/modules/providers/",
+)
+
+EXCLUDED_PATH_PREFIXES = (
+  ".git/",
+  ".venv/",
+  "node_modules/",
+  "client/",
+)
+
+
+def _is_excluded(path: Path) -> bool:
+  rel = path.relative_to(ROOT).as_posix()
+  return any(rel.startswith(prefix) for prefix in EXCLUDED_PATH_PREFIXES)
+
+
+def _is_allowlisted(path: Path) -> bool:
+  rel = path.relative_to(ROOT).as_posix()
+  return any(rel.startswith(prefix) for prefix in APPROVED_PATH_PREFIXES)
+
+
+def _find_direct_db_run_calls(path: Path) -> list[int]:
+  source = path.read_text(encoding="utf-8")
+  tree = ast.parse(source, filename=str(path))
+
+  lines: list[int] = []
+  for node in ast.walk(tree):
+    if not isinstance(node, ast.Call):
+      continue
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+      continue
+    if func.attr != "run":
+      continue
+    if not isinstance(func.value, ast.Name):
+      continue
+    if func.value.id != "db":
+      continue
+    lines.append(node.lineno)
+
+  return sorted(lines)
+
+
+def main() -> int:
+  offenders: list[tuple[str, int]] = []
+
+  for path in ROOT.rglob("*.py"):
+    if _is_excluded(path) or _is_allowlisted(path):
+      continue
+
+    for line_no in _find_direct_db_run_calls(path):
+      offenders.append((path.relative_to(ROOT).as_posix(), line_no))
+
+  if offenders:
+    print("Direct db.run(...) usage is restricted to approved infrastructure paths only.")
+    print("Move business/module data access to canonical QueryRegistry request builders/operations.")
+    print("\nOffending call sites:")
+    for rel_path, line_no in offenders:
+      print(f"  - {rel_path}:{line_no}")
+    return 1
+
+  print("db.run boundary check passed.")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -147,6 +147,8 @@ def main() -> None:
   # subprocess.check_call([sys.executable, 'scripts/generate_db_namespace.py'], cwd=ROOT)
   # subprocess.check_call([sys.executable, 'scripts/generate_nav_pages.py'], cwd=ROOT)
 
+  subprocess.check_call([sys.executable, 'scripts/check_db_run_boundaries.py'], cwd=ROOT)
+
   subprocess.check_call(['npm', 'run', 'lint'], cwd=ROOT / 'client')
   subprocess.check_call(['npm', 'run', 'type-check'], cwd=ROOT / 'client')
 


### PR DESCRIPTION
### Motivation

- Prevent business/module code from executing provider calls directly and ensure all data access uses canonical QueryRegistry operations/request builders. 
- Make this a repository-wide, CI-enforced guardrail so accidental provider execution is caught early. 

### Description

- Added `scripts/check_db_run_boundaries.py`, an AST-based static checker that fails when it finds `db.run(...)` calls outside an explicit allowlist (`server/modules/providers/`).
- Integrated the guardrail into the canonical test harness by invoking the checker from `scripts/run_tests.py` so it runs in standard local/CI runs via the unified harness.
- Refactored `queryregistry/finance/staging_purge_log/services.py` to remove direct `DBRequest` construction: it now uses the canonical request builders (`get_purge_log_request`, `upsert_purge_log_request`) and accepts a `run_request` callable boundary instead of calling `db.run(...)` inline.
- Documented the policy in `PATTERNS.md` and `queryregistry/AGENTS.md` with a “Direct execution guardrail” that instructs modules to use QueryRegistry builders and not invoke provider execution directly.

### Testing

- Ran `python scripts/check_db_run_boundaries.py`, which initially reported offending sites and after the refactor printed `db.run boundary check passed.` indicating success. 
- Verified syntax of the new/modified files with `python -m py_compile scripts/check_db_run_boundaries.py queryregistry/finance/staging_purge_log/services.py scripts/run_tests.py`, which completed without errors. 
- Confirmed the new checker executes as part of the harness by adding it to `scripts/run_tests.py` (no full CI run included in this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df67c22548325b9bdedaa6dca83d0)